### PR TITLE
Add wget to dependencies for building on osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ For OsX:
 
   Via MacPorts:
 
-      sudo port install md5sha1sum cmake libtool automake
+      sudo port install md5sha1sum cmake libtool automake wget
 
   Via Homebrew:
 
-      brew install md5sha1sum cmake libtool automake
+      brew install md5sha1sum cmake libtool automake wget
 
 For Arch Linux:
 


### PR DESCRIPTION
wget is needed to build on osx (scripts/common.sh)
