### PR TITLE
Change binary output dir from src/ to bin/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,7 @@ include_directories ("${PROJECT_SOURCE_DIR}/.deps/usr/include")
 
 include_directories ("${PROJECT_BINARY_DIR}/config") 
 
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 add_subdirectory(src)
 add_subdirectory(config)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=Debug
 
-build/src/vim: deps
+build/bin/vim: deps
 	cd build && make
 
-test: build/src/vim
+test: build/bin/vim
 	cd src/testdir && make
 
 deps: .deps/usr/lib/libuv.a
@@ -23,4 +23,4 @@ clean:
 
 .PHONY: test deps cmake
 
-.DEFAULT: build/src/vim
+.DEFAULT: build/bin/vim

--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -127,7 +127,7 @@ CHECKFILES = \
 
 PACKAGE = vim
 SHELL = /bin/sh
-VIM = ../../build/src/vim
+VIM = ../../build/bin/vim
 
 # The OLD_PO_FILE_INPUT and OLD_PO_FILE_OUTPUT are for the new GNU gettext
 # tools 0.10.37, which use a slightly different .po file format that is not

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -2,7 +2,7 @@
 # Makefile to run all tests for Vim
 #
 
-VIMPROG = ../../build/src/vim
+VIMPROG = ../../build/bin/vim
 
 # Uncomment this line to use valgrind for memory leaks and extra warnings.
 #   The output goes into a file "valgrind.testN"

--- a/src/testdir/test49.vim
+++ b/src/testdir/test49.vim
@@ -456,7 +456,7 @@ function! ExtraVim(...)
     " messing up the user's viminfo file.
     let redirect = a:0 ?
 	\ " -c 'au VimLeave * redir END' -c 'redir\\! >" . a:1 . "'" : ""
-    exec "!echo '" . debug_quits . "q' | ../../build/src/vim -u NONE -N -Xes" . redirect .
+    exec "!echo '" . debug_quits . "q' | ../../build/bin/vim -u NONE -N -Xes" . redirect .
 	\ " -c 'debuggreedy|set viminfo+=nviminfo'" .
 	\ " -c 'let ExtraVimBegin = " . extra_begin . "'" .
 	\ " -c 'let ExtraVimResult = \"" . resultfile . "\"'" . breakpoints .


### PR DESCRIPTION
It doesn't make sense to output the binary on build/src/. This changeset sets the binary output directory to build/bin/.
