### PR TITLE
Add Homebrew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,25 +181,15 @@ For Debian/Ubuntu:
 For FreeBSD 10:
 
     sudo pkg install cmake libtool sha
-    
+
 For OsX:
 
-* Install [Xcode](https://developer.apple.com/)
-* Install sha1sum
+* Install [Xcode](https://developer.apple.com/) and [Homebrew][http://brew.sh]
 
-  Via MacPorts:
-
-      sudo port install md5sha1sum cmake libtool automake
-
-  Via Homebrew:
-
-      brew install md5sha1sum cmake libtool automake
 
 For Arch Linux:
 
       sudo pacman -S base-devel cmake ncurses
-
-
 
 ###Building
 
@@ -210,6 +200,10 @@ To generate the `Makefile`s:
 To build and run the tests:
 
     make test
+
+Using Homebrew on Mac:
+
+    brew install neovim/neovim/neovim
 
 ### Community
 

--- a/neovim.rb
+++ b/neovim.rb
@@ -11,5 +11,6 @@ class Neovim < Formula
 
   def install
     system "make", "PREFIX=#{prefix}", "cmake"
+    system "make", "PREFIX=#{prefix}"
   end
 end

--- a/neovim.rb
+++ b/neovim.rb
@@ -1,0 +1,15 @@
+require 'formula'
+
+class Neovim < Formula
+  homepage 'http://neovim.org'
+  head 'https://github.com/neovim/neovim.git'
+
+  depends_on 'md5sha1sum'
+  depends_on 'cmake'
+  depends_on 'libtool'
+  depends_on 'automake'
+
+  def install
+    system "make", "PREFIX=#{prefix}", "cmake"
+  end
+end


### PR DESCRIPTION
This makes it very easy to install Neovim for Mac users.

To test this, you can run `brew install --HEAD cweagans/neovim/neovim`.

Also, don't merge this yet, as it's blocked on #89.
