### PR TITLE
Silence wget

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -26,7 +26,7 @@ download() {
 		local download_command=""
 		if which wget > /dev/null 2>&1; then
 			# -O - to send output to stdout
-			download_command="wget $url -O -"
+			download_command="wget --no-verbose $url -O -"
 		elif which curl >/dev/null 2>&1; then
 			# -L to follow the redirects that github will send us
 			# -sS to supress the progress bar, but show errors


### PR DESCRIPTION
Silenced wget's progress bar

This way it won't show up in travis-ci like:

```
0% [                                       ] 0           --.-K/s
100%[======================================>] 371,453     --.-K/s
```

interleaved with the rest of the output.

This builds off of #61, but it is logically a separate fix.  I'm not sure what the proper etiquette is in terms of github pull requests.
