### PR TITLE
Added automake as build dependency on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,15 +183,16 @@ For OsX:
 
   Via MacPorts:
 
-      sudo port install md5sha1sum cmake libtool
+      sudo port install md5sha1sum cmake libtool automake
 
   Via Homebrew:
 
-      brew install md5sha1sum cmake libtool
+      brew install md5sha1sum cmake libtool automake
 
 For Arch Linux:
 
       sudo pacman -S base-devel cmake ncurses
+
 
 TODO: release the Dockerfile which has this in it
 


### PR DESCRIPTION
## From the build process on my Mac OS X 10.9:

...
- aclocal -I m4
  autogen.sh: line 44: aclocal: command not found
  make: **\* [.deps/usr/lib/libuv.a] Error 127
  ...

This is fixed by installing automake using:
$ brew install automake
