### PR TITLE
Use bash to run libuv install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: build/src/vim
 deps: .deps/usr/lib/libuv.a
 
 .deps/usr/lib/libuv.a:
-	sh -e scripts/get-libuv.sh
+	bash -e scripts/get-libuv.sh
 
 cmake: clean
 	mkdir build


### PR DESCRIPTION
Running `make deps` on Ubuntu 13.10 causes the following errors

```
scripts/get-libuv.sh: 3: [: Linux: unexpected operator
scripts/get-libuv.sh: 5: [: Linux: unexpected operator
scripts/get-libuv.sh: 10: [: unknown: unexpected operator
```

I'm not sure if changing the runner to `bash` is the best way, but it fixed it for me :)
