### PR TITLE
Add libuv-dev to apt-get dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ and what is currently being worked on:
 
 For Ubuntu 12.04:
 
-    sudo apt-get install build-essential cmake libncurses5-dev
+    sudo apt-get install build-essential cmake libncurses5-dev libuv-dev
 
 For OsX:
 


### PR DESCRIPTION
For debian, I had to apt-get install libuv-dev to build the current version.
