### PR TITLE
Clean-up main.c: follow STRNICMP replacement.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -901,7 +901,7 @@ static void parse_command_name(parmp)
 
   set_vim_var_string(VV_PROGNAME, initstr, -1);
 
-  if (STRNICMP(initstr, "editor", 6) == 0)
+  if (parse_string(&initstr, "editor", 6))
     return;
 
   if (parse_char_i(&initstr, 'r'))


### PR DESCRIPTION
This is a follow-up to pull request #54.

@mitchellwrosen, can you confirm that this was not intended? I guess you might have missed this case while replacing TOLOWER_ASC by STRNICMP.
