### PR TITLE
OSX: remove homebrew dep on sha1sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,15 +185,15 @@ For FreeBSD 10:
 For OsX:
 
 * Install [Xcode](https://developer.apple.com/)
-* Install sha1sum
+* Install building tools
 
   Via MacPorts:
 
-      sudo port install md5sha1sum cmake libtool automake
+      sudo port install cmake libtool automake
 
   Via Homebrew:
 
-      brew install md5sha1sum cmake libtool automake
+      brew install cmake libtool automake
 
 For Arch Linux:
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -4,10 +4,12 @@ if [ "$unameval" == 'Linux' ]; then
 	platform='linux'
 elif [ "$unameval" == 'FreeBSD' ]; then
 	platform='freebsd'
+elif [ "$unameval" == 'Darwin' ]; then
+	platform='darwin'
 fi
 
 sha1sumcmd='sha1sum'
-if [ "$platform" == 'freebsd' ]; then
+if [ "$platform" == 'freebsd' ] || [ "$platform" == 'darwin' ]; then
 	sha1sumcmd='shasum'
 fi
 


### PR DESCRIPTION
... since OSX already provides md5 and sha1.
