### PR TITLE
Convert function declarations from K&R to ANSI style.

### DIFF
--- a/config/config.h.in
+++ b/config/config.h.in
@@ -12,7 +12,6 @@
 #define SIZEOF_OFF_T @SIZEOF_OFF_T@
 
 #define _FILE_OFFSET_BITS 64
-#define HAVE_ATTRIBUTE_UNUSED 1
 #define HAVE_BCMP 1
 #define HAVE_DATE_TIME 1
 #define HAVE_DIRENT_H 1

--- a/src/arabic.c
+++ b/src/arabic.c
@@ -42,8 +42,7 @@ static int A_is_special __ARGS((int c));
 /*
  * Returns True if c is an ISO-8859-6 shaped ARABIC letter (user entered)
  */
-static int A_is_a(cur_c)
-int cur_c;
+static int A_is_a(int cur_c)
 {
   switch (cur_c) {
   case a_HAMZA:
@@ -93,8 +92,7 @@ int cur_c;
 /*
  * Returns True if c is an Isolated Form-B ARABIC letter
  */
-static int A_is_s(cur_c)
-int cur_c;
+static int A_is_s(int cur_c)
 {
   switch (cur_c) {
   case a_s_HAMZA:
@@ -143,8 +141,7 @@ int cur_c;
 /*
  * Returns True if c is a Final shape of an ARABIC letter
  */
-static int A_is_f(cur_c)
-int cur_c;
+static int A_is_f(int cur_c)
 {
   switch (cur_c) {
   case a_f_ALEF_MADDA:
@@ -195,8 +192,7 @@ int cur_c;
 /*
  * Change shape - from ISO-8859-6/Isolated to Form-B Isolated
  */
-static int chg_c_a2s(cur_c)
-int cur_c;
+static int chg_c_a2s(int cur_c)
 {
   int tempc;
 
@@ -323,8 +319,7 @@ int cur_c;
 /*
  * Change shape - from ISO-8859-6/Isolated to Initial
  */
-static int chg_c_a2i(cur_c)
-int cur_c;
+static int chg_c_a2i(int cur_c)
 {
   int tempc;
 
@@ -451,8 +446,7 @@ int cur_c;
 /*
  * Change shape - from ISO-8859-6/Isolated to Medial
  */
-static int chg_c_a2m(cur_c)
-int cur_c;
+static int chg_c_a2m(int cur_c)
 {
   int tempc;
 
@@ -579,8 +573,7 @@ int cur_c;
 /*
  * Change shape - from ISO-8859-6/Isolated to final
  */
-static int chg_c_a2f(cur_c)
-int cur_c;
+static int chg_c_a2f(int cur_c)
 {
   int tempc;
 
@@ -717,8 +710,7 @@ int cur_c;
 /*
  * Change shape - from Initial to Medial
  */
-static int chg_c_i2m(cur_c)
-int cur_c;
+static int chg_c_i2m(int cur_c)
 {
   int tempc;
 
@@ -803,8 +795,7 @@ int cur_c;
 /*
  * Change shape - from Final to Medial
  */
-static int chg_c_f2m(cur_c)
-int cur_c;
+static int chg_c_f2m(int cur_c)
 {
   int tempc;
 
@@ -911,8 +902,7 @@ int cur_c;
 /*
  * Change shape - from Combination (2 char) to an Isolated
  */
-static int chg_c_laa2i(hid_c)
-int hid_c;
+static int chg_c_laa2i(int hid_c)
 {
   int tempc;
 
@@ -940,8 +930,7 @@ int hid_c;
 /*
  * Change shape - from Combination-Isolated to Final
  */
-static int chg_c_laa2f(hid_c)
-int hid_c;
+static int chg_c_laa2f(int hid_c)
 {
   int tempc;
 
@@ -968,8 +957,7 @@ int hid_c;
 /*
  * Do "half-shaping" on character "c".  Return zero if no shaping.
  */
-static int half_shape(c)
-int c;
+static int half_shape(int c)
 {
   if (A_is_a(c))
     return chg_c_a2i(c);
@@ -987,13 +975,7 @@ int c;
  *		     (not shaped)
  * in:     "next_c"  is the next character (not shaped).
  */
-int arabic_shape(c, ccp, c1p, prev_c, prev_c1, next_c)
-int c;
-int         *ccp;
-int         *c1p;
-int prev_c;
-int prev_c1;
-int next_c;
+int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1, int next_c)
 {
   int curr_c;
   int shape_c;
@@ -1054,9 +1036,11 @@ int next_c;
 /*
  * A_firstc_laa returns first character of LAA combination if it exists
  */
-static int A_firstc_laa(c, c1)
-int c;          /* base character */
-int c1;         /* first composing character */
+static int 
+A_firstc_laa (
+    int c,          /* base character */
+    int c1         /* first composing character */
+)
 {
   if (c1 != NUL && c == a_LAM && !A_is_harakat(c1))
     return c1;
@@ -1068,8 +1052,7 @@ int c1;         /* first composing character */
  * A_is_harakat returns TRUE if 'c' is an Arabic Harakat character
  *		(harakat/tanween)
  */
-static int A_is_harakat(c)
-int c;
+static int A_is_harakat(int c)
 {
   return c >= a_FATHATAN && c <= a_SUKUN;
 }
@@ -1079,8 +1062,7 @@ int c;
  * A_is_iso returns TRUE if 'c' is an Arabic ISO-8859-6 character
  *		(alphabet/number/punctuation)
  */
-static int A_is_iso(c)
-int c;
+static int A_is_iso(int c)
 {
   return (c >= a_HAMZA && c <= a_GHAIN)
          || (c >= a_TATWEEL && c <= a_HAMZA_BELOW)
@@ -1092,8 +1074,7 @@ int c;
  * A_is_formb returns TRUE if 'c' is an Arabic 10646-1 FormB character
  *		(alphabet/number/punctuation)
  */
-static int A_is_formb(c)
-int c;
+static int A_is_formb(int c)
 {
   return (c >= a_s_FATHATAN && c <= a_s_DAMMATAN)
          || c == a_s_KASRATAN
@@ -1105,8 +1086,7 @@ int c;
 /*
  * A_is_ok returns TRUE if 'c' is an Arabic 10646 (8859-6 or Form-B)
  */
-static int A_is_ok(c)
-int c;
+static int A_is_ok(int c)
 {
   return A_is_iso(c) || A_is_formb(c);
 }
@@ -1116,8 +1096,7 @@ int c;
  * A_is_valid returns TRUE if 'c' is an Arabic 10646 (8859-6 or Form-B)
  *		with some exceptions/exclusions
  */
-static int A_is_valid(c)
-int c;
+static int A_is_valid(int c)
 {
   return A_is_ok(c) && !A_is_special(c);
 }
@@ -1127,8 +1106,7 @@ int c;
  * A_is_special returns TRUE if 'c' is not a special Arabic character.
  *		Specials don't adhere to most of the rules.
  */
-static int A_is_special(c)
-int c;
+static int A_is_special(int c)
 {
   return c == a_HAMZA || c == a_s_HAMZA;
 }

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -319,9 +319,7 @@ static UINT32_T sbi[4][256] = {
         sbx[3][xr & 0xFF];
 
 
-static void bf_e_block(p_xl, p_xr)
-UINT32_T *p_xl;
-UINT32_T *p_xr;
+static void bf_e_block(UINT32_T *p_xl, UINT32_T *p_xr)
 {
   UINT32_T temp, xl = *p_xl, xr = *p_xr;
 
@@ -346,8 +344,7 @@ UINT32_T *p_xr;
 # define htonl2(x)
 #endif
 
-static void bf_e_cblock(block)
-char_u *block;
+static void bf_e_cblock(char_u *block)
 {
   block8 bk;
 
@@ -365,10 +362,7 @@ char_u *block;
  * Initialize the crypt method using "password" as the encryption key and
  * "salt[salt_len]" as the salt.
  */
-void bf_key_init(password, salt, salt_len)
-char_u *password;
-char_u *salt;
-int salt_len;
+void bf_key_init(char_u *password, char_u *salt, int salt_len)
 {
   int i, j, keypos = 0;
   unsigned u;
@@ -421,10 +415,7 @@ int salt_len;
 /*
  * BF Self test for corrupted tables or instructions
  */
-static int bf_check_tables(a_ipa, a_sbi, val)
-UINT32_T a_ipa[18];
-UINT32_T a_sbi[4][256];
-UINT32_T val;
+static int bf_check_tables(UINT32_T a_ipa[18], UINT32_T a_sbi[4][256], UINT32_T val)
 {
   int i, j;
   UINT32_T c = 0;
@@ -464,7 +455,7 @@ static struct_bf_test_data bf_test_data[] = {
 /*
  * Return FAIL when there is something wrong with blowfish encryption.
  */
-static int bf_self_test()                {
+static int bf_self_test(void)                {
   int i, bn;
   int err = 0;
   block8 bk;
@@ -509,9 +500,7 @@ static char_u ofb_buffer[BF_OFB_LEN]; /* 64 bytes */
 /*
  * Initialize with seed "iv[iv_len]".
  */
-void bf_ofb_init(iv, iv_len)
-char_u *iv;
-int iv_len;
+void bf_ofb_init(char_u *iv, int iv_len)
 {
   int i, mi;
 
@@ -542,10 +531,7 @@ int iv_len;
  * Encrypt "from[len]" into "to[len]".
  * "from" and "to" can be equal to encrypt in place.
  */
-void bf_crypt_encode(from, len, to)
-char_u      *from;
-size_t len;
-char_u      *to;
+void bf_crypt_encode(char_u *from, size_t len, char_u *to)
 {
   size_t i;
   int ztemp, t;
@@ -561,9 +547,7 @@ char_u      *to;
 /*
  * Decrypt "ptr[len]" in place.
  */
-void bf_crypt_decode(ptr, len)
-char_u      *ptr;
-long len;
+void bf_crypt_decode(char_u *ptr, long len)
 {
   char_u      *p;
   int t;
@@ -579,8 +563,10 @@ long len;
  * Initialize the encryption keys and the random header according to
  * the given password.
  */
-void bf_crypt_init_keys(passwd)
-char_u *passwd;                 /* password string with which to modify keys */
+void 
+bf_crypt_init_keys (
+    char_u *passwd                 /* password string with which to modify keys */
+)
 {
   char_u *p;
 
@@ -599,7 +585,7 @@ static UINT32_T save_sbx[4][256];
  * Save the current crypt state.  Can only be used once before
  * bf_crypt_restore().
  */
-void bf_crypt_save()          {
+void bf_crypt_save(void)          {
   save_randbyte_offset = randbyte_offset;
   save_update_offset = update_offset;
   mch_memmove(save_ofb_buffer, ofb_buffer, BF_OFB_LEN);
@@ -611,7 +597,7 @@ void bf_crypt_save()          {
  * Restore the current crypt state.  Can only be used after
  * bf_crypt_save().
  */
-void bf_crypt_restore()          {
+void bf_crypt_restore(void)          {
   randbyte_offset = save_randbyte_offset;
   update_offset = save_update_offset;
   mch_memmove(ofb_buffer, save_ofb_buffer, BF_OFB_LEN);
@@ -623,7 +609,7 @@ void bf_crypt_restore()          {
  * Run a test to check if the encryption works as expected.
  * Give an error and return FAIL when not.
  */
-int blowfish_self_test()         {
+int blowfish_self_test(void)         {
   if (sha256_self_test() == FAIL) {
     EMSG(_("E818: sha256 test failed"));
     return FAIL;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -64,10 +64,12 @@ static char *e_auabort = N_("E855: Autocommands caused command to abort");
  * memory.
  * Return FAIL for failure, OK otherwise.
  */
-int open_buffer(read_stdin, eap, flags)
-int read_stdin;                     /* read file from stdin */
-exarg_T     *eap;                   /* for forced 'ff' and 'fenc' or NULL */
-int flags;                          /* extra flags for readfile() */
+int 
+open_buffer (
+    int read_stdin,                     /* read file from stdin */
+    exarg_T *eap,                   /* for forced 'ff' and 'fenc' or NULL */
+    int flags                          /* extra flags for readfile() */
+)
 {
   int retval = OK;
   buf_T       *old_curbuf;
@@ -231,8 +233,7 @@ int flags;                          /* extra flags for readfile() */
 /*
  * Return TRUE if "buf" points to a valid buffer (in the buffer list).
  */
-int buf_valid(buf)
-buf_T       *buf;
+int buf_valid(buf_T *buf)
 {
   buf_T       *bp;
 
@@ -259,11 +260,13 @@ buf_T       *buf;
  * cause there to be only one window with this buffer.  e.g. when ":quit" is
  * supposed to close the window but autocommands close all other windows.
  */
-void close_buffer(win, buf, action, abort_if_last)
-win_T       *win;               /* if not NULL, set b_last_cursor */
-buf_T       *buf;
-int action;
-int abort_if_last UNUSED;
+void 
+close_buffer (
+    win_T *win,               /* if not NULL, set b_last_cursor */
+    buf_T *buf,
+    int action,
+    int abort_if_last
+)
 {
   int is_curbuf;
   int nwindows;
@@ -421,8 +424,7 @@ aucmd_abort:
 /*
  * Make buffer not contain a file.
  */
-void buf_clear_file(buf)
-buf_T       *buf;
+void buf_clear_file(buf_T *buf)
 {
   buf->b_ml.ml_line_count = 1;
   unchanged(buf, TRUE);
@@ -444,9 +446,7 @@ buf_T       *buf;
  * BFA_WIPE	  buffer is going to be wiped out
  * BFA_KEEP_UNDO  do not free undo information
  */
-void buf_freeall(buf, flags)
-buf_T       *buf;
-int flags;
+void buf_freeall(buf_T *buf, int flags)
 {
   int is_curbuf = (buf == curbuf);
 
@@ -506,8 +506,7 @@ int flags;
  * Free a buffer structure and the things it contains related to the buffer
  * itself (not the file, that must have been done already).
  */
-static void free_buffer(buf)
-buf_T       *buf;
+static void free_buffer(buf_T *buf)
 {
   free_buffer_stuff(buf, TRUE);
   unref_var_dict(buf->b_vars);
@@ -518,9 +517,11 @@ buf_T       *buf;
 /*
  * Free stuff in the buffer for ":bdel" and when wiping out the buffer.
  */
-static void free_buffer_stuff(buf, free_options)
-buf_T       *buf;
-int free_options;                       /* free options as well */
+static void 
+free_buffer_stuff (
+    buf_T *buf,
+    int free_options                       /* free options as well */
+)
 {
   if (free_options) {
     clear_wininfo(buf);                 /* including window-local options */
@@ -539,8 +540,7 @@ int free_options;                       /* free options as well */
 /*
  * Free the b_wininfo list for buffer "buf".
  */
-static void clear_wininfo(buf)
-buf_T       *buf;
+static void clear_wininfo(buf_T *buf)
 {
   wininfo_T   *wip;
 
@@ -558,11 +558,7 @@ buf_T       *buf;
 /*
  * Go to another buffer.  Handles the result of the ATTENTION dialog.
  */
-void goto_buffer(eap, start, dir, count)
-exarg_T     *eap;
-int start;
-int dir;
-int count;
+void goto_buffer(exarg_T *eap, int start, int dir, int count)
 {
 # if defined(FEAT_WINDOWS) && defined(HAS_SWAP_EXISTS_ACTION)
   buf_T       *old_curbuf = curbuf;
@@ -597,8 +593,7 @@ int count;
  * Handle the situation of swap_exists_action being set.
  * It is allowed for "old_curbuf" to be NULL or invalid.
  */
-void handle_swap_exists(old_curbuf)
-buf_T       *old_curbuf;
+void handle_swap_exists(buf_T *old_curbuf)
 {
   cleanup_T cs;
   long old_tw = curbuf->b_p_tw;
@@ -659,13 +654,15 @@ buf_T       *old_curbuf;
  *
  * Returns error message or NULL
  */
-char_u * do_bufdel(command, arg, addr_count, start_bnr, end_bnr, forceit)
-int command;
-char_u      *arg;               /* pointer to extra arguments */
-int addr_count;
-int start_bnr;                  /* first buffer number in a range */
-int end_bnr;                    /* buffer nr or last buffer nr in a range */
-int forceit;
+char_u *
+do_bufdel (
+    int command,
+    char_u *arg,               /* pointer to extra arguments */
+    int addr_count,
+    int start_bnr,                  /* first buffer number in a range */
+    int end_bnr,                    /* buffer nr or last buffer nr in a range */
+    int forceit
+)
 {
   int do_current = 0;           /* delete current buffer? */
   int deleted = 0;              /* number of buffers deleted */
@@ -762,10 +759,7 @@ static int empty_curbuf __ARGS((int close_others, int forceit, int action));
  * Make the current buffer empty.
  * Used when it is wiped out and it's the last buffer.
  */
-static int empty_curbuf(close_others, forceit, action)
-int close_others;
-int forceit;
-int action;
+static int empty_curbuf(int close_others, int forceit, int action)
 {
   int retval;
   buf_T   *buf = curbuf;
@@ -811,12 +805,14 @@ int action;
  *
  * Return FAIL or OK.
  */
-int do_buffer(action, start, dir, count, forceit)
-int action;
-int start;
-int dir;                        /* FORWARD or BACKWARD */
-int count;                      /* buffer number or number of buffers */
-int forceit;                    /* TRUE for :...! */
+int 
+do_buffer (
+    int action,
+    int start,
+    int dir,                        /* FORWARD or BACKWARD */
+    int count,                      /* buffer number or number of buffers */
+    int forceit                    /* TRUE for :...! */
+)
 {
   buf_T       *buf;
   buf_T       *bp;
@@ -1100,9 +1096,7 @@ int forceit;                    /* TRUE for :...! */
  * DOBUF_DEL	    delete it
  * DOBUF_WIPE	    wipe it out
  */
-void set_curbuf(buf, action)
-buf_T       *buf;
-int action;
+void set_curbuf(buf_T *buf, int action)
 {
   buf_T       *prevbuf;
   int unload = (action == DOBUF_UNLOAD || action == DOBUF_DEL
@@ -1158,8 +1152,7 @@ int action;
  * Old curbuf must have been abandoned already!  This also means "curbuf" may
  * be pointing to freed memory.
  */
-void enter_buffer(buf)
-buf_T       *buf;
+void enter_buffer(buf_T *buf)
 {
   /* Copy buffer and window local option values.  Not for a help buffer. */
   buf_copy_options(buf, BCO_ENTER | BCO_NOHELP);
@@ -1237,7 +1230,7 @@ buf_T       *buf;
 /*
  * Change to the directory of the current buffer.
  */
-void do_autochdir()          {
+void do_autochdir(void)          {
   if (curbuf->b_ffname != NULL && vim_chdirfile(curbuf->b_ffname) == OK)
     shorten_fnames(TRUE);
 }
@@ -1257,11 +1250,13 @@ void do_autochdir()          {
  */
 static int top_file_num = 1;            /* highest file number */
 
-buf_T * buflist_new(ffname, sfname, lnum, flags)
-char_u      *ffname;            /* full path of fname or relative */
-char_u      *sfname;            /* short fname or NULL */
-linenr_T lnum;                  /* preferred cursor line */
-int flags;                      /* BLN_ defines */
+buf_T *
+buflist_new (
+    char_u *ffname,            /* full path of fname or relative */
+    char_u *sfname,            /* short fname or NULL */
+    linenr_T lnum,                  /* preferred cursor line */
+    int flags                      /* BLN_ defines */
+)
 {
   buf_T       *buf;
 #ifdef UNIX
@@ -1451,9 +1446,7 @@ int flags;                      /* BLN_ defines */
  * If "free_p_ff" is TRUE also free 'fileformat', 'buftype' and
  * 'fileencoding'.
  */
-void free_buf_options(buf, free_p_ff)
-buf_T       *buf;
-int free_p_ff;
+void free_buf_options(buf_T *buf, int free_p_ff)
 {
   if (free_p_ff) {
     clear_string_option(&buf->b_p_fenc);
@@ -1516,11 +1509,7 @@ int free_p_ff;
  *
  * return FAIL for failure, OK for success
  */
-int buflist_getfile(n, lnum, options, forceit)
-int n;
-linenr_T lnum;
-int options;
-int forceit;
+int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
 {
   buf_T       *buf;
   win_T       *wp = NULL;
@@ -1596,7 +1585,7 @@ int forceit;
 /*
  * go to the last know line number for the current buffer
  */
-void buflist_getfpos()          {
+void buflist_getfpos(void)          {
   pos_T       *fpos;
 
   fpos = buflist_findfpos(curbuf);
@@ -1618,8 +1607,7 @@ void buflist_getfpos()          {
  * Find file in buffer list by name (it has to be for the current window).
  * Returns NULL if not found.
  */
-buf_T * buflist_findname_exp(fname)
-char_u *fname;
+buf_T *buflist_findname_exp(char_u *fname)
 {
   char_u      *ffname;
   buf_T       *buf = NULL;
@@ -1645,8 +1633,7 @@ char_u *fname;
  * Skips dummy buffers.
  * Returns NULL if not found.
  */
-buf_T * buflist_findname(ffname)
-char_u      *ffname;
+buf_T *buflist_findname(char_u *ffname)
 {
 #ifdef UNIX
   struct stat st;
@@ -1661,9 +1648,7 @@ char_u      *ffname;
  * twice for the same file.
  * Returns NULL if not found.
  */
-static buf_T * buflist_findname_stat(ffname, stp)
-char_u      *ffname;
-struct stat *stp;
+static buf_T *buflist_findname_stat(char_u *ffname, struct stat *stp)
 {
 #endif
   buf_T       *buf;
@@ -1685,12 +1670,14 @@ struct stat *stp;
  * Return fnum of the found buffer.
  * Return < 0 for error.
  */
-int buflist_findpat(pattern, pattern_end, unlisted, diffmode, curtab_only)
-char_u      *pattern;
-char_u      *pattern_end;       /* pointer to first char after pattern */
-int unlisted;                   /* find unlisted buffers */
-int diffmode UNUSED;             /* find diff-mode buffers only */
-int curtab_only;                /* find buffers in current tab only */
+int 
+buflist_findpat (
+    char_u *pattern,
+    char_u *pattern_end,       /* pointer to first char after pattern */
+    int unlisted,                   /* find unlisted buffers */
+    int diffmode,             /* find diff-mode buffers only */
+    int curtab_only                /* find buffers in current tab only */
+)
 {
   buf_T       *buf;
   regprog_T   *prog;
@@ -1794,11 +1781,7 @@ int curtab_only;                /* find buffers in current tab only */
  * For command line expansion of ":buf" and ":sbuf".
  * Return OK if matches found, FAIL otherwise.
  */
-int ExpandBufnames(pat, num_file, file, options)
-char_u      *pat;
-int         *num_file;
-char_u      ***file;
-int options;
+int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
 {
   int count = 0;
   buf_T       *buf;
@@ -1886,9 +1869,7 @@ int options;
 /*
  * Check for a match on the file name for buffer "buf" with regprog "prog".
  */
-static char_u * buflist_match(prog, buf)
-regprog_T   *prog;
-buf_T       *buf;
+static char_u *buflist_match(regprog_T *prog, buf_T *buf)
 {
   char_u      *match;
 
@@ -1904,9 +1885,7 @@ buf_T       *buf;
  * Try matching the regexp in "prog" with file name "name".
  * Return "name" when there is a match, NULL when not.
  */
-static char_u * fname_match(prog, name)
-regprog_T   *prog;
-char_u      *name;
+static char_u *fname_match(regprog_T *prog, char_u *name)
 {
   char_u      *match = NULL;
   char_u      *p;
@@ -1933,8 +1912,7 @@ char_u      *name;
 /*
  * find file in buffer list by number
  */
-buf_T * buflist_findnr(nr)
-int nr;
+buf_T *buflist_findnr(int nr)
 {
   buf_T       *buf;
 
@@ -1952,10 +1930,12 @@ int nr;
  * home_replace() is used to shorten the file name (used for marks).
  * Returns a pointer to allocated memory, of NULL when failed.
  */
-char_u * buflist_nr2name(n, fullname, helptail)
-int n;
-int fullname;
-int helptail;                   /* for help buffers return tail only */
+char_u *
+buflist_nr2name (
+    int n,
+    int fullname,
+    int helptail                   /* for help buffers return tail only */
+)
 {
   buf_T       *buf;
 
@@ -1971,12 +1951,7 @@ int helptail;                   /* for help buffers return tail only */
  * When "copy_options" is TRUE save the local window option values.
  * When "lnum" is 0 only do the options.
  */
-static void buflist_setfpos(buf, win, lnum, col, copy_options)
-buf_T       *buf;
-win_T       *win;
-linenr_T lnum;
-colnr_T col;
-int copy_options;
+static void buflist_setfpos(buf_T *buf, win_T *win, linenr_T lnum, colnr_T col, int copy_options)
 {
   wininfo_T   *wip;
 
@@ -2032,8 +2007,7 @@ static int wininfo_other_tab_diff __ARGS((wininfo_T *wip));
  * Return TRUE when "wip" has 'diff' set and the diff is only for another tab
  * page.  That's because a diff is local to a tab page.
  */
-static int wininfo_other_tab_diff(wip)
-wininfo_T   *wip;
+static int wininfo_other_tab_diff(wininfo_T *wip)
 {
   win_T       *wp;
 
@@ -2055,9 +2029,7 @@ wininfo_T   *wip;
  * another tab page.
  * Returns NULL when there isn't any info.
  */
-static wininfo_T * find_wininfo(buf, skip_diff_buffer)
-buf_T       *buf;
-int skip_diff_buffer UNUSED;
+static wininfo_T *find_wininfo(buf_T *buf, int skip_diff_buffer)
 {
   wininfo_T   *wip;
 
@@ -2086,8 +2058,7 @@ int skip_diff_buffer UNUSED;
  * the most recently used window.  If the values were never set, use the
  * global values for the window.
  */
-void get_winopts(buf)
-buf_T       *buf;
+void get_winopts(buf_T *buf)
 {
   wininfo_T   *wip;
 
@@ -2114,8 +2085,7 @@ buf_T       *buf;
  * window.
  * Returns a pointer to no_position if no position is found.
  */
-pos_T * buflist_findfpos(buf)
-buf_T       *buf;
+pos_T *buflist_findfpos(buf_T *buf)
 {
   wininfo_T   *wip;
   static pos_T no_position = INIT_POS_T(1, 0, 0);
@@ -2130,8 +2100,7 @@ buf_T       *buf;
 /*
  * Find the lnum for the buffer 'buf' for the current window.
  */
-linenr_T buflist_findlnum(buf)
-buf_T       *buf;
+linenr_T buflist_findlnum(buf_T *buf)
 {
   return buflist_findfpos(buf)->lnum;
 }
@@ -2139,8 +2108,7 @@ buf_T       *buf;
 /*
  * List all know file names (for :files and :buffers command).
  */
-void buflist_list(eap)
-exarg_T     *eap;
+void buflist_list(exarg_T *eap)
 {
   buf_T       *buf;
   int len;
@@ -2188,10 +2156,7 @@ exarg_T     *eap;
  * Used by insert_reg() and cmdline_paste() for '#' register.
  * Return FAIL if not found, OK for success.
  */
-int buflist_name_nr(fnum, fname, lnum)
-int fnum;
-char_u      **fname;
-linenr_T    *lnum;
+int buflist_name_nr(int fnum, char_u **fname, linenr_T *lnum)
 {
   buf_T       *buf;
 
@@ -2211,10 +2176,13 @@ linenr_T    *lnum;
  * Returns FAIL for failure (file name already in use by other buffer)
  *	OK otherwise.
  */
-int setfname(buf, ffname, sfname, message)
-buf_T       *buf;
-char_u      *ffname, *sfname;
-int message;                    /* give message when buffer already exists */
+int 
+setfname (
+    buf_T *buf,
+    char_u *ffname,
+    char_u *sfname,
+    int message                    /* give message when buffer already exists */
+)
 {
   buf_T       *obuf = NULL;
 #ifdef UNIX
@@ -2300,9 +2268,7 @@ int message;                    /* give message when buffer already exists */
  * Crude way of changing the name of a buffer.  Use with care!
  * The name should be relative to the current directory.
  */
-void buf_set_name(fnum, name)
-int fnum;
-char_u      *name;
+void buf_set_name(int fnum, char_u *name)
 {
   buf_T       *buf;
 
@@ -2323,8 +2289,7 @@ char_u      *name;
  * Take care of what needs to be done when the name of buffer "buf" has
  * changed.
  */
-void buf_name_changed(buf)
-buf_T       *buf;
+void buf_name_changed(buf_T *buf)
 {
   /*
    * If the file name changed, also change the name of the swapfile
@@ -2346,10 +2311,7 @@ buf_T       *buf;
  * Used by do_one_cmd(), do_write() and do_ecmd().
  * Return the buffer.
  */
-buf_T * setaltfname(ffname, sfname, lnum)
-char_u      *ffname;
-char_u      *sfname;
-linenr_T lnum;
+buf_T *setaltfname(char_u *ffname, char_u *sfname, linenr_T lnum)
 {
   buf_T       *buf;
 
@@ -2364,8 +2326,10 @@ linenr_T lnum;
  * Get alternate file name for current window.
  * Return NULL if there isn't any, and give error message if requested.
  */
-char_u  * getaltfname(errmsg)
-int errmsg;                     /* give error message */
+char_u *
+getaltfname (
+    int errmsg                     /* give error message */
+)
 {
   char_u      *fname;
   linenr_T dummy;
@@ -2384,9 +2348,7 @@ int errmsg;                     /* give error message */
  *
  * used by qf_init(), main() and doarglist()
  */
-int buflist_add(fname, flags)
-char_u      *fname;
-int flags;
+int buflist_add(char_u *fname, int flags)
 {
   buf_T       *buf;
 
@@ -2400,7 +2362,7 @@ int flags;
 /*
  * Adjust slashes in file names.  Called after 'shellslash' was set.
  */
-void buflist_slash_adjust()          {
+void buflist_slash_adjust(void)          {
   buf_T       *bp;
 
   for (bp = firstbuf; bp != NULL; bp = bp->b_next) {
@@ -2417,8 +2379,7 @@ void buflist_slash_adjust()          {
  * Set alternate cursor position for the current buffer and window "win".
  * Also save the local window option values.
  */
-void buflist_altfpos(win)
-win_T *win;
+void buflist_altfpos(win_T *win)
 {
   buflist_setfpos(curbuf, win, win->w_cursor.lnum, win->w_cursor.col, TRUE);
 }
@@ -2427,8 +2388,7 @@ win_T *win;
  * Return TRUE if 'ffname' is not the same file as current file.
  * Fname must have a full path (expanded by mch_FullName()).
  */
-int otherfile(ffname)
-char_u      *ffname;
+int otherfile(char_u *ffname)
 {
   return otherfile_buf(curbuf, ffname
 #ifdef UNIX
@@ -2437,16 +2397,11 @@ char_u      *ffname;
       );
 }
 
-static int otherfile_buf(buf, ffname
+static int otherfile_buf(buf_T *buf, char_u *ffname
 #ifdef UNIX
-    , stp
+    , struct stat *stp
 #endif
-    )
-buf_T       *buf;
-char_u      *ffname;
-#ifdef UNIX
-struct stat *stp;
-#endif
+)
 {
   /* no name is different */
   if (ffname == NULL || *ffname == NUL || buf->b_ffname == NULL)
@@ -2487,8 +2442,7 @@ struct stat *stp;
  * Set inode and device number for a buffer.
  * Must always be called when b_fname is changed!.
  */
-void buf_setino(buf)
-buf_T       *buf;
+void buf_setino(buf_T *buf)
 {
   struct stat st;
 
@@ -2503,9 +2457,7 @@ buf_T       *buf;
 /*
  * Return TRUE if dev/ino in buffer "buf" matches with "stp".
  */
-static int buf_same_ino(buf, stp)
-buf_T       *buf;
-struct stat *stp;
+static int buf_same_ino(buf_T *buf, struct stat *stp)
 {
   return buf->b_dev_valid
          && stp->st_dev == buf->b_dev
@@ -2516,10 +2468,12 @@ struct stat *stp;
 /*
  * Print info about the current buffer.
  */
-void fileinfo(fullname, shorthelp, dont_truncate)
-int fullname;               /* when non-zero print full path */
-int shorthelp;
-int dont_truncate;
+void 
+fileinfo (
+    int fullname,               /* when non-zero print full path */
+    int shorthelp,
+    int dont_truncate
+)
 {
   char_u      *name;
   int n;
@@ -2617,11 +2571,7 @@ int dont_truncate;
   vim_free(buffer);
 }
 
-void col_print(buf, buflen, col, vcol)
-char_u  *buf;
-size_t buflen;
-int col;
-int vcol;
+void col_print(char_u *buf, size_t buflen, int col, int vcol)
 {
   if (col == vcol)
     vim_snprintf((char *)buf, buflen, "%d", col);
@@ -2636,7 +2586,7 @@ int vcol;
 static char_u *lasttitle = NULL;
 static char_u *lasticon = NULL;
 
-void maketitle()          {
+void maketitle(void)          {
   char_u      *p;
   char_u      *t_str = NULL;
   char_u      *i_name;
@@ -2803,9 +2753,7 @@ void maketitle()          {
  * from "str" if it does.
  * Return TRUE when "*last" changed.
  */
-static int ti_change(str, last)
-char_u      *str;
-char_u      **last;
+static int ti_change(char_u *str, char_u **last)
 {
   if ((str == NULL) != (*last == NULL)
       || (str != NULL && *last != NULL && STRCMP(str, *last) != 0)) {
@@ -2822,12 +2770,12 @@ char_u      **last;
 /*
  * Put current window title back (used after calling a shell)
  */
-void resettitle()          {
+void resettitle(void)          {
   mch_settitle(lasttitle, lasticon);
 }
 
 # if defined(EXITFREE) || defined(PROTO)
-void free_titles()          {
+void free_titles(void)          {
   vim_free(lasttitle);
   vim_free(lasticon);
 }
@@ -2849,17 +2797,18 @@ void free_titles()          {
  * If maxwidth is not zero, the string will be filled at any middle marker
  * or truncated if too long, fillchar is used for all whitespace.
  */
-int build_stl_str_hl(wp, out, outlen, fmt, use_sandbox, fillchar,
-    maxwidth, hltab, tabtab)
-win_T       *wp;
-char_u      *out;               /* buffer to write into != NameBuff */
-size_t outlen;                  /* length of out[] */
-char_u      *fmt;
-int use_sandbox UNUSED;             /* "fmt" was set insecurely, use sandbox */
-int fillchar;
-int maxwidth;
-struct stl_hlrec *hltab;        /* return: HL attributes (can be NULL) */
-struct stl_hlrec *tabtab;       /* return: tab page nrs (can be NULL) */
+int 
+build_stl_str_hl (
+    win_T *wp,
+    char_u *out,               /* buffer to write into != NameBuff */
+    size_t outlen,                  /* length of out[] */
+    char_u *fmt,
+    int use_sandbox,             /* "fmt" was set insecurely, use sandbox */
+    int fillchar,
+    int maxwidth,
+    struct stl_hlrec *hltab,        /* return: HL attributes (can be NULL) */
+    struct stl_hlrec *tabtab       /* return: tab page nrs (can be NULL) */
+)
 {
   char_u      *p;
   char_u      *s;
@@ -3574,10 +3523,7 @@ struct stl_hlrec *tabtab;       /* return: tab page nrs (can be NULL) */
  * Get relative cursor position in window into "buf[buflen]", in the form 99%,
  * using "Top", "Bot" or "All" when appropriate.
  */
-void get_rel_pos(wp, buf, buflen)
-win_T       *wp;
-char_u      *buf;
-int buflen;
+void get_rel_pos(win_T *wp, char_u *buf, int buflen)
 {
   long above;          /* number of lines above window */
   long below;          /* number of lines below window */
@@ -3601,11 +3547,13 @@ int buflen;
  * Append (file 2 of 8) to "buf[buflen]", if editing more than one file.
  * Return TRUE if it was appended.
  */
-static int append_arg_number(wp, buf, buflen, add_file)
-win_T       *wp;
-char_u      *buf;
-int buflen;
-int add_file;                   /* Add "file" before the arg number */
+static int 
+append_arg_number (
+    win_T *wp,
+    char_u *buf,
+    int buflen,
+    int add_file                   /* Add "file" before the arg number */
+)
 {
   char_u      *p;
 
@@ -3631,8 +3579,7 @@ int add_file;                   /* Add "file" before the arg number */
  * If fname is not a full path, make it a full path.
  * Returns pointer to allocated memory (NULL for failure).
  */
-char_u  * fix_fname(fname)
-char_u  *fname;
+char_u *fix_fname(char_u *fname)
 {
   /*
    * Force expanding the path always for Unix, because symbolic links may
@@ -3674,10 +3621,7 @@ char_u  *fname;
  * Make "ffname" a full file name, set "sfname" to "ffname" if not NULL.
  * "ffname" becomes a pointer to allocated memory (or NULL).
  */
-void fname_expand(buf, ffname, sfname)
-buf_T       *buf UNUSED;
-char_u      **ffname;
-char_u      **sfname;
+void fname_expand(buf_T *buf, char_u **ffname, char_u **sfname)
 {
   if (*ffname == NULL)          /* if no file name given, nothing to do */
     return;
@@ -3703,8 +3647,7 @@ char_u      **sfname;
 /*
  * Get the file name for an argument list entry.
  */
-char_u * alist_name(aep)
-aentry_T    *aep;
+char_u *alist_name(aentry_T *aep)
 {
   buf_T       *bp;
 
@@ -3718,10 +3661,12 @@ aentry_T    *aep;
 /*
  * do_arg_all(): Open up to 'count' windows, one for each argument.
  */
-void do_arg_all(count, forceit, keep_tabs)
-int count;
-int forceit;                    /* hide buffers in current windows */
-int keep_tabs;                  /* keep current tabs, for ":tab drop file" */
+void 
+do_arg_all (
+    int count,
+    int forceit,                    /* hide buffers in current windows */
+    int keep_tabs                  /* keep current tabs, for ":tab drop file" */
+)
 {
   int i;
   win_T       *wp, *wpnext;
@@ -3957,8 +3902,7 @@ int keep_tabs;                  /* keep current tabs, for ":tab drop file" */
 /*
  * Open a window for a number of buffers.
  */
-void ex_buffer_all(eap)
-exarg_T     *eap;
+void ex_buffer_all(exarg_T *eap)
 {
   buf_T       *buf;
   win_T       *wp, *wpnext;
@@ -4140,8 +4084,7 @@ static int chk_modeline __ARGS((linenr_T, int));
  *
  * Returns immediately if the "ml" option isn't set.
  */
-void do_modelines(flags)
-int flags;
+void do_modelines(int flags)
 {
   linenr_T lnum;
   int nmlines;
@@ -4174,9 +4117,11 @@ int flags;
  * chk_modeline() - check a single line for a mode string
  * Return FAIL if an error encountered.
  */
-static int chk_modeline(lnum, flags)
-linenr_T lnum;
-int flags;                      /* Same as for do_modelines(). */
+static int 
+chk_modeline (
+    linenr_T lnum,
+    int flags                      /* Same as for do_modelines(). */
+)
 {
   char_u      *s;
   char_u      *e;
@@ -4281,9 +4226,7 @@ int flags;                      /* Same as for do_modelines(). */
   return retval;
 }
 
-int read_viminfo_bufferlist(virp, writing)
-vir_T       *virp;
-int writing;
+int read_viminfo_bufferlist(vir_T *virp, int writing)
 {
   char_u      *tab;
   linenr_T lnum;
@@ -4330,8 +4273,7 @@ int writing;
   return viminfo_readline(virp);
 }
 
-void write_viminfo_bufferlist(fp)
-FILE    *fp;
+void write_viminfo_bufferlist(FILE *fp)
 {
   buf_T       *buf;
   win_T       *win;
@@ -4379,8 +4321,7 @@ FILE    *fp;
  * Return special buffer name.
  * Returns NULL when the buffer has a normal file name.
  */
-char_u * buf_spname(buf)
-buf_T       *buf;
+char_u *buf_spname(buf_T *buf)
 {
   if (bt_quickfix(buf)) {
     win_T       *win;
@@ -4415,10 +4356,7 @@ buf_T       *buf;
  * If found OK is returned and "wp" and "tp" are set to the window and tabpage.
  * If not found FAIL is returned.
  */
-int find_win_for_buf(buf, wp, tp)
-buf_T     *buf;
-win_T     **wp;
-tabpage_T **tp;
+int find_win_for_buf(buf_T *buf, win_T **wp, tabpage_T **tp)
 {
   FOR_ALL_TAB_WINDOWS(*tp, *wp)
   if ((*wp)->w_buffer == buf)
@@ -4433,8 +4371,7 @@ win_found:
 /*
  * Set 'buflisted' for curbuf to "on" and trigger autocommands if it changed.
  */
-void set_buflisted(on)
-int on;
+void set_buflisted(int on)
 {
   if (on != curbuf->b_p_bl) {
     curbuf->b_p_bl = on;
@@ -4449,8 +4386,7 @@ int on;
  * Read the file for "buf" again and check if the contents changed.
  * Return TRUE if it changed or this could not be checked.
  */
-int buf_contents_changed(buf)
-buf_T       *buf;
+int buf_contents_changed(buf_T *buf)
 {
   buf_T       *newbuf;
   int differ = TRUE;
@@ -4502,9 +4438,11 @@ buf_T       *buf;
  * this buffer.  Call this to wipe out a temp buffer that does not contain any
  * marks.
  */
-void wipe_buffer(buf, aucmd)
-buf_T       *buf;
-int aucmd UNUSED;                   /* When TRUE trigger autocommands. */
+void 
+wipe_buffer (
+    buf_T *buf,
+    int aucmd                   /* When TRUE trigger autocommands. */
+)
 {
   if (buf->b_fnum == top_file_num - 1)
     --top_file_num;

--- a/src/charset.c
+++ b/src/charset.c
@@ -56,13 +56,15 @@ static int chartab_initialized = FALSE;
  * Return FAIL if 'iskeyword', 'isident', 'isfname' or 'isprint' option has an
  * error, OK otherwise.
  */
-int init_chartab()         {
+int init_chartab(void)         {
   return buf_init_chartab(curbuf, TRUE);
 }
 
-int buf_init_chartab(buf, global)
-buf_T       *buf;
-int global;                     /* FALSE: only set buf->b_chartab[] */
+int 
+buf_init_chartab (
+    buf_T *buf,
+    int global                     /* FALSE: only set buf->b_chartab[] */
+)
 {
   int c;
   int c2;
@@ -246,9 +248,7 @@ int global;                     /* FALSE: only set buf->b_chartab[] */
  * The result is a string with only printable characters, but if there is not
  * enough room, not all characters will be translated.
  */
-void trans_characters(buf, bufsize)
-char_u      *buf;
-int bufsize;
+void trans_characters(char_u *buf, int bufsize)
 {
   int len;                      /* length of string needing translation */
   int room;                     /* room in buffer after string */
@@ -283,8 +283,7 @@ int bufsize;
  * Translate a string into allocated memory, replacing special chars with
  * printable chars.  Returns NULL when out of memory.
  */
-char_u * transstr(s)
-char_u      *s;
+char_u *transstr(char_u *s)
 {
   char_u      *res;
   char_u      *p;
@@ -342,11 +341,7 @@ char_u      *s;
  * When "buf" is NULL returns an allocated string (NULL for out-of-memory).
  * Otherwise puts the result in "buf[buflen]".
  */
-char_u * str_foldcase(str, orglen, buf, buflen)
-char_u      *str;
-int orglen;
-char_u      *buf;
-int buflen;
+char_u *str_foldcase(char_u *str, int orglen, char_u *buf, int buflen)
 {
   garray_T ga;
   int i;
@@ -440,8 +435,7 @@ int buflen;
  */
 static char_u transchar_buf[7];
 
-char_u * transchar(c)
-int c;
+char_u *transchar(int c)
 {
   int i;
 
@@ -469,8 +463,7 @@ int c;
  * Like transchar(), but called with a byte instead of a character.  Checks
  * for an illegal UTF-8 byte.
  */
-char_u * transchar_byte(c)
-int c;
+char_u *transchar_byte(int c)
 {
   if (enc_utf8 && c >= 0x80) {
     transchar_nonprint(transchar_buf, c);
@@ -484,9 +477,7 @@ int c;
  * "buf[]".  "buf" needs to be able to hold five bytes.
  * Does NOT work for multi-byte characters, c must be <= 255.
  */
-void transchar_nonprint(buf, c)
-char_u      *buf;
-int c;
+void transchar_nonprint(char_u *buf, int c)
 {
   if (c == NL)
     c = NUL;                    /* we use newline in place of a NUL */
@@ -518,9 +509,7 @@ int c;
   }
 }
 
-void transchar_hex(buf, c)
-char_u      *buf;
-int c;
+void transchar_hex(char_u *buf, int c)
 {
   int i = 0;
 
@@ -540,8 +529,7 @@ int c;
  * Lower case letters are used to avoid the confusion of <F1> being 0xf1 or
  * function key 1.
  */
-static unsigned nr2hex(c)
-unsigned c;
+static unsigned nr2hex(unsigned c)
 {
   if ((c & 0xf) <= 9)
     return (c & 0xf) + '0';
@@ -556,8 +544,7 @@ unsigned c;
  * For UTF-8 mode this will return 0 for bytes >= 0x80, because the number of
  * cells depends on further bytes.
  */
-int byte2cells(b)
-int b;
+int byte2cells(int b)
 {
   if (enc_utf8 && b >= 0x80)
     return 0;
@@ -569,8 +556,7 @@ int b;
  * "c" can be a special key (negative number) in which case 3 or 4 is returned.
  * A TAB is counted as two cells: "^I" or four: "<09>".
  */
-int char2cells(c)
-int c;
+int char2cells(int c)
 {
   if (IS_SPECIAL(c))
     return char2cells(K_SECOND(c)) + 2;
@@ -593,8 +579,7 @@ int c;
  * Return number of display cells occupied by character at "*p".
  * A TAB is counted as two cells: "^I" or four: "<09>".
  */
-int ptr2cells(p)
-char_u      *p;
+int ptr2cells(char_u *p)
 {
   /* For UTF-8 we need to look at more bytes if the first byte is >= 0x80. */
   if (enc_utf8 && *p >= 0x80)
@@ -607,8 +592,7 @@ char_u      *p;
  * Return the number of character cells string "s" will take on the screen,
  * counting TABs as two characters: "^I".
  */
-int vim_strsize(s)
-char_u      *s;
+int vim_strsize(char_u *s)
 {
   return vim_strnsize(s, (int)MAXCOL);
 }
@@ -617,9 +601,7 @@ char_u      *s;
  * Return the number of character cells string "s[len]" will take on the
  * screen, counting TABs as two characters: "^I".
  */
-int vim_strnsize(s, len)
-char_u      *s;
-int len;
+int vim_strnsize(char_u *s, int len)
 {
   int size = 0;
 
@@ -655,18 +637,13 @@ int len;
 
 #if defined(FEAT_VREPLACE) || defined(FEAT_EX_EXTRA) || defined(FEAT_GUI) \
   || defined(FEAT_VIRTUALEDIT) || defined(PROTO)
-int chartabsize(p, col)
-char_u      *p;
-colnr_T col;
+int chartabsize(char_u *p, colnr_T col)
 {
   RET_WIN_BUF_CHARTABSIZE(curwin, curbuf, p, col)
 }
 #endif
 
-static int win_chartabsize(wp, p, col)
-win_T       *wp;
-char_u      *p;
-colnr_T col;
+static int win_chartabsize(win_T *wp, char_u *p, colnr_T col)
 {
   RET_WIN_BUF_CHARTABSIZE(wp, wp->w_buffer, p, col)
 }
@@ -675,8 +652,7 @@ colnr_T col;
  * Return the number of characters the string 's' will take on the screen,
  * taking into account the size of a tab.
  */
-int linetabsize(s)
-char_u      *s;
+int linetabsize(char_u *s)
 {
   return linetabsize_col(0, s);
 }
@@ -684,9 +660,7 @@ char_u      *s;
 /*
  * Like linetabsize(), but starting at column "startcol".
  */
-int linetabsize_col(startcol, s)
-int startcol;
-char_u      *s;
+int linetabsize_col(int startcol, char_u *s)
 {
   colnr_T col = startcol;
 
@@ -698,10 +672,7 @@ char_u      *s;
 /*
  * Like linetabsize(), but for a given window instead of the current one.
  */
-int win_linetabsize(wp, p, len)
-win_T       *wp;
-char_u      *p;
-colnr_T len;
+int win_linetabsize(win_T *wp, char_u *p, colnr_T len)
 {
   colnr_T col = 0;
   char_u      *s;
@@ -715,8 +686,7 @@ colnr_T len;
  * Return TRUE if 'c' is a normal identifier character:
  * Letters and characters from the 'isident' option.
  */
-int vim_isIDc(c)
-int c;
+int vim_isIDc(int c)
 {
   return c > 0 && c < 0x100 && (chartab[c] & CT_ID_CHAR);
 }
@@ -726,15 +696,12 @@ int c;
  * 'iskeyword' option for current buffer.
  * For multi-byte characters mb_get_class() is used (builtin rules).
  */
-int vim_iswordc(c)
-int c;
+int vim_iswordc(int c)
 {
   return vim_iswordc_buf(c, curbuf);
 }
 
-int vim_iswordc_buf(c, buf)
-int c;
-buf_T       *buf;
+int vim_iswordc_buf(int c, buf_T *buf)
 {
   if (c >= 0x100) {
     if (enc_dbcs != 0)
@@ -748,17 +715,14 @@ buf_T       *buf;
 /*
  * Just like vim_iswordc() but uses a pointer to the (multi-byte) character.
  */
-int vim_iswordp(p)
-char_u *p;
+int vim_iswordp(char_u *p)
 {
   if (has_mbyte && MB_BYTE2LEN(*p) > 1)
     return mb_get_class(p) >= 2;
   return GET_CHARTAB(curbuf, *p) != 0;
 }
 
-int vim_iswordp_buf(p, buf)
-char_u      *p;
-buf_T       *buf;
+int vim_iswordp_buf(char_u *p, buf_T *buf)
 {
   if (has_mbyte && MB_BYTE2LEN(*p) > 1)
     return mb_get_class(p) >= 2;
@@ -769,8 +733,7 @@ buf_T       *buf;
  * return TRUE if 'c' is a valid file-name character
  * Assume characters above 0x100 are valid (multi-byte).
  */
-int vim_isfilec(c)
-int c;
+int vim_isfilec(int c)
 {
   return c >= 0x100 || (c > 0 && (chartab[c] & CT_FNAME_CHAR));
 }
@@ -781,8 +744,7 @@ int c;
  * Explicitly interpret ']' as a wildcard character as mch_has_wildcard("]")
  * returns false.
  */
-int vim_isfilec_or_wc(c)
-int c;
+int vim_isfilec_or_wc(int c)
 {
   char_u buf[2];
 
@@ -796,8 +758,7 @@ int c;
  * Assume characters above 0x100 are printable (multi-byte), except for
  * Unicode.
  */
-int vim_isprintc(c)
-int c;
+int vim_isprintc(int c)
 {
   if (enc_utf8 && c >= 0x100)
     return utf_printable(c);
@@ -808,8 +769,7 @@ int c;
  * Strict version of vim_isprintc(c), don't return TRUE if "c" is the head
  * byte of a double-byte character.
  */
-int vim_isprintc_strict(c)
-int c;
+int vim_isprintc_strict(int c)
 {
   if (enc_dbcs != 0 && c < 0x100 && MB_BYTE2LEN(c) > 1)
     return FALSE;
@@ -821,9 +781,7 @@ int c;
 /*
  * like chartabsize(), but also check for line breaks on the screen
  */
-int lbr_chartabsize(s, col)
-unsigned char       *s;
-colnr_T col;
+int lbr_chartabsize(unsigned char *s, colnr_T col)
 {
   if (!curwin->w_p_lbr && *p_sbr == NUL) {
     if (curwin->w_p_wrap)
@@ -836,9 +794,7 @@ colnr_T col;
 /*
  * Call lbr_chartabsize() and advance the pointer.
  */
-int lbr_chartabsize_adv(s, col)
-char_u      **s;
-colnr_T col;
+int lbr_chartabsize_adv(char_u **s, colnr_T col)
 {
   int retval;
 
@@ -854,11 +810,7 @@ colnr_T col;
  * string at start of line.  Warning: *headp is only set if it's a non-zero
  * value, init to 0 before calling.
  */
-int win_lbr_chartabsize(wp, s, col, headp)
-win_T       *wp;
-char_u      *s;
-colnr_T col;
-int         *headp UNUSED;
+int win_lbr_chartabsize(win_T *wp, char_u *s, colnr_T col, int *headp)
 {
   int c;
   int size;
@@ -967,11 +919,7 @@ int         *headp UNUSED;
  * 'wrap' is on.  This means we need to check for a double-byte character that
  * doesn't fit at the end of the screen line.
  */
-static int win_nolbr_chartabsize(wp, s, col, headp)
-win_T       *wp;
-char_u      *s;
-colnr_T col;
-int         *headp;
+static int win_nolbr_chartabsize(win_T *wp, char_u *s, colnr_T col, int *headp)
 {
   int n;
 
@@ -994,9 +942,7 @@ int         *headp;
  * Return TRUE if virtual column "vcol" is in the rightmost column of window
  * "wp".
  */
-int in_win_border(wp, vcol)
-win_T       *wp;
-colnr_T vcol;
+int in_win_border(win_T *wp, colnr_T vcol)
 {
   int width1;                   /* width of first line (after line number) */
   int width2;                   /* width of further lines */
@@ -1022,12 +968,7 @@ colnr_T vcol;
  *
  * This is used very often, keep it fast!
  */
-void getvcol(wp, pos, start, cursor, end)
-win_T       *wp;
-pos_T       *pos;
-colnr_T     *start;
-colnr_T     *cursor;
-colnr_T     *end;
+void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *end)
 {
   colnr_T vcol;
   char_u      *ptr;             /* points to current char */
@@ -1129,8 +1070,7 @@ colnr_T     *end;
 /*
  * Get virtual cursor column in the current window, pretending 'list' is off.
  */
-colnr_T getvcol_nolist(posp)
-pos_T       *posp;
+colnr_T getvcol_nolist(pos_T *posp)
 {
   int list_save = curwin->w_p_list;
   colnr_T vcol;
@@ -1144,12 +1084,7 @@ pos_T       *posp;
 /*
  * Get virtual column in virtual mode.
  */
-void getvvcol(wp, pos, start, cursor, end)
-win_T       *wp;
-pos_T       *pos;
-colnr_T     *start;
-colnr_T     *cursor;
-colnr_T     *end;
+void getvvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *end)
 {
   colnr_T col;
   colnr_T coladd;
@@ -1190,10 +1125,7 @@ colnr_T     *end;
  * Get the leftmost and rightmost virtual column of pos1 and pos2.
  * Used for Visual block mode.
  */
-void getvcols(wp, pos1, pos2, left, right)
-win_T       *wp;
-pos_T       *pos1, *pos2;
-colnr_T     *left, *right;
+void getvcols(win_T *wp, pos_T *pos1, pos_T *pos2, colnr_T *left, colnr_T *right)
 {
   colnr_T from1, from2, to1, to2;
 
@@ -1220,8 +1152,7 @@ colnr_T     *left, *right;
 /*
  * skipwhite: skip over ' ' and '\t'.
  */
-char_u * skipwhite(q)
-char_u      *q;
+char_u *skipwhite(char_u *q)
 {
   char_u      *p = q;
 
@@ -1233,8 +1164,7 @@ char_u      *q;
 /*
  * skip over digits
  */
-char_u * skipdigits(q)
-char_u      *q;
+char_u *skipdigits(char_u *q)
 {
   char_u      *p = q;
 
@@ -1246,8 +1176,7 @@ char_u      *q;
 /*
  * skip over digits and hex characters
  */
-char_u * skiphex(q)
-char_u      *q;
+char_u *skiphex(char_u *q)
 {
   char_u      *p = q;
 
@@ -1259,8 +1188,7 @@ char_u      *q;
 /*
  * skip to digit (or NUL after the string)
  */
-char_u * skiptodigit(q)
-char_u      *q;
+char_u *skiptodigit(char_u *q)
 {
   char_u      *p = q;
 
@@ -1272,8 +1200,7 @@ char_u      *q;
 /*
  * skip to hex character (or NUL after the string)
  */
-char_u * skiptohex(q)
-char_u      *q;
+char_u *skiptohex(char_u *q)
 {
   char_u      *p = q;
 
@@ -1288,8 +1215,7 @@ char_u      *q;
  * superscript 1 to be a digit.
  * Use the VIM_ISDIGIT() macro for simple arguments.
  */
-int vim_isdigit(c)
-int c;
+int vim_isdigit(int c)
 {
   return c >= '0' && c <= '9';
 }
@@ -1299,8 +1225,7 @@ int c;
  * We don't use isxdigit() here, because on some systems it also considers
  * superscript 1 to be a digit.
  */
-int vim_isxdigit(c)
-int c;
+int vim_isxdigit(int c)
 {
   return (c >= '0' && c <= '9')
          || (c >= 'a' && c <= 'f')
@@ -1323,8 +1248,7 @@ static char_u latin1upper[257] =
 static char_u latin1lower[257] =
   "                                 !\"#$%&'()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xd7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff";
 
-int vim_islower(c)
-int c;
+int vim_islower(int c)
 {
   if (c <= '@')
     return FALSE;
@@ -1345,8 +1269,7 @@ int c;
   return islower(c);
 }
 
-int vim_isupper(c)
-int c;
+int vim_isupper(int c)
 {
   if (c <= '@')
     return FALSE;
@@ -1367,8 +1290,7 @@ int c;
   return isupper(c);
 }
 
-int vim_toupper(c)
-int c;
+int vim_toupper(int c)
 {
   if (c <= '@')
     return c;
@@ -1389,8 +1311,7 @@ int c;
   return TOUPPER_LOC(c);
 }
 
-int vim_tolower(c)
-int c;
+int vim_tolower(int c)
 {
   if (c <= '@')
     return c;
@@ -1414,8 +1335,7 @@ int c;
 /*
  * skiptowhite: skip over text until ' ' or '\t' or NUL.
  */
-char_u * skiptowhite(p)
-char_u      *p;
+char_u *skiptowhite(char_u *p)
 {
   while (*p != ' ' && *p != '\t' && *p != NUL)
     ++p;
@@ -1427,8 +1347,7 @@ char_u      *p;
 /*
  * skiptowhite_esc: Like skiptowhite(), but also skip escaped chars
  */
-char_u * skiptowhite_esc(p)
-char_u      *p;
+char_u *skiptowhite_esc(char_u *p)
 {
   while (*p != ' ' && *p != '\t' && *p != NUL) {
     if ((*p == '\\' || *p == Ctrl_V) && *(p + 1) != NUL)
@@ -1443,8 +1362,7 @@ char_u      *p;
  * Getdigits: Get a number from a string and skip over it.
  * Note: the argument is a pointer to a char_u pointer!
  */
-long getdigits(pp)
-char_u **pp;
+long getdigits(char_u **pp)
 {
   char_u      *p;
   long retval;
@@ -1461,8 +1379,7 @@ char_u **pp;
 /*
  * Return TRUE if "lbuf" is empty or only contains blanks.
  */
-int vim_isblankline(lbuf)
-char_u      *lbuf;
+int vim_isblankline(char_u *lbuf)
 {
   char_u      *p;
 
@@ -1486,15 +1403,17 @@ char_u      *lbuf;
  * If "dohex" is non-zero recognize hex numbers, when > 1 always assume
  * hex number.
  */
-void vim_str2nr(start, hexp, len, dooct, dohex, nptr, unptr)
-char_u              *start;
-int                 *hexp;          /* return: type of number 0 = decimal, 'x'
+void 
+vim_str2nr (
+    char_u *start,
+    int *hexp,          /* return: type of number 0 = decimal, 'x'
                                        or 'X' is hex, '0' = octal */
-int                 *len;           /* return: detected length of number */
-int dooct;                          /* recognize octal number */
-int dohex;                          /* recognize hex number */
-long                *nptr;          /* return: signed result */
-unsigned long       *unptr;         /* return: unsigned result */
+    int *len,           /* return: detected length of number */
+    int dooct,                          /* recognize octal number */
+    int dohex,                          /* recognize hex number */
+    long *nptr,          /* return: signed result */
+    unsigned long *unptr         /* return: unsigned result */
+)
 {
   char_u          *ptr = start;
   int hex = 0;                          /* default is decimal */
@@ -1569,8 +1488,7 @@ unsigned long       *unptr;         /* return: unsigned result */
  * Return the value of a single hex character.
  * Only valid when the argument is '0' - '9', 'A' - 'F' or 'a' - 'f'.
  */
-int hex2nr(c)
-int c;
+int hex2nr(int c)
 {
   if (c >= 'a' && c <= 'f')
     return c - 'a' + 10;
@@ -1585,8 +1503,7 @@ int c;
  * Convert two hex characters to a byte.
  * Return -1 if one of the characters is not hex.
  */
-int hexhex2nr(p)
-char_u      *p;
+int hexhex2nr(char_u *p)
 {
   if (!vim_isxdigit(p[0]) || !vim_isxdigit(p[1]))
     return -1;
@@ -1607,8 +1524,7 @@ char_u      *p;
  * character, assume that all multi-byte characters are valid file name
  * characters.
  */
-int rem_backslash(str)
-char_u  *str;
+int rem_backslash(char_u *str)
 {
 #ifdef BACKSLASH_IN_FILENAME
   return str[0] == '\\'
@@ -1628,8 +1544,7 @@ char_u  *str;
  * For MS-DOS we only do this if the character after the backslash
  * is not a normal file character.
  */
-void backslash_halve(p)
-char_u      *p;
+void backslash_halve(char_u *p)
 {
   for (; *p; ++p)
     if (rem_backslash(p))
@@ -1639,8 +1554,7 @@ char_u      *p;
 /*
  * backslash_halve() plus save the result in allocated memory.
  */
-char_u * backslash_halve_save(p)
-char_u      *p;
+char_u *backslash_halve_save(char_u *p)
 {
   char_u      *res;
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -55,8 +55,7 @@ static diff_T *diff_alloc_new __ARGS((tabpage_T *tp, diff_T *dprev, diff_T *dp))
 /*
  * Called when deleting or unloading a buffer: No longer make a diff with it.
  */
-void diff_buf_delete(buf)
-buf_T       *buf;
+void diff_buf_delete(buf_T *buf)
 {
   int i;
   tabpage_T   *tp;
@@ -76,8 +75,7 @@ buf_T       *buf;
  * Check if the current buffer should be added to or removed from the list of
  * diff buffers.
  */
-void diff_buf_adjust(win)
-win_T       *win;
+void diff_buf_adjust(win_T *win)
 {
   win_T       *wp;
   int i;
@@ -108,8 +106,7 @@ win_T       *win;
  * This must be done before any autocmd, because a command may use info
  * about the screen contents.
  */
-void diff_buf_add(buf)
-buf_T       *buf;
+void diff_buf_add(buf_T *buf)
 {
   int i;
 
@@ -131,8 +128,7 @@ buf_T       *buf;
  * Find buffer "buf" in the list of diff buffers for the current tab page.
  * Return its index or DB_COUNT if not found.
  */
-static int diff_buf_idx(buf)
-buf_T       *buf;
+static int diff_buf_idx(buf_T *buf)
 {
   int idx;
 
@@ -146,9 +142,7 @@ buf_T       *buf;
  * Find buffer "buf" in the list of diff buffers for tab page "tp".
  * Return its index or DB_COUNT if not found.
  */
-static int diff_buf_idx_tp(buf, tp)
-buf_T       *buf;
-tabpage_T   *tp;
+static int diff_buf_idx_tp(buf_T *buf, tabpage_T *tp)
 {
   int idx;
 
@@ -162,8 +156,7 @@ tabpage_T   *tp;
  * Mark the diff info involving buffer "buf" as invalid, it will be updated
  * when info is requested.
  */
-void diff_invalidate(buf)
-buf_T       *buf;
+void diff_invalidate(buf_T *buf)
 {
   tabpage_T   *tp;
   int i;
@@ -181,11 +174,7 @@ buf_T       *buf;
 /*
  * Called by mark_adjust(): update line numbers in "curbuf".
  */
-void diff_mark_adjust(line1, line2, amount, amount_after)
-linenr_T line1;
-linenr_T line2;
-long amount;
-long amount_after;
+void diff_mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_after)
 {
   int idx;
   tabpage_T   *tp;
@@ -205,13 +194,7 @@ long amount_after;
  * new change block and update the line numbers in following blocks.
  * When inserting/deleting lines in existing change blocks, update them.
  */
-static void diff_mark_adjust_tp(tp, idx, line1, line2, amount, amount_after)
-tabpage_T   *tp;
-int idx;
-linenr_T line1;
-linenr_T line2;
-long amount;
-long amount_after;
+static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1, linenr_T line2, long amount, long amount_after)
 {
   diff_T      *dp;
   diff_T      *dprev;
@@ -417,10 +400,7 @@ long amount_after;
 /*
  * Allocate a new diff block and link it between "dprev" and "dp".
  */
-static diff_T * diff_alloc_new(tp, dprev, dp)
-tabpage_T   *tp;
-diff_T      *dprev;
-diff_T      *dp;
+static diff_T *diff_alloc_new(tabpage_T *tp, diff_T *dprev, diff_T *dp)
 {
   diff_T      *dnew;
 
@@ -441,9 +421,7 @@ diff_T      *dp;
  * This may result in a change where all buffers have zero lines, the caller
  * must take care of removing it.
  */
-static void diff_check_unchanged(tp, dp)
-tabpage_T   *tp;
-diff_T      *dp;
+static void diff_check_unchanged(tabpage_T *tp, diff_T *dp)
 {
   int i_org;
   int i_new;
@@ -512,9 +490,7 @@ diff_T      *dp;
  * Check if a diff block doesn't contain invalid line numbers.
  * This can happen when the diff program returns invalid results.
  */
-static int diff_check_sanity(tp, dp)
-tabpage_T   *tp;
-diff_T      *dp;
+static int diff_check_sanity(tabpage_T *tp, diff_T *dp)
 {
   int i;
 
@@ -529,8 +505,10 @@ diff_T      *dp;
 /*
  * Mark all diff buffers in the current tab page for redraw.
  */
-static void diff_redraw(dofold)
-int dofold;                 /* also recompute the folds */
+static void 
+diff_redraw (
+    int dofold                 /* also recompute the folds */
+)
 {
   win_T       *wp;
   int n;
@@ -557,9 +535,7 @@ int dofold;                 /* also recompute the folds */
  * Always use 'fileformat' set to "unix".
  * Return FAIL for failure
  */
-static int diff_write(buf, fname)
-buf_T       *buf;
-char_u      *fname;
+static int diff_write(buf_T *buf, char_u *fname)
 {
   int r;
   char_u      *save_ff;
@@ -579,8 +555,10 @@ char_u      *fname;
  * The buffers are written to a file, also for unmodified buffers (the file
  * could have been produced by autocommands, e.g. the netrw plugin).
  */
-void ex_diffupdate(eap)
-exarg_T     *eap UNUSED;            /* can be NULL */
+void 
+ex_diffupdate (
+    exarg_T *eap            /* can be NULL */
+)
 {
   buf_T       *buf;
   int idx_orig;
@@ -726,10 +704,7 @@ theend:
 /*
  * Make a diff between files "tmp_orig" and "tmp_new", results in "tmp_diff".
  */
-static void diff_file(tmp_orig, tmp_new, tmp_diff)
-char_u      *tmp_orig;
-char_u      *tmp_new;
-char_u      *tmp_diff;
+static void diff_file(char_u *tmp_orig, char_u *tmp_new, char_u *tmp_diff)
 {
   char_u      *cmd;
   size_t len;
@@ -769,8 +744,7 @@ char_u      *tmp_diff;
  * The buffer is written to a file, also for unmodified buffers (the file
  * could have been produced by autocommands, e.g. the netrw plugin).
  */
-void ex_diffpatch(eap)
-exarg_T     *eap;
+void ex_diffpatch(exarg_T *eap)
 {
   char_u      *tmp_orig;        /* name of original temp file */
   char_u      *tmp_new;         /* name of patched temp file */
@@ -925,8 +899,7 @@ theend:
 /*
  * Split the window and edit another file, setting options to show the diffs.
  */
-void ex_diffsplit(eap)
-exarg_T     *eap;
+void ex_diffsplit(exarg_T *eap)
 {
   win_T       *old_curwin = curwin;
 
@@ -950,8 +923,7 @@ exarg_T     *eap;
 /*
  * Set options to show diffs for the current window.
  */
-void ex_diffthis(eap)
-exarg_T     *eap UNUSED;
+void ex_diffthis(exarg_T *eap)
 {
   /* Set 'diff', 'scrollbind' on and 'wrap' off. */
   diff_win_options(curwin, TRUE);
@@ -960,9 +932,11 @@ exarg_T     *eap UNUSED;
 /*
  * Set options in window "wp" for diff mode.
  */
-void diff_win_options(wp, addbuf)
-win_T       *wp;
-int addbuf;                     /* Add buffer to diff. */
+void 
+diff_win_options (
+    win_T *wp,
+    int addbuf                     /* Add buffer to diff. */
+)
 {
   win_T *old_curwin = curwin;
 
@@ -1016,8 +990,7 @@ int addbuf;                     /* Add buffer to diff. */
  * Set options not to show diffs.  For the current window or all windows.
  * Only in the current tab page.
  */
-void ex_diffoff(eap)
-exarg_T     *eap;
+void ex_diffoff(exarg_T *eap)
 {
   win_T       *wp;
   win_T       *old_curwin = curwin;
@@ -1079,10 +1052,12 @@ exarg_T     *eap;
 /*
  * Read the diff output and add each entry to the diff list.
  */
-static void diff_read(idx_orig, idx_new, fname)
-int idx_orig;                   /* idx of original file */
-int idx_new;                    /* idx of new file */
-char_u      *fname;             /* name of diff output file */
+static void 
+diff_read (
+    int idx_orig,                   /* idx of original file */
+    int idx_new,                    /* idx of new file */
+    char_u *fname             /* name of diff output file */
+)
 {
   FILE        *fd;
   diff_T      *dprev = NULL;
@@ -1251,11 +1226,7 @@ done:
 /*
  * Copy an entry at "dp" from "idx_orig" to "idx_new".
  */
-static void diff_copy_entry(dprev, dp, idx_orig, idx_new)
-diff_T      *dprev;
-diff_T      *dp;
-int idx_orig;
-int idx_new;
+static void diff_copy_entry(diff_T *dprev, diff_T *dp, int idx_orig, int idx_new)
 {
   long off;
 
@@ -1271,8 +1242,7 @@ int idx_new;
 /*
  * Clear the list of diffblocks for tab page "tp".
  */
-void diff_clear(tp)
-tabpage_T   *tp;
+void diff_clear(tabpage_T *tp)
 {
   diff_T      *p, *next_p;
 
@@ -1292,9 +1262,7 @@ tabpage_T   *tp;
  * when 'diffopt' doesn't contain "filler").
  * This should only be used for windows where 'diff' is set.
  */
-int diff_check(wp, lnum)
-win_T       *wp;
-linenr_T lnum;
+int diff_check(win_T *wp, linenr_T lnum)
 {
   int idx;                      /* index in tp_diffbuf[] for this buffer */
   diff_T      *dp;
@@ -1379,10 +1347,7 @@ linenr_T lnum;
 /*
  * Compare two entries in diff "*dp" and return TRUE if they are equal.
  */
-static int diff_equal_entry(dp, idx1, idx2)
-diff_T      *dp;
-int idx1;
-int idx2;
+static int diff_equal_entry(diff_T *dp, int idx1, int idx2)
 {
   int i;
   char_u      *line;
@@ -1410,9 +1375,7 @@ int idx2;
  * Compare strings "s1" and "s2" according to 'diffopt'.
  * Return non-zero when they are different.
  */
-static int diff_cmp(s1, s2)
-char_u      *s1;
-char_u      *s2;
+static int diff_cmp(char_u *s1, char_u *s2)
 {
   char_u      *p1, *p2;
   int l;
@@ -1463,9 +1426,7 @@ char_u      *s2;
 /*
  * Return the number of filler lines above "lnum".
  */
-int diff_check_fill(wp, lnum)
-win_T       *wp;
-linenr_T lnum;
+int diff_check_fill(win_T *wp, linenr_T lnum)
 {
   int n;
 
@@ -1482,9 +1443,7 @@ linenr_T lnum;
  * Set the topline of "towin" to match the position in "fromwin", so that they
  * show the same diff'ed lines.
  */
-void diff_set_topline(fromwin, towin)
-win_T       *fromwin;
-win_T       *towin;
+void diff_set_topline(win_T *fromwin, win_T *towin)
 {
   buf_T       *frombuf = fromwin->w_buffer;
   linenr_T lnum = fromwin->w_topline;
@@ -1586,7 +1545,7 @@ win_T       *towin;
 /*
  * This is called when 'diffopt' is changed.
  */
-int diffopt_changed()         {
+int diffopt_changed(void)         {
   char_u      *p;
   int diff_context_new = 6;
   int diff_flags_new = 0;
@@ -1648,7 +1607,7 @@ int diffopt_changed()         {
 /*
  * Return TRUE if 'diffopt' contains "horizontal".
  */
-int diffopt_horizontal()         {
+int diffopt_horizontal(void)         {
   return (diff_flags & DIFF_HORIZONTAL) != 0;
 }
 
@@ -1656,11 +1615,13 @@ int diffopt_horizontal()         {
  * Find the difference within a changed line.
  * Returns TRUE if the line was added, no other buffer has it.
  */
-int diff_find_change(wp, lnum, startp, endp)
-win_T       *wp;
-linenr_T lnum;
-int         *startp;            /* first char of the change */
-int         *endp;              /* last char of the change */
+int 
+diff_find_change (
+    win_T *wp,
+    linenr_T lnum,
+    int *startp,            /* first char of the change */
+    int *endp              /* last char of the change */
+)
 {
   char_u      *line_org;
   char_u      *line_new;
@@ -1763,9 +1724,7 @@ int         *endp;              /* last char of the change */
  * be in a fold.
  * Return FALSE if there are no diff blocks at all in this window.
  */
-int diff_infold(wp, lnum)
-win_T       *wp;
-linenr_T lnum;
+int diff_infold(win_T *wp, linenr_T lnum)
 {
   int i;
   int idx = -1;
@@ -1808,8 +1767,7 @@ linenr_T lnum;
 /*
  * "dp" and "do" commands.
  */
-void nv_diffgetput(put)
-int put;
+void nv_diffgetput(int put)
 {
   exarg_T ea;
 
@@ -1828,8 +1786,7 @@ int put;
  * ":diffget"
  * ":diffput"
  */
-void ex_diffgetput(eap)
-exarg_T     *eap;
+void ex_diffgetput(exarg_T *eap)
 {
   linenr_T lnum;
   int count;
@@ -2107,9 +2064,7 @@ exarg_T     *eap;
  * Skip buffer with index "skip_idx".
  * When there are no diffs, all folds are removed.
  */
-static void diff_fold_update(dp, skip_idx)
-diff_T      *dp;
-int skip_idx;
+static void diff_fold_update(diff_T *dp, int skip_idx)
 {
   int i;
   win_T       *wp;
@@ -2124,8 +2079,7 @@ int skip_idx;
 /*
  * Return TRUE if buffer "buf" is in diff-mode.
  */
-int diff_mode_buf(buf)
-buf_T       *buf;
+int diff_mode_buf(buf_T *buf)
 {
   tabpage_T   *tp;
 
@@ -2139,9 +2093,7 @@ buf_T       *buf;
  * Move "count" times in direction "dir" to the next diff block.
  * Return FAIL if there isn't such a diff block.
  */
-int diff_move_to(dir, count)
-int dir;
-long count;
+int diff_move_to(int dir, long count)
 {
   int idx;
   linenr_T lnum = curwin->w_cursor.lnum;
@@ -2190,11 +2142,7 @@ long count;
   return OK;
 }
 
-linenr_T diff_get_corresponding_line(buf1, lnum1, buf2, lnum3)
-buf_T       *buf1;
-linenr_T lnum1;
-buf_T       *buf2;
-linenr_T lnum3;
+linenr_T diff_get_corresponding_line(buf_T *buf1, linenr_T lnum1, buf_T *buf2, linenr_T lnum3)
 {
   int idx1;
   int idx2;
@@ -2257,9 +2205,7 @@ linenr_T lnum3;
  * For line "lnum" in the current window find the equivalent lnum in window
  * "wp", compensating for inserted/deleted lines.
  */
-linenr_T diff_lnum_win(lnum, wp)
-linenr_T lnum;
-win_T       *wp;
+linenr_T diff_lnum_win(linenr_T lnum, win_T *wp)
 {
   diff_T      *dp;
   int idx;

--- a/src/digraph.c
+++ b/src/digraph.c
@@ -1623,8 +1623,7 @@ static digr_T digraphdefault[] =
 /*
  * handle digraphs after typing a character
  */
-int do_digraph(c)
-int c;
+int do_digraph(int c)
 {
   static int backspaced;        /* character before K_BS */
   static int lastchar;          /* last typed character */
@@ -1647,8 +1646,10 @@ int c;
  * mode.
  * Returns composed character, or NUL when ESC was used.
  */
-int get_digraph(cmdline)
-int cmdline;                    /* TRUE when called from the cmdline */
+int 
+get_digraph (
+    int cmdline                    /* TRUE when called from the cmdline */
+)
 {
   int c, cc;
 
@@ -1683,10 +1684,7 @@ int cmdline;                    /* TRUE when called from the cmdline */
  * If no match, return "char2".
  * If "meta_char" is TRUE and "char1" is a space, return "char2" | 0x80.
  */
-static int getexactdigraph(char1, char2, meta_char)
-int char1;
-int char2;
-int meta_char;
+static int getexactdigraph(int char1, int char2, int meta_char)
 {
   int i;
   int retval = 0;
@@ -1759,10 +1757,7 @@ int meta_char;
  * Get digraph.
  * Allow for both char1-char2 and char2-char1
  */
-int getdigraph(char1, char2, meta_char)
-int char1;
-int char2;
-int meta_char;
+int getdigraph(int char1, int char2, int meta_char)
 {
   int retval;
 
@@ -1777,8 +1772,7 @@ int meta_char;
  * Add the digraphs in the argument to the digraph table.
  * format: {c1}{c2} char {c1}{c2} char ...
  */
-void putdigraph(str)
-char_u *str;
+void putdigraph(char_u *str)
 {
   int char1, char2, n;
   int i;
@@ -1828,7 +1822,7 @@ char_u *str;
   }
 }
 
-void listdigraphs()          {
+void listdigraphs(void)          {
   int i;
   digr_T      *dp;
 
@@ -1867,8 +1861,7 @@ void listdigraphs()          {
                                wrong, in which case we messed up ScreenLines */
 }
 
-static void printdigraph(dp)
-digr_T      *dp;
+static void printdigraph(digr_T *dp)
 {
   char_u buf[30];
   char_u      *p;
@@ -1925,7 +1918,7 @@ static void keymap_unload __ARGS((void));
  * used when setting the option, not later when the value has already been
  * checked.
  */
-char_u * keymap_init()              {
+char_u *keymap_init(void)              {
   curbuf->b_kmap_state &= ~KEYMAP_INIT;
 
   if (*curbuf->b_p_keymap == NUL) {
@@ -1967,8 +1960,7 @@ char_u * keymap_init()              {
 /*
  * ":loadkeymap" command: load the following lines as the keymap.
  */
-void ex_loadkeymap(eap)
-exarg_T     *eap;
+void ex_loadkeymap(exarg_T *eap)
 {
   char_u      *line;
   char_u      *p;
@@ -2044,7 +2036,7 @@ exarg_T     *eap;
 /*
  * Stop using 'keymap'.
  */
-static void keymap_unload()                 {
+static void keymap_unload(void)                 {
   char_u buf[KMAP_MAXLEN + 10];
   int i;
   char_u      *save_cpo = p_cpo;

--- a/src/edit.c
+++ b/src/edit.c
@@ -284,10 +284,12 @@ static int did_add_space = FALSE;       /* auto_format() added an extra space
  *
  * Return TRUE if a CTRL-O command caused the return (insert mode pending).
  */
-int edit(cmdchar, startln, count)
-int cmdchar;
-int startln;                    /* if set, insert at start of line */
-long count;
+int 
+edit (
+    int cmdchar,
+    int startln,                    /* if set, insert at start of line */
+    long count
+)
 {
   int c = 0;
   char_u      *ptr;
@@ -1264,8 +1266,10 @@ force_cindent:
  * Only redraw when there are no characters available.  This speeds up
  * inserting sequences of characters (e.g., for CTRL-R).
  */
-static void ins_redraw(ready)
-int ready UNUSED;                   /* not busy with something */
+static void 
+ins_redraw (
+    int ready                   /* not busy with something */
+)
 {
   linenr_T conceal_old_cursor_line = 0;
   linenr_T conceal_new_cursor_line = 0;
@@ -1333,7 +1337,7 @@ int ready UNUSED;                   /* not busy with something */
 /*
  * Handle a CTRL-V or CTRL-Q typed in Insert mode.
  */
-static void ins_ctrl_v()                 {
+static void ins_ctrl_v(void)                 {
   int c;
   int did_putchar = FALSE;
 
@@ -1373,9 +1377,7 @@ static int pc_attr;
 static int pc_row;
 static int pc_col;
 
-void edit_putchar(c, highlight)
-int c;
-int highlight;
+void edit_putchar(int c, int highlight)
 {
   int attr;
 
@@ -1418,7 +1420,7 @@ int highlight;
 /*
  * Undo the previous edit_putchar().
  */
-void edit_unputchar()          {
+void edit_unputchar(void)          {
   if (pc_status != PC_STATUS_UNSET && pc_row >= msg_scrolled) {
     if (pc_status == PC_STATUS_RIGHT)
       ++curwin->w_wcol;
@@ -1433,8 +1435,7 @@ void edit_unputchar()          {
  * Called when p_dollar is set: display a '$' at the end of the changed text
  * Only works when cursor is in the line that changes.
  */
-void display_dollar(col)
-colnr_T col;
+void display_dollar(colnr_T col)
 {
   colnr_T save_col;
 
@@ -1463,7 +1464,7 @@ colnr_T col;
  * Call this function before moving the cursor from the normal insert position
  * in insert mode.
  */
-static void undisplay_dollar()                 {
+static void undisplay_dollar(void)                 {
   if (dollar_vcol >= 0) {
     dollar_vcol = -1;
     redrawWinline(curwin->w_cursor.lnum, FALSE);
@@ -1478,12 +1479,14 @@ static void undisplay_dollar()                 {
  * type == INDENT_SET	set indent to "amount"
  * if round is TRUE, round the indent to 'shiftwidth' (only with _INC and _Dec).
  */
-void change_indent(type, amount, round, replaced, call_changed_bytes)
-int type;
-int amount;
-int round;
-int replaced;                   /* replaced character, put on replace stack */
-int call_changed_bytes;                 /* call changed_bytes() */
+void 
+change_indent (
+    int type,
+    int amount,
+    int round,
+    int replaced,                   /* replaced character, put on replace stack */
+    int call_changed_bytes                 /* call changed_bytes() */
+)
 {
   int vcol;
   int last_vcol;
@@ -1701,8 +1704,7 @@ int call_changed_bytes;                 /* call changed_bytes() */
  * insert mode.  It handles fixing the replace stack for REPLACE and VREPLACE
  * modes.
  */
-void truncate_spaces(line)
-char_u  *line;
+void truncate_spaces(char_u *line)
 {
   int i;
 
@@ -1722,8 +1724,7 @@ char_u  *line;
  * Will attempt not to go before "col" even when there is a composing
  * character.
  */
-void backspace_until_column(col)
-int col;
+void backspace_until_column(int col)
 {
   while ((int)curwin->w_cursor.col > col) {
     curwin->w_cursor.col--;
@@ -1740,8 +1741,7 @@ int col;
  * Only matters when there are composing characters.
  * Return TRUE when something was deleted.
  */
-static int del_char_after_col(limit_col)
-int limit_col UNUSED;
+static int del_char_after_col(int limit_col)
 {
   if (enc_utf8 && limit_col >= 0) {
     colnr_T ecol = curwin->w_cursor.col + 1;
@@ -1768,7 +1768,7 @@ int limit_col UNUSED;
 /*
  * CTRL-X pressed in Insert mode.
  */
-static void ins_ctrl_x()                 {
+static void ins_ctrl_x(void)                 {
   /* CTRL-X after CTRL-X CTRL-V doesn't do anything, so that CTRL-X
    * CTRL-V works like CTRL-N */
   if (ctrl_x_mode != CTRL_X_CMDLINE) {
@@ -1789,8 +1789,7 @@ static void ins_ctrl_x()                 {
 /*
  * Return TRUE if the 'dict' or 'tsr' option can be used.
  */
-static int has_compl_option(dict_opt)
-int dict_opt;
+static int has_compl_option(int dict_opt)
 {
   if (dict_opt ? (*curbuf->b_p_dict == NUL && *p_dict == NUL
                   && !curwin->w_p_spell
@@ -1816,8 +1815,7 @@ int dict_opt;
  * Is the character 'c' a valid key to go to or keep us in CTRL-X mode?
  * This depends on the current mode.
  */
-int vim_is_ctrl_x_key(c)
-int c;
+int vim_is_ctrl_x_key(int c)
 {
   /* Always allow ^R - let it's results then be checked */
   if (c == Ctrl_R)
@@ -1872,8 +1870,7 @@ int c;
  * completed.  Used to decide whether to abandon complete mode when the menu
  * is visible.
  */
-static int ins_compl_accept_char(c)
-int c;
+static int ins_compl_accept_char(int c)
 {
   if (ctrl_x_mode & CTRL_X_WANT_IDENT)
     /* When expanding an identifier only accept identifier chars. */
@@ -1905,13 +1902,7 @@ int c;
  * text is inferred, ie this tries to work out what case you probably wanted
  * the rest of the word to be in -- webb
  */
-int ins_compl_add_infercase(str, len, icase, fname, dir, flags)
-char_u      *str;
-int len;
-int icase;
-char_u      *fname;
-int dir;
-int flags;
+int ins_compl_add_infercase(char_u *str, int len, int icase, char_u *fname, int dir, int flags)
 {
   char_u      *p;
   int i, c;
@@ -2044,15 +2035,17 @@ int flags;
  * NOTDONE, otherwise add it to the list and return OK.  If there is an error,
  * maybe because alloc() returns NULL, then FAIL is returned.
  */
-static int ins_compl_add(str, len, icase, fname, cptext, cdir, flags, adup)
-char_u      *str;
-int len;
-int icase;
-char_u      *fname;
-char_u      **cptext;       /* extra text for popup menu or NULL */
-int cdir;
-int flags;
-int adup;                   /* accept duplicate match */
+static int 
+ins_compl_add (
+    char_u *str,
+    int len,
+    int icase,
+    char_u *fname,
+    char_u **cptext,       /* extra text for popup menu or NULL */
+    int cdir,
+    int flags,
+    int adup                   /* accept duplicate match */
+)
 {
   compl_T     *match;
   int dir = (cdir == 0 ? compl_direction : cdir);
@@ -2153,10 +2146,7 @@ int adup;                   /* accept duplicate match */
  * Return TRUE if "str[len]" matches with match->cp_str, considering
  * match->cp_icase.
  */
-static int ins_compl_equal(match, str, len)
-compl_T     *match;
-char_u      *str;
-int len;
+static int ins_compl_equal(compl_T *match, char_u *str, int len)
 {
   if (match->cp_icase)
     return STRNICMP(match->cp_str, str, (size_t)len) == 0;
@@ -2166,8 +2156,7 @@ int len;
 /*
  * Reduce the longest common string for match "match".
  */
-static void ins_compl_longest_match(match)
-compl_T     *match;
+static void ins_compl_longest_match(compl_T *match)
 {
   char_u      *p, *s;
   int c1, c2;
@@ -2234,10 +2223,7 @@ compl_T     *match;
  * Add an array of matches to the list of matches.
  * Frees matches[].
  */
-static void ins_compl_add_matches(num_matches, matches, icase)
-int num_matches;
-char_u      **matches;
-int icase;
+static void ins_compl_add_matches(int num_matches, char_u **matches, int icase)
 {
   int i;
   int add_r = OK;
@@ -2254,7 +2240,7 @@ int icase;
 /* Make the completion list cyclic.
  * Return the number of matches (excluding the original).
  */
-static int ins_compl_make_cyclic()                {
+static int ins_compl_make_cyclic(void)                {
   compl_T *match;
   int count = 0;
 
@@ -2279,9 +2265,7 @@ static int ins_compl_make_cyclic()                {
  * "startcol" is where the matched text starts (1 is first column).
  * "list" is the list of matches.
  */
-void set_completion(startcol, list)
-colnr_T startcol;
-list_T  *list;
+void set_completion(colnr_T startcol, list_T *list)
 {
   /* If already doing completions stop it. */
   if (ctrl_x_mode != 0)
@@ -2325,7 +2309,7 @@ static int compl_match_arraysize;
 /*
  * Update the screen and when there is any scrolling remove the popup menu.
  */
-static void ins_compl_upd_pum()                 {
+static void ins_compl_upd_pum(void)                 {
   int h;
 
   if (compl_match_array != NULL) {
@@ -2339,7 +2323,7 @@ static void ins_compl_upd_pum()                 {
 /*
  * Remove any popup menu.
  */
-static void ins_compl_del_pum()                 {
+static void ins_compl_del_pum(void)                 {
   if (compl_match_array != NULL) {
     pum_undisplay();
     vim_free(compl_match_array);
@@ -2350,7 +2334,7 @@ static void ins_compl_del_pum()                 {
 /*
  * Return TRUE if the popup menu should be displayed.
  */
-static int pum_wanted()                {
+static int pum_wanted(void)                {
   /* 'completeopt' must contain "menu" or "menuone" */
   if (vim_strchr(p_cot, 'm') == NULL)
     return FALSE;
@@ -2366,7 +2350,7 @@ static int pum_wanted()                {
  * Return TRUE if there are two or more matches to be shown in the popup menu.
  * One if 'completopt' contains "menuone".
  */
-static int pum_enough_matches()                {
+static int pum_enough_matches(void)                {
   compl_T     *compl;
   int i;
 
@@ -2390,7 +2374,7 @@ static int pum_enough_matches()                {
  * Show the popup menu for the list of matches.
  * Also adjusts "compl_shown_match" to an entry that is actually displayed.
  */
-void ins_compl_show_pum()          {
+void ins_compl_show_pum(void)          {
   compl_T     *compl;
   compl_T     *shown_compl = NULL;
   int did_find_shown_match = FALSE;
@@ -2516,11 +2500,13 @@ void ins_compl_show_pum()          {
  * Add any identifiers that match the given pattern in the list of dictionary
  * files "dict_start" to the list of completions.
  */
-static void ins_compl_dictionaries(dict_start, pat, flags, thesaurus)
-char_u      *dict_start;
-char_u      *pat;
-int flags;                      /* DICT_FIRST and/or DICT_EXACT */
-int thesaurus;                  /* Thesaurus completion */
+static void 
+ins_compl_dictionaries (
+    char_u *dict_start,
+    char_u *pat,
+    int flags,                      /* DICT_FIRST and/or DICT_EXACT */
+    int thesaurus                  /* Thesaurus completion */
+)
 {
   char_u      *dict = dict_start;
   char_u      *ptr;
@@ -2619,14 +2605,7 @@ theend:
   vim_free(buf);
 }
 
-static void ins_compl_files(count, files, thesaurus, flags, regmatch, buf, dir)
-int count;
-char_u      **files;
-int thesaurus;
-int flags;
-regmatch_T  *regmatch;
-char_u      *buf;
-int         *dir;
+static void ins_compl_files(int count, char_u **files, int thesaurus, int flags, regmatch_T *regmatch, char_u *buf, int *dir)
 {
   char_u      *ptr;
   int i;
@@ -2717,8 +2696,7 @@ int         *dir;
  * Find the start of the next word.
  * Returns a pointer to the first char of the word.  Also stops at a NUL.
  */
-char_u * find_word_start(ptr)
-char_u      *ptr;
+char_u *find_word_start(char_u *ptr)
 {
   if (has_mbyte)
     while (*ptr != NUL && *ptr != '\n' && mb_get_class(ptr) <= 1)
@@ -2733,8 +2711,7 @@ char_u      *ptr;
  * Find the end of the word.  Assumes it starts inside a word.
  * Returns a pointer to just after the word.
  */
-char_u * find_word_end(ptr)
-char_u      *ptr;
+char_u *find_word_end(char_u *ptr)
 {
   int start_class;
 
@@ -2756,8 +2733,7 @@ char_u      *ptr;
  * Find the end of the line, omitting CR and NL at the end.
  * Returns a pointer to just after the line.
  */
-static char_u * find_line_end(ptr)
-char_u      *ptr;
+static char_u *find_line_end(char_u *ptr)
 {
   char_u      *s;
 
@@ -2770,7 +2746,7 @@ char_u      *ptr;
 /*
  * Free the list of completions
  */
-static void ins_compl_free()                 {
+static void ins_compl_free(void)                 {
   compl_T *match;
   int i;
 
@@ -2801,7 +2777,7 @@ static void ins_compl_free()                 {
   compl_shown_match = NULL;
 }
 
-static void ins_compl_clear()                 {
+static void ins_compl_clear(void)                 {
   compl_cont_status = 0;
   compl_started = FALSE;
   compl_matches = 0;
@@ -2818,7 +2794,7 @@ static void ins_compl_clear()                 {
 /*
  * Return TRUE when Insert completion is active.
  */
-int ins_compl_active()         {
+int ins_compl_active(void)         {
   return compl_started;
 }
 
@@ -2828,7 +2804,7 @@ int ins_compl_active()         {
  * Returns the character to be used, NUL if the work is done and another char
  * to be got from the user.
  */
-static int ins_compl_bs()                {
+static int ins_compl_bs(void)                {
   char_u      *line;
   char_u      *p;
 
@@ -2865,7 +2841,7 @@ static int ins_compl_bs()                {
  * Return TRUE when we need to find matches again, ins_compl_restart() is to
  * be called.
  */
-static int ins_compl_need_restart()                {
+static int ins_compl_need_restart(void)                {
   /* Return TRUE if we didn't complete finding matches or when the
    * 'completefunc' returned "always" in the "refresh" dictionary item. */
   return compl_was_interrupted
@@ -2878,7 +2854,7 @@ static int ins_compl_need_restart()                {
  * Show the popup menu with a different set of matches.
  * May also search for matches again if the previous search was interrupted.
  */
-static void ins_compl_new_leader()                 {
+static void ins_compl_new_leader(void)                 {
   ins_compl_del_pum();
   ins_compl_delete();
   ins_bytes(compl_leader + ins_compl_len());
@@ -2914,7 +2890,7 @@ static void ins_compl_new_leader()                 {
  * Return the length of the completion, from the completion start column to
  * the cursor column.  Making sure it never goes below zero.
  */
-static int ins_compl_len()                {
+static int ins_compl_len(void)                {
   int off = (int)curwin->w_cursor.col - (int)compl_col;
 
   if (off < 0)
@@ -2926,8 +2902,7 @@ static int ins_compl_len()                {
  * Append one character to the match leader.  May reduce the number of
  * matches.
  */
-static void ins_compl_addleader(c)
-int c;
+static void ins_compl_addleader(int c)
 {
   int cc;
 
@@ -2965,7 +2940,7 @@ int c;
  * Setup for finding completions again without leaving CTRL-X mode.  Used when
  * BS or a key was typed while still searching for matches.
  */
-static void ins_compl_restart()                 {
+static void ins_compl_restart(void)                 {
   ins_compl_free();
   compl_started = FALSE;
   compl_matches = 0;
@@ -2976,8 +2951,7 @@ static void ins_compl_restart()                 {
 /*
  * Set the first match, the original text.
  */
-static void ins_compl_set_original_text(str)
-char_u      *str;
+static void ins_compl_set_original_text(char_u *str)
 {
   char_u      *p;
 
@@ -2995,7 +2969,7 @@ char_u      *str;
  * Append one character to the match leader.  May reduce the number of
  * matches.
  */
-static void ins_compl_addfrommatch()                 {
+static void ins_compl_addfrommatch(void)                 {
   char_u      *p;
   int len = (int)curwin->w_cursor.col - (int)compl_col;
   int c;
@@ -3031,8 +3005,7 @@ static void ins_compl_addfrommatch()                 {
  * Called just after typing a character in Insert mode.
  * Returns TRUE when the character is not to be inserted;
  */
-static int ins_compl_prep(c)
-int c;
+static int ins_compl_prep(int c)
 {
   char_u      *ptr;
   int want_cindent;
@@ -3273,8 +3246,7 @@ int c;
  * text.  This inserts backspaces and appends the changed text.
  * "ptr" is the known leader text or NUL.
  */
-static void ins_compl_fixRedoBufForLeader(ptr_arg)
-char_u *ptr_arg;
+static void ins_compl_fixRedoBufForLeader(char_u *ptr_arg)
 {
   int len;
   char_u  *p;
@@ -3308,9 +3280,7 @@ char_u *ptr_arg;
  *
  * Returns the buffer to scan, if any, otherwise returns curbuf -- Acevedo
  */
-static buf_T * ins_compl_next_buf(buf, flag)
-buf_T       *buf;
-int flag;
+static buf_T *ins_compl_next_buf(buf_T *buf, int flag)
 {
   static win_T *wp;
 
@@ -3341,9 +3311,11 @@ static void expand_by_function __ARGS((int type, char_u *base));
  * Execute user defined complete function 'completefunc' or 'omnifunc', and
  * get matches in "matches".
  */
-static void expand_by_function(type, base)
-int type;                   /* CTRL_X_OMNI or CTRL_X_FUNCTION */
-char_u      *base;
+static void 
+expand_by_function (
+    int type,                   /* CTRL_X_OMNI or CTRL_X_FUNCTION */
+    char_u *base
+)
 {
   list_T      *matchlist = NULL;
   dict_T      *matchdict = NULL;
@@ -3408,8 +3380,7 @@ theend:
 /*
  * Add completions from a list.
  */
-static void ins_compl_add_list(list)
-list_T      *list;
+static void ins_compl_add_list(list_T *list)
 {
   listitem_T  *li;
   int dir = compl_direction;
@@ -3427,8 +3398,7 @@ list_T      *list;
 /*
  * Add completions from a dict.
  */
-static void ins_compl_add_dict(dict)
-dict_T      *dict;
+static void ins_compl_add_dict(dict_T *dict)
 {
   dictitem_T  *di_refresh;
   dictitem_T  *di_words;
@@ -3455,9 +3425,7 @@ dict_T      *dict;
  * NOTDONE, otherwise add it to the list and return OK.  If there is an error,
  * maybe because alloc() returns NULL, then FAIL is returned.
  */
-int ins_compl_add_tv(tv, dir)
-typval_T    *tv;
-int dir;
+int ins_compl_add_tv(typval_T *tv, int dir)
 {
   char_u      *word;
   int icase = FALSE;
@@ -3499,8 +3467,7 @@ int dir;
  * This may return before finding all the matches.
  * Return the total number of matches or -1 if still unknown -- Acevedo
  */
-static int ins_compl_get_exp(ini)
-pos_T       *ini;
+static int ins_compl_get_exp(pos_T *ini)
 {
   static pos_T first_match_pos;
   static pos_T last_match_pos;
@@ -3877,7 +3844,7 @@ pos_T       *ini;
 }
 
 /* Delete the old text being completed. */
-static void ins_compl_delete()                 {
+static void ins_compl_delete(void)                 {
   int i;
 
   /*
@@ -3890,7 +3857,7 @@ static void ins_compl_delete()                 {
 }
 
 /* Insert the new text being completed. */
-static void ins_compl_insert()                 {
+static void ins_compl_insert(void)                 {
   ins_bytes(compl_shown_match->cp_str + ins_compl_len());
   if (compl_shown_match->cp_flags & ORIGINAL_TEXT)
     compl_used_match = FALSE;
@@ -3914,11 +3881,13 @@ static void ins_compl_insert()                 {
  * "allow_get_expansion" TRUE, which calls ins_compl_get_exp(), which in turn
  * calls this function with "allow_get_expansion" FALSE.
  */
-static int ins_compl_next(allow_get_expansion, count, insert_match)
-int allow_get_expansion;
-int count;                      /* repeat completion this many times; should
+static int 
+ins_compl_next (
+    int allow_get_expansion,
+    int count,                      /* repeat completion this many times; should
                                    be at least 1 */
-int insert_match;               /* Insert the newly selected match */
+    int insert_match               /* Insert the newly selected match */
+)
 {
   int num_matches = -1;
   int i;
@@ -4094,8 +4063,7 @@ int insert_match;               /* Insert the newly selected match */
  * possible. -- webb
  * "frequency" specifies out of how many calls we actually check.
  */
-void ins_compl_check_keys(frequency)
-int frequency;
+void ins_compl_check_keys(int frequency)
 {
   static int count = 0;
 
@@ -4146,8 +4114,7 @@ int frequency;
  * Decide the direction of Insert mode complete from the key typed.
  * Returns BACKWARD or FORWARD.
  */
-static int ins_compl_key2dir(c)
-int c;
+static int ins_compl_key2dir(int c)
 {
   if (c == Ctrl_P || c == Ctrl_L
       || (pum_visible() && (c == K_PAGEUP || c == K_KPAGEUP
@@ -4160,8 +4127,7 @@ int c;
  * Return TRUE for keys that are used for completion only when the popup menu
  * is visible.
  */
-static int ins_compl_pum_key(c)
-int c;
+static int ins_compl_pum_key(int c)
 {
   return pum_visible() && (c == K_PAGEUP || c == K_KPAGEUP || c == K_S_UP
                            || c == K_PAGEDOWN || c == K_KPAGEDOWN || c ==
@@ -4173,8 +4139,7 @@ int c;
  * Decide the number of completions to move forward.
  * Returns 1 for most keys, height of the popup menu for page-up/down keys.
  */
-static int ins_compl_key2count(c)
-int c;
+static int ins_compl_key2count(int c)
 {
   int h;
 
@@ -4191,8 +4156,7 @@ int c;
  * Return TRUE if completion with "c" should insert the match, FALSE if only
  * to change the currently selected completion.
  */
-static int ins_compl_use_match(c)
-int c;
+static int ins_compl_use_match(int c)
 {
   switch (c) {
   case K_UP:
@@ -4213,8 +4177,7 @@ int c;
  * Called when character "c" was typed, which has a meaning for completion.
  * Returns OK if completion was done, FAIL if something failed (out of mem).
  */
-static int ins_complete(c)
-int c;
+static int ins_complete(int c)
 {
   char_u      *line;
   int startcol = 0;                 /* column where searched text starts */
@@ -4740,10 +4703,7 @@ int c;
  * a backslash) the metachars, and dest would be NUL terminated.
  * Returns the length (needed) of dest
  */
-static unsigned quote_meta(dest, src, len)
-char_u      *dest;
-char_u      *src;
-int len;
+static unsigned quote_meta(char_u *dest, char_u *src, int len)
 {
   unsigned m = (unsigned)len + 1;       /* one extra for the NUL */
 
@@ -4797,7 +4757,7 @@ int len;
  * If one or two digits are entered, the next character is given to vungetc().
  * For Unicode a character > 255 may be returned.
  */
-int get_literal()         {
+int get_literal(void)         {
   int cc;
   int nc;
   int i;
@@ -4887,10 +4847,12 @@ int get_literal()         {
 /*
  * Insert character, taking care of special keys and mod_mask
  */
-static void insert_special(c, allow_modmask, ctrlv)
-int c;
-int allow_modmask;
-int ctrlv;                  /* c was typed after CTRL-V */
+static void 
+insert_special (
+    int c,
+    int allow_modmask,
+    int ctrlv                  /* c was typed after CTRL-V */
+)
 {
   char_u  *p;
   int len;
@@ -4944,10 +4906,12 @@ int ctrlv;                  /* c was typed after CTRL-V */
  *	    INSCHAR_DO_COM   - format comments
  *	    INSCHAR_COM_LIST - format comments with num list or 2nd line indent
  */
-void insertchar(c, flags, second_indent)
-int c;                                  /* character to insert or NUL */
-int flags;                              /* INSCHAR_FORMAT, etc. */
-int second_indent;                      /* indent for second line if >= 0 */
+void 
+insertchar (
+    int c,                                  /* character to insert or NUL */
+    int flags,                              /* INSCHAR_FORMAT, etc. */
+    int second_indent                      /* indent for second line if >= 0 */
+)
 {
   int textwidth;
   char_u      *p;
@@ -5145,12 +5109,14 @@ int second_indent;                      /* indent for second line if >= 0 */
  * If the INSCHAR_COM_LIST flag is present, then the value of second_indent
  * will be the comment leader length sent to open_line().
  */
-static void internal_format(textwidth, second_indent, flags, format_only, c)
-int textwidth;
-int second_indent;
-int flags;
-int format_only;
-int c;             /* character to be inserted (can be NUL) */
+static void 
+internal_format (
+    int textwidth,
+    int second_indent,
+    int flags,
+    int format_only,
+    int c             /* character to be inserted (can be NUL) */
+)
 {
   int cc;
   int save_char = NUL;
@@ -5466,9 +5432,11 @@ int c;             /* character to be inserted (can be NUL) */
  * The caller must have saved the cursor line for undo, following ones will be
  * saved here.
  */
-void auto_format(trailblank, prev_line)
-int trailblank;                 /* when TRUE also format with trailing blank */
-int prev_line;                  /* may start in previous line */
+void 
+auto_format (
+    int trailblank,                 /* when TRUE also format with trailing blank */
+    int prev_line                  /* may start in previous line */
+)
 {
   pos_T pos;
   colnr_T len;
@@ -5566,8 +5534,10 @@ int prev_line;                  /* may start in previous line */
  * delete it now.  The space must be under the cursor, just after the insert
  * position.
  */
-static void check_auto_format(end_insert)
-int end_insert;                     /* TRUE when ending Insert mode */
+static void 
+check_auto_format (
+    int end_insert                     /* TRUE when ending Insert mode */
+)
 {
   int c = ' ';
   int cc;
@@ -5599,8 +5569,10 @@ int end_insert;                     /* TRUE when ending Insert mode */
  *	if invalid value, use 0.
  *	Set default to window width (maximum 79) for "gq" operator.
  */
-int comp_textwidth(ff)
-int ff;                 /* force formatting (for "gq" command) */
+int 
+comp_textwidth (
+    int ff                 /* force formatting (for "gq" command) */
+)
 {
   int textwidth;
 
@@ -5628,8 +5600,7 @@ int ff;                 /* force formatting (for "gq" command) */
 /*
  * Put a character in the redo buffer, for when just after a CTRL-V.
  */
-static void redo_literal(c)
-int c;
+static void redo_literal(int c)
 {
   char_u buf[10];
 
@@ -5646,8 +5617,10 @@ int c;
  * start_arrow() is called when an arrow key is used in insert mode.
  * For undo/redo it resembles hitting the <ESC> key.
  */
-static void start_arrow(end_insert_pos)
-pos_T    *end_insert_pos;           /* can be NULL */
+static void 
+start_arrow (
+    pos_T *end_insert_pos           /* can be NULL */
+)
 {
   if (!arrow_used) {        /* something has been inserted */
     AppendToRedobuff(ESC_STR);
@@ -5661,7 +5634,7 @@ pos_T    *end_insert_pos;           /* can be NULL */
  * If we skipped highlighting word at cursor, do it now.
  * It may be skipped again, thus reset spell_redraw_lnum first.
  */
-static void check_spell_redraw()                 {
+static void check_spell_redraw(void)                 {
   if (spell_redraw_lnum != 0) {
     linenr_T lnum = spell_redraw_lnum;
 
@@ -5674,7 +5647,7 @@ static void check_spell_redraw()                 {
  * Called when starting CTRL_X_SPELL mode: Move backwards to a previous badly
  * spelled word, if there is one.
  */
-static void spell_back_to_badword()                 {
+static void spell_back_to_badword(void)                 {
   pos_T tpos = curwin->w_cursor;
 
   spell_bad_len = spell_move_to(curwin, BACKWARD, TRUE, TRUE, NULL);
@@ -5687,7 +5660,7 @@ static void spell_back_to_badword()                 {
  * If an arrow key has been used, start a new insertion.
  * Returns FAIL if undo is impossible, shouldn't insert then.
  */
-int stop_arrow()         {
+int stop_arrow(void)         {
   if (arrow_used) {
     if (u_save_cursor() == OK) {
       arrow_used = FALSE;
@@ -5719,10 +5692,12 @@ int stop_arrow()         {
  * "end_insert_pos" is where insert ended.  It is NULL when we already jumped
  * to another window/buffer.
  */
-static void stop_insert(end_insert_pos, esc, nomove)
-pos_T       *end_insert_pos;
-int esc;                                /* called by ins_esc() */
-int nomove;                             /* <c-\><c-o>, don't move cursor */
+static void 
+stop_insert (
+    pos_T *end_insert_pos,
+    int esc,                                /* called by ins_esc() */
+    int nomove                             /* <c-\><c-o>, don't move cursor */
+)
 {
   int cc;
   char_u      *ptr;
@@ -5836,8 +5811,7 @@ int nomove;                             /* <c-\><c-o>, don't move cursor */
  * Set the last inserted text to a single character.
  * Used for the replace command.
  */
-void set_last_insert(c)
-int c;
+void set_last_insert(int c)
 {
   char_u      *s;
 
@@ -5856,7 +5830,7 @@ int c;
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_last_insert()          {
+void free_last_insert(void)          {
   vim_free(last_insert);
   last_insert = NULL;
   vim_free(compl_orig_text);
@@ -5870,9 +5844,7 @@ void free_last_insert()          {
  * and CSI.  Handle multi-byte characters.
  * Returns a pointer to after the added bytes.
  */
-char_u * add_char2buf(c, s)
-int c;
-char_u      *s;
+char_u *add_char2buf(int c, char_u *s)
 {
   char_u temp[MB_MAXBYTES + 1];
   int i;
@@ -5899,8 +5871,7 @@ char_u      *s;
  *			    otherwise keep "curswant" column
  * if flags & BL_FIX	don't leave the cursor on a NUL.
  */
-void beginline(flags)
-int flags;
+void beginline(int flags)
 {
   if ((flags & BL_SOL) && !p_sol)
     coladvance(curwin->w_curswant);
@@ -5927,7 +5898,7 @@ int flags;
  * Return OK when successful, FAIL when we hit a line of file boundary.
  */
 
-int oneright()         {
+int oneright(void)         {
   char_u      *ptr;
   int l;
 
@@ -5967,7 +5938,7 @@ int oneright()         {
   return OK;
 }
 
-int oneleft()         {
+int oneleft(void)         {
   if (virtual_active()) {
     int width;
     int v = getviscol();
@@ -6016,9 +5987,11 @@ int oneleft()         {
   return OK;
 }
 
-int cursor_up(n, upd_topline)
-long n;
-int upd_topline;                    /* When TRUE: update topline */
+int 
+cursor_up (
+    long n,
+    int upd_topline                    /* When TRUE: update topline */
+)
 {
   linenr_T lnum;
 
@@ -6067,9 +6040,11 @@ int upd_topline;                    /* When TRUE: update topline */
 /*
  * Cursor down a number of logical lines.
  */
-int cursor_down(n, upd_topline)
-long n;
-int upd_topline;                    /* When TRUE: update topline */
+int 
+cursor_down (
+    long n,
+    int upd_topline                    /* When TRUE: update topline */
+)
 {
   linenr_T lnum;
 
@@ -6118,10 +6093,12 @@ int upd_topline;                    /* When TRUE: update topline */
  * Last_insert actually is a copy of the redo buffer, so we
  * first have to remove the command.
  */
-int stuff_inserted(c, count, no_esc)
-int c;                  /* Command character to be inserted */
-long count;             /* Repeat this many times */
-int no_esc;             /* Don't add an ESC at the end */
+int 
+stuff_inserted (
+    int c,                  /* Command character to be inserted */
+    long count,             /* Repeat this many times */
+    int no_esc             /* Don't add an ESC at the end */
+)
 {
   char_u      *esc_ptr;
   char_u      *ptr;
@@ -6173,7 +6150,7 @@ int no_esc;             /* Don't add an ESC at the end */
   return OK;
 }
 
-char_u * get_last_insert()              {
+char_u *get_last_insert(void)              {
   if (last_insert == NULL)
     return NULL;
   return last_insert + last_insert_skip;
@@ -6183,7 +6160,7 @@ char_u * get_last_insert()              {
  * Get last inserted string, and remove trailing <Esc>.
  * Returns pointer to allocated memory (must be freed) or NULL.
  */
-char_u * get_last_insert_save()              {
+char_u *get_last_insert_save(void)              {
   char_u      *s;
   int len;
 
@@ -6204,8 +6181,7 @@ char_u * get_last_insert_save()              {
  * When an abbreviation is recognized it is removed from the text and
  * the replacement string is inserted in typebuf.tb_buf[], followed by "c".
  */
-static int echeck_abbr(c)
-int c;
+static int echeck_abbr(int c)
 {
   /* Don't check for abbreviation in paste mode, when disabled and just
    * after moving around with cursor keys. */
@@ -6239,8 +6215,10 @@ static char_u   *replace_stack = NULL;
 static long replace_stack_nr = 0;           /* next entry in replace stack */
 static long replace_stack_len = 0;          /* max. number of entries */
 
-void replace_push(c)
-int c;              /* character that is replaced (NUL is none) */
+void 
+replace_push (
+    int c              /* character that is replaced (NUL is none) */
+)
 {
   char_u  *p;
 
@@ -6272,8 +6250,7 @@ int c;              /* character that is replaced (NUL is none) */
  * reverse byte order, so that the first byte is popped off first.
  * Return the number of bytes done (includes composing characters).
  */
-int replace_push_mb(p)
-char_u *p;
+int replace_push_mb(char_u *p)
 {
   int l = (*mb_ptr2len)(p);
   int j;
@@ -6288,7 +6265,7 @@ char_u *p;
  * return -1 if stack empty
  * return replaced character or NUL otherwise
  */
-static int replace_pop()                {
+static int replace_pop(void)                {
   if (replace_stack_nr == 0)
     return -1;
   return (int)replace_stack[--replace_stack_nr];
@@ -6298,8 +6275,10 @@ static int replace_pop()                {
  * Join the top two items on the replace stack.  This removes to "off"'th NUL
  * encountered.
  */
-static void replace_join(off)
-int off;                /* offset for which NUL to remove */
+static void 
+replace_join (
+    int off                /* offset for which NUL to remove */
+)
 {
   int i;
 
@@ -6316,7 +6295,7 @@ int off;                /* offset for which NUL to remove */
  * Pop bytes from the replace stack until a NUL is found, and insert them
  * before the cursor.  Can only be used in REPLACE or VREPLACE mode.
  */
-static void replace_pop_ins()                 {
+static void replace_pop_ins(void)                 {
   int cc;
   int oldState = State;
 
@@ -6332,8 +6311,7 @@ static void replace_pop_ins()                 {
  * Insert bytes popped from the replace stack. "cc" is the first byte.  If it
  * indicates a multi-byte char, pop the other bytes too.
  */
-static void mb_replace_pop_ins(cc)
-int cc;
+static void mb_replace_pop_ins(int cc)
 {
   int n;
   char_u buf[MB_MAXBYTES + 1];
@@ -6378,7 +6356,7 @@ int cc;
  * make the replace stack empty
  * (called when exiting replace mode)
  */
-static void replace_flush()                 {
+static void replace_flush(void)                 {
   vim_free(replace_stack);
   replace_stack = NULL;
   replace_stack_len = 0;
@@ -6394,8 +6372,7 @@ static void replace_flush()                 {
  * When "limit_col" is >= 0, don't delete before this column.  Matters when
  * using composing characters, use del_char_after_col() instead of del_char().
  */
-static void replace_do_bs(limit_col)
-int limit_col;
+static void replace_do_bs(int limit_col)
 {
   int cc;
   int orig_len = 0;
@@ -6456,7 +6433,7 @@ int limit_col;
 /*
  * Return TRUE if C-indenting is on.
  */
-static int cindent_on()                {
+static int cindent_on(void)                {
   return !p_paste && (curbuf->b_p_cin
                       || *curbuf->b_p_inde != NUL
                       );
@@ -6477,7 +6454,7 @@ int (*get_the_indent)__ARGS((void));
     did_ai = TRUE;          /* delete the indent if the line stays empty */
 }
 
-void fix_indent()          {
+void fix_indent(void)          {
   if (p_paste)
     return;
   if (curbuf->b_p_lisp && curbuf->b_p_ai)
@@ -6499,10 +6476,7 @@ void fix_indent()          {
  *
  * If line_is_empty is TRUE accept keys with '0' before them.
  */
-int in_cinkeys(keytyped, when, line_is_empty)
-int keytyped;
-int when;
-int line_is_empty;
+int in_cinkeys(int keytyped, int when, int line_is_empty)
 {
   char_u      *look;
   int try_match;
@@ -6716,8 +6690,7 @@ int line_is_empty;
 /*
  * Map Hebrew keyboard when in hkmap mode.
  */
-int hkmap(c)
-int c;
+int hkmap(int c)
 {
   if (p_hkmapp) {   /* phonetic mapping, by Ilya Dogolazky */
     enum {hALEF=0, BET, GIMEL, DALET, HEI, VAV, ZAIN, HET, TET, IUD,
@@ -6782,7 +6755,7 @@ int c;
   }
 }
 
-static void ins_reg()                 {
+static void ins_reg(void)                 {
   int need_redraw = FALSE;
   int regname;
   int literally = 0;
@@ -6878,7 +6851,7 @@ static void ins_reg()                 {
 /*
  * CTRL-G commands in Insert mode.
  */
-static void ins_ctrl_g()                 {
+static void ins_ctrl_g(void)                 {
   int c;
 
   /* Right after CTRL-X the cursor will be after the ruler. */
@@ -6921,7 +6894,7 @@ static void ins_ctrl_g()                 {
 /*
  * CTRL-^ in Insert mode.
  */
-static void ins_ctrl_hat()                 {
+static void ins_ctrl_hat(void)                 {
   if (map_to_exists_mode((char_u *)"", LANGMAP, FALSE)) {
     /* ":lmap" mappings exists, Toggle use of ":lmap" mappings. */
     if (State & LANGMAP) {
@@ -6959,10 +6932,12 @@ static void ins_ctrl_hat()                 {
  * Returns TRUE when leaving insert mode, FALSE when going to repeat the
  * insert.
  */
-static int ins_esc(count, cmdchar, nomove)
-long        *count;
-int cmdchar;
-int nomove;                 /* don't move cursor */
+static int 
+ins_esc (
+    long *count,
+    int cmdchar,
+    int nomove                 /* don't move cursor */
+)
 {
   int temp;
   static int disabled_redraw = FALSE;
@@ -7085,7 +7060,7 @@ int nomove;                 /* don't move cursor */
  * Toggle language: hkmap and revins_on.
  * Move to end of reverse inserted text.
  */
-static void ins_ctrl_()                 {
+static void ins_ctrl_(void)                 {
   if (revins_on && revins_chars && revins_scol >= 0) {
     while (gchar_cursor() != NUL && revins_chars--)
       ++curwin->w_cursor.col;
@@ -7119,8 +7094,7 @@ static void ins_ctrl_()                 {
  * If 'keymodel' contains "startsel", may start selection.
  * Returns TRUE when a CTRL-O and other keys stuffed.
  */
-static int ins_start_select(c)
-int c;
+static int ins_start_select(int c)
 {
   if (km_startsel)
     switch (c) {
@@ -7163,8 +7137,7 @@ int c;
 /*
  * <Insert> key in Insert mode: toggle insert/replace mode.
  */
-static void ins_insert(replaceState)
-int replaceState;
+static void ins_insert(int replaceState)
 {
   if (p_fkmap && p_ri) {
     beep_flush();
@@ -7191,7 +7164,7 @@ int replaceState;
 /*
  * Pressed CTRL-O in Insert mode.
  */
-static void ins_ctrl_o()                 {
+static void ins_ctrl_o(void)                 {
   if (State & VREPLACE_FLAG)
     restart_edit = 'V';
   else if (State & REPLACE_FLAG)
@@ -7211,9 +7184,7 @@ static void ins_ctrl_o()                 {
  * with vi.  But vi only supports ^T and ^D after an
  * autoindent, we support it everywhere.
  */
-static void ins_shift(c, lastc)
-int c;
-int lastc;
+static void ins_shift(int c, int lastc)
 {
   if (stop_arrow() == FAIL)
     return;
@@ -7243,7 +7214,7 @@ int lastc;
   can_cindent = FALSE;          /* no cindenting after ^D or ^T */
 }
 
-static void ins_del()                 {
+static void ins_del(void)                 {
   int temp;
 
   if (stop_arrow() == FAIL)
@@ -7269,8 +7240,7 @@ static void ins_bs_one __ARGS((colnr_T *vcolp));
 /*
  * Delete one character for ins_bs().
  */
-static void ins_bs_one(vcolp)
-colnr_T     *vcolp;
+static void ins_bs_one(colnr_T *vcolp)
 {
   dec_cursor();
   getvcol(curwin, &curwin->w_cursor, vcolp, NULL, NULL);
@@ -7288,10 +7258,7 @@ colnr_T     *vcolp;
  * Handle Backspace, delete-word and delete-line in Insert mode.
  * Return TRUE when backspace was actually used.
  */
-static int ins_bs(c, mode, inserted_space_p)
-int c;
-int mode;
-int         *inserted_space_p;
+static int ins_bs(int c, int mode, int *inserted_space_p)
 {
   linenr_T lnum;
   int cc;
@@ -7600,8 +7567,7 @@ int         *inserted_space_p;
   return did_backspace;
 }
 
-static void ins_mouse(c)
-int c;
+static void ins_mouse(int c)
 {
   pos_T tpos;
   win_T       *old_curwin = curwin;
@@ -7632,8 +7598,7 @@ int c;
   redraw_statuslines();
 }
 
-static void ins_mousescroll(dir)
-int dir;
+static void ins_mousescroll(int dir)
 {
   pos_T tpos;
   win_T       *old_curwin = curwin;
@@ -7689,7 +7654,7 @@ int dir;
 
 
 
-static void ins_left()                 {
+static void ins_left(void)                 {
   pos_T tpos;
 
   if ((fdo_flags & FDO_HOR) && KeyTyped)
@@ -7716,8 +7681,7 @@ static void ins_left()                 {
     vim_beep();
 }
 
-static void ins_home(c)
-int c;
+static void ins_home(int c)
 {
   pos_T tpos;
 
@@ -7733,8 +7697,7 @@ int c;
   start_arrow(&tpos);
 }
 
-static void ins_end(c)
-int c;
+static void ins_end(int c)
 {
   pos_T tpos;
 
@@ -7750,7 +7713,7 @@ int c;
   start_arrow(&tpos);
 }
 
-static void ins_s_left()                 {
+static void ins_s_left(void)                 {
   if ((fdo_flags & FDO_HOR) && KeyTyped)
     foldOpenCursor();
   undisplay_dollar();
@@ -7762,7 +7725,7 @@ static void ins_s_left()                 {
     vim_beep();
 }
 
-static void ins_right()                 {
+static void ins_right(void)                 {
   if ((fdo_flags & FDO_HOR) && KeyTyped)
     foldOpenCursor();
   undisplay_dollar();
@@ -7796,7 +7759,7 @@ static void ins_right()                 {
     vim_beep();
 }
 
-static void ins_s_right()                 {
+static void ins_s_right(void)                 {
   if ((fdo_flags & FDO_HOR) && KeyTyped)
     foldOpenCursor();
   undisplay_dollar();
@@ -7809,8 +7772,10 @@ static void ins_s_right()                 {
     vim_beep();
 }
 
-static void ins_up(startcol)
-int startcol;                   /* when TRUE move to Insstart.col */
+static void 
+ins_up (
+    int startcol                   /* when TRUE move to Insstart.col */
+)
 {
   pos_T tpos;
   linenr_T old_topline = curwin->w_topline;
@@ -7831,7 +7796,7 @@ int startcol;                   /* when TRUE move to Insstart.col */
     vim_beep();
 }
 
-static void ins_pageup()                 {
+static void ins_pageup(void)                 {
   pos_T tpos;
 
   undisplay_dollar();
@@ -7853,8 +7818,10 @@ static void ins_pageup()                 {
     vim_beep();
 }
 
-static void ins_down(startcol)
-int startcol;                   /* when TRUE move to Insstart.col */
+static void 
+ins_down (
+    int startcol                   /* when TRUE move to Insstart.col */
+)
 {
   pos_T tpos;
   linenr_T old_topline = curwin->w_topline;
@@ -7875,7 +7842,7 @@ int startcol;                   /* when TRUE move to Insstart.col */
     vim_beep();
 }
 
-static void ins_pagedown()                 {
+static void ins_pagedown(void)                 {
   pos_T tpos;
 
   undisplay_dollar();
@@ -7901,7 +7868,7 @@ static void ins_pagedown()                 {
  * Handle TAB in Insert or Replace mode.
  * Return TRUE when the TAB needs to be inserted like a normal character.
  */
-static int ins_tab()                {
+static int ins_tab(void)                {
   int ind;
   int i;
   int temp;
@@ -8085,8 +8052,7 @@ static int ins_tab()                {
  * Handle CR or NL in insert mode.
  * Return TRUE when out of memory or can't undo.
  */
-static int ins_eol(c)
-int c;
+static int ins_eol(int c)
 {
   int i;
 
@@ -8142,7 +8108,7 @@ int c;
  * Returns character still to be inserted, or NUL when nothing remaining to be
  * done.
  */
-static int ins_digraph()                {
+static int ins_digraph(void)                {
   int c;
   int cc;
   int did_putchar = FALSE;
@@ -8215,8 +8181,7 @@ static int ins_digraph()                {
  * Handle CTRL-E and CTRL-Y in Insert mode: copy char from other line.
  * Returns the char to be inserted, or NUL if none found.
  */
-int ins_copychar(lnum)
-linenr_T lnum;
+int ins_copychar(linenr_T lnum)
 {
   int c;
   int temp;
@@ -8248,8 +8213,7 @@ linenr_T lnum;
 /*
  * CTRL-Y or CTRL-E typed in Insert mode.
  */
-static int ins_ctrl_ey(tc)
-int tc;
+static int ins_ctrl_ey(int tc)
 {
   int c = tc;
 
@@ -8287,8 +8251,7 @@ int tc;
  * Try to do some very smart auto-indenting.
  * Used when inserting a "normal" character.
  */
-static void ins_try_si(c)
-int c;
+static void ins_try_si(int c)
 {
   pos_T       *pos, old_pos;
   char_u      *ptr;
@@ -8369,7 +8332,7 @@ int c;
  * Get the value that w_virtcol would have when 'list' is off.
  * Unless 'cpo' contains the 'L' flag.
  */
-static colnr_T get_nolist_virtcol()                    {
+static colnr_T get_nolist_virtcol(void)                    {
   if (curwin->w_p_list && vim_strchr(p_cpo, CPO_LISTWM) == NULL)
     return getvcol_nolist(&curwin->w_cursor);
   validate_virtcol();
@@ -8382,8 +8345,7 @@ static colnr_T get_nolist_virtcol()                    {
  * Return a pointer to allocated memory with the replacement string.
  * Return NULL to continue inserting "c".
  */
-static char_u * do_insert_char_pre(c)
-int c;
+static char_u *do_insert_char_pre(int c)
 {
   char_u      *res;
   char_u buf[MB_MAXBYTES + 1];

--- a/src/eval.c
+++ b/src/eval.c
@@ -816,7 +816,7 @@ static void setwinvar __ARGS((typval_T *argvars, typval_T *rettv, int off));
 /*
  * Initialize the global and v: variables.
  */
-void eval_init()          {
+void eval_init(void)          {
   int i;
   struct vimvar   *p;
 
@@ -850,7 +850,7 @@ void eval_init()          {
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void eval_clear()          {
+void eval_clear(void)          {
   int i;
   struct vimvar   *p;
 
@@ -899,8 +899,7 @@ void eval_clear()          {
 /*
  * Return the name of the executed function.
  */
-char_u * func_name(cookie)
-void *cookie;
+char_u *func_name(void *cookie)
 {
   return ((funccall_T *)cookie)->func->uf_name;
 }
@@ -908,8 +907,7 @@ void *cookie;
 /*
  * Return the address holding the next breakpoint line for a funccall cookie.
  */
-linenr_T * func_breakpoint(cookie)
-void *cookie;
+linenr_T *func_breakpoint(void *cookie)
 {
   return &((funccall_T *)cookie)->breakpoint;
 }
@@ -917,8 +915,7 @@ void *cookie;
 /*
  * Return the address holding the debug tick for a funccall cookie.
  */
-int * func_dbg_tick(cookie)
-void *cookie;
+int *func_dbg_tick(void *cookie)
 {
   return &((funccall_T *)cookie)->dbg_tick;
 }
@@ -926,8 +923,7 @@ void *cookie;
 /*
  * Return the nesting level for a funccall cookie.
  */
-int func_level(cookie)
-void *cookie;
+int func_level(void *cookie)
 {
   return ((funccall_T *)cookie)->level;
 }
@@ -942,7 +938,7 @@ funccall_T *previous_funccal = NULL;
 /*
  * Return TRUE when a function was ended by a ":return" command.
  */
-int current_func_returned()         {
+int current_func_returned(void)         {
   return current_funccal->returned;
 }
 
@@ -950,9 +946,7 @@ int current_func_returned()         {
  * Set an internal variable to a string value. Creates the variable if it does
  * not already exist.
  */
-void set_internal_string_var(name, value)
-char_u      *name;
-char_u      *value;
+void set_internal_string_var(char_u *name, char_u *value)
 {
   char_u      *val;
   typval_T    *tvp;
@@ -976,9 +970,11 @@ static char_u   *redir_varname = NULL;
  * Start recording command output to a variable
  * Returns OK if successfully completed the setup.  FAIL otherwise.
  */
-int var_redir_start(name, append)
-char_u      *name;
-int append;                     /* append to an existing variable */
+int 
+var_redir_start (
+    char_u *name,
+    int append                     /* append to an existing variable */
+)
 {
   int save_emsg;
   int err;
@@ -1051,9 +1047,7 @@ int append;                     /* append to an existing variable */
  *   :let foo
  *   :redir END
  */
-void var_redir_str(value, value_len)
-char_u      *value;
-int value_len;
+void var_redir_str(char_u *value, int value_len)
 {
   int len;
 
@@ -1076,7 +1070,7 @@ int value_len;
  * Stop redirecting command output to a variable.
  * Frees the allocated memory.
  */
-void var_redir_stop()          {
+void var_redir_stop(void)          {
   typval_T tv;
 
   if (redir_lval != NULL) {
@@ -1105,11 +1099,7 @@ void var_redir_stop()          {
   redir_varname = NULL;
 }
 
-int eval_charconvert(enc_from, enc_to, fname_from, fname_to)
-char_u      *enc_from;
-char_u      *enc_to;
-char_u      *fname_from;
-char_u      *fname_to;
+int eval_charconvert(char_u *enc_from, char_u *enc_to, char_u *fname_from, char_u *fname_to)
 {
   int err = FALSE;
 
@@ -1129,9 +1119,7 @@ char_u      *fname_to;
   return OK;
 }
 
-int eval_printexpr(fname, args)
-char_u      *fname;
-char_u      *args;
+int eval_printexpr(char_u *fname, char_u *args)
 {
   int err = FALSE;
 
@@ -1149,10 +1137,7 @@ char_u      *args;
   return OK;
 }
 
-void eval_diff(origfile, newfile, outfile)
-char_u      *origfile;
-char_u      *newfile;
-char_u      *outfile;
+void eval_diff(char_u *origfile, char_u *newfile, char_u *outfile)
 {
   int err = FALSE;
 
@@ -1165,10 +1150,7 @@ char_u      *outfile;
   set_vim_var_string(VV_FNAME_OUT, NULL, -1);
 }
 
-void eval_patch(origfile, difffile, outfile)
-char_u      *origfile;
-char_u      *difffile;
-char_u      *outfile;
+void eval_patch(char_u *origfile, char_u *difffile, char_u *outfile)
 {
   int err;
 
@@ -1186,11 +1168,13 @@ char_u      *outfile;
  * Sets "error" to TRUE if there was an error.
  * Return TRUE or FALSE.
  */
-int eval_to_bool(arg, error, nextcmd, skip)
-char_u      *arg;
-int         *error;
-char_u      **nextcmd;
-int skip;                   /* only parse, don't execute */
+int 
+eval_to_bool (
+    char_u *arg,
+    int *error,
+    char_u **nextcmd,
+    int skip                   /* only parse, don't execute */
+)
 {
   typval_T tv;
   int retval = FALSE;
@@ -1217,10 +1201,12 @@ int skip;                   /* only parse, don't execute */
  * only parsing to "nextcmd" is done, without reporting errors.  Return
  * pointer to allocated memory, or NULL for failure or when "skip" is TRUE.
  */
-char_u * eval_to_string_skip(arg, nextcmd, skip)
-char_u      *arg;
-char_u      **nextcmd;
-int skip;                   /* only parse, don't execute */
+char_u *
+eval_to_string_skip (
+    char_u *arg,
+    char_u **nextcmd,
+    int skip                   /* only parse, don't execute */
+)
 {
   typval_T tv;
   char_u      *retval;
@@ -1243,8 +1229,7 @@ int skip;                   /* only parse, don't execute */
  * Skip over an expression at "*pp".
  * Return FAIL for an error, OK otherwise.
  */
-int skip_expr(pp)
-char_u      **pp;
+int skip_expr(char_u **pp)
 {
   typval_T rettv;
 
@@ -1258,10 +1243,7 @@ char_u      **pp;
  * a Float to a String.
  * Return pointer to allocated memory, or NULL for failure.
  */
-char_u * eval_to_string(arg, nextcmd, convert)
-char_u      *arg;
-char_u      **nextcmd;
-int convert;
+char_u *eval_to_string(char_u *arg, char_u **nextcmd, int convert)
 {
   typval_T tv;
   char_u      *retval;
@@ -1295,10 +1277,7 @@ int convert;
  * Call eval_to_string() without using current local variables and using
  * textlock.  When "use_sandbox" is TRUE use the sandbox.
  */
-char_u * eval_to_string_safe(arg, nextcmd, use_sandbox)
-char_u      *arg;
-char_u      **nextcmd;
-int use_sandbox;
+char_u *eval_to_string_safe(char_u *arg, char_u **nextcmd, int use_sandbox)
 {
   char_u      *retval;
   void        *save_funccalp;
@@ -1320,8 +1299,7 @@ int use_sandbox;
  * Evaluates "expr" silently.
  * Returns -1 for an error.
  */
-int eval_to_number(expr)
-char_u      *expr;
+int eval_to_number(char_u *expr)
 {
   typval_T rettv;
   int retval;
@@ -1345,9 +1323,7 @@ char_u      *expr;
  * Save the current typeval in "save_tv".
  * When not used yet add the variable to the v: hashtable.
  */
-static void prepare_vimvar(idx, save_tv)
-int idx;
-typval_T    *save_tv;
+static void prepare_vimvar(int idx, typval_T *save_tv)
 {
   *save_tv = vimvars[idx].vv_tv;
   if (vimvars[idx].vv_type == VAR_UNKNOWN)
@@ -1358,9 +1334,7 @@ typval_T    *save_tv;
  * Restore v: variable "idx" to typeval "save_tv".
  * When no longer defined, remove the variable from the v: hashtable.
  */
-static void restore_vimvar(idx, save_tv)
-int idx;
-typval_T    *save_tv;
+static void restore_vimvar(int idx, typval_T *save_tv)
 {
   hashitem_T  *hi;
 
@@ -1379,9 +1353,7 @@ typval_T    *save_tv;
  * For the "expr:" part of 'spellsuggest'.
  * Returns NULL when there is an error.
  */
-list_T * eval_spell_expr(badword, expr)
-char_u      *badword;
-char_u      *expr;
+list_T *eval_spell_expr(char_u *badword, char_u *expr)
 {
   typval_T save_val;
   typval_T rettv;
@@ -1415,9 +1387,7 @@ char_u      *expr;
  * Return -1 if anything isn't right.
  * Used to get the good word and score from the eval_spell_expr() result.
  */
-int get_spellword(list, pp)
-list_T      *list;
-char_u      **pp;
+int get_spellword(list_T *list, char_u **pp)
 {
   listitem_T  *li;
 
@@ -1437,9 +1407,7 @@ char_u      **pp;
  * Returns an allocated typval_T with the result.
  * Returns NULL when there is an error.
  */
-typval_T * eval_expr(arg, nextcmd)
-char_u      *arg;
-char_u      **nextcmd;
+typval_T *eval_expr(char_u *arg, char_u **nextcmd)
 {
   typval_T    *tv;
 
@@ -1459,13 +1427,15 @@ char_u      **nextcmd;
  * arguments are currently supported.
  * Returns OK or FAIL.
  */
-int call_vim_function(func, argc, argv, safe, str_arg_only, rettv)
-char_u      *func;
-int argc;
-char_u      **argv;
-int safe;                       /* use the sandbox */
-int str_arg_only;               /* all arguments are strings */
-typval_T    *rettv;
+int 
+call_vim_function (
+    char_u *func,
+    int argc,
+    char_u **argv,
+    int safe,                       /* use the sandbox */
+    int str_arg_only,               /* all arguments are strings */
+    typval_T *rettv
+)
 {
   typval_T    *argvars;
   long n;
@@ -1527,11 +1497,13 @@ typval_T    *rettv;
  * Returns -1 when calling the function fails.
  * Uses argv[argc] for the function arguments.
  */
-long call_func_retnr(func, argc, argv, safe)
-char_u      *func;
-int argc;
-char_u      **argv;
-int safe;                       /* use the sandbox */
+long 
+call_func_retnr (
+    char_u *func,
+    int argc,
+    char_u **argv,
+    int safe                       /* use the sandbox */
+)
 {
   typval_T rettv;
   long retval;
@@ -1553,11 +1525,13 @@ int safe;                       /* use the sandbox */
  * Returns NULL when calling the function fails.
  * Uses argv[argc] for the function arguments.
  */
-void * call_func_retstr(func, argc, argv, safe)
-char_u      *func;
-int argc;
-char_u      **argv;
-int safe;                       /* use the sandbox */
+void *
+call_func_retstr (
+    char_u *func,
+    int argc,
+    char_u **argv,
+    int safe                       /* use the sandbox */
+)
 {
   typval_T rettv;
   char_u      *retval;
@@ -1576,11 +1550,13 @@ int safe;                       /* use the sandbox */
  * Uses argv[argc] for the function arguments.
  * Returns NULL when there is something wrong.
  */
-void * call_func_retlist(func, argc, argv, safe)
-char_u      *func;
-int argc;
-char_u      **argv;
-int safe;                       /* use the sandbox */
+void *
+call_func_retlist (
+    char_u *func,
+    int argc,
+    char_u **argv,
+    int safe                       /* use the sandbox */
+)
 {
   typval_T rettv;
 
@@ -1601,15 +1577,14 @@ int safe;                       /* use the sandbox */
  * Save the current function call pointer, and set it to NULL.
  * Used when executing autocommands and for ":source".
  */
-void * save_funccal()            {
+void *save_funccal(void)            {
   funccall_T *fc = current_funccal;
 
   current_funccal = NULL;
   return (void *)fc;
 }
 
-void restore_funccal(vfc)
-void *vfc;
+void restore_funccal(void *vfc)
 {
   funccall_T *fc = (funccall_T *)vfc;
 
@@ -1654,9 +1629,7 @@ proftime_T *tm;         /* where waittime was stored */
  * Evaluate 'foldexpr'.  Returns the foldlevel, and any character preceding
  * it in "*cp".  Doesn't give error messages.
  */
-int eval_foldexpr(arg, cp)
-char_u      *arg;
-int         *cp;
+int eval_foldexpr(char_u *arg, int *cp)
 {
   typval_T tv;
   int retval;
@@ -1704,8 +1677,7 @@ int         *cp;
  * ":let var .= expr"		assignment command.
  * ":let [var1, var2] = expr"	unpack list.
  */
-void ex_let(eap)
-exarg_T     *eap;
+void ex_let(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   char_u      *expr = NULL;
@@ -1775,13 +1747,15 @@ exarg_T     *eap;
  * or concatenate.
  * Returns OK or FAIL;
  */
-static int ex_let_vars(arg_start, tv, copy, semicolon, var_count, nextchars)
-char_u      *arg_start;
-typval_T    *tv;
-int copy;                       /* copy values from "tv", don't move */
-int semicolon;                  /* from skip_var_list() */
-int var_count;                  /* from skip_var_list() */
-char_u      *nextchars;
+static int 
+ex_let_vars (
+    char_u *arg_start,
+    typval_T *tv,
+    int copy,                       /* copy values from "tv", don't move */
+    int semicolon,                  /* from skip_var_list() */
+    int var_count,                  /* from skip_var_list() */
+    char_u *nextchars
+)
 {
   char_u      *arg = arg_start;
   list_T      *l;
@@ -1863,10 +1837,7 @@ char_u      *nextchars;
  * for "[var, var; var]" set "semicolon".
  * Return NULL for an error.
  */
-static char_u * skip_var_list(arg, var_count, semicolon)
-char_u      *arg;
-int         *var_count;
-int         *semicolon;
+static char_u *skip_var_list(char_u *arg, int *var_count, int *semicolon)
 {
   char_u      *p, *s;
 
@@ -1905,8 +1876,7 @@ int         *semicolon;
  * Skip one (assignable) variable name, including @r, $VAR, &option, d.key,
  * l[idx].
  */
-static char_u * skip_var_one(arg)
-char_u      *arg;
+static char_u *skip_var_one(char_u *arg)
 {
   if (*arg == '@' && arg[1] != NUL)
     return arg + 2;
@@ -1918,11 +1888,7 @@ char_u      *arg;
  * List variables for hashtab "ht" with prefix "prefix".
  * If "empty" is TRUE also list NULL strings as empty strings.
  */
-static void list_hashtable_vars(ht, prefix, empty, first)
-hashtab_T   *ht;
-char_u      *prefix;
-int empty;
-int         *first;
+static void list_hashtable_vars(hashtab_T *ht, char_u *prefix, int empty, int *first)
 {
   hashitem_T  *hi;
   dictitem_T  *di;
@@ -1943,8 +1909,7 @@ int         *first;
 /*
  * List global variables.
  */
-static void list_glob_vars(first)
-int *first;
+static void list_glob_vars(int *first)
 {
   list_hashtable_vars(&globvarht, (char_u *)"", TRUE, first);
 }
@@ -1952,8 +1917,7 @@ int *first;
 /*
  * List buffer variables.
  */
-static void list_buf_vars(first)
-int *first;
+static void list_buf_vars(int *first)
 {
   char_u numbuf[NUMBUFLEN];
 
@@ -1968,8 +1932,7 @@ int *first;
 /*
  * List window variables.
  */
-static void list_win_vars(first)
-int *first;
+static void list_win_vars(int *first)
 {
   list_hashtable_vars(&curwin->w_vars->dv_hashtab,
       (char_u *)"w:", TRUE, first);
@@ -1978,8 +1941,7 @@ int *first;
 /*
  * List tab page variables.
  */
-static void list_tab_vars(first)
-int *first;
+static void list_tab_vars(int *first)
 {
   list_hashtable_vars(&curtab->tp_vars->dv_hashtab,
       (char_u *)"t:", TRUE, first);
@@ -1988,8 +1950,7 @@ int *first;
 /*
  * List Vim variables.
  */
-static void list_vim_vars(first)
-int *first;
+static void list_vim_vars(int *first)
 {
   list_hashtable_vars(&vimvarht, (char_u *)"v:", FALSE, first);
 }
@@ -1997,8 +1958,7 @@ int *first;
 /*
  * List script-local variables, if there is a script.
  */
-static void list_script_vars(first)
-int *first;
+static void list_script_vars(int *first)
 {
   if (current_SID > 0 && current_SID <= ga_scripts.ga_len)
     list_hashtable_vars(&SCRIPT_VARS(current_SID),
@@ -2008,8 +1968,7 @@ int *first;
 /*
  * List function variables, if there is a function.
  */
-static void list_func_vars(first)
-int *first;
+static void list_func_vars(int *first)
 {
   if (current_funccal != NULL)
     list_hashtable_vars(&current_funccal->l_vars.dv_hashtab,
@@ -2019,10 +1978,7 @@ int *first;
 /*
  * List variables in "arg".
  */
-static char_u * list_arg_vars(eap, arg, first)
-exarg_T     *eap;
-char_u      *arg;
-int         *first;
+static char_u *list_arg_vars(exarg_T *eap, char_u *arg, int *first)
 {
   int error = FALSE;
   int len;
@@ -2112,12 +2068,14 @@ int         *first;
  * Returns a pointer to the char just after the var name.
  * Returns NULL if there is an error.
  */
-static char_u * ex_let_one(arg, tv, copy, endchars, op)
-char_u      *arg;               /* points to variable name */
-typval_T    *tv;                /* value to assign to variable */
-int copy;                       /* copy value from "tv" */
-char_u      *endchars;          /* valid chars after variable name  or NULL */
-char_u      *op;                /* "+", "-", "."  or NULL*/
+static char_u *
+ex_let_one (
+    char_u *arg,               /* points to variable name */
+    typval_T *tv,                /* value to assign to variable */
+    int copy,                       /* copy value from "tv" */
+    char_u *endchars,          /* valid chars after variable name  or NULL */
+    char_u *op                /* "+", "-", "."  or NULL*/
+)
 {
   int c1;
   char_u      *name;
@@ -2278,8 +2236,7 @@ char_u      *op;                /* "+", "-", "."  or NULL*/
 /*
  * If "arg" is equal to "b:changedtick" give an error and return TRUE.
  */
-static int check_changedtick(arg)
-char_u      *arg;
+static int check_changedtick(char_u *arg)
 {
   if (STRNCMP(arg, "b:changedtick", 13) == 0 && !eval_isnamec(arg[13])) {
     EMSG2(_(e_readonlyvar), arg);
@@ -2306,14 +2263,16 @@ char_u      *arg;
  * When an evaluation error occurs "lp->ll_name" is NULL;
  * Returns NULL for a parsing error.  Still need to free items in "lp"!
  */
-static char_u * get_lval(name, rettv, lp, unlet, skip, flags, fne_flags)
-char_u      *name;
-typval_T    *rettv;
-lval_T      *lp;
-int unlet;
-int skip;
-int flags;                  /* GLV_ values */
-int fne_flags;              /* flags for find_name_end() */
+static char_u *
+get_lval (
+    char_u *name,
+    typval_T *rettv,
+    lval_T *lp,
+    int unlet,
+    int skip,
+    int flags,                  /* GLV_ values */
+    int fne_flags              /* flags for find_name_end() */
+)
 {
   char_u      *p;
   char_u      *expr_start, *expr_end;
@@ -2608,8 +2567,7 @@ int fne_flags;              /* flags for find_name_end() */
 /*
  * Clear lval "lp" that was filled by get_lval().
  */
-static void clear_lval(lp)
-lval_T      *lp;
+static void clear_lval(lval_T *lp)
 {
   vim_free(lp->ll_exp_name);
   vim_free(lp->ll_newkey);
@@ -2620,12 +2578,7 @@ lval_T      *lp;
  * "endp" points to just after the parsed name.
  * "op" is NULL, "+" for "+=", "-" for "-=", "." for ".=" or "=" for "=".
  */
-static void set_var_lval(lp, endp, rettv, copy, op)
-lval_T      *lp;
-char_u      *endp;
-typval_T    *rettv;
-int copy;
-char_u      *op;
+static void set_var_lval(lval_T *lp, char_u *endp, typval_T *rettv, int copy, char_u *op)
 {
   int cc;
   listitem_T  *ri;
@@ -2725,10 +2678,7 @@ char_u      *op;
  * Handle "tv1 += tv2", "tv1 -= tv2" and "tv1 .= tv2"
  * Returns OK or FAIL.
  */
-static int tv_op(tv1, tv2, op)
-typval_T *tv1;
-typval_T *tv2;
-char_u  *op;
+static int tv_op(typval_T *tv1, typval_T *tv2, char_u *op)
 {
   long n;
   char_u numbuf[NUMBUFLEN];
@@ -2816,9 +2766,7 @@ char_u  *op;
 /*
  * Add a watcher to a list.
  */
-void list_add_watch(l, lw)
-list_T      *l;
-listwatch_T *lw;
+void list_add_watch(list_T *l, listwatch_T *lw)
 {
   lw->lw_next = l->lv_watch;
   l->lv_watch = lw;
@@ -2828,9 +2776,7 @@ listwatch_T *lw;
  * Remove a watcher from a list.
  * No warning when it isn't found...
  */
-void list_rem_watch(l, lwrem)
-list_T      *l;
-listwatch_T *lwrem;
+void list_rem_watch(list_T *l, listwatch_T *lwrem)
 {
   listwatch_T *lw, **lwp;
 
@@ -2848,9 +2794,7 @@ listwatch_T *lwrem;
  * Just before removing an item from a list: advance watchers to the next
  * item.
  */
-static void list_fix_watch(l, item)
-list_T      *l;
-listitem_T  *item;
+static void list_fix_watch(list_T *l, listitem_T *item)
 {
   listwatch_T *lw;
 
@@ -2865,11 +2809,7 @@ listitem_T  *item;
  * Set "*errp" to TRUE for an error, FALSE otherwise;
  * Return a pointer that holds the info.  Null when there is an error.
  */
-void * eval_for_line(arg, errp, nextcmdp, skip)
-char_u      *arg;
-int         *errp;
-char_u      **nextcmdp;
-int skip;
+void *eval_for_line(char_u *arg, int *errp, char_u **nextcmdp, int skip)
 {
   forinfo_T   *fi;
   char_u      *expr;
@@ -2922,9 +2862,7 @@ int skip;
  * Return TRUE when a valid item was found, FALSE when at end of list or
  * something wrong.
  */
-int next_for_item(fi_void, arg)
-void        *fi_void;
-char_u      *arg;
+int next_for_item(void *fi_void, char_u *arg)
 {
   forinfo_T   *fi = (forinfo_T *)fi_void;
   int result;
@@ -2944,8 +2882,7 @@ char_u      *arg;
 /*
  * Free the structure used to store info used by ":for".
  */
-void free_for_info(fi_void)
-void *fi_void;
+void free_for_info(void *fi_void)
 {
   forinfo_T    *fi = (forinfo_T *)fi_void;
 
@@ -2957,10 +2894,7 @@ void *fi_void;
 }
 
 
-void set_context_for_expression(xp, arg, cmdidx)
-expand_T    *xp;
-char_u      *arg;
-cmdidx_T cmdidx;
+void set_context_for_expression(expand_T *xp, char_u *arg, cmdidx_T cmdidx)
 {
   int got_eq = FALSE;
   int c;
@@ -3042,8 +2976,7 @@ cmdidx_T cmdidx;
 /*
  * ":1,25call func(arg1, arg2)"	function call.
  */
-void ex_call(eap)
-exarg_T     *eap;
+void ex_call(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   char_u      *startarg;
@@ -3157,8 +3090,7 @@ end:
 /*
  * ":unlet[!] var1 ... " command.
  */
-void ex_unlet(eap)
-exarg_T     *eap;
+void ex_unlet(exarg_T *eap)
 {
   ex_unletlock(eap, eap->arg, 0);
 }
@@ -3166,8 +3098,7 @@ exarg_T     *eap;
 /*
  * ":lockvar" and ":unlockvar" commands
  */
-void ex_lockvar(eap)
-exarg_T     *eap;
+void ex_lockvar(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   int deep = 2;
@@ -3185,10 +3116,7 @@ exarg_T     *eap;
 /*
  * ":unlet", ":lockvar" and ":unlockvar" are quite similar.
  */
-static void ex_unletlock(eap, argstart, deep)
-exarg_T     *eap;
-char_u      *argstart;
-int deep;
+static void ex_unletlock(exarg_T *eap, char_u *argstart, int deep)
 {
   char_u      *arg = argstart;
   char_u      *name_end;
@@ -3232,10 +3160,7 @@ int deep;
   eap->nextcmd = check_nextcmd(arg);
 }
 
-static int do_unlet_var(lp, name_end, forceit)
-lval_T      *lp;
-char_u      *name_end;
-int forceit;
+static int do_unlet_var(lval_T *lp, char_u *name_end, int forceit)
 {
   int ret = OK;
   int cc;
@@ -3278,9 +3203,7 @@ int forceit;
  * "unlet" a variable.  Return OK if it existed, FAIL if not.
  * When "forceit" is TRUE don't complain if the variable doesn't exist.
  */
-int do_unlet(name, forceit)
-char_u      *name;
-int forceit;
+int do_unlet(char_u *name, int forceit)
 {
   hashtab_T   *ht;
   hashitem_T  *hi;
@@ -3310,11 +3233,7 @@ int forceit;
  * "deep" is the levels to go (-1 for unlimited);
  * "lock" is TRUE for ":lockvar", FALSE for ":unlockvar".
  */
-static int do_lock_var(lp, name_end, deep, lock)
-lval_T      *lp;
-char_u      *name_end;
-int deep;
-int lock;
+static int do_lock_var(lval_T *lp, char_u *name_end, int deep, int lock)
 {
   int ret = OK;
   int cc;
@@ -3365,10 +3284,7 @@ int lock;
 /*
  * Lock or unlock an item.  "deep" is nr of levels to go.
  */
-static void item_lock(tv, deep, lock)
-typval_T    *tv;
-int deep;
-int lock;
+static void item_lock(typval_T *tv, int deep, int lock)
 {
   static int recurse = 0;
   list_T      *l;
@@ -3429,8 +3345,7 @@ int lock;
  * Return TRUE if typeval "tv" is locked: Either that value is locked itself
  * or it refers to a List or Dictionary that is locked.
  */
-static int tv_islocked(tv)
-typval_T    *tv;
+static int tv_islocked(typval_T *tv)
 {
   return (tv->v_lock & VAR_LOCKED)
          || (tv->v_type == VAR_LIST
@@ -3444,7 +3359,7 @@ typval_T    *tv;
 /*
  * Delete all "menutrans_" variables.
  */
-void del_menutrans_vars()          {
+void del_menutrans_vars(void)          {
   hashitem_T  *hi;
   int todo;
 
@@ -3474,9 +3389,7 @@ static int varnamebuflen = 0;
 /*
  * Function to concatenate a prefix and a variable name.
  */
-static char_u * cat_prefix_varname(prefix, name)
-int prefix;
-char_u      *name;
+static char_u *cat_prefix_varname(int prefix, char_u *name)
 {
   int len;
 
@@ -3501,9 +3414,7 @@ char_u      *name;
  * Function given to ExpandGeneric() to obtain the list of user defined
  * (global/buffer/window/built-in) variable names.
  */
-char_u * get_user_var_name(xp, idx)
-expand_T    *xp;
-int idx;
+char_u *get_user_var_name(expand_T *xp, int idx)
 {
   static long_u gdone;
   static long_u bdone;
@@ -3610,11 +3521,7 @@ typedef enum {
  * Note: "rettv.v_lock" is not set.
  * Return OK or FAIL.
  */
-static int eval0(arg, rettv, nextcmd, evaluate)
-char_u      *arg;
-typval_T    *rettv;
-char_u      **nextcmd;
-int evaluate;
+static int eval0(char_u *arg, typval_T *rettv, char_u **nextcmd, int evaluate)
 {
   int ret;
   char_u      *p;
@@ -3650,10 +3557,7 @@ int evaluate;
  *
  * Return OK or FAIL.
  */
-static int eval1(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int eval1(char_u **arg, typval_T *rettv, int evaluate)
 {
   int result;
   typval_T var2;
@@ -3718,10 +3622,7 @@ int evaluate;
  *
  * Return OK or FAIL.
  */
-static int eval2(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int eval2(char_u **arg, typval_T *rettv, int evaluate)
 {
   typval_T var2;
   long result;
@@ -3784,10 +3685,7 @@ int evaluate;
  *
  * Return OK or FAIL.
  */
-static int eval3(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int eval3(char_u **arg, typval_T *rettv, int evaluate)
 {
   typval_T var2;
   long result;
@@ -3859,10 +3757,7 @@ int evaluate;
  *
  * Return OK or FAIL.
  */
-static int eval4(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int eval4(char_u **arg, typval_T *rettv, int evaluate)
 {
   typval_T var2;
   char_u      *p;
@@ -4121,10 +4016,7 @@ int evaluate;
  *
  * Return OK or FAIL.
  */
-static int eval5(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int eval5(char_u **arg, typval_T *rettv, int evaluate)
 {
   typval_T var2;
   typval_T var3;
@@ -4268,11 +4160,13 @@ int evaluate;
  *
  * Return OK or FAIL.
  */
-static int eval6(arg, rettv, evaluate, want_string)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
-int want_string;              /* after "." operator */
+static int 
+eval6 (
+    char_u **arg,
+    typval_T *rettv,
+    int evaluate,
+    int want_string              /* after "." operator */
+)
 {
   typval_T var2;
   int op;
@@ -4403,11 +4297,13 @@ int want_string;              /* after "." operator */
  *
  * Return OK or FAIL.
  */
-static int eval7(arg, rettv, evaluate, want_string)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
-int want_string UNUSED;                 /* after "." operator */
+static int 
+eval7 (
+    char_u **arg,
+    typval_T *rettv,
+    int evaluate,
+    int want_string                 /* after "." operator */
+)
 {
   long n;
   int len;
@@ -4656,11 +4552,13 @@ int want_string UNUSED;                 /* after "." operator */
  * "*arg" points to the '[' or '.'.
  * Returns FAIL or OK. "*arg" is advanced to after the ']'.
  */
-static int eval_index(arg, rettv, evaluate, verbose)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
-int verbose;                    /* give error messages */
+static int 
+eval_index (
+    char_u **arg,
+    typval_T *rettv,
+    int evaluate,
+    int verbose                    /* give error messages */
+)
 {
   int empty1 = FALSE, empty2 = FALSE;
   typval_T var1, var2;
@@ -4883,10 +4781,12 @@ int verbose;                    /* give error messages */
  * "arg" is advanced to character after the option name.
  * Return OK or FAIL.
  */
-static int get_option_tv(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;     /* when NULL, only check if option exists */
-int evaluate;
+static int 
+get_option_tv (
+    char_u **arg,
+    typval_T *rettv,     /* when NULL, only check if option exists */
+    int evaluate
+)
 {
   char_u      *option_end;
   long numval;
@@ -4948,10 +4848,7 @@ int evaluate;
  * Allocate a variable for a string constant.
  * Return OK or FAIL.
  */
-static int get_string_tv(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int get_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 {
   char_u      *p;
   char_u      *name;
@@ -5070,10 +4967,7 @@ int evaluate;
  * Allocate a variable for a 'str''ing' constant.
  * Return OK or FAIL.
  */
-static int get_lit_string_tv(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int get_lit_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 {
   char_u      *p;
   char_u      *str;
@@ -5129,10 +5023,7 @@ int evaluate;
  * Allocate a variable for a List and fill it from "*arg".
  * Return OK or FAIL.
  */
-static int get_list_tv(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int get_list_tv(char_u **arg, typval_T *rettv, int evaluate)
 {
   list_T      *l = NULL;
   typval_T tv;
@@ -5189,7 +5080,7 @@ failret:
  * Allocate an empty header for a list.
  * Caller should take care of the reference count.
  */
-list_T * list_alloc()              {
+list_T *list_alloc(void)              {
   list_T  *l;
 
   l = (list_T *)alloc_clear(sizeof(list_T));
@@ -5208,8 +5099,7 @@ list_T * list_alloc()              {
  * Allocate an empty list for a return value.
  * Returns OK or FAIL.
  */
-static int rettv_list_alloc(rettv)
-typval_T    *rettv;
+static int rettv_list_alloc(typval_T *rettv)
 {
   list_T      *l = list_alloc();
 
@@ -5226,8 +5116,7 @@ typval_T    *rettv;
  * Unreference a list: decrement the reference count and free it when it
  * becomes zero.
  */
-void list_unref(l)
-list_T *l;
+void list_unref(list_T *l)
 {
   if (l != NULL && --l->lv_refcount <= 0)
     list_free(l, TRUE);
@@ -5237,9 +5126,11 @@ list_T *l;
  * Free a list, including all items it points to.
  * Ignores the reference count.
  */
-void list_free(l, recurse)
-list_T  *l;
-int recurse;            /* Free Lists and Dictionaries recursively. */
+void 
+list_free (
+    list_T *l,
+    int recurse            /* Free Lists and Dictionaries recursively. */
+)
 {
   listitem_T *item;
 
@@ -5265,15 +5156,14 @@ int recurse;            /* Free Lists and Dictionaries recursively. */
 /*
  * Allocate a list item.
  */
-listitem_T * listitem_alloc()                  {
+listitem_T *listitem_alloc(void)                  {
   return (listitem_T *)alloc(sizeof(listitem_T));
 }
 
 /*
  * Free a list item.  Also clears the value.  Does not notify watchers.
  */
-void listitem_free(item)
-listitem_T *item;
+void listitem_free(listitem_T *item)
 {
   clear_tv(&item->li_tv);
   vim_free(item);
@@ -5282,9 +5172,7 @@ listitem_T *item;
 /*
  * Remove a list item from a List and free it.  Also clears the value.
  */
-void listitem_remove(l, item)
-list_T  *l;
-listitem_T *item;
+void listitem_remove(list_T *l, listitem_T *item)
 {
   list_remove(l, item, item);
   listitem_free(item);
@@ -5293,8 +5181,7 @@ listitem_T *item;
 /*
  * Get the number of items in a list.
  */
-static long list_len(l)
-list_T      *l;
+static long list_len(list_T *l)
 {
   if (l == NULL)
     return 0L;
@@ -5304,11 +5191,13 @@ list_T      *l;
 /*
  * Return TRUE when two lists have exactly the same values.
  */
-static int list_equal(l1, l2, ic, recursive)
-list_T      *l1;
-list_T      *l2;
-int ic;                 /* ignore case for strings */
-int recursive;              /* TRUE when used recursively */
+static int 
+list_equal (
+    list_T *l1,
+    list_T *l2,
+    int ic,                 /* ignore case for strings */
+    int recursive              /* TRUE when used recursively */
+)
 {
   listitem_T  *item1, *item2;
 
@@ -5332,8 +5221,7 @@ int recursive;              /* TRUE when used recursively */
 /*
  * Return the dictitem that an entry in a hashtable points to.
  */
-dictitem_T * dict_lookup(hi)
-hashitem_T *hi;
+dictitem_T *dict_lookup(hashitem_T *hi)
 {
   return HI2DI(hi);
 }
@@ -5342,11 +5230,13 @@ hashitem_T *hi;
 /*
  * Return TRUE when two dictionaries have exactly the same key/values.
  */
-static int dict_equal(d1, d2, ic, recursive)
-dict_T      *d1;
-dict_T      *d2;
-int ic;                 /* ignore case for strings */
-int recursive;             /* TRUE when used recursively */
+static int 
+dict_equal (
+    dict_T *d1,
+    dict_T *d2,
+    int ic,                 /* ignore case for strings */
+    int recursive             /* TRUE when used recursively */
+)
 {
   hashitem_T  *hi;
   dictitem_T  *item2;
@@ -5380,11 +5270,13 @@ static int tv_equal_recurse_limit;
  * Compares the items just like "==" would compare them, but strings and
  * numbers are different.  Floats and numbers are also different.
  */
-static int tv_equal(tv1, tv2, ic, recursive)
-typval_T *tv1;
-typval_T *tv2;
-int ic;                     /* ignore case */
-int recursive;              /* TRUE when used recursively */
+static int 
+tv_equal (
+    typval_T *tv1,
+    typval_T *tv2,
+    int ic,                     /* ignore case */
+    int recursive              /* TRUE when used recursively */
+)
 {
   char_u buf1[NUMBUFLEN], buf2[NUMBUFLEN];
   char_u      *s1, *s2;
@@ -5446,9 +5338,7 @@ int recursive;              /* TRUE when used recursively */
  * A negative index is counted from the end; -1 is the last item.
  * Returns NULL when "n" is out of range.
  */
-listitem_T * list_find(l, n)
-list_T      *l;
-long n;
+listitem_T *list_find(list_T *l, long n)
 {
   listitem_T  *item;
   long idx;
@@ -5512,10 +5402,12 @@ long n;
 /*
  * Get list item "l[idx]" as a number.
  */
-static long list_find_nr(l, idx, errorp)
-list_T      *l;
-long idx;
-int         *errorp;            /* set to TRUE when something wrong */
+static long 
+list_find_nr (
+    list_T *l,
+    long idx,
+    int *errorp            /* set to TRUE when something wrong */
+)
 {
   listitem_T  *li;
 
@@ -5531,9 +5423,7 @@ int         *errorp;            /* set to TRUE when something wrong */
 /*
  * Get list item "l[idx - 1]" as a string.  Returns NULL for failure.
  */
-char_u * list_find_str(l, idx)
-list_T      *l;
-long idx;
+char_u *list_find_str(list_T *l, long idx)
 {
   listitem_T  *li;
 
@@ -5549,9 +5439,7 @@ long idx;
  * Locate "item" list "l" and return its index.
  * Returns -1 when "item" is not in the list.
  */
-static long list_idx_of_item(l, item)
-list_T      *l;
-listitem_T  *item;
+static long list_idx_of_item(list_T *l, listitem_T *item)
 {
   long idx = 0;
   listitem_T  *li;
@@ -5569,9 +5457,7 @@ listitem_T  *item;
 /*
  * Append item "item" to the end of list "l".
  */
-void list_append(l, item)
-list_T      *l;
-listitem_T  *item;
+void list_append(list_T *l, listitem_T *item)
 {
   if (l->lv_last == NULL) {
     /* empty list */
@@ -5591,9 +5477,7 @@ listitem_T  *item;
  * Append typval_T "tv" to the end of list "l".
  * Return FAIL when out of memory.
  */
-int list_append_tv(l, tv)
-list_T      *l;
-typval_T    *tv;
+int list_append_tv(list_T *l, typval_T *tv)
 {
   listitem_T  *li = listitem_alloc();
 
@@ -5608,9 +5492,7 @@ typval_T    *tv;
  * Add a dictionary to a list.  Used by getqflist().
  * Return FAIL when out of memory.
  */
-int list_append_dict(list, dict)
-list_T      *list;
-dict_T      *dict;
+int list_append_dict(list_T *list, dict_T *dict)
 {
   listitem_T  *li = listitem_alloc();
 
@@ -5629,10 +5511,7 @@ dict_T      *dict;
  * When "len" >= 0 use "str[len]".
  * Returns FAIL when out of memory.
  */
-int list_append_string(l, str, len)
-list_T      *l;
-char_u      *str;
-int len;
+int list_append_string(list_T *l, char_u *str, int len)
 {
   listitem_T *li = listitem_alloc();
 
@@ -5653,9 +5532,7 @@ int len;
  * Append "n" to list "l".
  * Returns FAIL when out of memory.
  */
-static int list_append_number(l, n)
-list_T      *l;
-varnumber_T n;
+static int list_append_number(list_T *l, varnumber_T n)
 {
   listitem_T  *li;
 
@@ -5674,10 +5551,7 @@ varnumber_T n;
  * If "item" is NULL append at the end.
  * Return FAIL when out of memory.
  */
-int list_insert_tv(l, tv, item)
-list_T      *l;
-typval_T    *tv;
-listitem_T  *item;
+int list_insert_tv(list_T *l, typval_T *tv, listitem_T *item)
 {
   listitem_T  *ni = listitem_alloc();
 
@@ -5688,10 +5562,7 @@ listitem_T  *item;
   return OK;
 }
 
-void list_insert(l, ni, item)
-list_T      *l;
-listitem_T  *ni;
-listitem_T  *item;
+void list_insert(list_T *l, listitem_T *ni, listitem_T *item)
 {
   if (item == NULL)
     /* Append new item at end of list. */
@@ -5717,10 +5588,7 @@ listitem_T  *item;
  * If "bef" is NULL append at the end, otherwise insert before this item.
  * Returns FAIL when out of memory.
  */
-static int list_extend(l1, l2, bef)
-list_T      *l1;
-list_T      *l2;
-listitem_T  *bef;
+static int list_extend(list_T *l1, list_T *l2, listitem_T *bef)
 {
   listitem_T  *item;
   int todo = l2->lv_len;
@@ -5737,10 +5605,7 @@ listitem_T  *bef;
  * Concatenate lists "l1" and "l2" into a new list, stored in "tv".
  * Return FAIL when out of memory.
  */
-static int list_concat(l1, l2, tv)
-list_T      *l1;
-list_T      *l2;
-typval_T    *tv;
+static int list_concat(list_T *l1, list_T *l2, typval_T *tv)
 {
   list_T      *l;
 
@@ -5764,10 +5629,7 @@ typval_T    *tv;
  * See item_copy() for "copyID".
  * Returns NULL when out of memory.
  */
-static list_T * list_copy(orig, deep, copyID)
-list_T      *orig;
-int deep;
-int copyID;
+static list_T *list_copy(list_T *orig, int deep, int copyID)
 {
   list_T      *copy;
   listitem_T  *item;
@@ -5812,10 +5674,7 @@ int copyID;
  * Remove items "item" to "item2" from list "l".
  * Does not free the listitem or the value!
  */
-void list_remove(l, item, item2)
-list_T      *l;
-listitem_T  *item;
-listitem_T  *item2;
+void list_remove(list_T *l, listitem_T *item, listitem_T *item2)
 {
   listitem_T  *ip;
 
@@ -5842,9 +5701,7 @@ listitem_T  *item2;
  * Return an allocated string with the string representation of a list.
  * May return NULL.
  */
-static char_u * list2string(tv, copyID)
-typval_T    *tv;
-int copyID;
+static char_u *list2string(typval_T *tv, int copyID)
 {
   garray_T ga;
 
@@ -5866,13 +5723,15 @@ typedef struct join_S {
   char_u      *tofree;
 } join_T;
 
-static int list_join_inner(gap, l, sep, echo_style, copyID, join_gap)
-garray_T    *gap;               /* to store the result in */
-list_T      *l;
-char_u      *sep;
-int echo_style;
-int copyID;
-garray_T    *join_gap;          /* to keep each list item string */
+static int 
+list_join_inner (
+    garray_T *gap,               /* to store the result in */
+    list_T *l,
+    char_u *sep,
+    int echo_style,
+    int copyID,
+    garray_T *join_gap          /* to keep each list item string */
+)
 {
   int i;
   join_T      *p;
@@ -5936,12 +5795,7 @@ garray_T    *join_gap;          /* to keep each list item string */
  * When "echo_style" is TRUE use String as echoed, otherwise as inside a List.
  * Return FAIL or OK.
  */
-static int list_join(gap, l, sep, echo_style, copyID)
-garray_T    *gap;
-list_T      *l;
-char_u      *sep;
-int echo_style;
-int copyID;
+static int list_join(garray_T *gap, list_T *l, char_u *sep, int echo_style, int copyID)
 {
   garray_T join_ga;
   int retval;
@@ -5988,7 +5842,7 @@ int copyID;
  * Do garbage collection for lists and dicts.
  * Return TRUE if some memory was freed.
  */
-int garbage_collect()         {
+int garbage_collect(void)         {
   int copyID;
   buf_T       *buf;
   win_T       *wp;
@@ -6083,8 +5937,7 @@ int garbage_collect()         {
 /*
  * Free lists and dictionaries that are no longer referenced.
  */
-static int free_unref_items(copyID)
-int copyID;
+static int free_unref_items(int copyID)
 {
   dict_T      *dd;
   list_T      *ll;
@@ -6131,9 +5984,7 @@ int copyID;
 /*
  * Mark all lists and dicts referenced through hashtab "ht" with "copyID".
  */
-void set_ref_in_ht(ht, copyID)
-hashtab_T   *ht;
-int copyID;
+void set_ref_in_ht(hashtab_T *ht, int copyID)
 {
   int todo;
   hashitem_T  *hi;
@@ -6149,9 +6000,7 @@ int copyID;
 /*
  * Mark all lists and dicts referenced through list "l" with "copyID".
  */
-void set_ref_in_list(l, copyID)
-list_T      *l;
-int copyID;
+void set_ref_in_list(list_T *l, int copyID)
 {
   listitem_T *li;
 
@@ -6162,9 +6011,7 @@ int copyID;
 /*
  * Mark all lists and dicts referenced through typval "tv" with "copyID".
  */
-void set_ref_in_item(tv, copyID)
-typval_T    *tv;
-int copyID;
+void set_ref_in_item(typval_T *tv, int copyID)
 {
   dict_T      *dd;
   list_T      *ll;
@@ -6194,7 +6041,7 @@ int copyID;
 /*
  * Allocate an empty header for a dictionary.
  */
-dict_T * dict_alloc()              {
+dict_T *dict_alloc(void)              {
   dict_T *d;
 
   d = (dict_T *)alloc(sizeof(dict_T));
@@ -6219,8 +6066,7 @@ dict_T * dict_alloc()              {
  * Allocate an empty dict for a return value.
  * Returns OK or FAIL.
  */
-static int rettv_dict_alloc(rettv)
-typval_T    *rettv;
+static int rettv_dict_alloc(typval_T *rettv)
 {
   dict_T      *d = dict_alloc();
 
@@ -6238,8 +6084,7 @@ typval_T    *rettv;
  * Unreference a Dictionary: decrement the reference count and free it when it
  * becomes zero.
  */
-void dict_unref(d)
-dict_T *d;
+void dict_unref(dict_T *d)
 {
   if (d != NULL && --d->dv_refcount <= 0)
     dict_free(d, TRUE);
@@ -6249,9 +6094,11 @@ dict_T *d;
  * Free a Dictionary, including all items it contains.
  * Ignores the reference count.
  */
-void dict_free(d, recurse)
-dict_T  *d;
-int recurse;            /* Free Lists and Dictionaries recursively. */
+void 
+dict_free (
+    dict_T *d,
+    int recurse            /* Free Lists and Dictionaries recursively. */
+)
 {
   int todo;
   hashitem_T  *hi;
@@ -6291,8 +6138,7 @@ int recurse;            /* Free Lists and Dictionaries recursively. */
  * Note that the value of the item "di_tv" still needs to be initialized!
  * Returns NULL when out of memory.
  */
-dictitem_T * dictitem_alloc(key)
-char_u      *key;
+dictitem_T *dictitem_alloc(char_u *key)
 {
   dictitem_T *di;
 
@@ -6307,8 +6153,7 @@ char_u      *key;
 /*
  * Make a copy of a Dictionary item.
  */
-static dictitem_T * dictitem_copy(org)
-dictitem_T *org;
+static dictitem_T *dictitem_copy(dictitem_T *org)
 {
   dictitem_T *di;
 
@@ -6325,9 +6170,7 @@ dictitem_T *org;
 /*
  * Remove item "item" from Dictionary "dict" and free it.
  */
-static void dictitem_remove(dict, item)
-dict_T      *dict;
-dictitem_T  *item;
+static void dictitem_remove(dict_T *dict, dictitem_T *item)
 {
   hashitem_T  *hi;
 
@@ -6342,8 +6185,7 @@ dictitem_T  *item;
 /*
  * Free a dict item.  Also clears the value.
  */
-void dictitem_free(item)
-dictitem_T *item;
+void dictitem_free(dictitem_T *item)
 {
   clear_tv(&item->di_tv);
   vim_free(item);
@@ -6355,10 +6197,7 @@ dictitem_T *item;
  * See item_copy() for "copyID".
  * Returns NULL when out of memory.
  */
-static dict_T * dict_copy(orig, deep, copyID)
-dict_T      *orig;
-int deep;
-int copyID;
+static dict_T *dict_copy(dict_T *orig, int deep, int copyID)
 {
   dict_T      *copy;
   dictitem_T  *di;
@@ -6411,9 +6250,7 @@ int copyID;
  * Add item "item" to Dictionary "d".
  * Returns FAIL when out of memory and when key already exists.
  */
-int dict_add(d, item)
-dict_T      *d;
-dictitem_T  *item;
+int dict_add(dict_T *d, dictitem_T *item)
 {
   return hash_add(&d->dv_hashtab, item->di_key);
 }
@@ -6423,11 +6260,7 @@ dictitem_T  *item;
  * When "str" is NULL use number "nr", otherwise use "str".
  * Returns FAIL when out of memory and when key already exists.
  */
-int dict_add_nr_str(d, key, nr, str)
-dict_T      *d;
-char        *key;
-long nr;
-char_u      *str;
+int dict_add_nr_str(dict_T *d, char *key, long nr, char_u *str)
 {
   dictitem_T  *item;
 
@@ -6453,10 +6286,7 @@ char_u      *str;
  * Add a list entry to dictionary "d".
  * Returns FAIL when out of memory and when key already exists.
  */
-int dict_add_list(d, key, list)
-dict_T      *d;
-char        *key;
-list_T      *list;
+int dict_add_list(dict_T *d, char *key, list_T *list)
 {
   dictitem_T  *item;
 
@@ -6477,8 +6307,7 @@ list_T      *list;
 /*
  * Get the number of items in a Dictionary.
  */
-static long dict_len(d)
-dict_T      *d;
+static long dict_len(dict_T *d)
 {
   if (d == NULL)
     return 0L;
@@ -6490,10 +6319,7 @@ dict_T      *d;
  * If "len" is negative use strlen(key).
  * Returns NULL when not found.
  */
-dictitem_T * dict_find(d, key, len)
-dict_T      *d;
-char_u      *key;
-int len;
+dictitem_T *dict_find(dict_T *d, char_u *key, int len)
 {
 #define AKEYLEN 200
   char_u buf[AKEYLEN];
@@ -6525,10 +6351,7 @@ int len;
  * When "save" is TRUE allocate memory for it.
  * Returns NULL if the entry doesn't exist or out of memory.
  */
-char_u * get_dict_string(d, key, save)
-dict_T      *d;
-char_u      *key;
-int save;
+char_u *get_dict_string(dict_T *d, char_u *key, int save)
 {
   dictitem_T  *di;
   char_u      *s;
@@ -6546,9 +6369,7 @@ int save;
  * Get a number item from a dictionary.
  * Returns 0 if the entry doesn't exist or out of memory.
  */
-long get_dict_number(d, key)
-dict_T      *d;
-char_u      *key;
+long get_dict_number(dict_T *d, char_u *key)
 {
   dictitem_T  *di;
 
@@ -6562,9 +6383,7 @@ char_u      *key;
  * Return an allocated string with the string representation of a Dictionary.
  * May return NULL.
  */
-static char_u * dict2string(tv, copyID)
-typval_T    *tv;
-int copyID;
+static char_u *dict2string(typval_T *tv, int copyID)
 {
   garray_T ga;
   int first = TRUE;
@@ -6618,10 +6437,7 @@ int copyID;
  * Allocate a variable for a Dictionary and fill it from "*arg".
  * Return OK or FAIL.  Returns NOTDONE for {expr}.
  */
-static int get_dict_tv(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int get_dict_tv(char_u **arg, typval_T *rettv, int evaluate)
 {
   dict_T      *d = NULL;
   typval_T tvkey;
@@ -6732,11 +6548,7 @@ failret:
  * When "copyID" is not NULL replace recursive lists and dicts with "...".
  * May return NULL.
  */
-static char_u * echo_string(tv, tofree, numbuf, copyID)
-typval_T    *tv;
-char_u      **tofree;
-char_u      *numbuf;
-int copyID;
+static char_u *echo_string(typval_T *tv, char_u **tofree, char_u *numbuf, int copyID)
 {
   static int recurse = 0;
   char_u      *r = NULL;
@@ -6810,11 +6622,7 @@ int copyID;
  * Puts quotes around strings, so that they can be parsed back by eval().
  * May return NULL.
  */
-static char_u * tv2string(tv, tofree, numbuf, copyID)
-typval_T    *tv;
-char_u      **tofree;
-char_u      *numbuf;
-int copyID;
+static char_u *tv2string(typval_T *tv, char_u **tofree, char_u *numbuf, int copyID)
 {
   switch (tv->v_type) {
   case VAR_FUNC:
@@ -6842,9 +6650,7 @@ int copyID;
  * If "str" is NULL an empty string is assumed.
  * If "function" is TRUE make it function('string').
  */
-static char_u * string_quote(str, function)
-char_u      *str;
-int function;
+static char_u *string_quote(char_u *str, int function)
 {
   unsigned len;
   char_u      *p, *r, *s;
@@ -6883,9 +6689,11 @@ int function;
  * this always uses a decimal point.
  * Returns the length of the text that was consumed.
  */
-static int string2float(text, value)
-char_u      *text;
-float_T     *value;         /* result stored here */
+static int 
+string2float (
+    char_u *text,
+    float_T *value         /* result stored here */
+)
 {
   char        *s = (char *)text;
   float_T f;
@@ -6901,10 +6709,7 @@ float_T     *value;         /* result stored here */
  * If the environment variable was not set, silently assume it is empty.
  * Always return OK.
  */
-static int get_env_tv(arg, rettv, evaluate)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;
+static int get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
 {
   char_u      *string = NULL;
   int len;
@@ -7233,9 +7038,7 @@ static struct fst {
  * Function given to ExpandGeneric() to obtain the list of internal
  * or user defined function names.
  */
-char_u * get_function_name(xp, idx)
-expand_T    *xp;
-int idx;
+char_u *get_function_name(expand_T *xp, int idx)
 {
   static int intidx = -1;
   char_u      *name;
@@ -7262,9 +7065,7 @@ int idx;
  * Function given to ExpandGeneric() to obtain the list of internal or
  * user defined variable or function names.
  */
-char_u * get_expr_name(xp, idx)
-expand_T    *xp;
-int idx;
+char_u *get_expr_name(expand_T *xp, int idx)
 {
   static int intidx = -1;
   char_u      *name;
@@ -7286,8 +7087,10 @@ int idx;
  * Find internal function in table above.
  * Return index, or -1 if not found
  */
-static int find_internal_func(name)
-char_u      *name;              /* name of the function */
+static int 
+find_internal_func (
+    char_u *name              /* name of the function */
+)
 {
   int first = 0;
   int last = (int)(sizeof(functions) / sizeof(struct fst)) - 1;
@@ -7314,10 +7117,7 @@ char_u      *name;              /* name of the function */
  * Check if "name" is a variable of type VAR_FUNC.  If so, return the function
  * name it contains, otherwise return "name".
  */
-static char_u * deref_func_name(name, lenp, no_autoload)
-char_u      *name;
-int         *lenp;
-int no_autoload;
+static char_u *deref_func_name(char_u *name, int *lenp, int no_autoload)
 {
   dictitem_T  *v;
   int cc;
@@ -7342,17 +7142,18 @@ int no_autoload;
  * Allocate a variable for the result of a function.
  * Return OK or FAIL.
  */
-static int get_func_tv(name, len, rettv, arg, firstline, lastline, doesrange,
-    evaluate, selfdict)
-char_u      *name;              /* name of the function */
-int len;                        /* length of "name" */
-typval_T    *rettv;
-char_u      **arg;              /* argument, pointing to the '(' */
-linenr_T firstline;             /* first line of range */
-linenr_T lastline;              /* last line of range */
-int         *doesrange;         /* return: function handled range */
-int evaluate;
-dict_T      *selfdict;          /* Dictionary for "self" */
+static int 
+get_func_tv (
+    char_u *name,              /* name of the function */
+    int len,                        /* length of "name" */
+    typval_T *rettv,
+    char_u **arg,              /* argument, pointing to the '(' */
+    linenr_T firstline,             /* first line of range */
+    linenr_T lastline,              /* last line of range */
+    int *doesrange,         /* return: function handled range */
+    int evaluate,
+    dict_T *selfdict          /* Dictionary for "self" */
+)
 {
   char_u      *argp;
   int ret = OK;
@@ -7403,21 +7204,20 @@ dict_T      *selfdict;          /* Dictionary for "self" */
  * Return FAIL when the function can't be called,  OK otherwise.
  * Also returns OK when an error was encountered while executing the function.
  */
-static int call_func(funcname, len, rettv, argcount, argvars, firstline,
-    lastline,
-    doesrange, evaluate,
-    selfdict)
-char_u      *funcname;          /* name of the function */
-int len;                        /* length of "name" */
-typval_T    *rettv;             /* return value goes here */
-int argcount;                   /* number of "argvars" */
-typval_T    *argvars;           /* vars for arguments, must have "argcount"
+static int 
+call_func (
+    char_u *funcname,          /* name of the function */
+    int len,                        /* length of "name" */
+    typval_T *rettv,             /* return value goes here */
+    int argcount,                   /* number of "argvars" */
+    typval_T *argvars,           /* vars for arguments, must have "argcount"
                                    PLUS ONE elements! */
-linenr_T firstline;             /* first line of range */
-linenr_T lastline;              /* last line of range */
-int         *doesrange;         /* return: function handled range */
-int evaluate;
-dict_T      *selfdict;          /* Dictionary for "self" */
+    linenr_T firstline,             /* first line of range */
+    linenr_T lastline,              /* last line of range */
+    int *doesrange,         /* return: function handled range */
+    int evaluate,
+    dict_T *selfdict          /* Dictionary for "self" */
+)
 {
   int ret = FAIL;
 #define ERROR_UNKNOWN   0
@@ -7606,9 +7406,7 @@ dict_T      *selfdict;          /* Dictionary for "self" */
  * Give an error message with a function name.  Handle <SNR> things.
  * "ermsg" is to be passed without translation, use N_() instead of _().
  */
-static void emsg_funcname(ermsg, name)
-char        *ermsg;
-char_u      *name;
+static void emsg_funcname(char *ermsg, char_u *name)
 {
   char_u      *p;
 
@@ -7624,8 +7422,7 @@ char_u      *name;
 /*
  * Return TRUE for a non-zero Number and a non-empty String.
  */
-static int non_zero_arg(argvars)
-typval_T    *argvars;
+static int non_zero_arg(typval_T *argvars)
 {
   return (argvars[0].v_type == VAR_NUMBER
           && argvars[0].vval.v_number != 0)
@@ -7644,9 +7441,7 @@ static int get_float_arg __ARGS((typval_T *argvars, float_T *f));
  * Get the float value of "argvars[0]" into "f".
  * Returns FAIL when the argument is not a Number or Float.
  */
-static int get_float_arg(argvars, f)
-typval_T    *argvars;
-float_T     *f;
+static int get_float_arg(typval_T *argvars, float_T *f)
 {
   if (argvars[0].v_type == VAR_FLOAT) {
     *f = argvars[0].vval.v_float;
@@ -7663,9 +7458,7 @@ float_T     *f;
 /*
  * "abs(expr)" function
  */
-static void f_abs(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_abs(typval_T *argvars, typval_T *rettv)
 {
   if (argvars[0].v_type == VAR_FLOAT) {
     rettv->v_type = VAR_FLOAT;
@@ -7687,9 +7480,7 @@ typval_T    *rettv;
 /*
  * "acos()" function
  */
-static void f_acos(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_acos(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -7703,9 +7494,7 @@ typval_T    *rettv;
 /*
  * "add(list, item)" function
  */
-static void f_add(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_add(typval_T *argvars, typval_T *rettv)
 {
   list_T      *l;
 
@@ -7722,9 +7511,7 @@ typval_T    *rettv;
 /*
  * "and(expr, expr)" function
  */
-static void f_and(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_and(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = get_tv_number_chk(&argvars[0], NULL)
                          & get_tv_number_chk(&argvars[1], NULL);
@@ -7733,9 +7520,7 @@ typval_T    *rettv;
 /*
  * "append(lnum, string/list)" function
  */
-static void f_append(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_append(typval_T *argvars, typval_T *rettv)
 {
   long lnum;
   char_u      *line;
@@ -7790,9 +7575,7 @@ typval_T    *rettv;
 /*
  * "argc()" function
  */
-static void f_argc(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_argc(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = ARGCOUNT;
 }
@@ -7800,9 +7583,7 @@ typval_T    *rettv;
 /*
  * "argidx()" function
  */
-static void f_argidx(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_argidx(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = curwin->w_arg_idx;
 }
@@ -7810,9 +7591,7 @@ typval_T    *rettv;
 /*
  * "argv(nr)" function
  */
-static void f_argv(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_argv(typval_T *argvars, typval_T *rettv)
 {
   int idx;
 
@@ -7832,9 +7611,7 @@ typval_T    *rettv;
 /*
  * "asin()" function
  */
-static void f_asin(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_asin(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -7848,9 +7625,7 @@ typval_T    *rettv;
 /*
  * "atan()" function
  */
-static void f_atan(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_atan(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -7864,9 +7639,7 @@ typval_T    *rettv;
 /*
  * "atan2()" function
  */
-static void f_atan2(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_atan2(typval_T *argvars, typval_T *rettv)
 {
   float_T fx, fy;
 
@@ -7881,9 +7654,7 @@ typval_T    *rettv;
 /*
  * "browse(save, title, initdir, default)" function
  */
-static void f_browse(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_browse(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_string = NULL;
   rettv->v_type = VAR_STRING;
@@ -7892,9 +7663,7 @@ typval_T    *rettv;
 /*
  * "browsedir(title, initdir)" function
  */
-static void f_browsedir(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_browsedir(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_string = NULL;
   rettv->v_type = VAR_STRING;
@@ -7905,8 +7674,7 @@ static buf_T *find_buffer __ARGS((typval_T *avar));
 /*
  * Find a buffer by number or exact name.
  */
-static buf_T * find_buffer(avar)
-typval_T    *avar;
+static buf_T *find_buffer(typval_T *avar)
 {
   buf_T       *buf = NULL;
 
@@ -7932,9 +7700,7 @@ typval_T    *avar;
 /*
  * "bufexists(expr)" function
  */
-static void f_bufexists(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_bufexists(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = (find_buffer(&argvars[0]) != NULL);
 }
@@ -7942,9 +7708,7 @@ typval_T    *rettv;
 /*
  * "buflisted(expr)" function
  */
-static void f_buflisted(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_buflisted(typval_T *argvars, typval_T *rettv)
 {
   buf_T       *buf;
 
@@ -7955,9 +7719,7 @@ typval_T    *rettv;
 /*
  * "bufloaded(expr)" function
  */
-static void f_bufloaded(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_bufloaded(typval_T *argvars, typval_T *rettv)
 {
   buf_T       *buf;
 
@@ -7970,9 +7732,7 @@ static buf_T *get_buf_tv __ARGS((typval_T *tv, int curtab_only));
 /*
  * Get buffer by number or pattern.
  */
-static buf_T * get_buf_tv(tv, curtab_only)
-typval_T    *tv;
-int curtab_only;
+static buf_T *get_buf_tv(typval_T *tv, int curtab_only)
 {
   char_u      *name = tv->vval.v_string;
   int save_magic;
@@ -8010,9 +7770,7 @@ int curtab_only;
 /*
  * "bufname(expr)" function
  */
-static void f_bufname(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_bufname(typval_T *argvars, typval_T *rettv)
 {
   buf_T       *buf;
 
@@ -8030,9 +7788,7 @@ typval_T    *rettv;
 /*
  * "bufnr(expr)" function
  */
-static void f_bufnr(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_bufnr(typval_T *argvars, typval_T *rettv)
 {
   buf_T       *buf;
   int error = FALSE;
@@ -8062,9 +7818,7 @@ typval_T    *rettv;
 /*
  * "bufwinnr(nr)" function
  */
-static void f_bufwinnr(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_bufwinnr(typval_T *argvars, typval_T *rettv)
 {
   win_T       *wp;
   int winnr = 0;
@@ -8085,9 +7839,7 @@ typval_T    *rettv;
 /*
  * "byte2line(byte)" function
  */
-static void f_byte2line(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_byte2line(typval_T *argvars, typval_T *rettv)
 {
   long boff = 0;
 
@@ -8099,10 +7851,7 @@ typval_T    *rettv;
         (linenr_T)0, &boff);
 }
 
-static void byteidx(argvars, rettv, comp)
-typval_T    *argvars;
-typval_T    *rettv;
-int comp;
+static void byteidx(typval_T *argvars, typval_T *rettv, int comp)
 {
   char_u      *t;
   char_u      *str;
@@ -8129,9 +7878,7 @@ int comp;
 /*
  * "byteidx()" function
  */
-static void f_byteidx(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_byteidx(typval_T *argvars, typval_T *rettv)
 {
   byteidx(argvars, rettv, FALSE);
 }
@@ -8139,18 +7886,12 @@ typval_T    *rettv;
 /*
  * "byteidxcomp()" function
  */
-static void f_byteidxcomp(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_byteidxcomp(typval_T *argvars, typval_T *rettv)
 {
   byteidx(argvars, rettv, TRUE);
 }
 
-int func_call(name, args, selfdict, rettv)
-char_u      *name;
-typval_T    *args;
-dict_T      *selfdict;
-typval_T    *rettv;
+int func_call(char_u *name, typval_T *args, dict_T *selfdict, typval_T *rettv)
 {
   listitem_T  *item;
   typval_T argv[MAX_FUNC_ARGS + 1];
@@ -8185,9 +7926,7 @@ typval_T    *rettv;
 /*
  * "call(func, arglist)" function
  */
-static void f_call(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_call(typval_T *argvars, typval_T *rettv)
 {
   char_u      *func;
   dict_T      *selfdict = NULL;
@@ -8220,9 +7959,7 @@ typval_T    *rettv;
 /*
  * "ceil({float})" function
  */
-static void f_ceil(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_ceil(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -8236,9 +7973,7 @@ typval_T    *rettv;
 /*
  * "changenr()" function
  */
-static void f_changenr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_changenr(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = curbuf->b_u_seq_cur;
 }
@@ -8246,9 +7981,7 @@ typval_T    *rettv;
 /*
  * "char2nr(string)" function
  */
-static void f_char2nr(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_char2nr(typval_T *argvars, typval_T *rettv)
 {
   if (has_mbyte) {
     int utf8 = 0;
@@ -8267,9 +8000,7 @@ typval_T    *rettv;
 /*
  * "cindent(lnum)" function
  */
-static void f_cindent(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_cindent(typval_T *argvars, typval_T *rettv)
 {
   pos_T pos;
   linenr_T lnum;
@@ -8287,9 +8018,7 @@ typval_T    *rettv;
 /*
  * "clearmatches()" function
  */
-static void f_clearmatches(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_clearmatches(typval_T *argvars, typval_T *rettv)
 {
   clear_matches(curwin);
 }
@@ -8297,9 +8026,7 @@ typval_T    *rettv UNUSED;
 /*
  * "col(string)" function
  */
-static void f_col(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_col(typval_T *argvars, typval_T *rettv)
 {
   colnr_T col = 0;
   pos_T       *fp;
@@ -8336,9 +8063,7 @@ typval_T    *rettv;
 /*
  * "complete()" function
  */
-static void f_complete(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv UNUSED;
+static void f_complete(typval_T *argvars, typval_T *rettv)
 {
   int startcol;
 
@@ -8367,9 +8092,7 @@ typval_T    *rettv UNUSED;
 /*
  * "complete_add()" function
  */
-static void f_complete_add(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_complete_add(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = ins_compl_add_tv(&argvars[0], 0);
 }
@@ -8377,9 +8100,7 @@ typval_T    *rettv;
 /*
  * "complete_check()" function
  */
-static void f_complete_check(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_complete_check(typval_T *argvars, typval_T *rettv)
 {
   int saved = RedrawingDisabled;
 
@@ -8392,9 +8113,7 @@ typval_T    *rettv;
 /*
  * "confirm(message, buttons[, default [, type]])" function
  */
-static void f_confirm(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_confirm(typval_T *argvars, typval_T *rettv)
 {
   char_u      *message;
   char_u      *buttons = NULL;
@@ -8442,9 +8161,7 @@ typval_T    *rettv UNUSED;
 /*
  * "copy()" function
  */
-static void f_copy(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_copy(typval_T *argvars, typval_T *rettv)
 {
   item_copy(&argvars[0], rettv, FALSE, 0);
 }
@@ -8452,9 +8169,7 @@ typval_T    *rettv;
 /*
  * "cos()" function
  */
-static void f_cos(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_cos(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -8468,9 +8183,7 @@ typval_T    *rettv;
 /*
  * "cosh()" function
  */
-static void f_cosh(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_cosh(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -8484,9 +8197,7 @@ typval_T    *rettv;
 /*
  * "count()" function
  */
-static void f_count(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_count(typval_T *argvars, typval_T *rettv)
 {
   long n = 0;
   int ic = FALSE;
@@ -8551,9 +8262,7 @@ typval_T    *rettv;
  *
  * Checks the existence of a cscope connection.
  */
-static void f_cscope_connection(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_cscope_connection(typval_T *argvars, typval_T *rettv)
 {
   int num = 0;
   char_u      *dbpath = NULL;
@@ -8577,9 +8286,7 @@ typval_T    *rettv UNUSED;
  * Moves the cursor to the specified line and column.
  * Returns 0 when the position could be set, -1 otherwise.
  */
-static void f_cursor(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_cursor(typval_T *argvars, typval_T *rettv)
 {
   long line, col;
   long coladd = 0;
@@ -8622,9 +8329,7 @@ typval_T    *rettv;
 /*
  * "deepcopy()" function
  */
-static void f_deepcopy(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_deepcopy(typval_T *argvars, typval_T *rettv)
 {
   int noref = 0;
 
@@ -8641,9 +8346,7 @@ typval_T    *rettv;
 /*
  * "delete()" function
  */
-static void f_delete(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_delete(typval_T *argvars, typval_T *rettv)
 {
   if (check_restricted() || check_secure())
     rettv->vval.v_number = -1;
@@ -8654,9 +8357,7 @@ typval_T    *rettv;
 /*
  * "did_filetype()" function
  */
-static void f_did_filetype(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_did_filetype(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = did_filetype;
 }
@@ -8664,9 +8365,7 @@ typval_T    *rettv UNUSED;
 /*
  * "diff_filler()" function
  */
-static void f_diff_filler(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_diff_filler(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = diff_check_fill(curwin, get_tv_lnum(argvars));
 }
@@ -8674,9 +8373,7 @@ typval_T    *rettv UNUSED;
 /*
  * "diff_hlID()" function
  */
-static void f_diff_hlID(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_diff_hlID(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum = get_tv_lnum(argvars);
   static linenr_T prev_lnum = 0;
@@ -8725,9 +8422,7 @@ typval_T    *rettv UNUSED;
 /*
  * "empty({expr})" function
  */
-static void f_empty(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_empty(typval_T *argvars, typval_T *rettv)
 {
   int n;
 
@@ -8762,9 +8457,7 @@ typval_T    *rettv;
 /*
  * "escape({string}, {chars})" function
  */
-static void f_escape(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_escape(typval_T *argvars, typval_T *rettv)
 {
   char_u buf[NUMBUFLEN];
 
@@ -8776,9 +8469,7 @@ typval_T    *rettv;
 /*
  * "eval()" function
  */
-static void f_eval(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_eval(typval_T *argvars, typval_T *rettv)
 {
   char_u      *s;
 
@@ -8796,9 +8487,7 @@ typval_T    *rettv;
 /*
  * "eventhandler()" function
  */
-static void f_eventhandler(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_eventhandler(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = vgetc_busy;
 }
@@ -8806,9 +8495,7 @@ typval_T    *rettv;
 /*
  * "executable()" function
  */
-static void f_executable(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_executable(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = mch_can_exe(get_tv_string(&argvars[0]));
 }
@@ -8816,9 +8503,7 @@ typval_T    *rettv;
 /*
  * "exists()" function
  */
-static void f_exists(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_exists(typval_T *argvars, typval_T *rettv)
 {
   char_u      *p;
   char_u      *name;
@@ -8880,9 +8565,7 @@ typval_T    *rettv;
 /*
  * "exp()" function
  */
-static void f_exp(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_exp(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -8896,9 +8579,7 @@ typval_T    *rettv;
 /*
  * "expand()" function
  */
-static void f_expand(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_expand(typval_T *argvars, typval_T *rettv)
 {
   char_u      *s;
   int len;
@@ -8962,10 +8643,7 @@ typval_T    *rettv;
  * When "action" is "force" then a duplicate key is overwritten.
  * Otherwise duplicate keys are ignored ("action" is "keep").
  */
-void dict_extend(d1, d2, action)
-dict_T      *d1;
-dict_T      *d2;
-char_u      *action;
+void dict_extend(dict_T *d1, dict_T *d2, char_u *action)
 {
   dictitem_T  *di1;
   hashitem_T  *hi2;
@@ -9007,9 +8685,7 @@ char_u      *action;
  * "extend(list, list [, idx])" function
  * "extend(dict, dict [, action])" function
  */
-static void f_extend(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_extend(typval_T *argvars, typval_T *rettv)
 {
   char      *arg_errmsg = N_("extend() argument");
 
@@ -9081,9 +8757,7 @@ typval_T    *rettv;
 /*
  * "feedkeys()" function
  */
-static void f_feedkeys(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv UNUSED;
+static void f_feedkeys(typval_T *argvars, typval_T *rettv)
 {
   int remap = TRUE;
   char_u      *keys, *flags;
@@ -9126,9 +8800,7 @@ typval_T    *rettv UNUSED;
 /*
  * "filereadable()" function
  */
-static void f_filereadable(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_filereadable(typval_T *argvars, typval_T *rettv)
 {
   int fd;
   char_u      *p;
@@ -9152,9 +8824,7 @@ typval_T    *rettv;
  * Return 0 for not writable, 1 for writable file, 2 for a dir which we have
  * rights to write into.
  */
-static void f_filewritable(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_filewritable(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = filewritable(get_tv_string(&argvars[0]));
 }
@@ -9162,10 +8832,7 @@ typval_T    *rettv;
 static void findfilendir __ARGS((typval_T *argvars, typval_T *rettv,
                                  int find_what));
 
-static void findfilendir(argvars, rettv, find_what)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
-int find_what UNUSED;
+static void findfilendir(typval_T *argvars, typval_T *rettv, int find_what)
 {
   char_u      *fname;
   char_u      *fresult = NULL;
@@ -9227,10 +8894,7 @@ static int filter_map_one __ARGS((typval_T *tv, char_u *expr, int map,
 /*
  * Implementation of map() and filter().
  */
-static void filter_map(argvars, rettv, map)
-typval_T    *argvars;
-typval_T    *rettv;
-int map;
+static void filter_map(typval_T *argvars, typval_T *rettv, int map)
 {
   char_u buf[NUMBUFLEN];
   char_u      *expr;
@@ -9326,11 +8990,7 @@ int map;
   copy_tv(&argvars[0], rettv);
 }
 
-static int filter_map_one(tv, expr, map, remp)
-typval_T    *tv;
-char_u      *expr;
-int map;
-int         *remp;
+static int filter_map_one(typval_T *tv, char_u *expr, int map, int *remp)
 {
   typval_T rettv;
   char_u      *s;
@@ -9369,9 +9029,7 @@ theend:
 /*
  * "filter()" function
  */
-static void f_filter(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_filter(typval_T *argvars, typval_T *rettv)
 {
   filter_map(argvars, rettv, FALSE);
 }
@@ -9379,9 +9037,7 @@ typval_T    *rettv;
 /*
  * "finddir({fname}[, {path}[, {count}]])" function
  */
-static void f_finddir(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_finddir(typval_T *argvars, typval_T *rettv)
 {
   findfilendir(argvars, rettv, FINDFILE_DIR);
 }
@@ -9389,9 +9045,7 @@ typval_T    *rettv;
 /*
  * "findfile({fname}[, {path}[, {count}]])" function
  */
-static void f_findfile(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_findfile(typval_T *argvars, typval_T *rettv)
 {
   findfilendir(argvars, rettv, FINDFILE_FILE);
 }
@@ -9399,9 +9053,7 @@ typval_T    *rettv;
 /*
  * "float2nr({float})" function
  */
-static void f_float2nr(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_float2nr(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -9418,9 +9070,7 @@ typval_T    *rettv;
 /*
  * "floor({float})" function
  */
-static void f_floor(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_floor(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -9434,9 +9084,7 @@ typval_T    *rettv;
 /*
  * "fmod()" function
  */
-static void f_fmod(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_fmod(typval_T *argvars, typval_T *rettv)
 {
   float_T fx, fy;
 
@@ -9451,9 +9099,7 @@ typval_T    *rettv;
 /*
  * "fnameescape({string})" function
  */
-static void f_fnameescape(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_fnameescape(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_string = vim_strsave_fnameescape(
       get_tv_string(&argvars[0]), FALSE);
@@ -9463,9 +9109,7 @@ typval_T    *rettv;
 /*
  * "fnamemodify({fname}, {mods})" function
  */
-static void f_fnamemodify(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_fnamemodify(typval_T *argvars, typval_T *rettv)
 {
   char_u      *fname;
   char_u      *mods;
@@ -9496,10 +9140,7 @@ static void foldclosed_both __ARGS((typval_T *argvars, typval_T *rettv, int end)
 /*
  * "foldclosed()" function
  */
-static void foldclosed_both(argvars, rettv, end)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
-int end UNUSED;
+static void foldclosed_both(typval_T *argvars, typval_T *rettv, int end)
 {
   linenr_T lnum;
   linenr_T first, last;
@@ -9520,9 +9161,7 @@ int end UNUSED;
 /*
  * "foldclosed()" function
  */
-static void f_foldclosed(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_foldclosed(typval_T *argvars, typval_T *rettv)
 {
   foldclosed_both(argvars, rettv, FALSE);
 }
@@ -9530,9 +9169,7 @@ typval_T    *rettv;
 /*
  * "foldclosedend()" function
  */
-static void f_foldclosedend(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_foldclosedend(typval_T *argvars, typval_T *rettv)
 {
   foldclosed_both(argvars, rettv, TRUE);
 }
@@ -9540,9 +9177,7 @@ typval_T    *rettv;
 /*
  * "foldlevel()" function
  */
-static void f_foldlevel(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_foldlevel(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
 
@@ -9554,9 +9189,7 @@ typval_T    *rettv UNUSED;
 /*
  * "foldtext()" function
  */
-static void f_foldtext(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_foldtext(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
   char_u      *s;
@@ -9611,9 +9244,7 @@ typval_T    *rettv;
 /*
  * "foldtextresult(lnum)" function
  */
-static void f_foldtextresult(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_foldtextresult(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
   char_u      *text;
@@ -9640,18 +9271,14 @@ typval_T    *rettv;
 /*
  * "foreground()" function
  */
-static void f_foreground(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_foreground(typval_T *argvars, typval_T *rettv)
 {
 }
 
 /*
  * "function()" function
  */
-static void f_function(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_function(typval_T *argvars, typval_T *rettv)
 {
   char_u      *s;
 
@@ -9686,9 +9313,7 @@ typval_T    *rettv;
 /*
  * "garbagecollect()" function
  */
-static void f_garbagecollect(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv UNUSED;
+static void f_garbagecollect(typval_T *argvars, typval_T *rettv)
 {
   /* This is postponed until we are back at the toplevel, because we may be
   * using Lists and Dicts internally.  E.g.: ":echo [garbagecollect()]". */
@@ -9701,9 +9326,7 @@ typval_T    *rettv UNUSED;
 /*
  * "get()" function
  */
-static void f_get(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_get(typval_T *argvars, typval_T *rettv)
 {
   listitem_T  *li;
   list_T      *l;
@@ -9745,12 +9368,7 @@ static void get_buffer_lines __ARGS((buf_T *buf, linenr_T start, linenr_T end,
  * buffer.
  * If 'retlist' is TRUE, then the lines are returned as a Vim List.
  */
-static void get_buffer_lines(buf, start, end, retlist, rettv)
-buf_T       *buf;
-linenr_T start;
-linenr_T end;
-int retlist;
-typval_T    *rettv;
+static void get_buffer_lines(buf_T *buf, linenr_T start, linenr_T end, int retlist, typval_T *rettv)
 {
   char_u      *p;
 
@@ -9786,9 +9404,7 @@ typval_T    *rettv;
 /*
  * "getbufline()" function
  */
-static void f_getbufline(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getbufline(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
   linenr_T end;
@@ -9811,9 +9427,7 @@ typval_T    *rettv;
 /*
  * "getbufvar()" function
  */
-static void f_getbufvar(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getbufvar(typval_T *argvars, typval_T *rettv)
 {
   buf_T       *buf;
   buf_T       *save_curbuf;
@@ -9866,9 +9480,7 @@ typval_T    *rettv;
 /*
  * "getchar()" function
  */
-static void f_getchar(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getchar(typval_T *argvars, typval_T *rettv)
 {
   varnumber_T n;
   int error = FALSE;
@@ -9951,9 +9563,7 @@ typval_T    *rettv;
 /*
  * "getcharmod()" function
  */
-static void f_getcharmod(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_getcharmod(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = mod_mask;
 }
@@ -9961,9 +9571,7 @@ typval_T    *rettv;
 /*
  * "getcmdline()" function
  */
-static void f_getcmdline(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_getcmdline(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = get_cmdline_str();
@@ -9972,9 +9580,7 @@ typval_T    *rettv;
 /*
  * "getcmdpos()" function
  */
-static void f_getcmdpos(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_getcmdpos(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = get_cmdline_pos() + 1;
 }
@@ -9982,9 +9588,7 @@ typval_T    *rettv;
 /*
  * "getcmdtype()" function
  */
-static void f_getcmdtype(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_getcmdtype(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = alloc(2);
@@ -9997,9 +9601,7 @@ typval_T    *rettv;
 /*
  * "getcwd()" function
  */
-static void f_getcwd(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_getcwd(typval_T *argvars, typval_T *rettv)
 {
   char_u      *cwd;
 
@@ -10021,9 +9623,7 @@ typval_T    *rettv;
 /*
  * "getfontname()" function
  */
-static void f_getfontname(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_getfontname(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
@@ -10032,9 +9632,7 @@ typval_T    *rettv;
 /*
  * "getfperm({fname})" function
  */
-static void f_getfperm(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getfperm(typval_T *argvars, typval_T *rettv)
 {
   char_u      *fname;
   struct stat st;
@@ -10060,9 +9658,7 @@ typval_T    *rettv;
 /*
  * "getfsize({fname})" function
  */
-static void f_getfsize(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getfsize(typval_T *argvars, typval_T *rettv)
 {
   char_u      *fname;
   struct stat st;
@@ -10088,9 +9684,7 @@ typval_T    *rettv;
 /*
  * "getftime({fname})" function
  */
-static void f_getftime(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getftime(typval_T *argvars, typval_T *rettv)
 {
   char_u      *fname;
   struct stat st;
@@ -10106,9 +9700,7 @@ typval_T    *rettv;
 /*
  * "getftype({fname})" function
  */
-static void f_getftype(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getftype(typval_T *argvars, typval_T *rettv)
 {
   char_u      *fname;
   struct stat st;
@@ -10183,9 +9775,7 @@ typval_T    *rettv;
 /*
  * "getline(lnum, [end])" function
  */
-static void f_getline(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getline(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
   linenr_T end;
@@ -10206,9 +9796,7 @@ typval_T    *rettv;
 /*
  * "getmatches()" function
  */
-static void f_getmatches(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_getmatches(typval_T *argvars, typval_T *rettv)
 {
   dict_T      *dict;
   matchitem_T *cur = curwin->w_match_head;
@@ -10231,9 +9819,7 @@ typval_T    *rettv UNUSED;
 /*
  * "getpid()" function
  */
-static void f_getpid(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_getpid(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = mch_get_pid();
 }
@@ -10241,9 +9827,7 @@ typval_T    *rettv;
 /*
  * "getpos(string)" function
  */
-static void f_getpos(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getpos(typval_T *argvars, typval_T *rettv)
 {
   pos_T       *fp;
   list_T      *l;
@@ -10271,9 +9855,7 @@ typval_T    *rettv;
 /*
  * "getqflist()" and "getloclist()" functions
  */
-static void f_getqflist(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_getqflist(typval_T *argvars, typval_T *rettv)
 {
   win_T       *wp;
 
@@ -10292,9 +9874,7 @@ typval_T    *rettv UNUSED;
 /*
  * "getreg()" function
  */
-static void f_getreg(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getreg(typval_T *argvars, typval_T *rettv)
 {
   char_u      *strregname;
   int regname;
@@ -10320,9 +9900,7 @@ typval_T    *rettv;
 /*
  * "getregtype()" function
  */
-static void f_getregtype(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getregtype(typval_T *argvars, typval_T *rettv)
 {
   char_u      *strregname;
   int regname;
@@ -10361,9 +9939,7 @@ typval_T    *rettv;
 /*
  * "gettabvar()" function
  */
-static void f_gettabvar(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_gettabvar(typval_T *argvars, typval_T *rettv)
 {
   tabpage_T   *tp;
   dictitem_T  *v;
@@ -10391,9 +9967,7 @@ typval_T    *rettv;
 /*
  * "gettabwinvar()" function
  */
-static void f_gettabwinvar(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_gettabwinvar(typval_T *argvars, typval_T *rettv)
 {
   getwinvar(argvars, rettv, 1);
 }
@@ -10401,9 +9975,7 @@ typval_T    *rettv;
 /*
  * "getwinposx()" function
  */
-static void f_getwinposx(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_getwinposx(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = -1;
 }
@@ -10411,9 +9983,7 @@ typval_T    *rettv;
 /*
  * "getwinposy()" function
  */
-static void f_getwinposy(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_getwinposy(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = -1;
 }
@@ -10421,9 +9991,11 @@ typval_T    *rettv;
 /*
  * Find window specified by "vp" in tabpage "tp".
  */
-static win_T * find_win_by_nr(vp, tp)
-typval_T    *vp;
-tabpage_T   *tp UNUSED;         /* NULL for current tab page */
+static win_T *
+find_win_by_nr (
+    typval_T *vp,
+    tabpage_T *tp         /* NULL for current tab page */
+)
 {
   win_T       *wp;
   int nr;
@@ -10445,9 +10017,7 @@ tabpage_T   *tp UNUSED;         /* NULL for current tab page */
 /*
  * "getwinvar()" function
  */
-static void f_getwinvar(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_getwinvar(typval_T *argvars, typval_T *rettv)
 {
   getwinvar(argvars, rettv, 0);
 }
@@ -10455,10 +10025,12 @@ typval_T    *rettv;
 /*
  * getwinvar() and gettabwinvar()
  */
-static void getwinvar(argvars, rettv, off)
-typval_T    *argvars;
-typval_T    *rettv;
-int off;                    /* 1 for gettabwinvar() */
+static void 
+getwinvar (
+    typval_T *argvars,
+    typval_T *rettv,
+    int off                    /* 1 for gettabwinvar() */
+)
 {
   win_T       *win, *oldcurwin;
   char_u      *varname;
@@ -10510,9 +10082,7 @@ int off;                    /* 1 for gettabwinvar() */
 /*
  * "glob()" function
  */
-static void f_glob(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_glob(typval_T *argvars, typval_T *rettv)
 {
   int options = WILD_SILENT|WILD_USE_NL;
   expand_T xpc;
@@ -10555,9 +10125,7 @@ typval_T    *rettv;
 /*
  * "globpath()" function
  */
-static void f_globpath(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_globpath(typval_T *argvars, typval_T *rettv)
 {
   int flags = 0;
   char_u buf1[NUMBUFLEN];
@@ -10580,9 +10148,7 @@ typval_T    *rettv;
 /*
  * "has()" function
  */
-static void f_has(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_has(typval_T *argvars, typval_T *rettv)
 {
   int i;
   char_u      *name;
@@ -10773,9 +10339,7 @@ typval_T    *rettv;
 /*
  * "has_key()" function
  */
-static void f_has_key(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_has_key(typval_T *argvars, typval_T *rettv)
 {
   if (argvars[0].v_type != VAR_DICT) {
     EMSG(_(e_dictreq));
@@ -10791,9 +10355,7 @@ typval_T    *rettv;
 /*
  * "haslocaldir()" function
  */
-static void f_haslocaldir(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_haslocaldir(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = (curwin->w_localdir != NULL);
 }
@@ -10801,9 +10363,7 @@ typval_T    *rettv;
 /*
  * "hasmapto()" function
  */
-static void f_hasmapto(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_hasmapto(typval_T *argvars, typval_T *rettv)
 {
   char_u      *name;
   char_u      *mode;
@@ -10828,9 +10388,7 @@ typval_T    *rettv;
 /*
  * "histadd()" function
  */
-static void f_histadd(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_histadd(typval_T *argvars, typval_T *rettv)
 {
   int histype;
   char_u      *str;
@@ -10855,9 +10413,7 @@ typval_T    *rettv;
 /*
  * "histdel()" function
  */
-static void f_histdel(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_histdel(typval_T *argvars, typval_T *rettv)
 {
   int n;
   char_u buf[NUMBUFLEN];
@@ -10883,9 +10439,7 @@ typval_T    *rettv UNUSED;
 /*
  * "histget()" function
  */
-static void f_histget(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_histget(typval_T *argvars, typval_T *rettv)
 {
   int type;
   int idx;
@@ -10909,9 +10463,7 @@ typval_T    *rettv;
 /*
  * "histnr()" function
  */
-static void f_histnr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_histnr(typval_T *argvars, typval_T *rettv)
 {
   int i;
 
@@ -10928,9 +10480,7 @@ typval_T    *rettv;
 /*
  * "highlightID(name)" function
  */
-static void f_hlID(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_hlID(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = syn_name2id(get_tv_string(&argvars[0]));
 }
@@ -10938,9 +10488,7 @@ typval_T    *rettv;
 /*
  * "highlight_exists()" function
  */
-static void f_hlexists(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_hlexists(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = highlight_exists(get_tv_string(&argvars[0]));
 }
@@ -10948,9 +10496,7 @@ typval_T    *rettv;
 /*
  * "hostname()" function
  */
-static void f_hostname(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_hostname(typval_T *argvars, typval_T *rettv)
 {
   char_u hostname[256];
 
@@ -10962,9 +10508,7 @@ typval_T    *rettv;
 /*
  * iconv() function
  */
-static void f_iconv(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_iconv(typval_T *argvars, typval_T *rettv)
 {
   char_u buf1[NUMBUFLEN];
   char_u buf2[NUMBUFLEN];
@@ -10994,9 +10538,7 @@ typval_T    *rettv;
 /*
  * "indent()" function
  */
-static void f_indent(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_indent(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
 
@@ -11010,9 +10552,7 @@ typval_T    *rettv;
 /*
  * "index()" function
  */
-static void f_index(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_index(typval_T *argvars, typval_T *rettv)
 {
   list_T      *l;
   listitem_T  *item;
@@ -11059,10 +10599,7 @@ static void get_user_input __ARGS((typval_T *argvars, typval_T *rettv,
  * prompt. The third argument to f_inputdialog() specifies the value to return
  * when the user cancels the prompt.
  */
-static void get_user_input(argvars, rettv, inputdialog)
-typval_T    *argvars;
-typval_T    *rettv;
-int inputdialog;
+static void get_user_input(typval_T *argvars, typval_T *rettv, int inputdialog)
 {
   char_u      *prompt = get_tv_string_chk(&argvars[0]);
   char_u      *p = NULL;
@@ -11154,9 +10691,7 @@ int inputdialog;
  * "input()" function
  *     Also handles inputsecret() when inputsecret is set.
  */
-static void f_input(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_input(typval_T *argvars, typval_T *rettv)
 {
   get_user_input(argvars, rettv, FALSE);
 }
@@ -11164,9 +10699,7 @@ typval_T    *rettv;
 /*
  * "inputdialog()" function
  */
-static void f_inputdialog(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_inputdialog(typval_T *argvars, typval_T *rettv)
 {
   get_user_input(argvars, rettv, TRUE);
 }
@@ -11174,9 +10707,7 @@ typval_T    *rettv;
 /*
  * "inputlist()" function
  */
-static void f_inputlist(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_inputlist(typval_T *argvars, typval_T *rettv)
 {
   listitem_T  *li;
   int selected;
@@ -11217,9 +10748,7 @@ static garray_T ga_userinput = {0, 0, sizeof(tasave_T), 4, NULL};
 /*
  * "inputrestore()" function
  */
-static void f_inputrestore(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_inputrestore(typval_T *argvars, typval_T *rettv)
 {
   if (ga_userinput.ga_len > 0) {
     --ga_userinput.ga_len;
@@ -11235,9 +10764,7 @@ typval_T    *rettv;
 /*
  * "inputsave()" function
  */
-static void f_inputsave(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_inputsave(typval_T *argvars, typval_T *rettv)
 {
   /* Add an entry to the stack of typeahead storage. */
   if (ga_grow(&ga_userinput, 1) == OK) {
@@ -11252,9 +10779,7 @@ typval_T    *rettv;
 /*
  * "inputsecret()" function
  */
-static void f_inputsecret(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_inputsecret(typval_T *argvars, typval_T *rettv)
 {
   ++cmdline_star;
   ++inputsecret_flag;
@@ -11266,9 +10791,7 @@ typval_T    *rettv;
 /*
  * "insert()" function
  */
-static void f_insert(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_insert(typval_T *argvars, typval_T *rettv)
 {
   long before = 0;
   listitem_T  *item;
@@ -11303,9 +10826,7 @@ typval_T    *rettv;
 /*
  * "invert(expr)" function
  */
-static void f_invert(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_invert(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = ~get_tv_number_chk(&argvars[0], NULL);
 }
@@ -11313,9 +10834,7 @@ typval_T    *rettv;
 /*
  * "isdirectory()" function
  */
-static void f_isdirectory(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_isdirectory(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = mch_isdir(get_tv_string(&argvars[0]));
 }
@@ -11323,9 +10842,7 @@ typval_T    *rettv;
 /*
  * "islocked()" function
  */
-static void f_islocked(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_islocked(typval_T *argvars, typval_T *rettv)
 {
   lval_T lv;
   char_u      *end;
@@ -11377,10 +10894,7 @@ static void dict_list __ARGS((typval_T *argvars, typval_T *rettv, int what));
  * "what" == 1: list of values
  * "what" == 2: list of items
  */
-static void dict_list(argvars, rettv, what)
-typval_T    *argvars;
-typval_T    *rettv;
-int what;
+static void dict_list(typval_T *argvars, typval_T *rettv, int what)
 {
   list_T      *l2;
   dictitem_T  *di;
@@ -11450,9 +10964,7 @@ int what;
 /*
  * "items(dict)" function
  */
-static void f_items(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_items(typval_T *argvars, typval_T *rettv)
 {
   dict_list(argvars, rettv, 2);
 }
@@ -11460,9 +10972,7 @@ typval_T    *rettv;
 /*
  * "join()" function
  */
-static void f_join(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_join(typval_T *argvars, typval_T *rettv)
 {
   garray_T ga;
   char_u      *sep;
@@ -11492,9 +11002,7 @@ typval_T    *rettv;
 /*
  * "keys()" function
  */
-static void f_keys(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_keys(typval_T *argvars, typval_T *rettv)
 {
   dict_list(argvars, rettv, 0);
 }
@@ -11502,9 +11010,7 @@ typval_T    *rettv;
 /*
  * "last_buffer_nr()" function.
  */
-static void f_last_buffer_nr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_last_buffer_nr(typval_T *argvars, typval_T *rettv)
 {
   int n = 0;
   buf_T       *buf;
@@ -11519,9 +11025,7 @@ typval_T    *rettv;
 /*
  * "len()" function
  */
-static void f_len(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_len(typval_T *argvars, typval_T *rettv)
 {
   switch (argvars[0].v_type) {
   case VAR_STRING:
@@ -11543,10 +11047,7 @@ typval_T    *rettv;
 
 static void libcall_common __ARGS((typval_T *argvars, typval_T *rettv, int type));
 
-static void libcall_common(argvars, rettv, type)
-typval_T    *argvars;
-typval_T    *rettv;
-int type;
+static void libcall_common(typval_T *argvars, typval_T *rettv, int type)
 {
 #ifdef FEAT_LIBCALL
   char_u              *string_in;
@@ -11586,9 +11087,7 @@ int type;
 /*
  * "libcall()" function
  */
-static void f_libcall(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_libcall(typval_T *argvars, typval_T *rettv)
 {
   libcall_common(argvars, rettv, VAR_STRING);
 }
@@ -11596,9 +11095,7 @@ typval_T    *rettv;
 /*
  * "libcallnr()" function
  */
-static void f_libcallnr(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_libcallnr(typval_T *argvars, typval_T *rettv)
 {
   libcall_common(argvars, rettv, VAR_NUMBER);
 }
@@ -11606,9 +11103,7 @@ typval_T    *rettv;
 /*
  * "line(string)" function
  */
-static void f_line(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_line(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum = 0;
   pos_T       *fp;
@@ -11623,9 +11118,7 @@ typval_T    *rettv;
 /*
  * "line2byte(lnum)" function
  */
-static void f_line2byte(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_line2byte(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
 
@@ -11641,9 +11134,7 @@ typval_T    *rettv;
 /*
  * "lispindent(lnum)" function
  */
-static void f_lispindent(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_lispindent(typval_T *argvars, typval_T *rettv)
 {
   pos_T pos;
   linenr_T lnum;
@@ -11661,19 +11152,14 @@ typval_T    *rettv;
 /*
  * "localtime()" function
  */
-static void f_localtime(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_localtime(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = (varnumber_T)time(NULL);
 }
 
 static void get_maparg __ARGS((typval_T *argvars, typval_T *rettv, int exact));
 
-static void get_maparg(argvars, rettv, exact)
-typval_T    *argvars;
-typval_T    *rettv;
-int exact;
+static void get_maparg(typval_T *argvars, typval_T *rettv, int exact)
 {
   char_u      *keys;
   char_u      *which;
@@ -11741,9 +11227,7 @@ int exact;
 /*
  * "log()" function
  */
-static void f_log(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_log(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -11757,9 +11241,7 @@ typval_T    *rettv;
 /*
  * "log10()" function
  */
-static void f_log10(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_log10(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -11774,9 +11256,7 @@ typval_T    *rettv;
 /*
  * "map()" function
  */
-static void f_map(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_map(typval_T *argvars, typval_T *rettv)
 {
   filter_map(argvars, rettv, TRUE);
 }
@@ -11784,9 +11264,7 @@ typval_T    *rettv;
 /*
  * "maparg()" function
  */
-static void f_maparg(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_maparg(typval_T *argvars, typval_T *rettv)
 {
   get_maparg(argvars, rettv, TRUE);
 }
@@ -11794,9 +11272,7 @@ typval_T    *rettv;
 /*
  * "mapcheck()" function
  */
-static void f_mapcheck(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_mapcheck(typval_T *argvars, typval_T *rettv)
 {
   get_maparg(argvars, rettv, FALSE);
 }
@@ -11804,10 +11280,7 @@ typval_T    *rettv;
 static void find_some_match __ARGS((typval_T *argvars, typval_T *rettv,
                                     int start));
 
-static void find_some_match(argvars, rettv, type)
-typval_T    *argvars;
-typval_T    *rettv;
-int type;
+static void find_some_match(typval_T *argvars, typval_T *rettv, int type)
 {
   char_u      *str = NULL;
   char_u      *expr = NULL;
@@ -11960,9 +11433,7 @@ theend:
 /*
  * "match()" function
  */
-static void f_match(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_match(typval_T *argvars, typval_T *rettv)
 {
   find_some_match(argvars, rettv, 1);
 }
@@ -11970,9 +11441,7 @@ typval_T    *rettv;
 /*
  * "matchadd()" function
  */
-static void f_matchadd(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_matchadd(typval_T *argvars, typval_T *rettv)
 {
   char_u buf[NUMBUFLEN];
   char_u      *grp = get_tv_string_buf_chk(&argvars[0], buf);   /* group */
@@ -12003,9 +11472,7 @@ typval_T    *rettv UNUSED;
 /*
  * "matcharg()" function
  */
-static void f_matcharg(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_matcharg(typval_T *argvars, typval_T *rettv)
 {
   if (rettv_list_alloc(rettv) == OK) {
     int id = get_tv_number(&argvars[0]);
@@ -12027,9 +11494,7 @@ typval_T    *rettv;
 /*
  * "matchdelete()" function
  */
-static void f_matchdelete(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_matchdelete(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = match_delete(curwin,
       (int)get_tv_number(&argvars[0]), TRUE);
@@ -12038,9 +11503,7 @@ typval_T    *rettv UNUSED;
 /*
  * "matchend()" function
  */
-static void f_matchend(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_matchend(typval_T *argvars, typval_T *rettv)
 {
   find_some_match(argvars, rettv, 0);
 }
@@ -12048,9 +11511,7 @@ typval_T    *rettv;
 /*
  * "matchlist()" function
  */
-static void f_matchlist(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_matchlist(typval_T *argvars, typval_T *rettv)
 {
   find_some_match(argvars, rettv, 3);
 }
@@ -12058,19 +11519,14 @@ typval_T    *rettv;
 /*
  * "matchstr()" function
  */
-static void f_matchstr(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_matchstr(typval_T *argvars, typval_T *rettv)
 {
   find_some_match(argvars, rettv, 2);
 }
 
 static void max_min __ARGS((typval_T *argvars, typval_T *rettv, int domax));
 
-static void max_min(argvars, rettv, domax)
-typval_T    *argvars;
-typval_T    *rettv;
-int domax;
+static void max_min(typval_T *argvars, typval_T *rettv, int domax)
 {
   long n = 0;
   long i;
@@ -12124,9 +11580,7 @@ int domax;
 /*
  * "max()" function
  */
-static void f_max(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_max(typval_T *argvars, typval_T *rettv)
 {
   max_min(argvars, rettv, TRUE);
 }
@@ -12134,9 +11588,7 @@ typval_T    *rettv;
 /*
  * "min()" function
  */
-static void f_min(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_min(typval_T *argvars, typval_T *rettv)
 {
   max_min(argvars, rettv, FALSE);
 }
@@ -12147,9 +11599,7 @@ static int mkdir_recurse __ARGS((char_u *dir, int prot));
  * Create the directory in which "dir" is located, and higher levels when
  * needed.
  */
-static int mkdir_recurse(dir, prot)
-char_u      *dir;
-int prot;
+static int mkdir_recurse(char_u *dir, int prot)
 {
   char_u      *p;
   char_u      *updir;
@@ -12177,9 +11627,7 @@ int prot;
 /*
  * "mkdir()" function
  */
-static void f_mkdir(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_mkdir(typval_T *argvars, typval_T *rettv)
 {
   char_u      *dir;
   char_u buf[NUMBUFLEN];
@@ -12211,9 +11659,7 @@ typval_T    *rettv;
 /*
  * "mode()" function
  */
-static void f_mode(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_mode(typval_T *argvars, typval_T *rettv)
 {
   char_u buf[3];
 
@@ -12268,9 +11714,7 @@ typval_T    *rettv;
 /*
  * "nextnonblank()" function
  */
-static void f_nextnonblank(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_nextnonblank(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
 
@@ -12288,9 +11732,7 @@ typval_T    *rettv;
 /*
  * "nr2char()" function
  */
-static void f_nr2char(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_nr2char(typval_T *argvars, typval_T *rettv)
 {
   char_u buf[NUMBUFLEN];
 
@@ -12314,9 +11756,7 @@ typval_T    *rettv;
 /*
  * "or(expr, expr)" function
  */
-static void f_or(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_or(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = get_tv_number_chk(&argvars[0], NULL)
                          | get_tv_number_chk(&argvars[1], NULL);
@@ -12325,9 +11765,7 @@ typval_T    *rettv;
 /*
  * "pathshorten()" function
  */
-static void f_pathshorten(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_pathshorten(typval_T *argvars, typval_T *rettv)
 {
   char_u      *p;
 
@@ -12346,9 +11784,7 @@ typval_T    *rettv;
 /*
  * "pow()" function
  */
-static void f_pow(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_pow(typval_T *argvars, typval_T *rettv)
 {
   float_T fx, fy;
 
@@ -12363,9 +11799,7 @@ typval_T    *rettv;
 /*
  * "prevnonblank()" function
  */
-static void f_prevnonblank(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_prevnonblank(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
 
@@ -12389,9 +11823,7 @@ static va_list ap;
 /*
  * "printf()" function
  */
-static void f_printf(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_printf(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
@@ -12422,9 +11854,7 @@ typval_T    *rettv;
 /*
  * "pumvisible()" function
  */
-static void f_pumvisible(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_pumvisible(typval_T *argvars, typval_T *rettv)
 {
   if (pum_visible())
     rettv->vval.v_number = 1;
@@ -12435,9 +11865,7 @@ typval_T    *rettv UNUSED;
 /*
  * "range()" function
  */
-static void f_range(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_range(typval_T *argvars, typval_T *rettv)
 {
   long start;
   long end;
@@ -12473,9 +11901,7 @@ typval_T    *rettv;
 /*
  * "readfile()" function
  */
-static void f_readfile(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_readfile(typval_T *argvars, typval_T *rettv)
 {
   int binary = FALSE;
   int failed = FALSE;
@@ -12686,9 +12112,7 @@ proftime_T  *tm;
 /*
  * "reltime()" function
  */
-static void f_reltime(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_reltime(typval_T *argvars, typval_T *rettv)
 {
   proftime_T res;
   proftime_T start;
@@ -12721,9 +12145,7 @@ typval_T    *rettv UNUSED;
 /*
  * "reltimestr()" function
  */
-static void f_reltimestr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_reltimestr(typval_T *argvars, typval_T *rettv)
 {
   proftime_T tm;
 
@@ -12738,9 +12160,7 @@ typval_T    *rettv;
 /*
  * "remote_expr()" function
  */
-static void f_remote_expr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_remote_expr(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
@@ -12749,22 +12169,16 @@ typval_T    *rettv;
 /*
  * "remote_foreground()" function
  */
-static void f_remote_foreground(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_remote_foreground(typval_T *argvars, typval_T *rettv)
 {
 }
 
-static void f_remote_peek(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_remote_peek(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = -1;
 }
 
-static void f_remote_read(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_remote_read(typval_T *argvars, typval_T *rettv)
 {
   char_u      *r = NULL;
 
@@ -12775,9 +12189,7 @@ typval_T    *rettv;
 /*
  * "remote_send()" function
  */
-static void f_remote_send(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_remote_send(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
@@ -12786,9 +12198,7 @@ typval_T    *rettv;
 /*
  * "remove()" function
  */
-static void f_remove(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_remove(typval_T *argvars, typval_T *rettv)
 {
   list_T      *l;
   listitem_T  *item, *item2;
@@ -12871,9 +12281,7 @@ typval_T    *rettv;
 /*
  * "rename({from}, {to})" function
  */
-static void f_rename(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_rename(typval_T *argvars, typval_T *rettv)
 {
   char_u buf[NUMBUFLEN];
 
@@ -12887,9 +12295,7 @@ typval_T    *rettv;
 /*
  * "repeat()" function
  */
-static void f_repeat(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_repeat(typval_T *argvars, typval_T *rettv)
 {
   char_u      *p;
   int n;
@@ -12929,9 +12335,7 @@ typval_T    *rettv;
 /*
  * "resolve()" function
  */
-static void f_resolve(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_resolve(typval_T *argvars, typval_T *rettv)
 {
   char_u      *p;
 #ifdef HAVE_READLINK
@@ -13116,9 +12520,7 @@ fail:
 /*
  * "reverse({list})" function
  */
-static void f_reverse(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_reverse(typval_T *argvars, typval_T *rettv)
 {
   list_T      *l;
   listitem_T  *li, *ni;
@@ -13157,9 +12559,7 @@ static int get_search_arg __ARGS((typval_T *varp, int *flagsp));
  * Possibly sets "p_ws".
  * Returns BACKWARD, FORWARD or zero (for an error).
  */
-static int get_search_arg(varp, flagsp)
-typval_T    *varp;
-int         *flagsp;
+static int get_search_arg(typval_T *varp, int *flagsp)
 {
   int dir = FORWARD;
   char_u      *flags;
@@ -13203,10 +12603,7 @@ int         *flagsp;
 /*
  * Shared by search() and searchpos() functions
  */
-static int search_cmn(argvars, match_pos, flagsp)
-typval_T    *argvars;
-pos_T       *match_pos;
-int         *flagsp;
+static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
 {
   int flags;
   char_u      *pat;
@@ -13294,8 +12691,7 @@ theend:
 /*
  * round() is not in C90, use ceil() or floor() instead.
  */
-float_T vim_round(f)
-float_T f;
+float_T vim_round(float_T f)
 {
   return f > 0 ? floor(f + 0.5) : ceil(f - 0.5);
 }
@@ -13303,9 +12699,7 @@ float_T f;
 /*
  * "round({float})" function
  */
-static void f_round(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_round(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -13319,9 +12713,7 @@ typval_T    *rettv;
 /*
  * "screenattr()" function
  */
-static void f_screenattr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_screenattr(typval_T *argvars, typval_T *rettv)
 {
   int row;
   int col;
@@ -13340,9 +12732,7 @@ typval_T    *rettv;
 /*
  * "screenchar()" function
  */
-static void f_screenchar(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_screenchar(typval_T *argvars, typval_T *rettv)
 {
   int row;
   int col;
@@ -13369,9 +12759,7 @@ typval_T    *rettv;
  *
  * First column is 1 to be consistent with virtcol().
  */
-static void f_screencol(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_screencol(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = screen_screencol() + 1;
 }
@@ -13379,9 +12767,7 @@ typval_T    *rettv;
 /*
  * "screenrow()" function
  */
-static void f_screenrow(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_screenrow(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = screen_screenrow() + 1;
 }
@@ -13389,9 +12775,7 @@ typval_T    *rettv;
 /*
  * "search()" function
  */
-static void f_search(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_search(typval_T *argvars, typval_T *rettv)
 {
   int flags = 0;
 
@@ -13401,9 +12785,7 @@ typval_T    *rettv;
 /*
  * "searchdecl()" function
  */
-static void f_searchdecl(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_searchdecl(typval_T *argvars, typval_T *rettv)
 {
   int locally = 1;
   int thisblock = 0;
@@ -13426,9 +12808,7 @@ typval_T    *rettv;
 /*
  * Used by searchpair() and searchpairpos()
  */
-static int searchpair_cmn(argvars, match_pos)
-typval_T    *argvars;
-pos_T       *match_pos;
+static int searchpair_cmn(typval_T *argvars, pos_T *match_pos)
 {
   char_u      *spat, *mpat, *epat;
   char_u      *skip;
@@ -13499,9 +12879,7 @@ theend:
 /*
  * "searchpair()" function
  */
-static void f_searchpair(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_searchpair(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = searchpair_cmn(argvars, NULL);
 }
@@ -13509,9 +12887,7 @@ typval_T    *rettv;
 /*
  * "searchpairpos()" function
  */
-static void f_searchpairpos(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_searchpairpos(typval_T *argvars, typval_T *rettv)
 {
   pos_T match_pos;
   int lnum = 0;
@@ -13534,17 +12910,18 @@ typval_T    *rettv;
  * Used by searchpair(), see its documentation for the details.
  * Returns 0 or -1 for no match,
  */
-long do_searchpair(spat, mpat, epat, dir, skip, flags, match_pos,
-    lnum_stop, time_limit)
-char_u      *spat;          /* start pattern */
-char_u      *mpat;          /* middle pattern */
-char_u      *epat;          /* end pattern */
-int dir;                    /* BACKWARD or FORWARD */
-char_u      *skip;          /* skip expression */
-int flags;                  /* SP_SETPCMARK and other SP_ values */
-pos_T       *match_pos;
-linenr_T lnum_stop;         /* stop at this line if not zero */
-long time_limit UNUSED;            /* stop after this many msec */
+long 
+do_searchpair (
+    char_u *spat,          /* start pattern */
+    char_u *mpat,          /* middle pattern */
+    char_u *epat,          /* end pattern */
+    int dir,                    /* BACKWARD or FORWARD */
+    char_u *skip,          /* skip expression */
+    int flags,                  /* SP_SETPCMARK and other SP_ values */
+    pos_T *match_pos,
+    linenr_T lnum_stop,         /* stop at this line if not zero */
+    long time_limit            /* stop after this many msec */
+)
 {
   char_u      *save_cpo;
   char_u      *pat, *pat2 = NULL, *pat3 = NULL;
@@ -13679,9 +13056,7 @@ theend:
 /*
  * "searchpos()" function
  */
-static void f_searchpos(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_searchpos(typval_T *argvars, typval_T *rettv)
 {
   pos_T match_pos;
   int lnum = 0;
@@ -13705,16 +13080,12 @@ typval_T    *rettv;
 }
 
 
-static void f_server2client(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_server2client(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = -1;
 }
 
-static void f_serverlist(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_serverlist(typval_T *argvars, typval_T *rettv)
 {
   char_u      *r = NULL;
 
@@ -13725,9 +13096,7 @@ typval_T    *rettv;
 /*
  * "setbufvar()" function
  */
-static void f_setbufvar(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv UNUSED;
+static void f_setbufvar(typval_T *argvars, typval_T *rettv)
 {
   buf_T       *buf;
   aco_save_T aco;
@@ -13774,9 +13143,7 @@ typval_T    *rettv UNUSED;
 /*
  * "setcmdpos()" function
  */
-static void f_setcmdpos(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_setcmdpos(typval_T *argvars, typval_T *rettv)
 {
   int pos = (int)get_tv_number(&argvars[0]) - 1;
 
@@ -13787,9 +13154,7 @@ typval_T    *rettv;
 /*
  * "setline()" function
  */
-static void f_setline(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_setline(typval_T *argvars, typval_T *rettv)
 {
   linenr_T lnum;
   char_u      *line = NULL;
@@ -13857,11 +13222,7 @@ static void set_qf_ll_list __ARGS((win_T *wp, typval_T *list_arg, typval_T *
 /*
  * Used by "setqflist()" and "setloclist()" functions
  */
-static void set_qf_ll_list(wp, list_arg, action_arg, rettv)
-win_T       *wp UNUSED;
-typval_T    *list_arg UNUSED;
-typval_T    *action_arg UNUSED;
-typval_T    *rettv;
+static void set_qf_ll_list(win_T *wp, typval_T *list_arg, typval_T *action_arg, typval_T *rettv)
 {
   char_u      *act;
   int action = ' ';
@@ -13890,9 +13251,7 @@ typval_T    *rettv;
 /*
  * "setloclist()" function
  */
-static void f_setloclist(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_setloclist(typval_T *argvars, typval_T *rettv)
 {
   win_T       *win;
 
@@ -13906,9 +13265,7 @@ typval_T    *rettv;
 /*
  * "setmatches()" function
  */
-static void f_setmatches(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_setmatches(typval_T *argvars, typval_T *rettv)
 {
   list_T      *l;
   listitem_T  *li;
@@ -13957,9 +13314,7 @@ typval_T    *rettv UNUSED;
 /*
  * "setpos()" function
  */
-static void f_setpos(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_setpos(typval_T *argvars, typval_T *rettv)
 {
   pos_T pos;
   int fnum;
@@ -13992,9 +13347,7 @@ typval_T    *rettv;
 /*
  * "setqflist()" function
  */
-static void f_setqflist(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_setqflist(typval_T *argvars, typval_T *rettv)
 {
   set_qf_ll_list(NULL, &argvars[0], &argvars[1], rettv);
 }
@@ -14002,9 +13355,7 @@ typval_T    *rettv;
 /*
  * "setreg()" function
  */
-static void f_setreg(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_setreg(typval_T *argvars, typval_T *rettv)
 {
   int regname;
   char_u      *strregname;
@@ -14065,9 +13416,7 @@ typval_T    *rettv;
 /*
  * "settabvar()" function
  */
-static void f_settabvar(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_settabvar(typval_T *argvars, typval_T *rettv)
 {
   tabpage_T   *save_curtab;
   tabpage_T   *tp;
@@ -14106,9 +13455,7 @@ typval_T    *rettv;
 /*
  * "settabwinvar()" function
  */
-static void f_settabwinvar(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_settabwinvar(typval_T *argvars, typval_T *rettv)
 {
   setwinvar(argvars, rettv, 1);
 }
@@ -14116,9 +13463,7 @@ typval_T    *rettv;
 /*
  * "setwinvar()" function
  */
-static void f_setwinvar(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_setwinvar(typval_T *argvars, typval_T *rettv)
 {
   setwinvar(argvars, rettv, 0);
 }
@@ -14127,10 +13472,7 @@ typval_T    *rettv;
  * "setwinvar()" and "settabwinvar()" functions
  */
 
-static void setwinvar(argvars, rettv, off)
-typval_T    *argvars;
-typval_T    *rettv UNUSED;
-int off;
+static void setwinvar(typval_T *argvars, typval_T *rettv, int off)
 {
   win_T       *win;
   win_T       *save_curwin;
@@ -14182,9 +13524,7 @@ int off;
 /*
  * "sha256({string})" function
  */
-static void f_sha256(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_sha256(typval_T *argvars, typval_T *rettv)
 {
   char_u      *p;
 
@@ -14197,9 +13537,7 @@ typval_T    *rettv;
 /*
  * "shellescape({string})" function
  */
-static void f_shellescape(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_shellescape(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_string = vim_strsave_shellescape(
       get_tv_string(&argvars[0]), non_zero_arg(&argvars[1]));
@@ -14209,9 +13547,7 @@ typval_T    *rettv;
 /*
  * shiftwidth() function
  */
-static void f_shiftwidth(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_shiftwidth(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = get_sw_value(curbuf);
 }
@@ -14219,9 +13555,7 @@ typval_T    *rettv;
 /*
  * "simplify()" function
  */
-static void f_simplify(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_simplify(typval_T *argvars, typval_T *rettv)
 {
   char_u      *p;
 
@@ -14234,9 +13568,7 @@ typval_T    *rettv;
 /*
  * "sin()" function
  */
-static void f_sin(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_sin(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -14250,9 +13582,7 @@ typval_T    *rettv;
 /*
  * "sinh()" function
  */
-static void f_sinh(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_sinh(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -14277,9 +13607,7 @@ static int item_compare_func_err;
 /*
  * Compare functions for f_sort() below.
  */
-static int item_compare(s1, s2)
-const void  *s1;
-const void  *s2;
+static int item_compare(const void *s1, const void *s2)
 {
   char_u      *p1, *p2;
   char_u      *tofree1, *tofree2;
@@ -14302,9 +13630,7 @@ const void  *s2;
   return res;
 }
 
-static int item_compare2(s1, s2)
-const void  *s1;
-const void  *s2;
+static int item_compare2(const void *s1, const void *s2)
 {
   int res;
   typval_T rettv;
@@ -14340,9 +13666,7 @@ const void  *s2;
 /*
  * "sort({list})" function
  */
-static void f_sort(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_sort(typval_T *argvars, typval_T *rettv)
 {
   list_T      *l;
   listitem_T  *li;
@@ -14429,9 +13753,7 @@ typval_T    *rettv;
 /*
  * "soundfold({word})" function
  */
-static void f_soundfold(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_soundfold(typval_T *argvars, typval_T *rettv)
 {
   char_u      *s;
 
@@ -14443,9 +13765,7 @@ typval_T    *rettv;
 /*
  * "spellbadword()" function
  */
-static void f_spellbadword(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_spellbadword(typval_T *argvars, typval_T *rettv)
 {
   char_u      *word = (char_u *)"";
   hlf_T attr = HLF_COUNT;
@@ -14488,9 +13808,7 @@ typval_T    *rettv;
 /*
  * "spellsuggest()" function
  */
-static void f_spellsuggest(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_spellsuggest(typval_T *argvars, typval_T *rettv)
 {
   char_u      *str;
   int typeerr = FALSE;
@@ -14536,9 +13854,7 @@ typval_T    *rettv;
   }
 }
 
-static void f_split(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_split(typval_T *argvars, typval_T *rettv)
 {
   char_u      *str;
   char_u      *end;
@@ -14611,9 +13927,7 @@ typval_T    *rettv;
 /*
  * "sqrt()" function
  */
-static void f_sqrt(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_sqrt(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -14627,9 +13941,7 @@ typval_T    *rettv;
 /*
  * "str2float()" function
  */
-static void f_str2float(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_str2float(typval_T *argvars, typval_T *rettv)
 {
   char_u *p = skipwhite(get_tv_string(&argvars[0]));
 
@@ -14642,9 +13954,7 @@ typval_T    *rettv;
 /*
  * "str2nr()" function
  */
-static void f_str2nr(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_str2nr(typval_T *argvars, typval_T *rettv)
 {
   int base = 10;
   char_u      *p;
@@ -14669,9 +13979,7 @@ typval_T    *rettv;
 /*
  * "strftime({format}[, {time}])" function
  */
-static void f_strftime(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_strftime(typval_T *argvars, typval_T *rettv)
 {
   char_u result_buf[256];
   struct tm   *curtime;
@@ -14722,9 +14030,7 @@ typval_T    *rettv;
 /*
  * "stridx()" function
  */
-static void f_stridx(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_stridx(typval_T *argvars, typval_T *rettv)
 {
   char_u buf[NUMBUFLEN];
   char_u      *needle;
@@ -14757,9 +14063,7 @@ typval_T    *rettv;
 /*
  * "string()" function
  */
-static void f_string(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_string(typval_T *argvars, typval_T *rettv)
 {
   char_u      *tofree;
   char_u numbuf[NUMBUFLEN];
@@ -14774,9 +14078,7 @@ typval_T    *rettv;
 /*
  * "strlen()" function
  */
-static void f_strlen(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_strlen(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = (varnumber_T)(STRLEN(
                                            get_tv_string(&argvars[0])));
@@ -14785,9 +14087,7 @@ typval_T    *rettv;
 /*
  * "strchars()" function
  */
-static void f_strchars(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_strchars(typval_T *argvars, typval_T *rettv)
 {
   char_u              *s = get_tv_string(&argvars[0]);
   varnumber_T len = 0;
@@ -14802,9 +14102,7 @@ typval_T    *rettv;
 /*
  * "strdisplaywidth()" function
  */
-static void f_strdisplaywidth(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_strdisplaywidth(typval_T *argvars, typval_T *rettv)
 {
   char_u      *s = get_tv_string(&argvars[0]);
   int col = 0;
@@ -14818,9 +14116,7 @@ typval_T    *rettv;
 /*
  * "strwidth()" function
  */
-static void f_strwidth(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_strwidth(typval_T *argvars, typval_T *rettv)
 {
   char_u      *s = get_tv_string(&argvars[0]);
 
@@ -14832,9 +14128,7 @@ typval_T    *rettv;
 /*
  * "strpart()" function
  */
-static void f_strpart(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_strpart(typval_T *argvars, typval_T *rettv)
 {
   char_u      *p;
   int n;
@@ -14874,9 +14168,7 @@ typval_T    *rettv;
 /*
  * "strridx()" function
  */
-static void f_strridx(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_strridx(typval_T *argvars, typval_T *rettv)
 {
   char_u buf[NUMBUFLEN];
   char_u      *needle;
@@ -14922,9 +14214,7 @@ typval_T    *rettv;
 /*
  * "strtrans()" function
  */
-static void f_strtrans(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_strtrans(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = transstr(get_tv_string(&argvars[0]));
@@ -14933,9 +14223,7 @@ typval_T    *rettv;
 /*
  * "submatch()" function
  */
-static void f_submatch(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_submatch(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string =
@@ -14945,9 +14233,7 @@ typval_T    *rettv;
 /*
  * "substitute()" function
  */
-static void f_substitute(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_substitute(typval_T *argvars, typval_T *rettv)
 {
   char_u patbuf[NUMBUFLEN];
   char_u subbuf[NUMBUFLEN];
@@ -14968,9 +14254,7 @@ typval_T    *rettv;
 /*
  * "synID(lnum, col, trans)" function
  */
-static void f_synID(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_synID(typval_T *argvars, typval_T *rettv)
 {
   int id = 0;
   long lnum;
@@ -14992,9 +14276,7 @@ typval_T    *rettv;
 /*
  * "synIDattr(id, what [, mode])" function
  */
-static void f_synIDattr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_synIDattr(typval_T *argvars, typval_T *rettv)
 {
   char_u      *p = NULL;
   int id;
@@ -15071,9 +14353,7 @@ typval_T    *rettv;
 /*
  * "synIDtrans(id)" function
  */
-static void f_synIDtrans(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_synIDtrans(typval_T *argvars, typval_T *rettv)
 {
   int id;
 
@@ -15090,9 +14370,7 @@ typval_T    *rettv;
 /*
  * "synconcealed(lnum, col)" function
  */
-static void f_synconcealed(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_synconcealed(typval_T *argvars, typval_T *rettv)
 {
   long lnum;
   long col;
@@ -15141,9 +14419,7 @@ typval_T    *rettv;
 /*
  * "synstack(lnum, col)" function
  */
-static void f_synstack(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_synstack(typval_T *argvars, typval_T *rettv)
 {
   long lnum;
   long col;
@@ -15173,9 +14449,7 @@ typval_T    *rettv;
 /*
  * "system()" function
  */
-static void f_system(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_system(typval_T *argvars, typval_T *rettv)
 {
   char_u      *res = NULL;
   char_u      *p;
@@ -15259,9 +14533,7 @@ done:
 /*
  * "tabpagebuflist()" function
  */
-static void f_tabpagebuflist(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_tabpagebuflist(typval_T *argvars, typval_T *rettv)
 {
   tabpage_T   *tp;
   win_T       *wp = NULL;
@@ -15285,9 +14557,7 @@ typval_T    *rettv UNUSED;
 /*
  * "tabpagenr()" function
  */
-static void f_tabpagenr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_tabpagenr(typval_T *argvars, typval_T *rettv)
 {
   int nr = 1;
   char_u      *arg;
@@ -15312,9 +14582,7 @@ static int get_winnr __ARGS((tabpage_T *tp, typval_T *argvar));
 /*
  * Common code for tabpagewinnr() and winnr().
  */
-static int get_winnr(tp, argvar)
-tabpage_T   *tp;
-typval_T    *argvar;
+static int get_winnr(tabpage_T *tp, typval_T *argvar)
 {
   win_T       *twin;
   int nr = 1;
@@ -15354,9 +14622,7 @@ typval_T    *argvar;
 /*
  * "tabpagewinnr()" function
  */
-static void f_tabpagewinnr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_tabpagewinnr(typval_T *argvars, typval_T *rettv)
 {
   int nr = 1;
   tabpage_T   *tp;
@@ -15373,9 +14639,7 @@ typval_T    *rettv;
 /*
  * "tagfiles()" function
  */
-static void f_tagfiles(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_tagfiles(typval_T *argvars, typval_T *rettv)
 {
   char_u      *fname;
   tagname_T tn;
@@ -15398,9 +14662,7 @@ typval_T    *rettv;
 /*
  * "taglist()" function
  */
-static void f_taglist(argvars, rettv)
-typval_T  *argvars;
-typval_T  *rettv;
+static void f_taglist(typval_T *argvars, typval_T *rettv)
 {
   char_u  *tag_pattern;
 
@@ -15417,9 +14679,7 @@ typval_T  *rettv;
 /*
  * "tempname()" function
  */
-static void f_tempname(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_tempname(typval_T *argvars, typval_T *rettv)
 {
   static int x = 'A';
 
@@ -15442,9 +14702,7 @@ typval_T    *rettv;
 /*
  * "test(list)" function: Just checking the walls...
  */
-static void f_test(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_test(typval_T *argvars, typval_T *rettv)
 {
   /* Used for unit testing.  Change the code below to your liking. */
 }
@@ -15452,9 +14710,7 @@ typval_T    *rettv UNUSED;
 /*
  * "tan()" function
  */
-static void f_tan(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_tan(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -15468,9 +14724,7 @@ typval_T    *rettv;
 /*
  * "tanh()" function
  */
-static void f_tanh(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_tanh(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -15484,9 +14738,7 @@ typval_T    *rettv;
 /*
  * "tolower(string)" function
  */
-static void f_tolower(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_tolower(typval_T *argvars, typval_T *rettv)
 {
   char_u      *p;
 
@@ -15520,9 +14772,7 @@ typval_T    *rettv;
 /*
  * "toupper(string)" function
  */
-static void f_toupper(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_toupper(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = strup_save(get_tv_string(&argvars[0]));
@@ -15531,9 +14781,7 @@ typval_T    *rettv;
 /*
  * "tr(string, fromstr, tostr)" function
  */
-static void f_tr(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_tr(typval_T *argvars, typval_T *rettv)
 {
   char_u      *in_str;
   char_u      *fromstr;
@@ -15634,9 +14882,7 @@ error:
 /*
  * "trunc({float})" function
  */
-static void f_trunc(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_trunc(typval_T *argvars, typval_T *rettv)
 {
   float_T f;
 
@@ -15651,9 +14897,7 @@ typval_T    *rettv;
 /*
  * "type(expr)" function
  */
-static void f_type(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_type(typval_T *argvars, typval_T *rettv)
 {
   int n;
 
@@ -15672,9 +14916,7 @@ typval_T    *rettv;
 /*
  * "undofile(name)" function
  */
-static void f_undofile(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_undofile(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
   {
@@ -15696,9 +14938,7 @@ typval_T    *rettv;
 /*
  * "undotree()" function
  */
-static void f_undotree(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_undotree(typval_T *argvars, typval_T *rettv)
 {
   if (rettv_dict_alloc(rettv) == OK) {
     dict_T *dict = rettv->vval.v_dict;
@@ -15723,9 +14963,7 @@ typval_T    *rettv;
 /*
  * "values(dict)" function
  */
-static void f_values(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_values(typval_T *argvars, typval_T *rettv)
 {
   dict_list(argvars, rettv, 1);
 }
@@ -15733,9 +14971,7 @@ typval_T    *rettv;
 /*
  * "virtcol(string)" function
  */
-static void f_virtcol(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_virtcol(typval_T *argvars, typval_T *rettv)
 {
   colnr_T vcol = 0;
   pos_T       *fp;
@@ -15754,9 +14990,7 @@ typval_T    *rettv;
 /*
  * "visualmode()" function
  */
-static void f_visualmode(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_visualmode(typval_T *argvars, typval_T *rettv)
 {
   char_u str[2];
 
@@ -15773,9 +15007,7 @@ typval_T    *rettv UNUSED;
 /*
  * "wildmenumode()" function
  */
-static void f_wildmenumode(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv UNUSED;
+static void f_wildmenumode(typval_T *argvars, typval_T *rettv)
 {
   if (wild_menu_showing)
     rettv->vval.v_number = 1;
@@ -15784,9 +15016,7 @@ typval_T    *rettv UNUSED;
 /*
  * "winbufnr(nr)" function
  */
-static void f_winbufnr(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_winbufnr(typval_T *argvars, typval_T *rettv)
 {
   win_T       *wp;
 
@@ -15800,9 +15030,7 @@ typval_T    *rettv;
 /*
  * "wincol()" function
  */
-static void f_wincol(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_wincol(typval_T *argvars, typval_T *rettv)
 {
   validate_cursor();
   rettv->vval.v_number = curwin->w_wcol + 1;
@@ -15811,9 +15039,7 @@ typval_T    *rettv;
 /*
  * "winheight(nr)" function
  */
-static void f_winheight(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_winheight(typval_T *argvars, typval_T *rettv)
 {
   win_T       *wp;
 
@@ -15827,9 +15053,7 @@ typval_T    *rettv;
 /*
  * "winline()" function
  */
-static void f_winline(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_winline(typval_T *argvars, typval_T *rettv)
 {
   validate_cursor();
   rettv->vval.v_number = curwin->w_wrow + 1;
@@ -15838,9 +15062,7 @@ typval_T    *rettv;
 /*
  * "winnr()" function
  */
-static void f_winnr(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_winnr(typval_T *argvars, typval_T *rettv)
 {
   int nr = 1;
 
@@ -15851,9 +15073,7 @@ typval_T    *rettv;
 /*
  * "winrestcmd()" function
  */
-static void f_winrestcmd(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_winrestcmd(typval_T *argvars, typval_T *rettv)
 {
   win_T       *wp;
   int winnr = 1;
@@ -15877,9 +15097,7 @@ typval_T    *rettv;
 /*
  * "winrestview()" function
  */
-static void f_winrestview(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv UNUSED;
+static void f_winrestview(typval_T *argvars, typval_T *rettv)
 {
   dict_T      *dict;
 
@@ -15914,9 +15132,7 @@ typval_T    *rettv UNUSED;
 /*
  * "winsaveview()" function
  */
-static void f_winsaveview(argvars, rettv)
-typval_T    *argvars UNUSED;
-typval_T    *rettv;
+static void f_winsaveview(typval_T *argvars, typval_T *rettv)
 {
   dict_T      *dict;
 
@@ -15939,9 +15155,7 @@ typval_T    *rettv;
 /*
  * "winwidth(nr)" function
  */
-static void f_winwidth(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_winwidth(typval_T *argvars, typval_T *rettv)
 {
   win_T       *wp;
 
@@ -15955,9 +15169,7 @@ typval_T    *rettv;
 /*
  * "writefile()" function
  */
-static void f_writefile(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_writefile(typval_T *argvars, typval_T *rettv)
 {
   int binary = FALSE;
   char_u      *fname;
@@ -16019,9 +15231,7 @@ typval_T    *rettv;
 /*
  * "xor(expr, expr)" function
  */
-static void f_xor(argvars, rettv)
-typval_T    *argvars;
-typval_T    *rettv;
+static void f_xor(typval_T *argvars, typval_T *rettv)
 {
   rettv->vval.v_number = get_tv_number_chk(&argvars[0], NULL)
                          ^ get_tv_number_chk(&argvars[1], NULL);
@@ -16032,10 +15242,12 @@ typval_T    *rettv;
  * Translate a String variable into a position.
  * Returns NULL when there is an error.
  */
-static pos_T * var2fpos(varp, dollar_lnum, fnum)
-typval_T    *varp;
-int dollar_lnum;                /* TRUE when $ is last line */
-int         *fnum;              /* set to fnum for '0, 'A, etc. */
+static pos_T *
+var2fpos (
+    typval_T *varp,
+    int dollar_lnum,                /* TRUE when $ is last line */
+    int *fnum              /* set to fnum for '0, 'A, etc. */
+)
 {
   char_u              *name;
   static pos_T pos;
@@ -16134,10 +15346,7 @@ int         *fnum;              /* set to fnum for '0, 'A, etc. */
  * Return FAIL when conversion is not possible, doesn't check the position for
  * validity.
  */
-static int list2fpos(arg, posp, fnump)
-typval_T    *arg;
-pos_T       *posp;
-int         *fnump;
+static int list2fpos(typval_T *arg, pos_T *posp, int *fnump)
 {
   list_T      *l = arg->vval.v_list;
   long i = 0;
@@ -16184,8 +15393,7 @@ int         *fnump;
  * Advance "arg" to the first character after the name.
  * Return 0 for error.
  */
-static int get_env_len(arg)
-char_u      **arg;
+static int get_env_len(char_u **arg)
 {
   char_u      *p;
   int len;
@@ -16205,8 +15413,7 @@ char_u      **arg;
  * "arg" is advanced to the first non-white character after the name.
  * Return 0 if something is wrong.
  */
-static int get_id_len(arg)
-char_u      **arg;
+static int get_id_len(char_u **arg)
 {
   char_u      *p;
   int len;
@@ -16232,11 +15439,7 @@ char_u      **arg;
  * If the name contains 'magic' {}'s, expand them and return the
  * expanded name in an allocated string via 'alias' - caller must free.
  */
-static int get_name_len(arg, alias, evaluate, verbose)
-char_u      **arg;
-char_u      **alias;
-int evaluate;
-int verbose;
+static int get_name_len(char_u **arg, char_u **alias, int evaluate, int verbose)
 {
   int len;
   char_u      *p;
@@ -16298,11 +15501,7 @@ int verbose;
  * Return a pointer to just after the name.  Equal to "arg" if there is no
  * valid name.
  */
-static char_u * find_name_end(arg, expr_start, expr_end, flags)
-char_u      *arg;
-char_u      **expr_start;
-char_u      **expr_end;
-int flags;
+static char_u *find_name_end(char_u *arg, char_u **expr_start, char_u **expr_end, int flags)
 {
   int mb_nest = 0;
   int br_nest = 0;
@@ -16374,11 +15573,7 @@ int flags;
  * Returns a new allocated string, which the caller must free.
  * Returns NULL for failure.
  */
-static char_u * make_expanded_name(in_start, expr_start, expr_end, in_end)
-char_u      *in_start;
-char_u      *expr_start;
-char_u      *expr_end;
-char_u      *in_end;
+static char_u *make_expanded_name(char_u *in_start, char_u *expr_start, char_u *expr_end, char_u *in_end)
 {
   char_u c1;
   char_u      *retval = NULL;
@@ -16426,8 +15621,7 @@ char_u      *in_end;
  * Return TRUE if character "c" can be used in a variable or function name.
  * Does not include '{' or '}' for magic braces.
  */
-static int eval_isnamec(c)
-int c;
+static int eval_isnamec(int c)
 {
   return ASCII_ISALNUM(c) || c == '_' || c == ':' || c == AUTOLOAD_CHAR;
 }
@@ -16436,8 +15630,7 @@ int c;
  * Return TRUE if character "c" can be used as the first character in a
  * variable or function name (excluding '{' and '}').
  */
-static int eval_isnamec1(c)
-int c;
+static int eval_isnamec1(int c)
 {
   return ASCII_ISALPHA(c) || c == '_';
 }
@@ -16445,9 +15638,7 @@ int c;
 /*
  * Set number v: variable to "val".
  */
-void set_vim_var_nr(idx, val)
-int idx;
-long val;
+void set_vim_var_nr(int idx, long val)
 {
   vimvars[idx].vv_nr = val;
 }
@@ -16455,8 +15646,7 @@ long val;
 /*
  * Get number v: variable value.
  */
-long get_vim_var_nr(idx)
-int idx;
+long get_vim_var_nr(int idx)
 {
   return vimvars[idx].vv_nr;
 }
@@ -16464,8 +15654,7 @@ int idx;
 /*
  * Get string v: variable value.  Uses a static buffer, can only be used once.
  */
-char_u * get_vim_var_str(idx)
-int idx;
+char_u *get_vim_var_str(int idx)
 {
   return get_tv_string(&vimvars[idx].vv_tv);
 }
@@ -16474,8 +15663,7 @@ int idx;
  * Get List v: variable value.  Caller must take care of reference count when
  * needed.
  */
-list_T * get_vim_var_list(idx)
-int idx;
+list_T *get_vim_var_list(int idx)
 {
   return vimvars[idx].vv_list;
 }
@@ -16483,8 +15671,7 @@ int idx;
 /*
  * Set v:char to character "c".
  */
-void set_vim_var_char(c)
-int c;
+void set_vim_var_char(int c)
 {
   char_u buf[MB_MAXBYTES + 1];
 
@@ -16501,10 +15688,7 @@ int c;
  * Set v:count to "count" and v:count1 to "count1".
  * When "set_prevcount" is TRUE first set v:prevcount from v:count.
  */
-void set_vcount(count, count1, set_prevcount)
-long count;
-long count1;
-int set_prevcount;
+void set_vcount(long count, long count1, int set_prevcount)
 {
   if (set_prevcount)
     vimvars[VV_PREVCOUNT].vv_nr = vimvars[VV_COUNT].vv_nr;
@@ -16515,10 +15699,12 @@ int set_prevcount;
 /*
  * Set string v: variable to a copy of "val".
  */
-void set_vim_var_string(idx, val, len)
-int idx;
-char_u      *val;
-int len;                    /* length of "val" to use or -1 (whole string) */
+void 
+set_vim_var_string (
+    int idx,
+    char_u *val,
+    int len                    /* length of "val" to use or -1 (whole string) */
+)
 {
   /* Need to do this (at least) once, since we can't initialize a union.
    * Will always be invoked when "v:progname" is set. */
@@ -16536,9 +15722,7 @@ int len;                    /* length of "val" to use or -1 (whole string) */
 /*
  * Set List v: variable to "val".
  */
-void set_vim_var_list(idx, val)
-int idx;
-list_T      *val;
+void set_vim_var_list(int idx, list_T *val)
 {
   list_unref(vimvars[idx].vv_list);
   vimvars[idx].vv_list = val;
@@ -16549,8 +15733,7 @@ list_T      *val;
 /*
  * Set v:register if needed.
  */
-void set_reg_var(c)
-int c;
+void set_reg_var(int c)
 {
   char_u regname;
 
@@ -16569,8 +15752,7 @@ int c;
  * Must always be called in pairs to save and restore v:exception!  Does not
  * take care of memory allocations.
  */
-char_u * v_exception(oldval)
-char_u      *oldval;
+char_u *v_exception(char_u *oldval)
 {
   if (oldval == NULL)
     return vimvars[VV_EXCEPTION].vv_str;
@@ -16585,8 +15767,7 @@ char_u      *oldval;
  * Must always be called in pairs to save and restore v:throwpoint!  Does not
  * take care of memory allocations.
  */
-char_u * v_throwpoint(oldval)
-char_u      *oldval;
+char_u *v_throwpoint(char_u *oldval)
 {
   if (oldval == NULL)
     return vimvars[VV_THROWPOINT].vv_str;
@@ -16601,9 +15782,7 @@ char_u      *oldval;
  * If "oldarg" != NULL, restore the value to "oldarg" and return NULL.
  * Must always be called in pairs!
  */
-char_u * set_cmdarg(eap, oldarg)
-exarg_T     *eap;
-char_u      *oldarg;
+char_u *set_cmdarg(exarg_T *eap, char_u *oldarg)
 {
   char_u      *oldval;
   char_u      *newval;
@@ -16667,12 +15846,14 @@ char_u      *oldarg;
  * Get the value of internal variable "name".
  * Return OK or FAIL.
  */
-static int get_var_tv(name, len, rettv, verbose, no_autoload)
-char_u      *name;
-int len;                        /* length of "name" */
-typval_T    *rettv;             /* NULL when only checking existence */
-int verbose;                    /* may give error message */
-int no_autoload;                /* do not use script autoloading */
+static int 
+get_var_tv (
+    char_u *name,
+    int len,                        /* length of "name" */
+    typval_T *rettv,             /* NULL when only checking existence */
+    int verbose,                    /* may give error message */
+    int no_autoload                /* do not use script autoloading */
+)
 {
   int ret = OK;
   typval_T    *tv = NULL;
@@ -16718,11 +15899,13 @@ int no_autoload;                /* do not use script autoloading */
  * Also handle function call with Funcref variable: func(expr)
  * Can all be combined: dict.func(expr)[idx]['func'](expr)
  */
-static int handle_subscript(arg, rettv, evaluate, verbose)
-char_u      **arg;
-typval_T    *rettv;
-int evaluate;                   /* do more than finding the end */
-int verbose;                    /* give error messages */
+static int 
+handle_subscript (
+    char_u **arg,
+    typval_T *rettv,
+    int evaluate,                   /* do more than finding the end */
+    int verbose                    /* give error messages */
+)
 {
   int ret = OK;
   dict_T      *selfdict = NULL;
@@ -16786,7 +15969,7 @@ int verbose;                    /* give error messages */
  * Allocate memory for a variable type-value, and make it empty (0 or NULL
  * value).
  */
-static typval_T * alloc_tv()                       {
+static typval_T *alloc_tv(void)                       {
   return (typval_T *)alloc_clear((unsigned)sizeof(typval_T));
 }
 
@@ -16795,8 +15978,7 @@ static typval_T * alloc_tv()                       {
  * The string "s" must have been allocated, it is consumed.
  * Return NULL for out of memory, the variable otherwise.
  */
-static typval_T * alloc_string_tv(s)
-char_u      *s;
+static typval_T *alloc_string_tv(char_u *s)
 {
   typval_T    *rettv;
 
@@ -16812,8 +15994,7 @@ char_u      *s;
 /*
  * Free the memory for a variable type-value.
  */
-void free_tv(varp)
-typval_T *varp;
+void free_tv(typval_T *varp)
 {
   if (varp != NULL) {
     switch (varp->v_type) {
@@ -16844,8 +16025,7 @@ typval_T *varp;
 /*
  * Free the memory for a variable value and set the value to NULL or 0.
  */
-void clear_tv(varp)
-typval_T *varp;
+void clear_tv(typval_T *varp)
 {
   if (varp != NULL) {
     switch (varp->v_type) {
@@ -16882,8 +16062,7 @@ typval_T *varp;
 /*
  * Set the value of a variable to NULL without freeing items.
  */
-static void init_tv(varp)
-typval_T *varp;
+static void init_tv(typval_T *varp)
 {
   if (varp != NULL)
     vim_memset(varp, 0, sizeof(typval_T));
@@ -16897,17 +16076,14 @@ typval_T *varp;
  * caller of incompatible types: it sets *denote to TRUE if "denote"
  * is not NULL or returns -1 otherwise.
  */
-static long get_tv_number(varp)
-typval_T    *varp;
+static long get_tv_number(typval_T *varp)
 {
   int error = FALSE;
 
   return get_tv_number_chk(varp, &error);       /* return 0L on error */
 }
 
-long get_tv_number_chk(varp, denote)
-typval_T    *varp;
-int         *denote;
+long get_tv_number_chk(typval_T *varp, int *denote)
 {
   long n = 0L;
 
@@ -16947,8 +16123,7 @@ int         *denote;
  * Also accepts ".", "$", etc., but that only works for the current buffer.
  * Returns -1 on error.
  */
-static linenr_T get_tv_lnum(argvars)
-typval_T    *argvars;
+static linenr_T get_tv_lnum(typval_T *argvars)
 {
   typval_T rettv;
   linenr_T lnum;
@@ -16968,9 +16143,7 @@ typval_T    *argvars;
  * Also accepts "$", then "buf" is used.
  * Returns 0 on error.
  */
-static linenr_T get_tv_lnum_buf(argvars, buf)
-typval_T    *argvars;
-buf_T       *buf;
+static linenr_T get_tv_lnum_buf(typval_T *argvars, buf_T *buf)
 {
   if (argvars[0].v_type == VAR_STRING
       && argvars[0].vval.v_string != NULL
@@ -16990,34 +16163,28 @@ buf_T       *buf;
  * get_tv_string_chk() and get_tv_string_buf_chk() are similar, but return
  * NULL on error.
  */
-static char_u * get_tv_string(varp)
-typval_T    *varp;
+static char_u *get_tv_string(typval_T *varp)
 {
   static char_u mybuf[NUMBUFLEN];
 
   return get_tv_string_buf(varp, mybuf);
 }
 
-static char_u * get_tv_string_buf(varp, buf)
-typval_T    *varp;
-char_u      *buf;
+static char_u *get_tv_string_buf(typval_T *varp, char_u *buf)
 {
   char_u      *res =  get_tv_string_buf_chk(varp, buf);
 
   return res != NULL ? res : (char_u *)"";
 }
 
-char_u * get_tv_string_chk(varp)
-typval_T    *varp;
+char_u *get_tv_string_chk(typval_T *varp)
 {
   static char_u mybuf[NUMBUFLEN];
 
   return get_tv_string_buf_chk(varp, mybuf);
 }
 
-static char_u * get_tv_string_buf_chk(varp, buf)
-typval_T    *varp;
-char_u      *buf;
+static char_u *get_tv_string_buf_chk(typval_T *varp, char_u *buf)
 {
   switch (varp->v_type) {
   case VAR_NUMBER:
@@ -17053,10 +16220,7 @@ char_u      *buf;
  * When "htp" is not NULL we are writing to the variable, set "htp" to the
  * hashtab_T used.
  */
-static dictitem_T * find_var(name, htp, no_autoload)
-char_u      *name;
-hashtab_T   **htp;
-int no_autoload;
+static dictitem_T *find_var(char_u *name, hashtab_T **htp, int no_autoload)
 {
   char_u      *varname;
   hashtab_T   *ht;
@@ -17073,11 +16237,7 @@ int no_autoload;
  * Find variable "varname" in hashtab "ht" with name "htname".
  * Returns NULL if not found.
  */
-static dictitem_T * find_var_in_ht(ht, htname, varname, no_autoload)
-hashtab_T   *ht;
-int htname;
-char_u      *varname;
-int no_autoload;
+static dictitem_T *find_var_in_ht(hashtab_T *ht, int htname, char_u *varname, int no_autoload)
 {
   hashitem_T  *hi;
 
@@ -17121,9 +16281,7 @@ int no_autoload;
  * Find the hashtab used for a variable name.
  * Set "varname" to the start of name without ':'.
  */
-static hashtab_T * find_var_ht(name, varname)
-char_u  *name;
-char_u  **varname;
+static hashtab_T *find_var_ht(char_u *name, char_u **varname)
 {
   hashitem_T  *hi;
 
@@ -17173,8 +16331,7 @@ char_u  **varname;
  * Note: see get_tv_string() for how long the pointer remains valid.
  * Returns NULL when it doesn't exist.
  */
-char_u * get_var_value(name)
-char_u      *name;
+char_u *get_var_value(char_u *name)
 {
   dictitem_T  *v;
 
@@ -17188,8 +16345,7 @@ char_u      *name;
  * Allocate a new hashtab for a sourced script.  It will be used while
  * sourcing this script and when executing functions defined in the script.
  */
-void new_script_vars(id)
-scid_T id;
+void new_script_vars(scid_T id)
 {
   int i;
   hashtab_T   *ht;
@@ -17220,10 +16376,7 @@ scid_T id;
  * Initialize dictionary "dict" as a scope and set variable "dict_var" to
  * point to it.
  */
-void init_var_dict(dict, dict_var, scope)
-dict_T      *dict;
-dictitem_T  *dict_var;
-int scope;
+void init_var_dict(dict_T *dict, dictitem_T *dict_var, int scope)
 {
   hash_init(&dict->dv_hashtab);
   dict->dv_lock = 0;
@@ -17240,8 +16393,7 @@ int scope;
 /*
  * Unreference a dictionary initialized by init_var_dict().
  */
-void unref_var_dict(dict)
-dict_T      *dict;
+void unref_var_dict(dict_T *dict)
 {
   /* Now the dict needs to be freed if no one else is using it, go back to
    * normal reference counting. */
@@ -17254,8 +16406,7 @@ dict_T      *dict;
  * Frees all allocated variables and the value they contain.
  * Clears hashtab "ht", does not free it.
  */
-void vars_clear(ht)
-hashtab_T *ht;
+void vars_clear(hashtab_T *ht)
 {
   vars_clear_ext(ht, TRUE);
 }
@@ -17263,9 +16414,7 @@ hashtab_T *ht;
 /*
  * Like vars_clear(), but only free the value if "free_val" is TRUE.
  */
-static void vars_clear_ext(ht, free_val)
-hashtab_T   *ht;
-int free_val;
+static void vars_clear_ext(hashtab_T *ht, int free_val)
 {
   int todo;
   hashitem_T  *hi;
@@ -17295,9 +16444,7 @@ int free_val;
  * Delete a variable from hashtab "ht" at item "hi".
  * Clear the variable value and free the dictitem.
  */
-static void delete_var(ht, hi)
-hashtab_T   *ht;
-hashitem_T  *hi;
+static void delete_var(hashtab_T *ht, hashitem_T *hi)
 {
   dictitem_T  *di = HI2DI(hi);
 
@@ -17309,10 +16456,7 @@ hashitem_T  *hi;
 /*
  * List the value of one internal variable.
  */
-static void list_one_var(v, prefix, first)
-dictitem_T  *v;
-char_u      *prefix;
-int         *first;
+static void list_one_var(dictitem_T *v, char_u *prefix, int *first)
 {
   char_u      *tofree;
   char_u      *s;
@@ -17325,12 +16469,14 @@ int         *first;
   vim_free(tofree);
 }
 
-static void list_one_var_a(prefix, name, type, string, first)
-char_u      *prefix;
-char_u      *name;
-int type;
-char_u      *string;
-int         *first;      /* when TRUE clear rest of screen and set to FALSE */
+static void 
+list_one_var_a (
+    char_u *prefix,
+    char_u *name,
+    int type,
+    char_u *string,
+    int *first      /* when TRUE clear rest of screen and set to FALSE */
+)
 {
   /* don't use msg() or msg_attr() to avoid overwriting "v:statusmsg" */
   msg_start();
@@ -17369,10 +16515,12 @@ int         *first;      /* when TRUE clear rest of screen and set to FALSE */
  * If the variable already exists, the value is updated.
  * Otherwise the variable is created.
  */
-static void set_var(name, tv, copy)
-char_u      *name;
-typval_T    *tv;
-int copy;                   /* make copy of value in "tv" */
+static void 
+set_var (
+    char_u *name,
+    typval_T *tv,
+    int copy                   /* make copy of value in "tv" */
+)
 {
   dictitem_T  *v;
   char_u      *varname;
@@ -17472,9 +16620,7 @@ int copy;                   /* make copy of value in "tv" */
  * Return TRUE if di_flags "flags" indicates variable "name" is read-only.
  * Also give an error message.
  */
-static int var_check_ro(flags, name)
-int flags;
-char_u      *name;
+static int var_check_ro(int flags, char_u *name)
 {
   if (flags & DI_FLAGS_RO) {
     EMSG2(_(e_readonlyvar), name);
@@ -17491,9 +16637,7 @@ char_u      *name;
  * Return TRUE if di_flags "flags" indicates variable "name" is fixed.
  * Also give an error message.
  */
-static int var_check_fixed(flags, name)
-int flags;
-char_u      *name;
+static int var_check_fixed(int flags, char_u *name)
 {
   if (flags & DI_FLAGS_FIX) {
     EMSG2(_("E795: Cannot delete variable %s"), name);
@@ -17506,9 +16650,11 @@ char_u      *name;
  * Check if a funcref is assigned to a valid variable name.
  * Return TRUE and give an error if not.
  */
-static int var_check_func_name(name, new_var)
-char_u *name;        /* points to start of variable name */
-int new_var;         /* TRUE when creating the variable */
+static int 
+var_check_func_name (
+    char_u *name,        /* points to start of variable name */
+    int new_var         /* TRUE when creating the variable */
+)
 {
   if (!(vim_strchr((char_u *)"wbs", name[0]) != NULL && name[1] == ':')
       && !ASCII_ISUPPER((name[0] != NUL && name[1] == ':')
@@ -17532,8 +16678,7 @@ int new_var;         /* TRUE when creating the variable */
  * Check if a variable name is valid.
  * Return FALSE and give an error if not.
  */
-static int valid_varname(varname)
-char_u *varname;
+static int valid_varname(char_u *varname)
 {
   char_u *p;
 
@@ -17550,9 +16695,7 @@ char_u *varname;
  * Return TRUE if typeval "tv" is set to be locked (immutable).
  * Also give an error message, using "name".
  */
-static int tv_check_lock(lock, name)
-int lock;
-char_u      *name;
+static int tv_check_lock(int lock, char_u *name)
 {
   if (lock & VAR_LOCKED) {
     EMSG2(_("E741: Value is locked: %s"),
@@ -17574,9 +16717,7 @@ char_u      *name;
  * It is OK for "from" and "to" to point to the same item.  This is used to
  * make a copy later.
  */
-void copy_tv(from, to)
-typval_T *from;
-typval_T *to;
+void copy_tv(typval_T *from, typval_T *to)
 {
   to->v_type = from->v_type;
   to->v_lock = 0;
@@ -17626,11 +16767,7 @@ typval_T *to;
  * reference to an already copied list/dict can be used.
  * Returns FAIL or OK.
  */
-static int item_copy(from, to, deep, copyID)
-typval_T    *from;
-typval_T    *to;
-int deep;
-int copyID;
+static int item_copy(typval_T *from, typval_T *to, int deep, int copyID)
 {
   static int recurse = 0;
   int ret = OK;
@@ -17689,8 +16826,7 @@ int copyID;
  *			newline at the end.
  * ":echon expr1 ..."	print each argument plain.
  */
-void ex_echo(eap)
-exarg_T     *eap;
+void ex_echo(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   typval_T rettv;
@@ -17777,8 +16913,7 @@ exarg_T     *eap;
 /*
  * ":echohl {name}".
  */
-void ex_echohl(eap)
-exarg_T     *eap;
+void ex_echohl(exarg_T *eap)
 {
   int id;
 
@@ -17796,8 +16931,7 @@ exarg_T     *eap;
  * Each gets spaces around each argument and a newline at the end for
  * echo commands
  */
-void ex_execute(eap)
-exarg_T     *eap;
+void ex_execute(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   typval_T rettv;
@@ -17872,9 +17006,7 @@ exarg_T     *eap;
  * Returns NULL when no option name found.  Otherwise pointer to the char
  * after the option name.
  */
-static char_u * find_option_end(arg, opt_flags)
-char_u      **arg;
-int         *opt_flags;
+static char_u *find_option_end(char_u **arg, int *opt_flags)
 {
   char_u      *p = *arg;
 
@@ -17903,8 +17035,7 @@ int         *opt_flags;
 /*
  * ":function"
  */
-void ex_function(eap)
-exarg_T     *eap;
+void ex_function(exarg_T *eap)
 {
   char_u      *theline;
   int i;
@@ -18496,11 +17627,13 @@ ret_free:
  * TFN_NO_AUTOLOAD: do not use script autoloading
  * Advances "pp" to just after the function name (if no error).
  */
-static char_u * trans_function_name(pp, skip, flags, fdp)
-char_u      **pp;
-int skip;                       /* only find the end, don't evaluate */
-int flags;
-funcdict_T  *fdp;               /* return: info about dictionary used */
+static char_u *
+trans_function_name (
+    char_u **pp,
+    int skip,                       /* only find the end, don't evaluate */
+    int flags,
+    funcdict_T *fdp               /* return: info about dictionary used */
+)
 {
   char_u      *name = NULL;
   char_u      *start;
@@ -18662,8 +17795,7 @@ theend:
  * Return 2 if "p" starts with "s:".
  * Return 0 otherwise.
  */
-static int eval_fname_script(p)
-char_u      *p;
+static int eval_fname_script(char_u *p)
 {
   if (p[0] == '<' && (STRNICMP(p + 1, "SID>", 4) == 0
                       || STRNICMP(p + 1, "SNR>", 4) == 0))
@@ -18677,8 +17809,7 @@ char_u      *p;
  * Return TRUE if "p" starts with "<SID>" or "s:".
  * Only works if eval_fname_script() returned non-zero for "p"!
  */
-static int eval_fname_sid(p)
-char_u      *p;
+static int eval_fname_sid(char_u *p)
 {
   return *p == 's' || TOUPPER_ASC(p[2]) == 'I';
 }
@@ -18686,9 +17817,7 @@ char_u      *p;
 /*
  * List the head of the function: "name(arg1, arg2)".
  */
-static void list_func_head(fp, indent)
-ufunc_T     *fp;
-int indent;
+static void list_func_head(ufunc_T *fp, int indent)
 {
   int j;
 
@@ -18728,8 +17857,7 @@ int indent;
  * Find a function by name, return pointer to it in ufuncs.
  * Return NULL for unknown function.
  */
-static ufunc_T * find_func(name)
-char_u      *name;
+static ufunc_T *find_func(char_u *name)
 {
   hashitem_T  *hi;
 
@@ -18740,7 +17868,7 @@ char_u      *name;
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_all_functions()          {
+void free_all_functions(void)          {
   hashitem_T  *hi;
 
   /* Need to start all over every time, because func_free() may change the
@@ -18755,8 +17883,7 @@ void free_all_functions()          {
 
 #endif
 
-int translated_function_exists(name)
-char_u      *name;
+int translated_function_exists(char_u *name)
 {
   if (builtin_function(name))
     return find_internal_func(name) >= 0;
@@ -18766,8 +17893,7 @@ char_u      *name;
 /*
  * Return TRUE if a function "name" exists.
  */
-static int function_exists(name)
-char_u *name;
+static int function_exists(char_u *name)
 {
   char_u  *nm = name;
   char_u  *p;
@@ -18785,9 +17911,7 @@ char_u *name;
   return n;
 }
 
-char_u * get_expanded_name(name, check)
-char_u      *name;
-int check;
+char_u *get_expanded_name(char_u *name, int check)
 {
   char_u      *nm = name;
   char_u      *p;
@@ -18806,8 +17930,7 @@ int check;
  * Return TRUE if "name" looks like a builtin function name: starts with a
  * lower case letter and doesn't contain a ':' or AUTOLOAD_CHAR.
  */
-static int builtin_function(name)
-char_u *name;
+static int builtin_function(char_u *name)
 {
   return ASCII_ISLOWER(name[0]) && vim_strchr(name, ':') == NULL
          && vim_strchr(name, AUTOLOAD_CHAR) == NULL;
@@ -18816,8 +17939,7 @@ char_u *name;
 /*
  * Start profiling function "fp".
  */
-static void func_do_profile(fp)
-ufunc_T     *fp;
+static void func_do_profile(ufunc_T *fp)
 {
   int len = fp->uf_lines.ga_len;
 
@@ -18845,8 +17967,7 @@ ufunc_T     *fp;
 /*
  * Dump the profiling results for all functions in file "fd".
  */
-void func_dump_profile(fd)
-FILE    *fd;
+void func_dump_profile(FILE *fd)
 {
   hashitem_T  *hi;
   int todo;
@@ -18906,12 +18027,14 @@ FILE    *fd;
   vim_free(sorttab);
 }
 
-static void prof_sort_list(fd, sorttab, st_len, title, prefer_self)
-FILE        *fd;
-ufunc_T     **sorttab;
-int st_len;
-char        *title;
-int prefer_self;                /* when equal print only self time */
+static void 
+prof_sort_list (
+    FILE *fd,
+    ufunc_T **sorttab,
+    int st_len,
+    char *title,
+    int prefer_self                /* when equal print only self time */
+)
 {
   int i;
   ufunc_T     *fp;
@@ -18957,9 +18080,7 @@ int prefer_self;                /* when equal print only self time */
 /*
  * Compare function for total time sorting.
  */
-static int prof_total_cmp(s1, s2)
-const void  *s1;
-const void  *s2;
+static int prof_total_cmp(const void *s1, const void *s2)
 {
   ufunc_T     *p1, *p2;
 
@@ -18971,9 +18092,7 @@ const void  *s2;
 /*
  * Compare function for self time sorting.
  */
-static int prof_self_cmp(s1, s2)
-const void  *s1;
-const void  *s2;
+static int prof_self_cmp(const void *s1, const void *s2)
 {
   ufunc_T     *p1, *p2;
 
@@ -18987,9 +18106,11 @@ const void  *s2;
  * If "name" has a package name try autoloading the script for it.
  * Return TRUE if a package was loaded.
  */
-static int script_autoload(name, reload)
-char_u      *name;
-int reload;                 /* load script again when already loaded */
+static int 
+script_autoload (
+    char_u *name,
+    int reload                 /* load script again when already loaded */
+)
 {
   char_u      *p;
   char_u      *scriptname, *tofree;
@@ -19030,8 +18151,7 @@ int reload;                 /* load script again when already loaded */
  * Return the autoload script name for a function or variable name.
  * Returns NULL when out of memory.
  */
-static char_u * autoload_name(name)
-char_u      *name;
+static char_u *autoload_name(char_u *name)
 {
   char_u      *p;
   char_u      *scriptname;
@@ -19054,9 +18174,7 @@ char_u      *name;
  * Function given to ExpandGeneric() to obtain the list of user defined
  * function names.
  */
-char_u * get_user_func_name(xp, idx)
-expand_T    *xp;
-int idx;
+char_u *get_user_func_name(expand_T *xp, int idx)
 {
   static long_u done;
   static hashitem_T   *hi;
@@ -19096,9 +18214,7 @@ int idx;
  * "buf" must be able to hold the function name plus three bytes.
  * Takes care of script-local function names.
  */
-static void cat_func_name(buf, fp)
-char_u      *buf;
-ufunc_T     *fp;
+static void cat_func_name(char_u *buf, ufunc_T *fp)
 {
   if (fp->uf_name[0] == K_SPECIAL) {
     STRCPY(buf, "<SNR>");
@@ -19110,8 +18226,7 @@ ufunc_T     *fp;
 /*
  * ":delfunction {name}"
  */
-void ex_delfunction(eap)
-exarg_T     *eap;
+void ex_delfunction(exarg_T *eap)
 {
   ufunc_T     *fp = NULL;
   char_u      *p;
@@ -19161,8 +18276,7 @@ exarg_T     *eap;
 /*
  * Free a function and remove it from the list of functions.
  */
-static void func_free(fp)
-ufunc_T *fp;
+static void func_free(ufunc_T *fp)
 {
   hashitem_T  *hi;
 
@@ -19187,8 +18301,7 @@ ufunc_T *fp;
  * Unreference a Function: decrement the reference count and free it when it
  * becomes zero.  Only for numbered functions.
  */
-void func_unref(name)
-char_u      *name;
+void func_unref(char_u *name)
 {
   ufunc_T *fp;
 
@@ -19208,8 +18321,7 @@ char_u      *name;
 /*
  * Count a reference to a Function.
  */
-void func_ref(name)
-char_u      *name;
+void func_ref(char_u *name)
 {
   ufunc_T *fp;
 
@@ -19225,15 +18337,16 @@ char_u      *name;
 /*
  * Call a user function.
  */
-static void call_user_func(fp, argcount, argvars, rettv, firstline, lastline,
-    selfdict)
-ufunc_T     *fp;                /* pointer to function */
-int argcount;                   /* nr of args */
-typval_T    *argvars;           /* arguments */
-typval_T    *rettv;             /* return value */
-linenr_T firstline;             /* first line of range */
-linenr_T lastline;              /* last line of range */
-dict_T      *selfdict;          /* Dictionary for "self" */
+static void 
+call_user_func (
+    ufunc_T *fp,                /* pointer to function */
+    int argcount,                   /* nr of args */
+    typval_T *argvars,           /* arguments */
+    typval_T *rettv,             /* return value */
+    linenr_T firstline,             /* first line of range */
+    linenr_T lastline,              /* last line of range */
+    dict_T *selfdict          /* Dictionary for "self" */
+)
 {
   char_u      *save_sourcing_name;
   linenr_T save_sourcing_lnum;
@@ -19554,9 +18667,7 @@ dict_T      *selfdict;          /* Dictionary for "self" */
  * Return TRUE if items in "fc" do not have "copyID".  That means they are not
  * referenced from anywhere that is in use.
  */
-static int can_free_funccal(fc, copyID)
-funccall_T  *fc;
-int copyID;
+static int can_free_funccal(funccall_T *fc, int copyID)
 {
   return fc->l_varlist.lv_copyID != copyID
          && fc->l_vars.dv_copyID != copyID
@@ -19566,9 +18677,11 @@ int copyID;
 /*
  * Free "fc" and what it contains.
  */
-static void free_funccal(fc, free_val)
-funccall_T  *fc;
-int free_val;              /* a: vars were allocated */
+static void 
+free_funccal (
+    funccall_T *fc,
+    int free_val              /* a: vars were allocated */
+)
 {
   listitem_T  *li;
 
@@ -19590,11 +18703,7 @@ int free_val;              /* a: vars were allocated */
 /*
  * Add a number variable "name" to dict "dp" with value "nr".
  */
-static void add_nr_var(dp, v, name, nr)
-dict_T      *dp;
-dictitem_T  *v;
-char        *name;
-varnumber_T nr;
+static void add_nr_var(dict_T *dp, dictitem_T *v, char *name, varnumber_T nr)
 {
   STRCPY(v->di_key, name);
   v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
@@ -19607,8 +18716,7 @@ varnumber_T nr;
 /*
  * ":return [expr]"
  */
-void ex_return(eap)
-exarg_T     *eap;
+void ex_return(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   typval_T rettv;
@@ -19660,11 +18768,7 @@ exarg_T     *eap;
  * with the return rettv.  Returns TRUE when the return can be carried out,
  * FALSE when the return gets pending.
  */
-int do_return(eap, reanimate, is_cmd, rettv)
-exarg_T     *eap;
-int reanimate;
-int is_cmd;
-void        *rettv;
+int do_return(exarg_T *eap, int reanimate, int is_cmd, void *rettv)
 {
   int idx;
   struct condstack *cstack = eap->cstack;
@@ -19732,8 +18836,7 @@ void        *rettv;
 /*
  * Free the variable with a pending return value.
  */
-void discard_pending_return(rettv)
-void        *rettv;
+void discard_pending_return(void *rettv)
 {
   free_tv((typval_T *)rettv);
 }
@@ -19742,8 +18845,7 @@ void        *rettv;
  * Generate a return command for producing the value of "rettv".  The result
  * is an allocated string.  Used by report_pending() for verbose messages.
  */
-char_u * get_return_cmd(rettv)
-void        *rettv;
+char_u *get_return_cmd(void *rettv)
 {
   char_u      *s = NULL;
   char_u      *tofree = NULL;
@@ -19767,10 +18869,7 @@ void        *rettv;
  * Called by do_cmdline() to get the next line.
  * Returns allocated string, or NULL for end of function.
  */
-char_u * get_func_line(c, cookie, indent)
-int c UNUSED;
-void    *cookie;
-int indent UNUSED;
+char_u *get_func_line(int c, void *cookie, int indent)
 {
   funccall_T  *fcp = (funccall_T *)cookie;
   ufunc_T     *fp = fcp->func;
@@ -19823,8 +18922,7 @@ int indent UNUSED;
  * When skipping lines it may not actually be executed, but we won't find out
  * until later and we need to store the time now.
  */
-void func_line_start(cookie)
-void    *cookie;
+void func_line_start(void *cookie)
 {
   funccall_T  *fcp = (funccall_T *)cookie;
   ufunc_T     *fp = fcp->func;
@@ -19845,8 +18943,7 @@ void    *cookie;
 /*
  * Called when actually executing a function line.
  */
-void func_line_exec(cookie)
-void    *cookie;
+void func_line_exec(void *cookie)
 {
   funccall_T  *fcp = (funccall_T *)cookie;
   ufunc_T     *fp = fcp->func;
@@ -19858,8 +18955,7 @@ void    *cookie;
 /*
  * Called when done with a function line.
  */
-void func_line_end(cookie)
-void    *cookie;
+void func_line_end(void *cookie)
 {
   funccall_T  *fcp = (funccall_T *)cookie;
   ufunc_T     *fp = fcp->func;
@@ -19881,8 +18977,7 @@ void    *cookie;
  * Return TRUE if the currently active function should be ended, because a
  * return was encountered or an error occurred.  Used inside a ":while".
  */
-int func_has_ended(cookie)
-void    *cookie;
+int func_has_ended(void *cookie)
 {
   funccall_T  *fcp = (funccall_T *)cookie;
 
@@ -19895,8 +18990,7 @@ void    *cookie;
 /*
  * return TRUE if cookie indicates a function which "abort"s on errors.
  */
-int func_has_abort(cookie)
-void    *cookie;
+int func_has_abort(void *cookie)
 {
   return ((funccall_T *)cookie)->func->uf_flags & FC_ABORT;
 }
@@ -19909,8 +19003,7 @@ typedef enum {
 
 static var_flavour_T var_flavour __ARGS((char_u *varname));
 
-static var_flavour_T var_flavour(varname)
-char_u *varname;
+static var_flavour_T var_flavour(char_u *varname)
 {
   char_u *p = varname;
 
@@ -19926,9 +19019,7 @@ char_u *varname;
 /*
  * Restore global vars that start with a capital from the viminfo file
  */
-int read_viminfo_varlist(virp, writing)
-vir_T       *virp;
-int writing;
+int read_viminfo_varlist(vir_T *virp, int writing)
 {
   char_u      *tab;
   int type = VAR_NUMBER;
@@ -19985,8 +19076,7 @@ int writing;
 /*
  * Write global vars that start with a capital to the viminfo file
  */
-void write_viminfo_varlist(fp)
-FILE    *fp;
+void write_viminfo_varlist(FILE *fp)
 {
   hashitem_T  *hi;
   dictitem_T  *this_var;
@@ -20025,8 +19115,7 @@ FILE    *fp;
   }
 }
 
-int store_session_globals(fd)
-FILE        *fd;
+int store_session_globals(FILE *fd)
 {
   hashitem_T  *hi;
   dictitem_T  *this_var;
@@ -20087,8 +19176,7 @@ FILE        *fd;
  * Display script name where an item was last set.
  * Should only be invoked when 'verbose' is non-zero.
  */
-void last_set_msg(scriptID)
-scid_T scriptID;
+void last_set_msg(scid_T scriptID)
 {
   char_u *p;
 
@@ -20107,8 +19195,7 @@ scid_T scriptID;
 /*
  * List v:oldfiles in a nice way.
  */
-void ex_oldfiles(eap)
-exarg_T     *eap UNUSED;
+void ex_oldfiles(exarg_T *eap)
 {
   list_T      *l = vimvars[VV_OLDFILES].vv_list;
   listitem_T  *li;
@@ -20144,12 +19231,14 @@ exarg_T     *eap UNUSED;
  * Returns VALID_ flags or -1 for failure.
  * When there is an error, *fnamep is set to NULL.
  */
-int modify_fname(src, usedlen, fnamep, bufp, fnamelen)
-char_u      *src;               /* string with modifiers */
-int         *usedlen;           /* characters after src that are used */
-char_u      **fnamep;           /* file name so far */
-char_u      **bufp;             /* buffer for allocated file name or NULL */
-int         *fnamelen;          /* length of fnamep */
+int 
+modify_fname (
+    char_u *src,               /* string with modifiers */
+    int *usedlen,           /* characters after src that are used */
+    char_u **fnamep,           /* file name so far */
+    char_u **bufp,             /* buffer for allocated file name or NULL */
+    int *fnamelen          /* length of fnamep */
+)
 {
   int valid = 0;
   char_u      *tail;
@@ -20395,11 +19484,7 @@ repeat:
  * "flags" can be "g" to do a global substitute.
  * Returns an allocated string, NULL for error.
  */
-char_u * do_string_sub(str, pat, sub, flags)
-char_u      *str;
-char_u      *pat;
-char_u      *sub;
-char_u      *flags;
+char_u *do_string_sub(char_u *str, char_u *pat, char_u *sub, char_u *flags)
 {
   int sublen;
   regmatch_T regmatch;

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -32,8 +32,7 @@ help_compare __ARGS((const void *s1, const void *s2));
 /*
  * ":ascii" and "ga".
  */
-void do_ascii(eap)
-exarg_T     *eap UNUSED;
+void do_ascii(exarg_T *eap)
 {
   int c;
   int cval;
@@ -113,8 +112,7 @@ exarg_T     *eap UNUSED;
 /*
  * ":left", ":center" and ":right": align text.
  */
-void ex_align(eap)
-exarg_T     *eap;
+void ex_align(exarg_T *eap)
 {
   pos_T save_curpos;
   int len;
@@ -204,8 +202,7 @@ exarg_T     *eap;
 /*
  * Get the length of the current line, excluding trailing white space.
  */
-static int linelen(has_tab)
-int     *has_tab;
+static int linelen(int *has_tab)
 {
   char_u  *line;
   char_u  *first;
@@ -252,9 +249,7 @@ typedef struct {
 static int
 sort_compare __ARGS((const void *s1, const void *s2));
 
-static int sort_compare(s1, s2)
-const void  *s1;
-const void  *s2;
+static int sort_compare(const void *s1, const void *s2)
 {
   sorti_T l1 = *(sorti_T *)s1;
   sorti_T l2 = *(sorti_T *)s2;
@@ -298,8 +293,7 @@ const void  *s2;
 /*
  * ":sort".
  */
-void ex_sort(eap)
-exarg_T     *eap;
+void ex_sort(exarg_T *eap)
 {
   regmatch_T regmatch;
   int len;
@@ -509,8 +503,7 @@ sortend:
 /*
  * ":retab".
  */
-void ex_retab(eap)
-exarg_T     *eap;
+void ex_retab(exarg_T *eap)
 {
   linenr_T lnum;
   int got_tab = FALSE;
@@ -642,10 +635,7 @@ exarg_T     *eap;
  *
  * return FAIL for failure, OK otherwise
  */
-int do_move(line1, line2, dest)
-linenr_T line1;
-linenr_T line2;
-linenr_T dest;
+int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
 {
   char_u      *str;
   linenr_T l;
@@ -747,10 +737,7 @@ linenr_T dest;
 /*
  * ":copy"
  */
-void ex_copy(line1, line2, n)
-linenr_T line1;
-linenr_T line2;
-linenr_T n;
+void ex_copy(linenr_T line1, linenr_T line2, linenr_T n)
 {
   linenr_T count;
   char_u      *p;
@@ -802,7 +789,7 @@ linenr_T n;
 static char_u   *prevcmd = NULL;        /* the previous command */
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_prev_shellcmd()          {
+void free_prev_shellcmd(void)          {
   vim_free(prevcmd);
 }
 
@@ -813,11 +800,7 @@ void free_prev_shellcmd()          {
  * Bangs in the argument are replaced with the previously entered command.
  * Remember the argument.
  */
-void do_bang(addr_count, eap, forceit, do_in, do_out)
-int addr_count;
-exarg_T     *eap;
-int forceit;
-int do_in, do_out;
+void do_bang(int addr_count, exarg_T *eap, int forceit, int do_in, int do_out)
 {
   char_u              *arg = eap->arg;          /* command */
   linenr_T line1 = eap->line1;                  /* start of range */
@@ -952,11 +935,15 @@ int do_in, do_out;
  * We use input redirection if do_in is TRUE.
  * We use output redirection if do_out is TRUE.
  */
-static void do_filter(line1, line2, eap, cmd, do_in, do_out)
-linenr_T line1, line2;
-exarg_T     *eap;               /* for forced 'ff' and 'fenc' */
-char_u      *cmd;
-int do_in, do_out;
+static void 
+do_filter (
+    linenr_T line1,
+    linenr_T line2,
+    exarg_T *eap,               /* for forced 'ff' and 'fenc' */
+    char_u *cmd,
+    int do_in,
+    int do_out
+)
 {
   char_u      *itmp = NULL;
   char_u      *otmp = NULL;
@@ -1164,9 +1151,11 @@ filterend:
  * Call a shell to execute a command.
  * When "cmd" is NULL start an interactive shell.
  */
-void do_shell(cmd, flags)
-char_u      *cmd;
-int flags;              /* may be SHELL_DOOUT when output is redirected */
+void 
+do_shell (
+    char_u *cmd,
+    int flags              /* may be SHELL_DOOUT when output is redirected */
+)
 {
   buf_T       *buf;
   int save_nwr;
@@ -1269,10 +1258,12 @@ int flags;              /* may be SHELL_DOOUT when output is redirected */
  * output redirection file.
  * Returns an allocated string with the shell command, or NULL for failure.
  */
-char_u * make_filter_cmd(cmd, itmp, otmp)
-char_u      *cmd;               /* command */
-char_u      *itmp;              /* NULL or name of input file */
-char_u      *otmp;              /* NULL or name of output file */
+char_u *
+make_filter_cmd (
+    char_u *cmd,               /* command */
+    char_u *itmp,              /* NULL or name of input file */
+    char_u *otmp              /* NULL or name of output file */
+)
 {
   char_u      *buf;
   long_u len;
@@ -1342,11 +1333,7 @@ char_u      *otmp;              /* NULL or name of output file */
  * The caller should make sure that there is enough room:
  *	STRLEN(opt) + STRLEN(fname) + 3
  */
-void append_redir(buf, buflen, opt, fname)
-char_u      *buf;
-int buflen;
-char_u      *opt;
-char_u      *fname;
+void append_redir(char_u *buf, int buflen, char_u *opt, char_u *fname)
 {
   char_u      *p;
   char_u      *end;
@@ -1373,7 +1360,7 @@ char_u      *fname;
 static int no_viminfo __ARGS((void));
 static int viminfo_errcnt;
 
-static int no_viminfo()                {
+static int no_viminfo(void)                {
   /* "vim -i NONE" does not read or write a viminfo file */
   return use_viminfo != NULL && STRCMP(use_viminfo, "NONE") == 0;
 }
@@ -1382,10 +1369,7 @@ static int no_viminfo()                {
  * Report an error for reading a viminfo file.
  * Count the number of errors.	When there are more than 10, return TRUE.
  */
-int viminfo_error(errnum, message, line)
-char    *errnum;
-char    *message;
-char_u  *line;
+int viminfo_error(char *errnum, char *message, char_u *line)
 {
   vim_snprintf((char *)IObuff, IOSIZE, _("%sviminfo: %s in line: "),
       errnum, message);
@@ -1404,9 +1388,11 @@ char_u  *line;
  * read_viminfo() -- Read the viminfo file.  Registers etc. which are already
  * set are not over-written unless "flags" includes VIF_FORCEIT. -- webb
  */
-int read_viminfo(file, flags)
-char_u      *file;          /* file name or NULL to use default name */
-int flags;                  /* VIF_WANT_INFO et al. */
+int 
+read_viminfo (
+    char_u *file,          /* file name or NULL to use default name */
+    int flags                  /* VIF_WANT_INFO et al. */
+)
 {
   FILE        *fp;
   char_u      *fname;
@@ -1448,9 +1434,7 @@ int flags;                  /* VIF_WANT_INFO et al. */
  * If "forceit" is TRUE, then the old file is not read in, and only internal
  * info is written to the file.
  */
-void write_viminfo(file, forceit)
-char_u      *file;
-int forceit;
+void write_viminfo(char_u *file, int forceit)
 {
   char_u      *fname;
   FILE        *fp_in = NULL;    /* input viminfo file, if any */
@@ -1678,8 +1662,7 @@ end:
  * expand environment variables.
  * Returns an allocated string.  NULL when out of memory.
  */
-static char_u * viminfo_filename(file)
-char_u      *file;
+static char_u *viminfo_filename(char_u *file)
 {
   if (file == NULL || *file == NUL) {
     if (use_viminfo != NULL)
@@ -1707,10 +1690,7 @@ char_u      *file;
 /*
  * do_viminfo() -- Should only be called from read_viminfo() & write_viminfo().
  */
-static void do_viminfo(fp_in, fp_out, flags)
-FILE        *fp_in;
-FILE        *fp_out;
-int flags;
+static void do_viminfo(FILE *fp_in, FILE *fp_out, int flags)
 {
   int count = 0;
   int eof = FALSE;
@@ -1763,10 +1743,7 @@ int flags;
  * first part of the viminfo file which contains everything but the marks that
  * are local to a file.  Returns TRUE when end-of-file is reached. -- webb
  */
-static int read_viminfo_up_to_marks(virp, forceit, writing)
-vir_T       *virp;
-int forceit;
-int writing;
+static int read_viminfo_up_to_marks(vir_T *virp, int forceit, int writing)
 {
   int eof;
   buf_T       *buf;
@@ -1843,8 +1820,7 @@ int writing;
  * 'encoding'.  If different and the 'c' flag is in 'viminfo', setup for
  * conversion of text with iconv() in viminfo_readstring().
  */
-static int viminfo_encoding(virp)
-vir_T       *virp;
+static int viminfo_encoding(vir_T *virp)
 {
   char_u      *p;
   int i;
@@ -1868,8 +1844,7 @@ vir_T       *virp;
  * Read a line from the viminfo file.
  * Returns TRUE for end-of-file;
  */
-int viminfo_readline(virp)
-vir_T       *virp;
+int viminfo_readline(vir_T *virp)
 {
   return vim_fgets(virp->vir_line, LSIZE, virp->vir_fd);
 }
@@ -1884,10 +1859,12 @@ vir_T       *virp;
  *
  * Return the string in allocated memory (NULL when out of memory).
  */
-char_u * viminfo_readstring(virp, off, convert)
-vir_T       *virp;
-int off;                            /* offset for virp->vir_line */
-int convert UNUSED;                 /* convert the string */
+char_u *
+viminfo_readstring (
+    vir_T *virp,
+    int off,                            /* offset for virp->vir_line */
+    int convert                 /* convert the string */
+)
 {
   char_u      *retval;
   char_u      *s, *d;
@@ -1945,9 +1922,7 @@ int convert UNUSED;                 /* convert the string */
  * - write " CTRL-V <length> \n " in first line
  * - write " < <string> \n "	  in second line
  */
-void viminfo_writestring(fd, p)
-FILE        *fd;
-char_u      *p;
+void viminfo_writestring(FILE *fd, char_u *p)
 {
   int c;
   char_u      *s;
@@ -1983,8 +1958,7 @@ char_u      *p;
  *   ^?		^H
  * not ^?	^?
  */
-void do_fixdel(eap)
-exarg_T     *eap UNUSED;
+void do_fixdel(exarg_T *eap)
 {
   char_u  *p;
 
@@ -1993,10 +1967,7 @@ exarg_T     *eap UNUSED;
       && *p == DEL ? (char_u *)CTRL_H_STR : DEL_STR, FALSE);
 }
 
-void print_line_no_prefix(lnum, use_number, list)
-linenr_T lnum;
-int use_number;
-int list;
+void print_line_no_prefix(linenr_T lnum, int use_number, int list)
 {
   char_u numbuf[30];
 
@@ -2011,10 +1982,7 @@ int list;
 /*
  * Print a text line.  Also in silent mode ("ex -s").
  */
-void print_line(lnum, use_number, list)
-linenr_T lnum;
-int use_number;
-int list;
+void print_line(linenr_T lnum, int use_number, int list)
 {
   int save_silent = silent_mode;
 
@@ -2031,8 +1999,7 @@ int list;
   info_message = FALSE;
 }
 
-int rename_buffer(new_fname)
-char_u      *new_fname;
+int rename_buffer(char_u *new_fname)
 {
   char_u      *fname, *sfname, *xfname;
   buf_T       *buf;
@@ -2078,8 +2045,7 @@ char_u      *new_fname;
 /*
  * ":file[!] [fname]".
  */
-void ex_file(eap)
-exarg_T     *eap;
+void ex_file(exarg_T *eap)
 {
   /* ":0file" removes the file name.  Check for illegal uses ":3file",
    * "0file name", etc. */
@@ -2102,8 +2068,7 @@ exarg_T     *eap;
 /*
  * ":update".
  */
-void ex_update(eap)
-exarg_T     *eap;
+void ex_update(exarg_T *eap)
 {
   if (curbufIsChanged())
     (void)do_write(eap);
@@ -2112,8 +2077,7 @@ exarg_T     *eap;
 /*
  * ":write" and ":saveas".
  */
-void ex_write(eap)
-exarg_T     *eap;
+void ex_write(exarg_T *eap)
 {
   if (eap->usefilter)           /* input lines to shell command */
     do_bang(1, eap, FALSE, TRUE, FALSE);
@@ -2129,8 +2093,7 @@ exarg_T     *eap;
  *
  * return FAIL for failure, OK otherwise
  */
-int do_write(eap)
-exarg_T     *eap;
+int do_write(exarg_T *eap)
 {
   int other;
   char_u      *fname = NULL;            /* init to shut up gcc */
@@ -2287,13 +2250,15 @@ theend:
  * May set eap->forceit if a dialog says it's OK to overwrite.
  * Return OK if it's OK, FAIL if it is not.
  */
-int check_overwrite(eap, buf, fname, ffname, other)
-exarg_T     *eap;
-buf_T       *buf;
-char_u      *fname;         /* file name to be used (can differ from
+int 
+check_overwrite (
+    exarg_T *eap,
+    buf_T *buf,
+    char_u *fname,         /* file name to be used (can differ from
                                buf->ffname) */
-char_u      *ffname;        /* full path version of fname */
-int other;                  /* writing under other name */
+    char_u *ffname,        /* full path version of fname */
+    int other                  /* writing under other name */
+)
 {
   /*
    * write to other file or b_flags set or not writing the whole file:
@@ -2384,8 +2349,7 @@ int other;                  /* writing under other name */
 /*
  * Handle ":wnext", ":wNext" and ":wprevious" commands.
  */
-void ex_wnext(eap)
-exarg_T     *eap;
+void ex_wnext(exarg_T *eap)
 {
   int i;
 
@@ -2402,8 +2366,7 @@ exarg_T     *eap;
 /*
  * ":wall", ":wqall" and ":xall": Write all changed files (and exit).
  */
-void do_wqall(eap)
-exarg_T     *eap;
+void do_wqall(exarg_T *eap)
 {
   buf_T       *buf;
   int error = 0;
@@ -2453,7 +2416,7 @@ exarg_T     *eap;
  * Check the 'write' option.
  * Return TRUE and give a message when it's not st.
  */
-int not_writing()         {
+int not_writing(void)         {
   if (p_write)
     return FALSE;
   EMSG(_("E142: File not written: Writing is disabled by 'write' option"));
@@ -2465,9 +2428,7 @@ int not_writing()         {
  * read-only). Ask for overruling in a dialog. Return TRUE and give an error
  * message when the buffer is readonly.
  */
-static int check_readonly(forceit, buf)
-int         *forceit;
-buf_T       *buf;
+static int check_readonly(int *forceit, buf_T *buf)
 {
   struct stat st;
 
@@ -2517,13 +2478,7 @@ buf_T       *buf;
  * -1 for successfully opening another file.
  * 'lnum' is the line number for the cursor in the new file (if non-zero).
  */
-int getfile(fnum, ffname, sfname, setpm, lnum, forceit)
-int fnum;
-char_u      *ffname;
-char_u      *sfname;
-int setpm;
-linenr_T lnum;
-int forceit;
+int getfile(int fnum, char_u *ffname, char_u *sfname, int setpm, linenr_T lnum, int forceit)
 {
   int other;
   int retval;
@@ -2607,14 +2562,16 @@ theend:
  *
  * return FAIL for failure, OK otherwise
  */
-int do_ecmd(fnum, ffname, sfname, eap, newlnum, flags, oldwin)
-int fnum;
-char_u      *ffname;
-char_u      *sfname;
-exarg_T     *eap;                       /* can be NULL! */
-linenr_T newlnum;
-int flags;
-win_T       *oldwin;
+int 
+do_ecmd (
+    int fnum,
+    char_u *ffname,
+    char_u *sfname,
+    exarg_T *eap,                       /* can be NULL! */
+    linenr_T newlnum,
+    int flags,
+    win_T *oldwin
+)
 {
   int other_file;                       /* TRUE if editing another file */
   int oldbuf;                           /* TRUE if using existing buffer */
@@ -3173,8 +3130,7 @@ theend:
   return retval;
 }
 
-static void delbuf_msg(name)
-char_u      *name;
+static void delbuf_msg(char_u *name)
 {
   EMSG2(_("E143: Autocommands unexpectedly deleted new buffer %s"),
       name == NULL ? (char_u *)"" : name);
@@ -3187,8 +3143,7 @@ static int append_indent = 0;       /* autoindent for first line */
 /*
  * ":insert" and ":append", also used by ":change"
  */
-void ex_append(eap)
-exarg_T     *eap;
+void ex_append(exarg_T *eap)
 {
   char_u      *theline;
   int did_undo = FALSE;
@@ -3312,8 +3267,7 @@ exarg_T     *eap;
 /*
  * ":change"
  */
-void ex_change(eap)
-exarg_T     *eap;
+void ex_change(exarg_T *eap)
 {
   linenr_T lnum;
 
@@ -3340,8 +3294,7 @@ exarg_T     *eap;
   ex_append(eap);
 }
 
-void ex_z(eap)
-exarg_T     *eap;
+void ex_z(exarg_T *eap)
 {
   char_u      *x;
   int bigness;
@@ -3460,7 +3413,7 @@ exarg_T     *eap;
  * If so, give an error message and return TRUE.
  * Otherwise, return FALSE.
  */
-int check_restricted()         {
+int check_restricted(void)         {
   if (restricted) {
     EMSG(_("E145: Shell commands not allowed in rvim"));
     return TRUE;
@@ -3473,7 +3426,7 @@ int check_restricted()         {
  * If so, give an error message and return TRUE.
  * Otherwise, return FALSE.
  */
-int check_secure()         {
+int check_secure(void)         {
   if (secure) {
     secure = 2;
     EMSG(_(e_curdir));
@@ -3504,8 +3457,7 @@ static int global_need_beginline;       /* call beginline() after ":g" */
  *
  * The usual escapes are supported as described in the regexp docs.
  */
-void do_sub(eap)
-exarg_T     *eap;
+void do_sub(exarg_T *eap)
 {
   linenr_T lnum;
   long i = 0;
@@ -4416,8 +4368,10 @@ outofmem:
  * Can also be used after a ":global" command.
  * Return TRUE if a message was given.
  */
-int do_sub_msg(count_only)
-int count_only;                 /* used 'n' flag for ":s" */
+int 
+do_sub_msg (
+    int count_only                 /* used 'n' flag for ":s" */
+)
 {
   /*
    * Only report substitutions when:
@@ -4473,8 +4427,7 @@ int count_only;                 /* used 'n' flag for ":s" */
  * for each line that has a mark. This is required because after deleting
  * lines we do not know where to search for the next match.
  */
-void ex_global(eap)
-exarg_T     *eap;
+void ex_global(exarg_T *eap)
 {
   linenr_T lnum;                /* line number according to old situation */
   int ndone = 0;
@@ -4571,8 +4524,7 @@ exarg_T     *eap;
 /*
  * Execute "cmd" on lines marked with ml_setmarked().
  */
-void global_exe(cmd)
-char_u      *cmd;
+void global_exe(char_u *cmd)
 {
   linenr_T old_lcount;          /* b_ml.ml_line_count before the command */
   buf_T    *old_buf = curbuf;   /* remember what buffer we started in */
@@ -4626,9 +4578,7 @@ char_u      *cmd;
     msgmore(curbuf->b_ml.ml_line_count - old_lcount);
 }
 
-int read_viminfo_sub_string(virp, force)
-vir_T       *virp;
-int force;
+int read_viminfo_sub_string(vir_T *virp, int force)
 {
   if (force)
     vim_free(old_sub);
@@ -4637,8 +4587,7 @@ int force;
   return viminfo_readline(virp);
 }
 
-void write_viminfo_sub_string(fp)
-FILE    *fp;
+void write_viminfo_sub_string(FILE *fp)
 {
   if (get_viminfo_parameter('/') != 0 && old_sub != NULL) {
     fputs(_("\n# Last Substitute String:\n$"), fp);
@@ -4647,7 +4596,7 @@ FILE    *fp;
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_old_sub()          {
+void free_old_sub(void)          {
   vim_free(old_sub);
 }
 
@@ -4657,8 +4606,10 @@ void free_old_sub()          {
  * Set up for a tagpreview.
  * Return TRUE when it was created.
  */
-int prepare_tagpreview(undo_sync)
-int undo_sync;                  /* sync undo when leaving the window */
+int 
+prepare_tagpreview (
+    int undo_sync                  /* sync undo when leaving the window */
+)
 {
   win_T       *wp;
 
@@ -4696,8 +4647,7 @@ int undo_sync;                  /* sync undo when leaving the window */
 /*
  * ":help": open a read-only window on a help file
  */
-void ex_help(eap)
-exarg_T     *eap;
+void ex_help(exarg_T *eap)
 {
   char_u      *arg;
   char_u      *tag;
@@ -4870,8 +4820,7 @@ erret:
  * Changes the "@" to NUL if found, and returns a pointer to "xx".
  * Returns NULL if not found.
  */
-char_u * check_help_lang(arg)
-char_u *arg;
+char_u *check_help_lang(char_u *arg)
 {
   int len = (int)STRLEN(arg);
 
@@ -4894,10 +4843,12 @@ char_u *arg;
  * Assumption is made that the matched_string passed has already been found to
  * match some string for which help is requested.  webb.
  */
-int help_heuristic(matched_string, offset, wrong_case)
-char_u      *matched_string;
-int offset;                             /* offset for match */
-int wrong_case;                         /* no matching case */
+int 
+help_heuristic (
+    char_u *matched_string,
+    int offset,                             /* offset for match */
+    int wrong_case                         /* no matching case */
+)
 {
   int num_letters;
   char_u      *p;
@@ -4934,9 +4885,7 @@ int wrong_case;                         /* no matching case */
  * Compare functions for qsort() below, that checks the help heuristics number
  * that has been put after the tagname by find_tags().
  */
-static int help_compare(s1, s2)
-const void  *s1;
-const void  *s2;
+static int help_compare(const void *s1, const void *s2)
 {
   char    *p1;
   char    *p2;
@@ -4952,11 +4901,7 @@ const void  *s2;
  * The matches will be sorted with a "best" match algorithm.
  * When "keep_lang" is TRUE try keeping the language of the current buffer.
  */
-int find_help_tags(arg, num_matches, matches, keep_lang)
-char_u      *arg;
-int         *num_matches;
-char_u      ***matches;
-int keep_lang;
+int find_help_tags(char_u *arg, int *num_matches, char_u ***matches, int keep_lang)
 {
   char_u      *s, *d;
   int i;
@@ -5135,7 +5080,7 @@ int keep_lang;
  * After reading a help file: May cleanup a help buffer when syntax
  * highlighting is not used.
  */
-void fix_help_buffer()          {
+void fix_help_buffer(void)          {
   linenr_T lnum;
   char_u      *line;
   int in_example = FALSE;
@@ -5331,8 +5276,7 @@ void fix_help_buffer()          {
 /*
  * ":exusage"
  */
-void ex_exusage(eap)
-exarg_T     *eap UNUSED;
+void ex_exusage(exarg_T *eap)
 {
   do_cmdline_cmd((char_u *)"help ex-cmd-index");
 }
@@ -5340,8 +5284,7 @@ exarg_T     *eap UNUSED;
 /*
  * ":viusage"
  */
-void ex_viusage(eap)
-exarg_T     *eap UNUSED;
+void ex_viusage(exarg_T *eap)
 {
   do_cmdline_cmd((char_u *)"help normal-index");
 }
@@ -5352,8 +5295,7 @@ static void helptags_one __ARGS((char_u *dir, char_u *ext, char_u *lang,
 /*
  * ":helptags"
  */
-void ex_helptags(eap)
-exarg_T     *eap;
+void ex_helptags(exarg_T *eap)
 {
   garray_T ga;
   int i, j;
@@ -5454,11 +5396,13 @@ exarg_T     *eap;
   vim_free(dirname);
 }
 
-static void helptags_one(dir, ext, tagfname, add_help_tags)
-char_u      *dir;               /* doc directory */
-char_u      *ext;               /* suffix, ".txt", ".itx", ".frx", etc. */
-char_u      *tagfname;          /* "tags" for English, "tags-fr" for French. */
-int add_help_tags;              /* add "help-tags" tag */
+static void 
+helptags_one (
+    char_u *dir,               /* doc directory */
+    char_u *ext,               /* suffix, ".txt", ".itx", ".frx", etc. */
+    char_u *tagfname,          /* "tags" for English, "tags-fr" for French. */
+    int add_help_tags              /* add "help-tags" tag */
+)
 {
   FILE        *fd_tags;
   FILE        *fd;

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -64,8 +64,7 @@ static int debug_greedy = FALSE;        /* batch mode debugging: don't save
  * do_debug(): Debug mode.
  * Repeatedly get Ex commands, until told to continue normal execution.
  */
-void do_debug(cmd)
-char_u      *cmd;
+void do_debug(char_u *cmd)
 {
   int save_msg_scroll = msg_scroll;
   int save_State = State;
@@ -247,8 +246,7 @@ char_u      *cmd;
 /*
  * ":debug".
  */
-void ex_debug(eap)
-exarg_T     *eap;
+void ex_debug(exarg_T *eap)
 {
   int debug_break_level_save = debug_break_level;
 
@@ -277,8 +275,7 @@ static char_u   *debug_skipped_name;
  * decide to execute something themselves.
  * Called from do_one_cmd() before executing a command.
  */
-void dbg_check_breakpoint(eap)
-exarg_T     *eap;
+void dbg_check_breakpoint(exarg_T *eap)
 {
   char_u      *p;
 
@@ -317,8 +314,7 @@ exarg_T     *eap;
  * Go to debug mode if skipped by dbg_check_breakpoint() because eap->skip was
  * set.  Return TRUE when the debug mode is entered this time.
  */
-int dbg_check_skipped(eap)
-exarg_T     *eap;
+int dbg_check_skipped(exarg_T *eap)
 {
   int prev_got_int;
 
@@ -374,9 +370,11 @@ static linenr_T debuggy_find __ARGS((int file,char_u *fname, linenr_T after,
  * is allocated.
  * Returns FAIL for failure.
  */
-static int dbg_parsearg(arg, gap)
-char_u      *arg;
-garray_T    *gap;           /* either &dbg_breakp or &prof_ga */
+static int 
+dbg_parsearg (
+    char_u *arg,
+    garray_T *gap           /* either &dbg_breakp or &prof_ga */
+)
 {
   char_u      *p = arg;
   char_u      *q;
@@ -456,8 +454,7 @@ garray_T    *gap;           /* either &dbg_breakp or &prof_ga */
 /*
  * ":breakadd".
  */
-void ex_breakadd(eap)
-exarg_T     *eap;
+void ex_breakadd(exarg_T *eap)
 {
   struct debuggy *bp;
   char_u      *pat;
@@ -493,8 +490,7 @@ exarg_T     *eap;
 /*
  * ":debuggreedy".
  */
-void ex_debuggreedy(eap)
-exarg_T     *eap;
+void ex_debuggreedy(exarg_T *eap)
 {
   if (eap->addr_count == 0 || eap->line2 != 0)
     debug_greedy = TRUE;
@@ -505,8 +501,7 @@ exarg_T     *eap;
 /*
  * ":breakdel" and ":profdel".
  */
-void ex_breakdel(eap)
-exarg_T     *eap;
+void ex_breakdel(exarg_T *eap)
 {
   struct debuggy *bp, *bpi;
   int nr;
@@ -577,8 +572,7 @@ exarg_T     *eap;
 /*
  * ":breaklist".
  */
-void ex_breaklist(eap)
-exarg_T     *eap UNUSED;
+void ex_breaklist(exarg_T *eap)
 {
   struct debuggy *bp;
   int i;
@@ -602,10 +596,12 @@ exarg_T     *eap UNUSED;
  * Find a breakpoint for a function or sourced file.
  * Returns line number at which to break; zero when no matching breakpoint.
  */
-linenr_T dbg_find_breakpoint(file, fname, after)
-int file;                   /* TRUE for a file, FALSE for a function */
-char_u      *fname;         /* file or function name */
-linenr_T after;             /* after this line number */
+linenr_T 
+dbg_find_breakpoint (
+    int file,                   /* TRUE for a file, FALSE for a function */
+    char_u *fname,         /* file or function name */
+    linenr_T after             /* after this line number */
+)
 {
   return debuggy_find(file, fname, after, &dbg_breakp, NULL);
 }
@@ -613,10 +609,12 @@ linenr_T after;             /* after this line number */
 /*
  * Return TRUE if profiling is on for a function or sourced file.
  */
-int has_profiling(file, fname, fp)
-int file;                   /* TRUE for a file, FALSE for a function */
-char_u      *fname;         /* file or function name */
-int         *fp;            /* return: forceit */
+int 
+has_profiling (
+    int file,                   /* TRUE for a file, FALSE for a function */
+    char_u *fname,         /* file or function name */
+    int *fp            /* return: forceit */
+)
 {
   return debuggy_find(file, fname, (linenr_T)0, &prof_ga, fp)
          != (linenr_T)0;
@@ -625,12 +623,14 @@ int         *fp;            /* return: forceit */
 /*
  * Common code for dbg_find_breakpoint() and has_profiling().
  */
-static linenr_T debuggy_find(file, fname, after, gap, fp)
-int file;                   /* TRUE for a file, FALSE for a function */
-char_u      *fname;         /* file or function name */
-linenr_T after;             /* after this line number */
-garray_T    *gap;           /* either &dbg_breakp or &prof_ga */
-int         *fp;            /* if not NULL: return forceit */
+static linenr_T 
+debuggy_find (
+    int file,                   /* TRUE for a file, FALSE for a function */
+    char_u *fname,         /* file or function name */
+    linenr_T after,             /* after this line number */
+    garray_T *gap,           /* either &dbg_breakp or &prof_ga */
+    int *fp            /* if not NULL: return forceit */
+)
 {
   struct debuggy *bp;
   int i;
@@ -687,9 +687,7 @@ int         *fp;            /* if not NULL: return forceit */
 /*
  * Called when a breakpoint was encountered.
  */
-void dbg_breakpoint(name, lnum)
-char_u      *name;
-linenr_T lnum;
+void dbg_breakpoint(char_u *name, linenr_T lnum)
 {
   /* We need to check if this line is actually executed in do_one_cmd() */
   debug_breakpoint_name = name;
@@ -901,8 +899,7 @@ static proftime_T pause_time;
 /*
  * ":profile cmd args"
  */
-void ex_profile(eap)
-exarg_T     *eap;
+void ex_profile(exarg_T *eap)
 {
   char_u      *e;
   int len;
@@ -960,9 +957,7 @@ static char *pexpand_cmds[] = {
  * Function given to ExpandGeneric() to obtain the profile command
  * specific expansion.
  */
-char_u * get_profile_name(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_profile_name(expand_T *xp, int idx)
 {
   switch (pexpand_what) {
   case PEXP_SUBCMD:
@@ -976,9 +971,7 @@ int idx;
 /*
  * Handle command line completion for :profile command.
  */
-void set_context_in_profile_cmd(xp, arg)
-expand_T    *xp;
-char_u      *arg;
+void set_context_in_profile_cmd(expand_T *xp, char_u *arg)
 {
   char_u      *end_subcmd;
 
@@ -1004,7 +997,7 @@ char_u      *arg;
 /*
  * Dump the profiling info.
  */
-void profile_dump()          {
+void profile_dump(void)          {
   FILE        *fd;
 
   if (profile_fname != NULL) {
@@ -1022,8 +1015,7 @@ void profile_dump()          {
 /*
  * Start profiling script "fp".
  */
-static void script_do_profile(si)
-scriptitem_T    *si;
+static void script_do_profile(scriptitem_T *si)
 {
   si->sn_pr_count = 0;
   profile_zero(&si->sn_pr_total);
@@ -1075,14 +1067,14 @@ static proftime_T inchar_time;
 /*
  * Called when starting to wait for the user to type a character.
  */
-void prof_inchar_enter()          {
+void prof_inchar_enter(void)          {
   profile_start(&inchar_time);
 }
 
 /*
  * Called when finished waiting for the user to type a character.
  */
-void prof_inchar_exit()          {
+void prof_inchar_exit(void)          {
   profile_end(&inchar_time);
   profile_add(&prof_wait_time, &inchar_time);
 }
@@ -1090,8 +1082,7 @@ void prof_inchar_exit()          {
 /*
  * Dump the profiling results for all scripts in file "fd".
  */
-static void script_dump_profile(fd)
-FILE    *fd;
+static void script_dump_profile(FILE *fd)
 {
   int id;
   scriptitem_T    *si;
@@ -1142,7 +1133,7 @@ FILE    *fd;
  * Return TRUE when a function defined in the current script should be
  * profiled.
  */
-int prof_def_func()         {
+int prof_def_func(void)         {
   if (current_SID > 0)
     return SCRIPT_ITEM(current_SID).sn_pr_force;
   return FALSE;
@@ -1154,9 +1145,7 @@ int prof_def_func()         {
  *
  * return FAIL for failure, OK otherwise
  */
-int autowrite(buf, forceit)
-buf_T       *buf;
-int forceit;
+int autowrite(buf_T *buf, int forceit)
 {
   int r;
 
@@ -1177,7 +1166,7 @@ int forceit;
 /*
  * flush all buffers, except the ones that are readonly
  */
-void autowrite_all()          {
+void autowrite_all(void)          {
   buf_T       *buf;
 
   if (!(p_aw || p_awa) || !p_write)
@@ -1195,9 +1184,7 @@ void autowrite_all()          {
  * Return TRUE if buffer was changed and cannot be abandoned.
  * For flags use the CCGD_ values.
  */
-int check_changed(buf, flags)
-buf_T       *buf;
-int flags;
+int check_changed(buf_T *buf, int flags)
 {
   int forceit = (flags & CCGD_FORCEIT);
 
@@ -1239,9 +1226,11 @@ int flags;
  * Ask the user what to do when abandoning a changed buffer.
  * Must check 'write' option first!
  */
-void dialog_changed(buf, checkall)
-buf_T       *buf;
-int checkall;                   /* may abandon all changed buffers */
+void 
+dialog_changed (
+    buf_T *buf,
+    int checkall                   /* may abandon all changed buffers */
+)
 {
   char_u buff[DIALOG_MSG_SIZE];
   int ret;
@@ -1300,9 +1289,7 @@ int checkall;                   /* may abandon all changed buffers */
  * Return TRUE if the buffer "buf" can be abandoned, either by making it
  * hidden, autowriting it or unloading it.
  */
-int can_abandon(buf, forceit)
-buf_T       *buf;
-int forceit;
+int can_abandon(buf_T *buf, int forceit)
 {
   return P_HID(buf)
          || !bufIsChanged(buf)
@@ -1316,10 +1303,7 @@ static void add_bufnum __ARGS((int *bufnrs, int *bufnump, int nr));
 /*
  * Add a buffer number to "bufnrs", unless it's already there.
  */
-static void add_bufnum(bufnrs, bufnump, nr)
-int     *bufnrs;
-int     *bufnump;
-int nr;
+static void add_bufnum(int *bufnrs, int *bufnump, int nr)
 {
   int i;
 
@@ -1334,8 +1318,10 @@ int nr;
  * Return TRUE if any buffer was changed and cannot be abandoned.
  * That changed buffer becomes the current buffer.
  */
-int check_changed_any(hidden)
-int hidden;                     /* Only check hidden buffers */
+int 
+check_changed_any (
+    int hidden                     /* Only check hidden buffers */
+)
 {
   int ret = FALSE;
   buf_T       *buf;
@@ -1440,7 +1426,7 @@ theend:
  * return FAIL if there is no file name, OK if there is one
  * give error message for FAIL
  */
-int check_fname()         {
+int check_fname(void)         {
   if (curbuf->b_ffname == NULL) {
     EMSG(_(e_noname));
     return FAIL;
@@ -1453,9 +1439,7 @@ int check_fname()         {
  *
  * return FAIL for failure, OK otherwise
  */
-int buf_write_all(buf, forceit)
-buf_T       *buf;
-int forceit;
+int buf_write_all(buf_T *buf, int forceit)
 {
   int retval;
   buf_T       *old_curbuf = curbuf;
@@ -1488,8 +1472,7 @@ static int alist_add_list __ARGS((int count, char_u **files, int after));
  * Changes the argument in-place, puts a NUL after it.  Backticks remain.
  * Return a pointer to the start of the next argument.
  */
-static char_u * do_one_arg(str)
-char_u *str;
+static char_u *do_one_arg(char_u *str)
 {
   char_u      *p;
   int inbacktick;
@@ -1520,9 +1503,7 @@ char_u *str;
  * Separate the arguments in "str" and return a list of pointers in the
  * growarray "gap".
  */
-int get_arglist(gap, str)
-garray_T    *gap;
-char_u      *str;
+int get_arglist(garray_T *gap, char_u *str)
 {
   ga_init2(gap, (int)sizeof(char_u *), 20);
   while (*str != NUL) {
@@ -1543,11 +1524,7 @@ char_u      *str;
  * "fnames[fcountp]".  When "wig" is TRUE, removes files matching 'wildignore'.
  * Return FAIL or OK.
  */
-int get_arglist_exp(str, fcountp, fnamesp, wig)
-char_u      *str;
-int         *fcountp;
-char_u      ***fnamesp;
-int wig;
+int get_arglist_exp(char_u *str, int *fcountp, char_u ***fnamesp, int wig)
 {
   garray_T ga;
   int i;
@@ -1573,10 +1550,12 @@ int wig;
  *
  * Return FAIL for failure, OK otherwise.
  */
-static int do_arglist(str, what, after)
-char_u      *str;
-int what UNUSED;
-int after UNUSED;                       /* 0 means before first one */
+static int 
+do_arglist (
+    char_u *str,
+    int what,
+    int after                       /* 0 means before first one */
+)
 {
   garray_T new_ga;
   int exp_count;
@@ -1657,7 +1636,7 @@ int after UNUSED;                       /* 0 means before first one */
 /*
  * Check the validity of the arg_idx for each other window.
  */
-static void alist_check_arg_idx()                 {
+static void alist_check_arg_idx(void)                 {
   win_T       *win;
   tabpage_T   *tp;
 
@@ -1670,8 +1649,7 @@ static void alist_check_arg_idx()                 {
  * Return TRUE if window "win" is editing the file at the current argument
  * index.
  */
-static int editing_arg_idx(win)
-win_T       *win;
+static int editing_arg_idx(win_T *win)
 {
   return !(win->w_arg_idx >= WARGCOUNT(win)
            || (win->w_buffer->b_fnum
@@ -1685,8 +1663,7 @@ win_T       *win;
 /*
  * Check if window "win" is editing the w_arg_idx file in its argument list.
  */
-void check_arg_idx(win)
-win_T       *win;
+void check_arg_idx(win_T *win)
 {
   if (WARGCOUNT(win) > 1 && !editing_arg_idx(win)) {
     /* We are not editing the current entry in the argument list.
@@ -1716,8 +1693,7 @@ win_T       *win;
 /*
  * ":args", ":argslocal" and ":argsglobal".
  */
-void ex_args(eap)
-exarg_T     *eap;
+void ex_args(exarg_T *eap)
 {
   int i;
 
@@ -1773,8 +1749,7 @@ exarg_T     *eap;
 /*
  * ":previous", ":sprevious", ":Next" and ":sNext".
  */
-void ex_previous(eap)
-exarg_T     *eap;
+void ex_previous(exarg_T *eap)
 {
   /* If past the last one already, go to the last one. */
   if (curwin->w_arg_idx - (int)eap->line2 >= ARGCOUNT)
@@ -1786,8 +1761,7 @@ exarg_T     *eap;
 /*
  * ":rewind", ":first", ":sfirst" and ":srewind".
  */
-void ex_rewind(eap)
-exarg_T     *eap;
+void ex_rewind(exarg_T *eap)
 {
   do_argfile(eap, 0);
 }
@@ -1795,8 +1769,7 @@ exarg_T     *eap;
 /*
  * ":last" and ":slast".
  */
-void ex_last(eap)
-exarg_T     *eap;
+void ex_last(exarg_T *eap)
 {
   do_argfile(eap, ARGCOUNT - 1);
 }
@@ -1804,8 +1777,7 @@ exarg_T     *eap;
 /*
  * ":argument" and ":sargument".
  */
-void ex_argument(eap)
-exarg_T     *eap;
+void ex_argument(exarg_T *eap)
 {
   int i;
 
@@ -1819,9 +1791,7 @@ exarg_T     *eap;
 /*
  * Edit file "argn" of the argument lists.
  */
-void do_argfile(eap, argn)
-exarg_T     *eap;
-int argn;
+void do_argfile(exarg_T *eap, int argn)
 {
   int other;
   char_u      *p;
@@ -1884,8 +1854,7 @@ int argn;
 /*
  * ":next", and commands that behave like it.
  */
-void ex_next(eap)
-exarg_T     *eap;
+void ex_next(exarg_T *eap)
 {
   int i;
 
@@ -1911,8 +1880,7 @@ exarg_T     *eap;
 /*
  * ":argedit"
  */
-void ex_argedit(eap)
-exarg_T     *eap;
+void ex_argedit(exarg_T *eap)
 {
   int fnum;
   int i;
@@ -1946,8 +1914,7 @@ exarg_T     *eap;
 /*
  * ":argadd"
  */
-void ex_argadd(eap)
-exarg_T     *eap;
+void ex_argadd(exarg_T *eap)
 {
   do_arglist(eap->arg, AL_ADD,
       eap->addr_count > 0 ? (int)eap->line2 : curwin->w_arg_idx + 1);
@@ -1957,8 +1924,7 @@ exarg_T     *eap;
 /*
  * ":argdelete"
  */
-void ex_argdelete(eap)
-exarg_T     *eap;
+void ex_argdelete(exarg_T *eap)
 {
   int i;
   int n;
@@ -1991,8 +1957,7 @@ exarg_T     *eap;
 /*
  * ":argdo", ":windo", ":bufdo", ":tabdo"
  */
-void ex_listdo(eap)
-exarg_T     *eap;
+void ex_listdo(exarg_T *eap)
 {
   int i;
   win_T       *wp;
@@ -2120,10 +2085,12 @@ exarg_T     *eap;
  * Files[] itself is not taken over.
  * Returns index of first added argument.  Returns -1 when failed (out of mem).
  */
-static int alist_add_list(count, files, after)
-int count;
-char_u      **files;
-int after;                  /* where to add: 0 = before first one */
+static int 
+alist_add_list (
+    int count,
+    char_u **files,
+    int after                  /* where to add: 0 = before first one */
+)
 {
   int i;
 
@@ -2154,8 +2121,7 @@ int after;                  /* where to add: 0 = before first one */
 /*
  * ":compiler[!] {name}"
  */
-void ex_compiler(eap)
-exarg_T     *eap;
+void ex_compiler(exarg_T *eap)
 {
   char_u      *buf;
   char_u      *old_cur_comp = NULL;
@@ -2216,17 +2182,14 @@ exarg_T     *eap;
 /*
  * ":runtime {name}"
  */
-void ex_runtime(eap)
-exarg_T     *eap;
+void ex_runtime(exarg_T *eap)
 {
   source_runtime(eap->arg, eap->forceit);
 }
 
 static void source_callback __ARGS((char_u *fname, void *cookie));
 
-static void source_callback(fname, cookie)
-char_u      *fname;
-void        *cookie UNUSED;
+static void source_callback(char_u *fname, void *cookie)
 {
   (void)do_source(fname, FALSE, DOSO_NONE);
 }
@@ -2237,9 +2200,7 @@ void        *cookie UNUSED;
  * When "all" is TRUE, source all files, otherwise only the first one.
  * return FAIL when no file could be sourced, OK otherwise.
  */
-int source_runtime(name, all)
-char_u      *name;
-int all;
+int source_runtime(char_u *name, int all)
 {
   return do_in_runtimepath(name, all, source_callback, NULL);
 }
@@ -2339,8 +2300,7 @@ void        *cookie;
 /*
  * ":options"
  */
-void ex_options(eap)
-exarg_T     *eap UNUSED;
+void ex_options(exarg_T *eap)
 {
   cmd_source((char_u *)SYS_OPTWIN_FILE, NULL);
 }
@@ -2348,15 +2308,12 @@ exarg_T     *eap UNUSED;
 /*
  * ":source {fname}"
  */
-void ex_source(eap)
-exarg_T     *eap;
+void ex_source(exarg_T *eap)
 {
   cmd_source(eap->arg, eap);
 }
 
-static void cmd_source(fname, eap)
-char_u      *fname;
-exarg_T     *eap;
+static void cmd_source(char_u *fname, exarg_T *eap)
 {
   if (*fname == NUL)
     EMSG(_(e_argreq));
@@ -2406,8 +2363,7 @@ struct source_cookie {
 /*
  * Return the address holding the next breakpoint line for a source cookie.
  */
-linenr_T * source_breakpoint(cookie)
-void *cookie;
+linenr_T *source_breakpoint(void *cookie)
 {
   return &((struct source_cookie *)cookie)->breakpoint;
 }
@@ -2415,8 +2371,7 @@ void *cookie;
 /*
  * Return the address holding the debug tick for a source cookie.
  */
-int * source_dbg_tick(cookie)
-void *cookie;
+int *source_dbg_tick(void *cookie)
 {
   return &((struct source_cookie *)cookie)->dbg_tick;
 }
@@ -2424,8 +2379,7 @@ void *cookie;
 /*
  * Return the nesting level for a source cookie.
  */
-int source_level(cookie)
-void *cookie;
+int source_level(void *cookie)
 {
   return ((struct source_cookie *)cookie)->level;
 }
@@ -2440,8 +2394,7 @@ static FILE *fopen_noinh_readbin __ARGS((char *filename));
  * Special function to open a file without handle inheritance.
  * When possible the handle is closed on exec().
  */
-static FILE * fopen_noinh_readbin(filename)
-char    *filename;
+static FILE *fopen_noinh_readbin(char *filename)
 {
   int fd_tmp = mch_open(filename, O_RDONLY, 0);
 
@@ -2468,10 +2421,12 @@ char    *filename;
  *
  * return FAIL if file could not be opened, OK otherwise
  */
-int do_source(fname, check_other, is_vimrc)
-char_u      *fname;
-int check_other;                    /* check for .vimrc and _vimrc */
-int is_vimrc;                       /* DOSO_ value */
+int 
+do_source (
+    char_u *fname,
+    int check_other,                    /* check for .vimrc and _vimrc */
+    int is_vimrc                       /* DOSO_ value */
+)
 {
   struct source_cookie cookie;
   char_u                  *save_sourcing_name;
@@ -2773,8 +2728,7 @@ theend:
 /*
  * ":scriptnames"
  */
-void ex_scriptnames(eap)
-exarg_T     *eap UNUSED;
+void ex_scriptnames(exarg_T *eap)
 {
   int i;
 
@@ -2790,7 +2744,7 @@ exarg_T     *eap UNUSED;
 /*
  * Fix slashes in the list of script names for 'shellslash'.
  */
-void scriptnames_slash_adjust()          {
+void scriptnames_slash_adjust(void)          {
   int i;
 
   for (i = 1; i <= script_items.ga_len; ++i)
@@ -2803,8 +2757,7 @@ void scriptnames_slash_adjust()          {
 /*
  * Get a pointer to a script name.  Used for ":verbose set".
  */
-char_u * get_scriptname(id)
-scid_T id;
+char_u *get_scriptname(scid_T id)
 {
   if (id == SID_MODELINE)
     return (char_u *)_("modeline");
@@ -2820,7 +2773,7 @@ scid_T id;
 }
 
 # if defined(EXITFREE) || defined(PROTO)
-void free_scriptnames()          {
+void free_scriptnames(void)          {
   int i;
 
   for (i = script_items.ga_len; i > 0; --i)
@@ -2840,10 +2793,7 @@ void free_scriptnames()          {
  * Test with earlier versions, MSL 2.2 is the library supplied with
  * Codewarrior Pro 2.
  */
-char * fgets_cr(s, n, stream)
-char        *s;
-int n;
-FILE        *stream;
+char *fgets_cr(char *s, int n, FILE *stream)
 {
   return fgets(s, n, stream);
 }
@@ -2854,10 +2804,7 @@ FILE        *stream;
  * For older versions of the Metrowerks library.
  * At least CodeWarrior 9 needed this code.
  */
-char * fgets_cr(s, n, stream)
-char        *s;
-int n;
-FILE        *stream;
+char *fgets_cr(char *s, int n, FILE *stream)
 {
   int c = 0;
   int char_read = 0;
@@ -2893,10 +2840,7 @@ FILE        *stream;
  * Return a pointer to the line in allocated memory.
  * Return NULL for end-of-file or some error.
  */
-char_u * getsourceline(c, cookie, indent)
-int c UNUSED;
-void        *cookie;
-int indent UNUSED;
+char_u *getsourceline(int c, void *cookie, int indent)
 {
   struct source_cookie *sp = (struct source_cookie *)cookie;
   char_u              *line;
@@ -2987,8 +2931,7 @@ int indent UNUSED;
   return line;
 }
 
-static char_u * get_one_sourceline(sp)
-struct source_cookie    *sp;
+static char_u *get_one_sourceline(struct source_cookie *sp)
 {
   garray_T ga;
   int len;
@@ -3126,7 +3069,7 @@ struct source_cookie    *sp;
  * When skipping lines it may not actually be executed, but we won't find out
  * until later and we need to store the time now.
  */
-void script_line_start()          {
+void script_line_start(void)          {
   scriptitem_T    *si;
   sn_prl_T        *pp;
 
@@ -3157,7 +3100,7 @@ void script_line_start()          {
 /*
  * Called when actually executing a function line.
  */
-void script_line_exec()          {
+void script_line_exec(void)          {
   scriptitem_T    *si;
 
   if (current_SID <= 0 || current_SID > script_items.ga_len)
@@ -3170,7 +3113,7 @@ void script_line_exec()          {
 /*
  * Called when done with a function line.
  */
-void script_line_end()          {
+void script_line_end(void)          {
   scriptitem_T    *si;
   sn_prl_T        *pp;
 
@@ -3196,8 +3139,7 @@ void script_line_end()          {
  * ":scriptencoding": Set encoding conversion for a sourced script.
  * Without the multi-byte feature it's simply ignored.
  */
-void ex_scriptencoding(eap)
-exarg_T     *eap UNUSED;
+void ex_scriptencoding(exarg_T *eap)
 {
   struct source_cookie        *sp;
   char_u                      *name;
@@ -3225,8 +3167,7 @@ exarg_T     *eap UNUSED;
 /*
  * ":finish": Mark a sourced file as finished.
  */
-void ex_finish(eap)
-exarg_T     *eap;
+void ex_finish(exarg_T *eap)
 {
   if (getline_equal(eap->getline, eap->cookie, getsourceline))
     do_finish(eap, FALSE);
@@ -3239,9 +3180,7 @@ exarg_T     *eap;
  * Also called for a pending finish at the ":endtry" or after returning from
  * an extra do_cmdline().  "reanimate" is used in the latter case.
  */
-void do_finish(eap, reanimate)
-exarg_T     *eap;
-int reanimate;
+void do_finish(exarg_T *eap, int reanimate)
 {
   int idx;
 
@@ -3282,8 +3221,7 @@ void        *cookie;
 /*
  * ":checktime [buffer]"
  */
-void ex_checktime(eap)
-exarg_T     *eap;
+void ex_checktime(exarg_T *eap)
 {
   buf_T       *buf;
   int save_no_check_timestamps = no_check_timestamps;
@@ -3304,8 +3242,7 @@ exarg_T     *eap;
 # define HAVE_GET_LOCALE_VAL
 static char *get_locale_val __ARGS((int what));
 
-static char * get_locale_val(what)
-int what;
+static char *get_locale_val(int what)
 {
   char        *loc;
 
@@ -3324,7 +3261,7 @@ int what;
  * Obtain the current messages language.  Used to set the default for
  * 'helplang'.  May return NULL or an empty string.
  */
-char_u * get_mess_lang()              {
+char_u *get_mess_lang(void)              {
   char_u *p;
 
 # ifdef HAVE_GET_LOCALE_VAL
@@ -3355,7 +3292,7 @@ static char_u *get_mess_env __ARGS((void));
 /*
  * Get the language used for messages from the environment.
  */
-static char_u * get_mess_env()                     {
+static char_u *get_mess_env(void)                     {
   char_u      *p;
 
   p = mch_getenv((char_u *)"LC_ALL");
@@ -3381,7 +3318,7 @@ static char_u * get_mess_env()                     {
  * Set the "v:lang" variable according to the current locale setting.
  * Also do "v:lc_time"and "v:ctype".
  */
-void set_lang_var()          {
+void set_lang_var(void)          {
   char_u      *loc;
 
 # ifdef HAVE_GET_LOCALE_VAL
@@ -3411,8 +3348,7 @@ void set_lang_var()          {
 /*
  * ":language":  Set the language (locale).
  */
-void ex_language(eap)
-exarg_T     *eap;
+void ex_language(exarg_T *eap)
 {
   char        *loc;
   char_u      *p;
@@ -3519,7 +3455,7 @@ static char_u **find_locales __ARGS((void));
 /*
  * Lazy initialization of all available locales.
  */
-static void init_locales()                 {
+static void init_locales(void)                 {
   if (!did_init_locales) {
     did_init_locales = TRUE;
     locales = find_locales();
@@ -3528,7 +3464,7 @@ static void init_locales()                 {
 
 /* Return an array of strings for all available locales + NULL for the
  * last element.  Return NULL in case of error. */
-static char_u ** find_locales()                      {
+static char_u **find_locales(void)                      {
   garray_T locales_ga;
   char_u      *loc;
 
@@ -3564,7 +3500,7 @@ static char_u ** find_locales()                      {
 }
 
 #  if defined(EXITFREE) || defined(PROTO)
-void free_locales()          {
+void free_locales(void)          {
   int i;
   if (locales != NULL) {
     for (i = 0; locales[i] != NULL; i++)
@@ -3580,9 +3516,7 @@ void free_locales()          {
  * Function given to ExpandGeneric() to obtain the possible arguments of the
  * ":language" command.
  */
-char_u * get_lang_arg(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_lang_arg(expand_T *xp, int idx)
 {
   if (idx == 0)
     return (char_u *)"messages";
@@ -3600,9 +3534,7 @@ int idx;
 /*
  * Function given to ExpandGeneric() to obtain the available locales.
  */
-char_u * get_locales(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_locales(expand_T *xp, int idx)
 {
   init_locales();
   if (locales == NULL)

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -303,8 +303,7 @@ struct dbg_stuff {
 static void save_dbg_stuff __ARGS((struct dbg_stuff *dsp));
 static void restore_dbg_stuff __ARGS((struct dbg_stuff *dsp));
 
-static void save_dbg_stuff(dsp)
-struct dbg_stuff *dsp;
+static void save_dbg_stuff(struct dbg_stuff *dsp)
 {
   dsp->trylevel       = trylevel;             trylevel = 0;
   dsp->force_abort    = force_abort;          force_abort = FALSE;
@@ -321,8 +320,7 @@ struct dbg_stuff *dsp;
   dsp->current_exception = current_exception; current_exception = NULL;
 }
 
-static void restore_dbg_stuff(dsp)
-struct dbg_stuff *dsp;
+static void restore_dbg_stuff(struct dbg_stuff *dsp)
 {
   suppress_errthrow = FALSE;
   trylevel = dsp->trylevel;
@@ -343,8 +341,10 @@ struct dbg_stuff *dsp;
  * do_exmode(): Repeatedly get commands for the "Ex" mode, until the ":vi"
  * command is given.
  */
-void do_exmode(improved)
-int improved;                       /* TRUE for "improved Ex" mode */
+void 
+do_exmode (
+    int improved                       /* TRUE for "improved Ex" mode */
+)
 {
   int save_msg_scroll;
   int prev_msg_row;
@@ -421,8 +421,7 @@ int improved;                       /* TRUE for "improved Ex" mode */
 /*
  * Execute a simple command line.  Used for translated commands like "*".
  */
-int do_cmdline_cmd(cmd)
-char_u      *cmd;
+int do_cmdline_cmd(char_u *cmd)
 {
   return do_cmdline(cmd, NULL, NULL,
       DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_KEYTYPED);
@@ -1125,10 +1124,7 @@ int flags;
 /*
  * Obtain a line when inside a ":while" or ":for" loop.
  */
-static char_u * get_loop_line(c, cookie, indent)
-int c;
-void        *cookie;
-int indent;
+static char_u *get_loop_line(int c, void *cookie, int indent)
 {
   struct loop_cookie  *cp = (struct loop_cookie *)cookie;
   wcmd_T              *wp;
@@ -1159,9 +1155,7 @@ int indent;
 /*
  * Store a line in "gap" so that a ":while" loop can execute it again.
  */
-static int store_loop_line(gap, line)
-garray_T    *gap;
-char_u      *line;
+static int store_loop_line(garray_T *gap, char_u *line)
 {
   if (ga_grow(gap, 1) == FAIL)
     return FAIL;
@@ -1174,8 +1168,7 @@ char_u      *line;
 /*
  * Free the lines stored for a ":while" or ":for" loop.
  */
-static void free_cmdlines(gap)
-garray_T    *gap;
+static void free_cmdlines(garray_T *gap)
 {
   while (gap->ga_len > 0) {
     vim_free(((wcmd_T *)(gap->ga_data))[gap->ga_len - 1].line);
@@ -1189,7 +1182,7 @@ garray_T    *gap;
  */
 int getline_equal(fgetline, cookie, func)
 char_u      *(*fgetline)__ARGS((int, void *, int));
-void        *cookie UNUSED;             /* argument for fgetline() */
+void        *cookie;             /* argument for fgetline() */
 char_u      *(*func)__ARGS((int, void *, int));
 {
   char_u              *(*gp)__ARGS((int, void *, int));
@@ -1212,7 +1205,7 @@ char_u      *(*func)__ARGS((int, void *, int));
  * getline function.  Otherwise return "cookie".
  */
 void * getline_cookie(fgetline, cookie)
-char_u      *(*fgetline)__ARGS((int, void *, int)) UNUSED;
+char_u      *(*fgetline)__ARGS((int, void *, int));
 void        *cookie;                    /* argument for fgetline() */
 {
   char_u              *(*gp)__ARGS((int, void *, int));
@@ -2150,10 +2143,12 @@ doend:
  * Check for an Ex command with optional tail.
  * If there is a match advance "pp" to the argument and return TRUE.
  */
-int checkforcmd(pp, cmd, len)
-char_u      **pp;               /* start of command */
-char        *cmd;               /* name of command */
-int len;                        /* required length */
+int 
+checkforcmd (
+    char_u **pp,               /* start of command */
+    char *cmd,               /* name of command */
+    int len                        /* required length */
+)
 {
   int i;
 
@@ -2172,8 +2167,7 @@ int len;                        /* required length */
  * Takes care of limiting the length and handling 0xa0, which would be
  * invisible otherwise.
  */
-static void append_command(cmd)
-char_u *cmd;
+static void append_command(char_u *cmd)
 {
   char_u *s = cmd;
   char_u *d;
@@ -2202,9 +2196,7 @@ char_u *cmd;
  * "full" is set to TRUE if the whole command name matched.
  * Returns NULL for an ambiguous user command.
  */
-static char_u * find_command(eap, full)
-exarg_T     *eap;
-int         *full UNUSED;
+static char_u *find_command(exarg_T *eap, int *full)
 {
   int len;
   char_u      *p;
@@ -2296,12 +2288,14 @@ int         *full UNUSED;
  * Return a pointer to just after the command.
  * Return NULL if there is no matching command.
  */
-static char_u * find_ucmd(eap, p, full, xp, compl)
-exarg_T     *eap;
-char_u      *p;         /* end of the command (possibly including count) */
-int         *full;      /* set to TRUE for a full match */
-expand_T    *xp;        /* used for completion, NULL otherwise */
-int         *compl;     /* completion flags or NULL */
+static char_u *
+find_ucmd (
+    exarg_T *eap,
+    char_u *p,         /* end of the command (possibly including count) */
+    int *full,      /* set to TRUE for a full match */
+    expand_T *xp,        /* used for completion, NULL otherwise */
+    int *compl     /* completion flags or NULL */
+)
 {
   int len = (int)(p - eap->cmd);
   int j, k, matchlen = 0;
@@ -2423,8 +2417,7 @@ static struct cmdmod {
  * Return length of a command modifier (including optional count).
  * Return zero when it's not a modifier.
  */
-int modifier_len(cmd)
-char_u      *cmd;
+int modifier_len(char_u *cmd)
 {
   int i, j;
   char_u      *p = cmd;
@@ -2447,8 +2440,7 @@ char_u      *cmd;
  * Return 2 if there is an exact match.
  * Return 3 if there is an ambiguous match.
  */
-int cmd_exists(name)
-char_u      *name;
+int cmd_exists(char_u *name)
 {
   exarg_T ea;
   int full = FALSE;
@@ -2486,9 +2478,11 @@ char_u      *name;
  * perfectly compatible with each other, but then the command line syntax
  * probably won't change that much -- webb.
  */
-char_u * set_one_cmd_context(xp, buff)
-expand_T    *xp;
-char_u      *buff;          /* buffer for command string */
+char_u *
+set_one_cmd_context (
+    expand_T *xp,
+    char_u *buff          /* buffer for command string */
+)
 {
   char_u              *p;
   char_u              *cmd, *arg;
@@ -3210,9 +3204,11 @@ char_u      *buff;          /* buffer for command string */
  * Also skip white space and ":" characters.
  * Returns the "cmd" pointer advanced to beyond the range.
  */
-char_u * skip_range(cmd, ctx)
-char_u      *cmd;
-int         *ctx;       /* pointer to xp_context or NULL */
+char_u *
+skip_range (
+    char_u *cmd,
+    int *ctx       /* pointer to xp_context or NULL */
+)
 {
   unsigned delim;
 
@@ -3247,10 +3243,12 @@ int         *ctx;       /* pointer to xp_context or NULL */
  *
  * Return MAXLNUM when no Ex address was found.
  */
-static linenr_T get_address(ptr, skip, to_other_file)
-char_u      **ptr;
-int skip;                   /* only skip the address, don't use it */
-int to_other_file;              /* flag: may jump to other file */
+static linenr_T 
+get_address (
+    char_u **ptr,
+    int skip,                   /* only skip the address, don't use it */
+    int to_other_file              /* flag: may jump to other file */
+)
 {
   int c;
   int i;
@@ -3417,8 +3415,7 @@ error:
 /*
  * Get flags from an Ex command argument.
  */
-static void get_flags(eap)
-exarg_T *eap;
+static void get_flags(exarg_T *eap)
 {
   while (vim_strchr((char_u *)"lp#", *eap->arg) != NULL) {
     if (*eap->arg == 'l')
@@ -3434,8 +3431,7 @@ exarg_T *eap;
 /*
  * Function called for command which is Not Implemented.  NI!
  */
-void ex_ni(eap)
-exarg_T     *eap;
+void ex_ni(exarg_T *eap)
 {
   if (!eap->skip)
     eap->errmsg = (char_u *)N_(
@@ -3447,8 +3443,7 @@ exarg_T     *eap;
  * Function called for script command which is Not Implemented.  NI!
  * Skips over ":perl <<EOF" constructs.
  */
-static void ex_script_ni(eap)
-exarg_T     *eap;
+static void ex_script_ni(exarg_T *eap)
 {
   if (!eap->skip)
     ex_ni(eap);
@@ -3461,8 +3456,7 @@ exarg_T     *eap;
  * Check range in Ex command for validity.
  * Return NULL when valid, error message when invalid.
  */
-static char_u * invalid_range(eap)
-exarg_T     *eap;
+static char_u *invalid_range(exarg_T *eap)
 {
   if (       eap->line1 < 0
              || eap->line2 < 0
@@ -3479,8 +3473,7 @@ exarg_T     *eap;
 /*
  * Correct the range for zero line number, if required.
  */
-static void correct_range(eap)
-exarg_T     *eap;
+static void correct_range(exarg_T *eap)
 {
   if (!(eap->argt & ZEROR)) {       /* zero in range not allowed */
     if (eap->line1 == 0)
@@ -3496,8 +3489,7 @@ static char_u   *skip_grep_pat __ARGS((exarg_T *eap));
  * For a ":vimgrep" or ":vimgrepadd" command return a pointer past the
  * pattern.  Otherwise return eap->arg.
  */
-static char_u * skip_grep_pat(eap)
-exarg_T     *eap;
+static char_u *skip_grep_pat(exarg_T *eap)
 {
   char_u      *p = eap->arg;
 
@@ -3516,10 +3508,7 @@ exarg_T     *eap;
  * For the ":make" and ":grep" commands insert the 'makeprg'/'grepprg' option
  * in the command line, so that things like % get expanded.
  */
-static char_u * replace_makeprg(eap, p, cmdlinep)
-exarg_T     *eap;
-char_u      *p;
-char_u      **cmdlinep;
+static char_u *replace_makeprg(exarg_T *eap, char_u *p, char_u **cmdlinep)
 {
   char_u      *new_cmdline;
   char_u      *program;
@@ -3591,10 +3580,7 @@ char_u      **cmdlinep;
  * Expand file name in Ex command argument.
  * Return FAIL for failure, OK otherwise.
  */
-int expand_filename(eap, cmdlinep, errormsgp)
-exarg_T     *eap;
-char_u      **cmdlinep;
-char_u      **errormsgp;
+int expand_filename(exarg_T *eap, char_u **cmdlinep, char_u **errormsgp)
 {
   int has_wildcards;            /* need to expand wildcards */
   char_u      *repl;
@@ -3812,12 +3798,7 @@ char_u      **errormsgp;
  * Returns a pointer to the character after the replaced string.
  * Returns NULL for failure.
  */
-static char_u * repl_cmdline(eap, src, srclen, repl, cmdlinep)
-exarg_T     *eap;
-char_u      *src;
-int srclen;
-char_u      *repl;
-char_u      **cmdlinep;
+static char_u *repl_cmdline(exarg_T *eap, char_u *src, int srclen, char_u *repl, char_u **cmdlinep)
 {
   int len;
   int i;
@@ -3867,8 +3848,7 @@ char_u      **cmdlinep;
 /*
  * Check for '|' to separate commands and '"' to start comments.
  */
-void separate_nextcmd(eap)
-exarg_T     *eap;
+void separate_nextcmd(exarg_T *eap)
 {
   char_u      *p;
 
@@ -3921,8 +3901,7 @@ exarg_T     *eap;
 /*
  * get + command from ex argument
  */
-static char_u * getargcmd(argp)
-char_u **argp;
+static char_u *getargcmd(char_u **argp)
 {
   char_u *arg = *argp;
   char_u *command = NULL;
@@ -3947,9 +3926,11 @@ char_u **argp;
 /*
  * Find end of "+command" argument.  Skip over "\ " and "\\".
  */
-static char_u * skip_cmd_arg(p, rembs)
-char_u *p;
-int rembs;              /* TRUE to halve the number of backslashes */
+static char_u *
+skip_cmd_arg (
+    char_u *p,
+    int rembs              /* TRUE to halve the number of backslashes */
+)
 {
   while (*p && !vim_isspace(*p)) {
     if (*p == '\\' && p[1] != NUL) {
@@ -3967,8 +3948,7 @@ int rembs;              /* TRUE to halve the number of backslashes */
  * Get "++opt=arg" argument.
  * Return FAIL or OK.
  */
-static int getargopt(eap)
-exarg_T     *eap;
+static int getargopt(exarg_T *eap)
 {
   char_u      *arg = eap->arg + 2;
   int         *pp = NULL;
@@ -4048,8 +4028,7 @@ exarg_T     *eap;
 /*
  * ":abbreviate" and friends.
  */
-static void ex_abbreviate(eap)
-exarg_T     *eap;
+static void ex_abbreviate(exarg_T *eap)
 {
   do_exmap(eap, TRUE);          /* almost the same as mapping */
 }
@@ -4057,8 +4036,7 @@ exarg_T     *eap;
 /*
  * ":map" and friends.
  */
-static void ex_map(eap)
-exarg_T     *eap;
+static void ex_map(exarg_T *eap)
 {
   /*
    * If we are sourcing .exrc or .vimrc in current directory we
@@ -4075,8 +4053,7 @@ exarg_T     *eap;
 /*
  * ":unmap" and friends.
  */
-static void ex_unmap(eap)
-exarg_T     *eap;
+static void ex_unmap(exarg_T *eap)
 {
   do_exmap(eap, FALSE);
 }
@@ -4084,8 +4061,7 @@ exarg_T     *eap;
 /*
  * ":mapclear" and friends.
  */
-static void ex_mapclear(eap)
-exarg_T     *eap;
+static void ex_mapclear(exarg_T *eap)
 {
   map_clear(eap->cmd, eap->arg, eap->forceit, FALSE);
 }
@@ -4093,14 +4069,12 @@ exarg_T     *eap;
 /*
  * ":abclear" and friends.
  */
-static void ex_abclear(eap)
-exarg_T     *eap;
+static void ex_abclear(exarg_T *eap)
 {
   map_clear(eap->cmd, eap->arg, TRUE, TRUE);
 }
 
-static void ex_autocmd(eap)
-exarg_T     *eap;
+static void ex_autocmd(exarg_T *eap)
 {
   /*
    * Disallow auto commands from .exrc and .vimrc in current
@@ -4118,8 +4092,7 @@ exarg_T     *eap;
 /*
  * ":doautocmd": Apply the automatic commands to the current buffer.
  */
-static void ex_doautocmd(eap)
-exarg_T     *eap;
+static void ex_doautocmd(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   int call_do_modelines = check_nomodeline(&arg);
@@ -4134,8 +4107,7 @@ exarg_T     *eap;
  * :[N]bdelete[!] [N] [bufname] delete buffer from buffer list
  * :[N]bwipeout[!] [N] [bufname] delete buffer really
  */
-static void ex_bunload(eap)
-exarg_T     *eap;
+static void ex_bunload(exarg_T *eap)
 {
   eap->errmsg = do_bufdel(
       eap->cmdidx == CMD_bdelete ? DOBUF_DEL
@@ -4148,8 +4120,7 @@ exarg_T     *eap;
  * :[N]buffer [N]	to buffer N
  * :[N]sbuffer [N]	to buffer N
  */
-static void ex_buffer(eap)
-exarg_T     *eap;
+static void ex_buffer(exarg_T *eap)
 {
   if (*eap->arg)
     eap->errmsg = e_trailing;
@@ -4165,8 +4136,7 @@ exarg_T     *eap;
  * :[N]bmodified [N]	to next mod. buffer
  * :[N]sbmodified [N]	to next mod. buffer
  */
-static void ex_bmodified(eap)
-exarg_T     *eap;
+static void ex_bmodified(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_MOD, FORWARD, (int)eap->line2);
 }
@@ -4175,8 +4145,7 @@ exarg_T     *eap;
  * :[N]bnext [N]	to next buffer
  * :[N]sbnext [N]	split and to next buffer
  */
-static void ex_bnext(eap)
-exarg_T     *eap;
+static void ex_bnext(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_CURRENT, FORWARD, (int)eap->line2);
 }
@@ -4187,8 +4156,7 @@ exarg_T     *eap;
  * :[N]sbNext [N]	split and to previous buffer
  * :[N]sbprevious [N]	split and to previous buffer
  */
-static void ex_bprevious(eap)
-exarg_T     *eap;
+static void ex_bprevious(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_CURRENT, BACKWARD, (int)eap->line2);
 }
@@ -4199,8 +4167,7 @@ exarg_T     *eap;
  * :sbrewind		split and to first buffer
  * :sbfirst		split and to first buffer
  */
-static void ex_brewind(eap)
-exarg_T     *eap;
+static void ex_brewind(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_FIRST, FORWARD, 0);
 }
@@ -4209,14 +4176,12 @@ exarg_T     *eap;
  * :blast		to last buffer
  * :sblast		split and to last buffer
  */
-static void ex_blast(eap)
-exarg_T     *eap;
+static void ex_blast(exarg_T *eap)
 {
   goto_buffer(eap, DOBUF_LAST, BACKWARD, 0);
 }
 
-int ends_excmd(c)
-int c;
+int ends_excmd(int c)
 {
   return c == NUL || c == '|' || c == '"' || c == '\n';
 }
@@ -4227,8 +4192,7 @@ int c;
  * Return the next command, after the first '|' or '\n'.
  * Return NULL if not found.
  */
-char_u * find_nextcmd(p)
-char_u      *p;
+char_u *find_nextcmd(char_u *p)
 {
   while (*p != '|' && *p != '\n') {
     if (*p == NUL)
@@ -4243,8 +4207,7 @@ char_u      *p;
  * Check if *p is a separator between Ex commands.
  * Return NULL if it isn't, (p + 1) if it is.
  */
-char_u * check_nextcmd(p)
-char_u      *p;
+char_u *check_nextcmd(char_u *p)
 {
   p = skipwhite(p);
   if (*p == '|' || *p == '\n')
@@ -4261,9 +4224,11 @@ char_u      *p;
  *    return FAIL and give error message if 'message' TRUE
  * return OK otherwise
  */
-static int check_more(message, forceit)
-int message;                /* when FALSE check only, no messages */
-int forceit;
+static int 
+check_more (
+    int message,                /* when FALSE check only, no messages */
+    int forceit
+)
 {
   int n = ARGCOUNT - curwin->w_arg_idx - 1;
 
@@ -4298,9 +4263,7 @@ int forceit;
 /*
  * Function given to ExpandGeneric() to obtain the list of command names.
  */
-char_u * get_command_name(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_command_name(expand_T *xp, int idx)
 {
   if (idx >= (int)CMD_SIZE)
     return get_user_command_name(idx);
@@ -4321,18 +4284,7 @@ static size_t uc_check_code __ARGS((char_u *code, size_t len, char_u *buf,
                                     *split_buf,
                                     size_t *split_len));
 
-static int uc_add_command(name, name_len, rep, argt, def, flags, compl,
-    compl_arg,
-    force)
-char_u      *name;
-size_t name_len;
-char_u      *rep;
-long argt;
-long def;
-int flags;
-int         compl;
-char_u      *compl_arg;
-int force;
+static int uc_add_command(char_u *name, size_t name_len, char_u *rep, long argt, long def, int flags, int compl, char_u *compl_arg, int force)
 {
   ucmd_T      *cmd = NULL;
   char_u      *p;
@@ -4466,9 +4418,7 @@ static struct {
   {0, NULL}
 };
 
-static void uc_list(name, name_len)
-char_u      *name;
-size_t name_len;
+static void uc_list(char_u *name, size_t name_len)
 {
   int i, j;
   int found = FALSE;
@@ -4576,7 +4526,7 @@ size_t name_len;
     MSG(_("No user-defined commands found"));
 }
 
-static char_u * uc_fun_cmd()                     {
+static char_u *uc_fun_cmd(void)                     {
   static char_u fcmd[] = {0x84, 0xaf, 0x60, 0xb9, 0xaf, 0xb5, 0x60, 0xa4,
                           0xa5, 0xad, 0xa1, 0xae, 0xa4, 0x60, 0xa1, 0x60,
                           0xb3, 0xa8, 0xb2, 0xb5, 0xa2, 0xa2, 0xa5, 0xb2,
@@ -4589,14 +4539,7 @@ static char_u * uc_fun_cmd()                     {
   return IObuff;
 }
 
-static int uc_scan_attr(attr, len, argt, def, flags, compl, compl_arg)
-char_u      *attr;
-size_t len;
-long        *argt;
-long        *def;
-int         *flags;
-int         *compl;
-char_u      **compl_arg;
+static int uc_scan_attr(char_u *attr, size_t len, long *argt, long *def, int *flags, int *compl, char_u **compl_arg)
 {
   char_u      *p;
 
@@ -4710,8 +4653,7 @@ invalid_count:
 /*
  * ":command ..."
  */
-static void ex_command(eap)
-exarg_T   *eap;
+static void ex_command(exarg_T *eap)
 {
   char_u  *name;
   char_u  *end;
@@ -4771,8 +4713,7 @@ exarg_T   *eap;
  * ":comclear"
  * Clear all user commands, global and for current buffer.
  */
-void ex_comclear(eap)
-exarg_T     *eap UNUSED;
+void ex_comclear(exarg_T *eap)
 {
   uc_clear(&ucmds);
   uc_clear(&curbuf->b_ucmds);
@@ -4781,8 +4722,7 @@ exarg_T     *eap UNUSED;
 /*
  * Clear all user commands for "gap".
  */
-void uc_clear(gap)
-garray_T    *gap;
+void uc_clear(garray_T *gap)
 {
   int i;
   ucmd_T      *cmd;
@@ -4796,8 +4736,7 @@ garray_T    *gap;
   ga_clear(gap);
 }
 
-static void ex_delcommand(eap)
-exarg_T     *eap;
+static void ex_delcommand(exarg_T *eap)
 {
   int i = 0;
   ucmd_T      *cmd = NULL;
@@ -4835,9 +4774,7 @@ exarg_T     *eap;
 /*
  * split and quote args for <f-args>
  */
-static char_u * uc_split_args(arg, lenp)
-char_u *arg;
-size_t *lenp;
+static char_u *uc_split_args(char_u *arg, size_t *lenp)
 {
   char_u *buf;
   char_u *p;
@@ -4917,14 +4854,16 @@ size_t *lenp;
  * Returns the length of the replacement, which has been added to "buf".
  * Returns -1 if there was no match, and only the "<" has been copied.
  */
-static size_t uc_check_code(code, len, buf, cmd, eap, split_buf, split_len)
-char_u      *code;
-size_t len;
-char_u      *buf;
-ucmd_T      *cmd;               /* the user command we're expanding */
-exarg_T     *eap;               /* ex arguments */
-char_u      **split_buf;
-size_t      *split_len;
+static size_t 
+uc_check_code (
+    char_u *code,
+    size_t len,
+    char_u *buf,
+    ucmd_T *cmd,               /* the user command we're expanding */
+    exarg_T *eap,               /* ex arguments */
+    char_u **split_buf,
+    size_t *split_len
+)
 {
   size_t result = 0;
   char_u      *p = code + 1;
@@ -5094,8 +5033,7 @@ size_t      *split_len;
   return result;
 }
 
-static void do_ucmd(eap)
-exarg_T     *eap;
+static void do_ucmd(exarg_T *eap)
 {
   char_u      *buf;
   char_u      *p;
@@ -5203,8 +5141,7 @@ exarg_T     *eap;
   vim_free(split_buf);
 }
 
-static char_u * get_user_command_name(idx)
-int idx;
+static char_u *get_user_command_name(int idx)
 {
   return get_user_commands(NULL, idx - (int)CMD_SIZE);
 }
@@ -5212,9 +5149,7 @@ int idx;
 /*
  * Function given to ExpandGeneric() to obtain the list of user command names.
  */
-char_u * get_user_commands(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_user_commands(expand_T *xp, int idx)
 {
   if (idx < curbuf->b_ucmds.ga_len)
     return USER_CMD_GA(&curbuf->b_ucmds, idx)->uc_name;
@@ -5228,9 +5163,7 @@ int idx;
  * Function given to ExpandGeneric() to obtain the list of user command
  * attributes.
  */
-char_u * get_user_cmd_flags(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_user_cmd_flags(expand_T *xp, int idx)
 {
   static char *user_cmd_flags[] =
   {"bang", "bar", "buffer", "complete", "count",
@@ -5244,9 +5177,7 @@ int idx;
 /*
  * Function given to ExpandGeneric() to obtain the list of values for -nargs.
  */
-char_u * get_user_cmd_nargs(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_user_cmd_nargs(expand_T *xp, int idx)
 {
   static char *user_cmd_nargs[] = {"0", "1", "*", "?", "+"};
 
@@ -5258,9 +5189,7 @@ int idx;
 /*
  * Function given to ExpandGeneric() to obtain the list of values for -complete.
  */
-char_u * get_user_cmd_complete(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_user_cmd_complete(expand_T *xp, int idx)
 {
   return (char_u *)command_complete[idx].name;
 }
@@ -5273,12 +5202,7 @@ int idx;
  * copied to allocated memory and stored in "*compl_arg".
  * Returns FAIL if something is wrong.
  */
-int parse_compl_arg(value, vallen, complp, argt, compl_arg)
-char_u      *value;
-int vallen;
-int         *complp;
-long        *argt;
-char_u      **compl_arg UNUSED;
+int parse_compl_arg(char_u *value, int vallen, int *complp, long *argt, char_u **compl_arg)
 {
   char_u      *arg = NULL;
   size_t arglen = 0;
@@ -5330,8 +5254,7 @@ char_u      **compl_arg UNUSED;
   return OK;
 }
 
-static void ex_colorscheme(eap)
-exarg_T     *eap;
+static void ex_colorscheme(exarg_T *eap)
 {
   if (*eap->arg == NUL) {
     char_u *expr = vim_strsave((char_u *)"g:colors_name");
@@ -5352,8 +5275,7 @@ exarg_T     *eap;
     EMSG2(_("E185: Cannot find color scheme '%s'"), eap->arg);
 }
 
-static void ex_highlight(eap)
-exarg_T     *eap;
+static void ex_highlight(exarg_T *eap)
 {
   if (*eap->arg == NUL && eap->cmd[2] == '!')
     MSG(_("Greetings, Vim user!"));
@@ -5365,7 +5287,7 @@ exarg_T     *eap;
  * Call this function if we thought we were going to exit, but we won't
  * (because of an error).  May need to restore the terminal mode.
  */
-void not_exiting()          {
+void not_exiting(void)          {
   exiting = FALSE;
   settmode(TMODE_RAW);
 }
@@ -5373,8 +5295,7 @@ void not_exiting()          {
 /*
  * ":quit": quit current window, quit Vim if closed the last window.
  */
-static void ex_quit(eap)
-exarg_T     *eap;
+static void ex_quit(exarg_T *eap)
 {
   if (cmdwin_type != 0) {
     cmdwin_result = Ctrl_C;
@@ -5415,8 +5336,7 @@ exarg_T     *eap;
 /*
  * ":cquit".
  */
-static void ex_cquit(eap)
-exarg_T     *eap UNUSED;
+static void ex_cquit(exarg_T *eap)
 {
   getout(1);    /* this does not always pass on the exit code to the Manx
                    compiler. why? */
@@ -5425,8 +5345,7 @@ exarg_T     *eap UNUSED;
 /*
  * ":qall": try to quit all windows
  */
-static void ex_quit_all(eap)
-exarg_T     *eap;
+static void ex_quit_all(exarg_T *eap)
 {
   if (cmdwin_type != 0) {
     if (eap->forceit)
@@ -5456,8 +5375,7 @@ exarg_T     *eap;
 /*
  * ":close": close current window, unless it is the last one
  */
-static void ex_close(eap)
-exarg_T     *eap;
+static void ex_close(exarg_T *eap)
 {
   if (cmdwin_type != 0)
     cmdwin_result = Ctrl_C;
@@ -5470,8 +5388,7 @@ exarg_T     *eap;
 /*
  * ":pclose": Close any preview window.
  */
-static void ex_pclose(eap)
-exarg_T     *eap;
+static void ex_pclose(exarg_T *eap)
 {
   win_T       *win;
 
@@ -5486,10 +5403,12 @@ exarg_T     *eap;
  * Close window "win" and take care of handling closing the last window for a
  * modified buffer.
  */
-static void ex_win_close(forceit, win, tp)
-int forceit;
-win_T       *win;
-tabpage_T   *tp;                /* NULL or the tab page "win" is in */
+static void 
+ex_win_close (
+    int forceit,
+    win_T *win,
+    tabpage_T *tp                /* NULL or the tab page "win" is in */
+)
 {
   int need_hide;
   buf_T       *buf = win->w_buffer;
@@ -5519,8 +5438,7 @@ tabpage_T   *tp;                /* NULL or the tab page "win" is in */
  * ":tabclose": close current tab page, unless it is the last one.
  * ":tabclose N": close tab page N.
  */
-static void ex_tabclose(eap)
-exarg_T     *eap;
+static void ex_tabclose(exarg_T *eap)
 {
   tabpage_T   *tp;
 
@@ -5550,8 +5468,7 @@ exarg_T     *eap;
 /*
  * ":tabonly": close all tab pages except the current one
  */
-static void ex_tabonly(eap)
-exarg_T     *eap;
+static void ex_tabonly(exarg_T *eap)
 {
   tabpage_T   *tp;
   int done;
@@ -5582,8 +5499,7 @@ exarg_T     *eap;
 /*
  * Close the current tab page.
  */
-void tabpage_close(forceit)
-int forceit;
+void tabpage_close(int forceit)
 {
   /* First close all the windows but the current one.  If that worked then
    * close the last window in this tab, that will close it. */
@@ -5599,9 +5515,7 @@ int forceit;
  * Also takes care of the tab pages line disappearing when closing the
  * last-but-one tab page.
  */
-void tabpage_close_other(tp, forceit)
-tabpage_T   *tp;
-int forceit;
+void tabpage_close_other(tabpage_T *tp, int forceit)
 {
   int done = 0;
   win_T       *wp;
@@ -5627,8 +5541,7 @@ int forceit;
 /*
  * ":only".
  */
-static void ex_only(eap)
-exarg_T     *eap;
+static void ex_only(exarg_T *eap)
 {
   close_others(TRUE, eap->forceit);
 }
@@ -5637,16 +5550,14 @@ exarg_T     *eap;
  * ":all" and ":sall".
  * Also used for ":tab drop file ..." after setting the argument list.
  */
-void ex_all(eap)
-exarg_T     *eap;
+void ex_all(exarg_T *eap)
 {
   if (eap->addr_count == 0)
     eap->line2 = 9999;
   do_arg_all((int)eap->line2, eap->forceit, eap->cmdidx == CMD_drop);
 }
 
-static void ex_hide(eap)
-exarg_T     *eap;
+static void ex_hide(exarg_T *eap)
 {
   if (*eap->arg != NUL && check_nextcmd(eap->arg) == NULL)
     eap->errmsg = e_invarg;
@@ -5662,8 +5573,7 @@ exarg_T     *eap;
 /*
  * ":stop" and ":suspend": Suspend Vim.
  */
-static void ex_stop(eap)
-exarg_T     *eap;
+static void ex_stop(exarg_T *eap)
 {
   /*
    * Disallow suspending for "rvim".
@@ -5691,8 +5601,7 @@ exarg_T     *eap;
 /*
  * ":exit", ":xit" and ":wq": Write file and exit Vim.
  */
-static void ex_exit(eap)
-exarg_T     *eap;
+static void ex_exit(exarg_T *eap)
 {
   if (cmdwin_type != 0) {
     cmdwin_result = Ctrl_C;
@@ -5731,8 +5640,7 @@ exarg_T     *eap;
 /*
  * ":print", ":list", ":number".
  */
-static void ex_print(eap)
-exarg_T     *eap;
+static void ex_print(exarg_T *eap)
 {
   if (curbuf->b_ml.ml_flags & ML_EMPTY)
     EMSG(_(e_emptybuf));
@@ -5755,8 +5663,7 @@ exarg_T     *eap;
   ex_no_reprint = TRUE;
 }
 
-static void ex_goto(eap)
-exarg_T     *eap;
+static void ex_goto(exarg_T *eap)
 {
   goto_byte(eap->line2);
 }
@@ -5764,8 +5671,7 @@ exarg_T     *eap;
 /*
  * ":shell".
  */
-static void ex_shell(eap)
-exarg_T     *eap UNUSED;
+static void ex_shell(exarg_T *eap)
 {
   do_shell(NULL, 0);
 }
@@ -5793,10 +5699,12 @@ exarg_T     *eap UNUSED;
  * file functionality is (currently) not in EMX this is not presently a
  * problem.
  */
-void handle_drop(filec, filev, split)
-int filec;                      /* the number of files dropped */
-char_u      **filev;            /* the list of files dropped */
-int split;                      /* force splitting the window */
+void 
+handle_drop (
+    int filec,                      /* the number of files dropped */
+    char_u **filev,            /* the list of files dropped */
+    int split                      /* force splitting the window */
+)
 {
   exarg_T ea;
   int save_msg_scroll = msg_scroll;
@@ -5859,8 +5767,7 @@ int split;                      /* force splitting the window */
 /*
  * Clear an argument list: free all file names and reset it to zero entries.
  */
-void alist_clear(al)
-alist_T     *al;
+void alist_clear(alist_T *al)
 {
   while (--al->al_ga.ga_len >= 0)
     vim_free(AARGLIST(al)[al->al_ga.ga_len].ae_fname);
@@ -5870,8 +5777,7 @@ alist_T     *al;
 /*
  * Init an argument list.
  */
-void alist_init(al)
-alist_T     *al;
+void alist_init(alist_T *al)
 {
   ga_init2(&al->al_ga, (int)sizeof(aentry_T), 5);
 }
@@ -5882,8 +5788,7 @@ alist_T     *al;
  * Ignored when the argument list is the global one.
  * If the argument list is no longer used by any window, free it.
  */
-void alist_unlink(al)
-alist_T     *al;
+void alist_unlink(alist_T *al)
 {
   if (al != &global_alist && --al->al_refcount <= 0) {
     alist_clear(al);
@@ -5894,7 +5799,7 @@ alist_T     *al;
 /*
  * Create a new argument list and use it for the current window.
  */
-void alist_new()          {
+void alist_new(void)          {
   curwin->w_alist = (alist_T *)alloc((unsigned)sizeof(alist_T));
   if (curwin->w_alist == NULL) {
     curwin->w_alist = &global_alist;
@@ -5911,9 +5816,7 @@ void alist_new()          {
  * If "fnum_list" is not NULL, use "fnum_list[fnum_len]" as a list of buffer
  * numbers to be re-used.
  */
-void alist_expand(fnum_list, fnum_len)
-int         *fnum_list;
-int fnum_len;
+void alist_expand(int *fnum_list, int fnum_len)
 {
   char_u      **old_arg_files;
   int old_arg_count;
@@ -5948,13 +5851,7 @@ int fnum_len;
  * Set the argument list for the current window.
  * Takes over the allocated files[] and the allocated fnames in it.
  */
-void alist_set(al, count, files, use_curbuf, fnum_list, fnum_len)
-alist_T     *al;
-int count;
-char_u      **files;
-int use_curbuf;
-int         *fnum_list;
-int fnum_len;
+void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum_list, int fnum_len)
 {
   int i;
 
@@ -5988,10 +5885,12 @@ int fnum_len;
  * Add file "fname" to argument list "al".
  * "fname" must have been allocated and "al" must have been checked for room.
  */
-void alist_add(al, fname, set_fnum)
-alist_T     *al;
-char_u      *fname;
-int set_fnum;                   /* 1: set buffer number; 2: re-use curbuf */
+void 
+alist_add (
+    alist_T *al,
+    char_u *fname,
+    int set_fnum                   /* 1: set buffer number; 2: re-use curbuf */
+)
 {
   if (fname == NULL)            /* don't add NULL file names */
     return;
@@ -6009,7 +5908,7 @@ int set_fnum;                   /* 1: set buffer number; 2: re-use curbuf */
 /*
  * Adjust slashes in file names.  Called after 'shellslash' was set.
  */
-void alist_slash_adjust()          {
+void alist_slash_adjust(void)          {
   int i;
   win_T       *wp;
   tabpage_T   *tp;
@@ -6029,8 +5928,7 @@ void alist_slash_adjust()          {
 /*
  * ":preserve".
  */
-static void ex_preserve(eap)
-exarg_T     *eap UNUSED;
+static void ex_preserve(exarg_T *eap)
 {
   curbuf->b_flags |= BF_PRESERVED;
   ml_preserve(curbuf, TRUE);
@@ -6039,8 +5937,7 @@ exarg_T     *eap UNUSED;
 /*
  * ":recover".
  */
-static void ex_recover(eap)
-exarg_T     *eap;
+static void ex_recover(exarg_T *eap)
 {
   /* Set recoverymode right away to avoid the ATTENTION prompt. */
   recoverymode = TRUE;
@@ -6058,8 +5955,7 @@ exarg_T     *eap;
 /*
  * Command modifier used in a wrong way.
  */
-static void ex_wrongmodifier(eap)
-exarg_T     *eap;
+static void ex_wrongmodifier(exarg_T *eap)
 {
   eap->errmsg = e_invcmd;
 }
@@ -6077,8 +5973,7 @@ exarg_T     *eap;
  * :tabnew [[+command] file]	just like :tabedit
  * :tabfind [+command] file	open new Tab page and find "file"
  */
-void ex_splitview(eap)
-exarg_T     *eap;
+void ex_splitview(exarg_T *eap)
 {
   win_T       *old_curwin = curwin;
   char_u      *fname = NULL;
@@ -6140,7 +6035,7 @@ theend:
 /*
  * Open a new tab page.
  */
-void tabpage_new()          {
+void tabpage_new(void)          {
   exarg_T ea;
 
   vim_memset(&ea, 0, sizeof(ea));
@@ -6153,8 +6048,7 @@ void tabpage_new()          {
 /*
  * :tabnext command
  */
-static void ex_tabnext(eap)
-exarg_T     *eap;
+static void ex_tabnext(exarg_T *eap)
 {
   switch (eap->cmdidx) {
   case CMD_tabfirst:
@@ -6177,8 +6071,7 @@ exarg_T     *eap;
 /*
  * :tabmove command
  */
-static void ex_tabmove(eap)
-exarg_T     *eap;
+static void ex_tabmove(exarg_T *eap)
 {
   int tab_number = 9999;
 
@@ -6214,8 +6107,7 @@ exarg_T     *eap;
 /*
  * :tabs command: List tabs and their contents.
  */
-static void ex_tabs(eap)
-exarg_T     *eap UNUSED;
+static void ex_tabs(exarg_T *eap)
 {
   tabpage_T   *tp;
   win_T       *wp;
@@ -6257,8 +6149,7 @@ exarg_T     *eap UNUSED;
  * ":mode": Set screen mode.
  * If no argument given, just get the screen size and redraw.
  */
-static void ex_mode(eap)
-exarg_T     *eap;
+static void ex_mode(exarg_T *eap)
 {
   if (*eap->arg == NUL)
     shell_resized();
@@ -6270,8 +6161,7 @@ exarg_T     *eap;
  * ":resize".
  * set, increment or decrement current window height
  */
-static void ex_resize(eap)
-exarg_T     *eap;
+static void ex_resize(exarg_T *eap)
 {
   int n;
   win_T       *wp = curwin;
@@ -6301,8 +6191,7 @@ exarg_T     *eap;
 /*
  * ":find [+command] <file>" command.
  */
-static void ex_find(eap)
-exarg_T     *eap;
+static void ex_find(exarg_T *eap)
 {
   char_u      *fname;
   int count;
@@ -6330,8 +6219,7 @@ exarg_T     *eap;
 /*
  * ":open" simulation: for now just work like ":visual".
  */
-static void ex_open(eap)
-exarg_T     *eap;
+static void ex_open(exarg_T *eap)
 {
   regmatch_T regmatch;
   char_u      *p;
@@ -6365,8 +6253,7 @@ exarg_T     *eap;
 /*
  * ":edit", ":badd", ":visual".
  */
-static void ex_edit(eap)
-exarg_T     *eap;
+static void ex_edit(exarg_T *eap)
 {
   do_exedit(eap, NULL);
 }
@@ -6374,9 +6261,11 @@ exarg_T     *eap;
 /*
  * ":edit <file>" command and alikes.
  */
-void do_exedit(eap, old_curwin)
-exarg_T     *eap;
-win_T       *old_curwin;            /* curwin before doing a split or NULL */
+void 
+do_exedit (
+    exarg_T *eap,
+    win_T *old_curwin            /* curwin before doing a split or NULL */
+)
 {
   int n;
   int need_hide;
@@ -6506,16 +6395,14 @@ win_T       *old_curwin;            /* curwin before doing a split or NULL */
 /*
  * ":gui" and ":gvim" when there is no GUI.
  */
-static void ex_nogui(eap)
-exarg_T     *eap;
+static void ex_nogui(exarg_T *eap)
 {
   eap->errmsg = e_nogvim;
 }
 
 
 
-static void ex_swapname(eap)
-exarg_T     *eap UNUSED;
+static void ex_swapname(exarg_T *eap)
 {
   if (curbuf->b_ml.ml_mfp == NULL || curbuf->b_ml.ml_mfp->mf_fname == NULL)
     MSG(_("No swap file"));
@@ -6528,8 +6415,7 @@ exarg_T     *eap UNUSED;
  * offset.
  * (1998-11-02 16:21:01  R. Edward Ralston <eralston@computer.org>)
  */
-static void ex_syncbind(eap)
-exarg_T     *eap UNUSED;
+static void ex_syncbind(exarg_T *eap)
 {
   win_T       *wp;
   win_T       *save_curwin = curwin;
@@ -6592,8 +6478,7 @@ exarg_T     *eap UNUSED;
 }
 
 
-static void ex_read(eap)
-exarg_T     *eap;
+static void ex_read(exarg_T *eap)
 {
   int i;
   int empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
@@ -6644,7 +6529,7 @@ exarg_T     *eap;
 static char_u   *prev_dir = NULL;
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_cd_dir()          {
+void free_cd_dir(void)          {
   vim_free(prev_dir);
   prev_dir = NULL;
 
@@ -6658,8 +6543,7 @@ void free_cd_dir()          {
  * Deal with the side effects of changing the current directory.
  * When "local" is TRUE then this was after an ":lcd" command.
  */
-void post_chdir(local)
-int local;
+void post_chdir(int local)
 {
   vim_free(curwin->w_localdir);
   curwin->w_localdir = NULL;
@@ -6685,8 +6569,7 @@ int local;
 /*
  * ":cd", ":lcd", ":chdir" and ":lchdir".
  */
-void ex_cd(eap)
-exarg_T     *eap;
+void ex_cd(exarg_T *eap)
 {
   char_u              *new_dir;
   char_u              *tofree;
@@ -6748,8 +6631,7 @@ exarg_T     *eap;
 /*
  * ":pwd".
  */
-static void ex_pwd(eap)
-exarg_T     *eap UNUSED;
+static void ex_pwd(exarg_T *eap)
 {
   if (mch_dirname(NameBuff, MAXPATHL) == OK) {
 #ifdef BACKSLASH_IN_FILENAME
@@ -6763,15 +6645,13 @@ exarg_T     *eap UNUSED;
 /*
  * ":=".
  */
-static void ex_equal(eap)
-exarg_T     *eap;
+static void ex_equal(exarg_T *eap)
 {
   smsg((char_u *)"%ld", (long)eap->line2);
   ex_may_print(eap);
 }
 
-static void ex_sleep(eap)
-exarg_T     *eap;
+static void ex_sleep(exarg_T *eap)
 {
   int n;
   long len;
@@ -6794,8 +6674,7 @@ exarg_T     *eap;
 /*
  * Sleep for "msec" milliseconds, but keep checking for a CTRL-C every second.
  */
-void do_sleep(msec)
-long msec;
+void do_sleep(long msec)
 {
   long done;
 
@@ -6807,9 +6686,7 @@ long msec;
   }
 }
 
-static void do_exmap(eap, isabbrev)
-exarg_T     *eap;
-int isabbrev;
+static void do_exmap(exarg_T *eap, int isabbrev)
 {
   int mode;
   char_u  *cmdp;
@@ -6829,8 +6706,7 @@ int isabbrev;
 /*
  * ":winsize" command (obsolete).
  */
-static void ex_winsize(eap)
-exarg_T     *eap;
+static void ex_winsize(exarg_T *eap)
 {
   int w, h;
   char_u      *arg = eap->arg;
@@ -6846,8 +6722,7 @@ exarg_T     *eap;
     EMSG(_("E465: :winsize requires two number arguments"));
 }
 
-static void ex_wincmd(eap)
-exarg_T     *eap;
+static void ex_wincmd(exarg_T *eap)
 {
   int xchar = NUL;
   char_u      *p;
@@ -6910,8 +6785,7 @@ exarg_T     *eap;
 /*
  * Handle command that work like operators: ":delete", ":yank", ":>" and ":<".
  */
-static void ex_operators(eap)
-exarg_T     *eap;
+static void ex_operators(exarg_T *eap)
 {
   oparg_T oa;
 
@@ -6959,8 +6833,7 @@ exarg_T     *eap;
 /*
  * ":put".
  */
-static void ex_put(eap)
-exarg_T     *eap;
+static void ex_put(exarg_T *eap)
 {
   /* ":0put" works like ":1put!". */
   if (eap->line2 == 0) {
@@ -6975,8 +6848,7 @@ exarg_T     *eap;
 /*
  * Handle ":copy" and ":move".
  */
-static void ex_copymove(eap)
-exarg_T     *eap;
+static void ex_copymove(exarg_T *eap)
 {
   long n;
 
@@ -7008,8 +6880,7 @@ exarg_T     *eap;
 /*
  * Print the current line if flags were given to the Ex command.
  */
-static void ex_may_print(eap)
-exarg_T     *eap;
+static void ex_may_print(exarg_T *eap)
 {
   if (eap->flags != 0) {
     print_line(curwin->w_cursor.lnum, (eap->flags & EXFLAG_NR),
@@ -7021,8 +6892,7 @@ exarg_T     *eap;
 /*
  * ":smagic" and ":snomagic".
  */
-static void ex_submagic(eap)
-exarg_T     *eap;
+static void ex_submagic(exarg_T *eap)
 {
   int magic_save = p_magic;
 
@@ -7034,8 +6904,7 @@ exarg_T     *eap;
 /*
  * ":join".
  */
-static void ex_join(eap)
-exarg_T     *eap;
+static void ex_join(exarg_T *eap)
 {
   curwin->w_cursor.lnum = eap->line1;
   if (eap->line1 == eap->line2) {
@@ -7055,8 +6924,7 @@ exarg_T     *eap;
 /*
  * ":[addr]@r" or ":[addr]*r": execute register
  */
-static void ex_at(eap)
-exarg_T     *eap;
+static void ex_at(exarg_T *eap)
 {
   int c;
   int prev_len = typebuf.tb_len;
@@ -7095,8 +6963,7 @@ exarg_T     *eap;
 /*
  * ":!".
  */
-static void ex_bang(eap)
-exarg_T     *eap;
+static void ex_bang(exarg_T *eap)
 {
   do_bang(eap->addr_count, eap, eap->forceit, TRUE, TRUE);
 }
@@ -7104,8 +6971,7 @@ exarg_T     *eap;
 /*
  * ":undo".
  */
-static void ex_undo(eap)
-exarg_T     *eap UNUSED;
+static void ex_undo(exarg_T *eap)
 {
   if (eap->addr_count == 1)         /* :undo 123 */
     undo_time(eap->line2, FALSE, FALSE, TRUE);
@@ -7113,8 +6979,7 @@ exarg_T     *eap UNUSED;
     u_undo(1);
 }
 
-static void ex_wundo(eap)
-exarg_T *eap;
+static void ex_wundo(exarg_T *eap)
 {
   char_u hash[UNDO_HASH_SIZE];
 
@@ -7122,8 +6987,7 @@ exarg_T *eap;
   u_write_undo(eap->arg, eap->forceit, curbuf, hash);
 }
 
-static void ex_rundo(eap)
-exarg_T *eap;
+static void ex_rundo(exarg_T *eap)
 {
   char_u hash[UNDO_HASH_SIZE];
 
@@ -7134,8 +6998,7 @@ exarg_T *eap;
 /*
  * ":redo".
  */
-static void ex_redo(eap)
-exarg_T     *eap UNUSED;
+static void ex_redo(exarg_T *eap)
 {
   u_redo(1);
 }
@@ -7143,8 +7006,7 @@ exarg_T     *eap UNUSED;
 /*
  * ":earlier" and ":later".
  */
-static void ex_later(eap)
-exarg_T     *eap;
+static void ex_later(exarg_T *eap)
 {
   long count = 0;
   int sec = FALSE;
@@ -7174,8 +7036,7 @@ exarg_T     *eap;
 /*
  * ":redir": start/stop redirection.
  */
-static void ex_redir(eap)
-exarg_T     *eap;
+static void ex_redir(exarg_T *eap)
 {
   char        *mode;
   char_u      *fname;
@@ -7257,8 +7118,7 @@ exarg_T     *eap;
 /*
  * ":redraw": force redraw
  */
-static void ex_redraw(eap)
-exarg_T     *eap;
+static void ex_redraw(exarg_T *eap)
 {
   int r = RedrawingDisabled;
   int p = p_lz;
@@ -7287,8 +7147,7 @@ exarg_T     *eap;
 /*
  * ":redrawstatus": force redraw of status line(s)
  */
-static void ex_redrawstatus(eap)
-exarg_T     *eap UNUSED;
+static void ex_redrawstatus(exarg_T *eap)
 {
   int r = RedrawingDisabled;
   int p = p_lz;
@@ -7307,7 +7166,7 @@ exarg_T     *eap UNUSED;
   out_flush();
 }
 
-static void close_redir()                 {
+static void close_redir(void)                 {
   if (redir_fd != NULL) {
     fclose(redir_fd);
     redir_fd = NULL;
@@ -7327,8 +7186,7 @@ static int mksession_nl = FALSE;    /* use NL only in put_eol() */
 /*
  * ":mkexrc", ":mkvimrc", ":mkview" and ":mksession".
  */
-static void ex_mkrc(eap)
-exarg_T     *eap;
+static void ex_mkrc(exarg_T *eap)
 {
   FILE        *fd;
   int failed = FALSE;
@@ -7490,9 +7348,7 @@ exarg_T     *eap;
 
 #if ((defined(FEAT_SESSION) || defined(FEAT_EVAL)) && defined(vim_mkdir)) \
   || defined(PROTO)
-int vim_mkdir_emsg(name, prot)
-char_u      *name;
-int prot UNUSED;
+int vim_mkdir_emsg(char_u *name, int prot)
 {
   if (vim_mkdir(name, prot) != 0) {
     EMSG2(_("E739: Cannot create directory: %s"), name);
@@ -7506,10 +7362,12 @@ int prot UNUSED;
  * Open a file for writing for an Ex command, with some checks.
  * Return file descriptor, or NULL on failure.
  */
-FILE * open_exfile(fname, forceit, mode)
-char_u      *fname;
-int forceit;
-char        *mode;          /* "w" for create new file or "a" for append */
+FILE *
+open_exfile (
+    char_u *fname,
+    int forceit,
+    char *mode          /* "w" for create new file or "a" for append */
+)
 {
   FILE        *fd;
 
@@ -7534,8 +7392,7 @@ char        *mode;          /* "w" for create new file or "a" for append */
 /*
  * ":mark" and ":k".
  */
-static void ex_mark(eap)
-exarg_T     *eap;
+static void ex_mark(exarg_T *eap)
 {
   pos_T pos;
 
@@ -7556,7 +7413,7 @@ exarg_T     *eap;
 /*
  * Update w_topline, w_leftcol and the cursor position.
  */
-void update_topline_cursor()          {
+void update_topline_cursor(void)          {
   check_cursor();               /* put cursor on valid line */
   update_topline();
   if (!curwin->w_p_wrap)
@@ -7567,8 +7424,7 @@ void update_topline_cursor()          {
 /*
  * ":normal[!] {commands}": Execute normal mode commands.
  */
-static void ex_normal(eap)
-exarg_T     *eap;
+static void ex_normal(exarg_T *eap)
 {
   int save_msg_scroll = msg_scroll;
   int save_restart_edit = restart_edit;
@@ -7677,8 +7533,7 @@ exarg_T     *eap;
 /*
  * ":startinsert", ":startreplace" and ":startgreplace"
  */
-static void ex_startinsert(eap)
-exarg_T     *eap;
+static void ex_startinsert(exarg_T *eap)
 {
   if (eap->forceit) {
     coladvance((colnr_T)MAXCOL);
@@ -7708,8 +7563,7 @@ exarg_T     *eap;
 /*
  * ":stopinsert"
  */
-static void ex_stopinsert(eap)
-exarg_T     *eap UNUSED;
+static void ex_stopinsert(exarg_T *eap)
 {
   restart_edit = 0;
   stop_insert_mode = TRUE;
@@ -7719,10 +7573,7 @@ exarg_T     *eap UNUSED;
  * Execute normal mode command "cmd".
  * "remap" can be REMAP_NONE or REMAP_YES.
  */
-void exec_normal_cmd(cmd, remap, silent)
-char_u      *cmd;
-int remap;
-int silent;
+void exec_normal_cmd(char_u *cmd, int remap, int silent)
 {
   oparg_T oa;
 
@@ -7740,8 +7591,7 @@ int silent;
   }
 }
 
-static void ex_checkpath(eap)
-exarg_T     *eap;
+static void ex_checkpath(exarg_T *eap)
 {
   find_pattern_in_path(NULL, 0, 0, FALSE, FALSE, CHECK_PATH, 1L,
       eap->forceit ? ACTION_SHOW_ALL : ACTION_SHOW,
@@ -7751,16 +7601,14 @@ exarg_T     *eap;
 /*
  * ":psearch"
  */
-static void ex_psearch(eap)
-exarg_T     *eap;
+static void ex_psearch(exarg_T *eap)
 {
   g_do_tagpreview = p_pvh;
   ex_findpat(eap);
   g_do_tagpreview = 0;
 }
 
-static void ex_findpat(eap)
-exarg_T     *eap;
+static void ex_findpat(exarg_T *eap)
 {
   int whole = TRUE;
   long n;
@@ -7816,8 +7664,7 @@ exarg_T     *eap;
 /*
  * ":ptag", ":ptselect", ":ptjump", ":ptnext", etc.
  */
-static void ex_ptag(eap)
-exarg_T     *eap;
+static void ex_ptag(exarg_T *eap)
 {
   g_do_tagpreview = p_pvh;    /* will be reset to 0 in ex_tag_cmd() */
   ex_tag_cmd(eap, cmdnames[eap->cmdidx].cmd_name + 1);
@@ -7826,8 +7673,7 @@ exarg_T     *eap;
 /*
  * ":pedit"
  */
-static void ex_pedit(eap)
-exarg_T     *eap;
+static void ex_pedit(exarg_T *eap)
 {
   win_T       *curwin_save = curwin;
 
@@ -7848,8 +7694,7 @@ exarg_T     *eap;
 /*
  * ":stag", ":stselect" and ":stjump".
  */
-static void ex_stag(eap)
-exarg_T     *eap;
+static void ex_stag(exarg_T *eap)
 {
   postponed_split = -1;
   postponed_split_flags = cmdmod.split;
@@ -7862,15 +7707,12 @@ exarg_T     *eap;
 /*
  * ":tag", ":tselect", ":tjump", ":tnext", etc.
  */
-static void ex_tag(eap)
-exarg_T     *eap;
+static void ex_tag(exarg_T *eap)
 {
   ex_tag_cmd(eap, cmdnames[eap->cmdidx].cmd_name);
 }
 
-static void ex_tag_cmd(eap, name)
-exarg_T     *eap;
-char_u      *name;
+static void ex_tag_cmd(exarg_T *eap, char_u *name)
 {
   int cmd;
 
@@ -7914,9 +7756,7 @@ char_u      *name;
  * If found return one of the SPEC_ values and set "*usedlen" to the length of
  * the variable.  Otherwise return -1 and "*usedlen" is unchanged.
  */
-int find_cmdline_var(src, usedlen)
-char_u      *src;
-int         *usedlen;
+int find_cmdline_var(char_u *src, int *usedlen)
 {
   int len;
   int i;
@@ -7973,14 +7813,16 @@ int         *usedlen;
  * Returns NULL if no match was found.	"usedlen" then still contains the
  * number of characters to skip.
  */
-char_u * eval_vars(src, srcstart, usedlen, lnump, errormsg, escaped)
-char_u      *src;               /* pointer into commandline */
-char_u      *srcstart;          /* beginning of valid memory for src */
-int         *usedlen;           /* characters after src that are used */
-linenr_T    *lnump;             /* line number for :e command, or NULL */
-char_u      **errormsg;         /* pointer to error message */
-int         *escaped;           /* return value has escaped white space (can
+char_u *
+eval_vars (
+    char_u *src,               /* pointer into commandline */
+    char_u *srcstart,          /* beginning of valid memory for src */
+    int *usedlen,           /* characters after src that are used */
+    linenr_T *lnump,             /* line number for :e command, or NULL */
+    char_u **errormsg,         /* pointer to error message */
+    int *escaped           /* return value has escaped white space (can
                                  * be NULL) */
+)
 {
   int i;
   char_u      *s;
@@ -8188,7 +8030,7 @@ int         *escaped;           /* return value has escaped white space (can
  * Spaces and backslashes in the file names are escaped with a backslash.
  * Returns NULL when out of memory.
  */
-static char_u * arg_all()                     {
+static char_u *arg_all(void)                     {
   int len;
   int idx;
   char_u      *retval = NULL;
@@ -8244,8 +8086,7 @@ static char_u * arg_all()                     {
  *
  * Returns an allocated string, or NULL for any error.
  */
-char_u * expand_sfile(arg)
-char_u      *arg;
+char_u *expand_sfile(char_u *arg)
 {
   char_u      *errormsg;
   int len;
@@ -8311,9 +8152,11 @@ static int ses_fname __ARGS((FILE *fd, buf_T *buf, unsigned *flagp));
  * Write openfile commands for the current buffers to an .exrc file.
  * Return FAIL on error, OK otherwise.
  */
-static int makeopens(fd, dirnow)
-FILE        *fd;
-char_u      *dirnow;            /* Current directory name */
+static int 
+makeopens (
+    FILE *fd,
+    char_u *dirnow            /* Current directory name */
+)
 {
   buf_T       *buf;
   int only_save_windows = TRUE;
@@ -8581,10 +8424,7 @@ char_u      *dirnow;            /* Current directory name */
   return OK;
 }
 
-static int ses_winsizes(fd, restore_size, tab_firstwin)
-FILE        *fd;
-int restore_size;
-win_T       *tab_firstwin;
+static int ses_winsizes(FILE *fd, int restore_size, win_T *tab_firstwin)
 {
   int n = 0;
   win_T       *wp;
@@ -8625,9 +8465,7 @@ win_T       *tab_firstwin;
  * After the commands the last window in the frame is the current window.
  * Returns FAIL when writing the commands to "fd" fails.
  */
-static int ses_win_rec(fd, fr)
-FILE        *fd;
-frame_T     *fr;
+static int ses_win_rec(FILE *fd, frame_T *fr)
 {
   frame_T     *frc;
   int count = 0;
@@ -8671,8 +8509,7 @@ frame_T     *fr;
  * Skip frames that don't contain windows we want to save in the Session.
  * Returns NULL when there none.
  */
-static frame_T * ses_skipframe(fr)
-frame_T     *fr;
+static frame_T *ses_skipframe(frame_T *fr)
 {
   frame_T     *frc;
 
@@ -8686,8 +8523,7 @@ frame_T     *fr;
  * Return TRUE if frame "fr" has a window somewhere that we want to save in
  * the Session.
  */
-static int ses_do_frame(fr)
-frame_T     *fr;
+static int ses_do_frame(frame_T *fr)
 {
   frame_T     *frc;
 
@@ -8702,8 +8538,7 @@ frame_T     *fr;
 /*
  * Return non-zero if window "wp" is to be stored in the Session.
  */
-static int ses_do_win(wp)
-win_T       *wp;
+static int ses_do_win(win_T *wp)
 {
   if (wp->w_buffer->b_fname == NULL
       /* When 'buftype' is "nofile" can't restore the window contents. */
@@ -8719,13 +8554,15 @@ win_T       *wp;
  * Write commands to "fd" to restore the view of a window.
  * Caller must make sure 'scrolloff' is zero.
  */
-static int put_view(fd, wp, add_edit, flagp, current_arg_idx)
-FILE        *fd;
-win_T       *wp;
-int add_edit;                   /* add ":edit" command to view */
-unsigned    *flagp;             /* vop_flags or ssop_flags */
-int current_arg_idx;             /* current argument index of the window, use
+static int 
+put_view (
+    FILE *fd,
+    win_T *wp,
+    int add_edit,                   /* add ":edit" command to view */
+    unsigned *flagp,             /* vop_flags or ssop_flags */
+    int current_arg_idx             /* current argument index of the window, use
                                   * -1 if unknown */
+)
 {
   win_T       *save_curwin;
   int f;
@@ -8895,12 +8732,14 @@ int current_arg_idx;             /* current argument index of the window, use
  * Write an argument list to the session file.
  * Returns FAIL if writing fails.
  */
-static int ses_arglist(fd, cmd, gap, fullname, flagp)
-FILE        *fd;
-char        *cmd;
-garray_T    *gap;
-int fullname;                   /* TRUE: use full path name */
-unsigned    *flagp;
+static int 
+ses_arglist (
+    FILE *fd,
+    char *cmd,
+    garray_T *gap,
+    int fullname,                   /* TRUE: use full path name */
+    unsigned *flagp
+)
 {
   int i;
   char_u      *buf = NULL;
@@ -8936,10 +8775,7 @@ unsigned    *flagp;
  * Also ends the line.
  * Returns FAIL if writing fails.
  */
-static int ses_fname(fd, buf, flagp)
-FILE        *fd;
-buf_T       *buf;
-unsigned    *flagp;
+static int ses_fname(FILE *fd, buf_T *buf, unsigned *flagp)
 {
   char_u      *name;
 
@@ -8967,10 +8803,7 @@ unsigned    *flagp;
  * characters.
  * Returns FAIL if writing fails or out of memory.
  */
-static int ses_put_fname(fd, name, flagp)
-FILE        *fd;
-char_u      *name;
-unsigned    *flagp;
+static int ses_put_fname(FILE *fd, char_u *name, unsigned *flagp)
 {
   char_u      *sname;
   char_u      *p;
@@ -9004,8 +8837,7 @@ unsigned    *flagp;
 /*
  * ":loadview [nr]"
  */
-static void ex_loadview(eap)
-exarg_T     *eap;
+static void ex_loadview(exarg_T *eap)
 {
   char_u      *fname;
 
@@ -9019,8 +8851,7 @@ exarg_T     *eap;
 /*
  * Get the name of the view file for the current buffer.
  */
-static char_u * get_view_file(c)
-int c;
+static char_u *get_view_file(int c)
 {
   int len = 0;
   char_u      *p, *s;
@@ -9079,8 +8910,7 @@ int c;
  * Write end-of-line character(s) for ":mkexrc", ":mkvimrc" and ":mksession".
  * Return FAIL for a write error.
  */
-int put_eol(fd)
-FILE        *fd;
+int put_eol(FILE *fd)
 {
   if (
 #ifdef USE_CRNL
@@ -9099,9 +8929,7 @@ FILE        *fd;
  * Write a line to "fd".
  * Return FAIL for a write error.
  */
-int put_line(fd, s)
-FILE        *fd;
-char        *s;
+int put_line(FILE *fd, char *s)
 {
   if (fputs(s, fd) < 0 || put_eol(fd) == FAIL)
     return FAIL;
@@ -9111,8 +8939,7 @@ char        *s;
 /*
  * ":rviminfo" and ":wviminfo".
  */
-static void ex_viminfo(eap)
-exarg_T     *eap;
+static void ex_viminfo(exarg_T *eap)
 {
   char_u      *save_viminfo;
 
@@ -9132,10 +8959,7 @@ exarg_T     *eap;
  * Make a dialog message in "buff[DIALOG_MSG_SIZE]".
  * "format" must contain "%s".
  */
-void dialog_msg(buff, format, fname)
-char_u      *buff;
-char        *format;
-char_u      *fname;
+void dialog_msg(char_u *buff, char *format, char_u *fname)
 {
   if (fname == NULL)
     fname = (char_u *)_("Untitled");
@@ -9145,8 +8969,7 @@ char_u      *fname;
 /*
  * ":behave {mswin,xterm}"
  */
-static void ex_behave(eap)
-exarg_T     *eap;
+static void ex_behave(exarg_T *eap)
 {
   if (STRCMP(eap->arg, "mswin") == 0) {
     set_option_value((char_u *)"selection", 0L, (char_u *)"exclusive", 0);
@@ -9167,9 +8990,7 @@ exarg_T     *eap;
  * Function given to ExpandGeneric() to obtain the possible arguments of the
  * ":behave {mswin,xterm}" command.
  */
-char_u * get_behave_arg(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_behave_arg(expand_T *xp, int idx)
 {
   if (idx == 0)
     return (char_u *)"mswin";
@@ -9191,8 +9012,7 @@ static int filetype_indent = FALSE;
  * indent on: load filetype.vim and indent.vim
  * indent off: load indoff.vim
  */
-static void ex_filetype(eap)
-exarg_T     *eap;
+static void ex_filetype(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   int plugin = FALSE;
@@ -9259,15 +9079,13 @@ exarg_T     *eap;
 /*
  * ":setfiletype {name}"
  */
-static void ex_setfiletype(eap)
-exarg_T     *eap;
+static void ex_setfiletype(exarg_T *eap)
 {
   if (!did_filetype)
     set_option_value((char_u *)"filetype", 0L, eap->arg, OPT_LOCAL);
 }
 
-static void ex_digraphs(eap)
-exarg_T     *eap UNUSED;
+static void ex_digraphs(exarg_T *eap)
 {
   if (*eap->arg != NUL)
     putdigraph(eap->arg);
@@ -9275,8 +9093,7 @@ exarg_T     *eap UNUSED;
     listdigraphs();
 }
 
-static void ex_set(eap)
-exarg_T     *eap;
+static void ex_set(exarg_T *eap)
 {
   int flags = 0;
 
@@ -9290,8 +9107,7 @@ exarg_T     *eap;
 /*
  * ":nohlsearch"
  */
-static void ex_nohlsearch(eap)
-exarg_T     *eap UNUSED;
+static void ex_nohlsearch(exarg_T *eap)
 {
   SET_NO_HLSEARCH(TRUE);
   redraw_all_later(SOME_VALID);
@@ -9302,8 +9118,7 @@ exarg_T     *eap UNUSED;
  * Sets nextcmd to the start of the next command, if any.  Also called when
  * skipping commands to find the next command.
  */
-static void ex_match(eap)
-exarg_T     *eap;
+static void ex_match(exarg_T *eap)
 {
   char_u      *p;
   char_u      *g = NULL;
@@ -9361,29 +9176,25 @@ exarg_T     *eap;
 /*
  * ":X": Get crypt key
  */
-static void ex_X(eap)
-exarg_T     *eap UNUSED;
+static void ex_X(exarg_T *eap)
 {
   if (get_crypt_method(curbuf) == 0 || blowfish_self_test() == OK)
     (void)get_crypt_key(TRUE, TRUE);
 }
 
-static void ex_fold(eap)
-exarg_T     *eap;
+static void ex_fold(exarg_T *eap)
 {
   if (foldManualAllowed(TRUE))
     foldCreate(eap->line1, eap->line2);
 }
 
-static void ex_foldopen(eap)
-exarg_T     *eap;
+static void ex_foldopen(exarg_T *eap)
 {
   opFoldRange(eap->line1, eap->line2, eap->cmdidx == CMD_foldopen,
       eap->forceit, FALSE);
 }
 
-static void ex_folddo(eap)
-exarg_T     *eap;
+static void ex_folddo(exarg_T *eap)
 {
   linenr_T lnum;
 

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -84,7 +84,7 @@ static int cause_abort = FALSE;
  * cancellation of an expression evaluation after an aborting function call or
  * due to a parsing error, aborting() always returns the same value.
  */
-int aborting()         {
+int aborting(void)         {
   return (did_emsg && force_abort) || got_int || did_throw;
 }
 
@@ -94,7 +94,7 @@ int aborting()         {
  * be necessary to restore "force_abort" even before the throw point for the
  * error message has been reached.  update_force_abort() should be called then.
  */
-void update_force_abort()          {
+void update_force_abort(void)          {
   if (cause_abort)
     force_abort = TRUE;
 }
@@ -105,8 +105,7 @@ void update_force_abort()          {
  * execution of a failing subcommand as long as the error message has not been
  * displayed and actually caused the abortion.
  */
-int should_abort(retcode)
-int retcode;
+int should_abort(int retcode)
 {
   return (retcode == FAIL && trylevel != 0 && !emsg_silent) || aborting();
 }
@@ -117,7 +116,7 @@ int retcode;
  * to find finally clauses to be executed, and that some errors in skipped
  * commands are still reported.
  */
-int aborted_in_try()         {
+int aborted_in_try(void)         {
   /* This function is only called after an error.  In this case, "force_abort"
    * determines whether searching for finally clauses is necessary. */
   return force_abort;
@@ -132,10 +131,7 @@ int aborted_in_try()         {
  * most specific one and used as the exception value.  The "severe" flag can be
  * set to TRUE, if a later but severer message should be used instead.
  */
-int cause_errthrow(mesg, severe, ignore)
-char_u      *mesg;
-int severe;
-int         *ignore;
+int cause_errthrow(char_u *mesg, int severe, int *ignore)
 {
   struct msglist *elem;
   struct msglist **plist;
@@ -275,8 +271,7 @@ int         *ignore;
 /*
  * Free a "msg_list" and the messages it contains.
  */
-static void free_msglist(l)
-struct msglist  *l;
+static void free_msglist(struct msglist *l)
 {
   struct msglist  *messages, *next;
 
@@ -293,7 +288,7 @@ struct msglist  *l;
  * Free global "*msg_list" and the messages it contains, then set "*msg_list"
  * to NULL.
  */
-void free_global_msglist()          {
+void free_global_msglist(void)          {
   free_msglist(*msg_list);
   *msg_list = NULL;
 }
@@ -303,9 +298,7 @@ void free_global_msglist()          {
  * error exception.  If cstack is NULL, postpone the throw until do_cmdline()
  * has returned (see do_one_cmd()).
  */
-void do_errthrow(cstack, cmdname)
-struct condstack    *cstack;
-char_u              *cmdname;
+void do_errthrow(struct condstack *cstack, char_u *cmdname)
 {
   /*
    * Ensure that all commands in nested function calls and sourced files
@@ -337,8 +330,7 @@ char_u              *cmdname;
  * exception if appropriate.  Return TRUE if the current exception is discarded,
  * FALSE otherwise.
  */
-int do_intthrow(cstack)
-struct condstack    *cstack;
+int do_intthrow(struct condstack *cstack)
 {
   /*
    * If no interrupt occurred or no try conditional is active and no exception
@@ -384,11 +376,7 @@ struct condstack    *cstack;
 /*
  * Get an exception message that is to be stored in current_exception->value.
  */
-char_u * get_exception_string(value, type, cmdname, should_free)
-void        *value;
-int type;
-char_u      *cmdname;
-int         *should_free;
+char_u *get_exception_string(void *value, int type, char_u *cmdname, int *should_free)
 {
   char_u      *ret, *mesg;
   int cmdlen;
@@ -457,10 +445,7 @@ int         *should_free;
  * user or interrupt exception, or points to a message list in case of an
  * error exception.
  */
-static int throw_exception(value, type, cmdname)
-void        *value;
-int type;
-char_u      *cmdname;
+static int throw_exception(void *value, int type, char_u *cmdname)
 {
   except_T    *excp;
   int should_free;
@@ -541,9 +526,7 @@ fail:
  * Discard an exception.  "was_finished" is set when the exception has been
  * caught and the catch clause has been ended normally.
  */
-static void discard_exception(excp, was_finished)
-except_T            *excp;
-int was_finished;
+static void discard_exception(except_T *excp, int was_finished)
 {
   char_u              *saved_IObuff;
 
@@ -589,7 +572,7 @@ int was_finished;
 /*
  * Discard the exception currently being thrown.
  */
-void discard_current_exception()          {
+void discard_current_exception(void)          {
   discard_exception(current_exception, FALSE);
   current_exception = NULL;
   did_throw = FALSE;
@@ -599,8 +582,7 @@ void discard_current_exception()          {
 /*
  * Put an exception on the caught stack.
  */
-static void catch_exception(excp)
-except_T    *excp;
+static void catch_exception(except_T *excp)
 {
   excp->caught = caught_stack;
   caught_stack = excp;
@@ -643,8 +625,7 @@ except_T    *excp;
 /*
  * Remove an exception from the caught stack.
  */
-static void finish_exception(excp)
-except_T    *excp;
+static void finish_exception(except_T *excp)
 {
   if (excp != caught_stack)
     EMSG(_(e_internal));
@@ -687,10 +668,7 @@ except_T    *excp;
  * what is pending.  "value" specifies the return value for a pending ":return"
  * or the exception value for a pending exception.
  */
-static void report_pending(action, pending, value)
-int action;
-int pending;
-void        *value;
+static void report_pending(int action, int pending, void *value)
 {
   char_u      *mesg;
   char        *s;
@@ -765,9 +743,7 @@ void        *value;
  * If something is made pending in a finally clause, report it if required by
  * the 'verbose' option or when debugging.
  */
-void report_make_pending(pending, value)
-int pending;
-void        *value;
+void report_make_pending(int pending, void *value)
 {
   if (p_verbose >= 14 || debug_break_level > 0) {
     if (debug_break_level <= 0)
@@ -782,9 +758,7 @@ void        *value;
  * If something pending in a finally clause is resumed at the ":endtry", report
  * it if required by the 'verbose' option or when debugging.
  */
-void report_resume_pending(pending, value)
-int pending;
-void        *value;
+void report_resume_pending(int pending, void *value)
 {
   if (p_verbose >= 14 || debug_break_level > 0) {
     if (debug_break_level <= 0)
@@ -799,9 +773,7 @@ void        *value;
  * If something pending in a finally clause is discarded, report it if required
  * by the 'verbose' option or when debugging.
  */
-void report_discard_pending(pending, value)
-int pending;
-void        *value;
+void report_discard_pending(int pending, void *value)
 {
   if (p_verbose >= 14 || debug_break_level > 0) {
     if (debug_break_level <= 0)
@@ -816,8 +788,7 @@ void        *value;
 /*
  * ":if".
  */
-void ex_if(eap)
-exarg_T     *eap;
+void ex_if(exarg_T *eap)
 {
   int error;
   int skip;
@@ -854,8 +825,7 @@ exarg_T     *eap;
 /*
  * ":endif".
  */
-void ex_endif(eap)
-exarg_T     *eap;
+void ex_endif(exarg_T *eap)
 {
   did_endif = TRUE;
   if (eap->cstack->cs_idx < 0
@@ -883,8 +853,7 @@ exarg_T     *eap;
 /*
  * ":else" and ":elseif".
  */
-void ex_else(eap)
-exarg_T     *eap;
+void ex_else(exarg_T *eap)
 {
   int error;
   int skip;
@@ -965,8 +934,7 @@ exarg_T     *eap;
 /*
  * Handle ":while" and ":for".
  */
-void ex_while(eap)
-exarg_T     *eap;
+void ex_while(exarg_T *eap)
 {
   int error;
   int skip;
@@ -1055,8 +1023,7 @@ exarg_T     *eap;
 /*
  * ":continue"
  */
-void ex_continue(eap)
-exarg_T     *eap;
+void ex_continue(exarg_T *eap)
 {
   int idx;
   struct condstack    *cstack = eap->cstack;
@@ -1089,8 +1056,7 @@ exarg_T     *eap;
 /*
  * ":break"
  */
-void ex_break(eap)
-exarg_T     *eap;
+void ex_break(exarg_T *eap)
 {
   int idx;
   struct condstack    *cstack = eap->cstack;
@@ -1113,8 +1079,7 @@ exarg_T     *eap;
 /*
  * ":endwhile" and ":endfor"
  */
-void ex_endwhile(eap)
-exarg_T     *eap;
+void ex_endwhile(exarg_T *eap)
 {
   struct condstack    *cstack = eap->cstack;
   int idx;
@@ -1190,8 +1155,7 @@ exarg_T     *eap;
 /*
  * ":throw expr"
  */
-void ex_throw(eap)
-exarg_T     *eap;
+void ex_throw(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   char_u      *value;
@@ -1218,8 +1182,7 @@ exarg_T     *eap;
  * for ":throw" (user exception) and error and interrupt exceptions.  Also
  * used for rethrowing an uncaught exception.
  */
-void do_throw(cstack)
-struct condstack    *cstack;
+void do_throw(struct condstack *cstack)
 {
   int idx;
   int inactivate_try = FALSE;
@@ -1279,8 +1242,7 @@ struct condstack    *cstack;
 /*
  * ":try"
  */
-void ex_try(eap)
-exarg_T     *eap;
+void ex_try(exarg_T *eap)
 {
   int skip;
   struct condstack    *cstack = eap->cstack;
@@ -1347,8 +1309,7 @@ exarg_T     *eap;
 /*
  * ":catch /{pattern}/" and ":catch"
  */
-void ex_catch(eap)
-exarg_T     *eap;
+void ex_catch(exarg_T *eap)
 {
   int idx = 0;
   int give_up = FALSE;
@@ -1489,8 +1450,7 @@ exarg_T     *eap;
 /*
  * ":finally"
  */
-void ex_finally(eap)
-exarg_T     *eap;
+void ex_finally(exarg_T *eap)
 {
   int idx;
   int skip = FALSE;
@@ -1608,8 +1568,7 @@ exarg_T     *eap;
 /*
  * ":endtry"
  */
-void ex_endtry(eap)
-exarg_T     *eap;
+void ex_endtry(exarg_T *eap)
 {
   int idx;
   int skip;
@@ -1797,8 +1756,7 @@ exarg_T     *eap;
  * do_cmdline() that is going to be made for the cleanup autocommand
  * execution.
  */
-void enter_cleanup(csp)
-cleanup_T   *csp;
+void enter_cleanup(cleanup_T *csp)
 {
   int pending = CSTP_NONE;
 
@@ -1854,8 +1812,7 @@ cleanup_T   *csp;
  * cleanup autocommands.  In the latter case, the saved error/interrupt/
  * exception state is discarded.
  */
-void leave_cleanup(csp)
-cleanup_T   *csp;
+void leave_cleanup(cleanup_T *csp)
 {
   int pending = csp->pending;
 
@@ -1935,10 +1892,7 @@ cleanup_T   *csp;
  * entered, is restored (used by ex_endtry()).  This is normally done only
  * when such a try conditional is left.
  */
-int cleanup_conditionals(cstack, searched_cond, inclusive)
-struct condstack   *cstack;
-int searched_cond;
-int inclusive;
+int cleanup_conditionals(struct condstack *cstack, int searched_cond, int inclusive)
 {
   int idx;
   int stop = FALSE;
@@ -2046,8 +2000,7 @@ int inclusive;
 /*
  * Return an appropriate error message for a missing endwhile/endfor/endif.
  */
-static char_u * get_end_emsg(cstack)
-struct condstack    *cstack;
+static char_u *get_end_emsg(struct condstack *cstack)
 {
   if (cstack->cs_flags[cstack->cs_idx] & CSF_WHILE)
     return e_endwhile;
@@ -2064,11 +2017,7 @@ struct condstack    *cstack;
  * type.
  * Also free "for info" structures where needed.
  */
-void rewind_conditionals(cstack, idx, cond_type, cond_level)
-struct condstack   *cstack;
-int idx;
-int cond_type;
-int         *cond_level;
+void rewind_conditionals(struct condstack *cstack, int idx, int cond_type, int *cond_level)
 {
   while (cstack->cs_idx > idx) {
     if (cstack->cs_flags[cstack->cs_idx] & cond_type)
@@ -2082,8 +2031,7 @@ int         *cond_level;
 /*
  * ":endfunction" when not after a ":function"
  */
-void ex_endfunction(eap)
-exarg_T     *eap UNUSED;
+void ex_endfunction(exarg_T *eap)
 {
   EMSG(_("E193: :endfunction not inside a function"));
 }
@@ -2091,8 +2039,7 @@ exarg_T     *eap UNUSED;
 /*
  * Return TRUE if the string "p" looks like a ":while" or ":for" command.
  */
-int has_loop_cmd(p)
-char_u      *p;
+int has_loop_cmd(char_u *p)
 {
   int len;
 

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -125,10 +125,12 @@ sort_func_compare __ARGS((const void *s1, const void *s2));
  * Return pointer to allocated string if there is a commandline, NULL
  * otherwise.
  */
-char_u * getcmdline(firstc, count, indent)
-int firstc;
-long count UNUSED;              /* only used for incremental search */
-int indent;                     /* indent for inside conditionals */
+char_u *
+getcmdline (
+    int firstc,
+    long count,              /* only used for incremental search */
+    int indent                     /* indent for inside conditionals */
+)
 {
   int c;
   int i;
@@ -1545,12 +1547,14 @@ returncmd:
  * f_input() when evaluating an expression from CTRL-R =).
  * Returns the command line in allocated memory, or NULL.
  */
-char_u * getcmdline_prompt(firstc, prompt, attr, xp_context, xp_arg)
-int firstc;
-char_u      *prompt;            /* command line prompt */
-int attr;                       /* attributes for prompt */
-int xp_context;                 /* type of expansion */
-char_u      *xp_arg;            /* user-defined expansion argument */
+char_u *
+getcmdline_prompt (
+    int firstc,
+    char_u *prompt,            /* command line prompt */
+    int attr,                       /* attributes for prompt */
+    int xp_context,                 /* type of expansion */
+    char_u *xp_arg            /* user-defined expansion argument */
+)
 {
   char_u              *s;
   struct cmdline_info save_ccline;
@@ -1579,7 +1583,7 @@ char_u      *xp_arg;            /* user-defined expansion argument */
  * another window or buffer.  Used when editing the command line, evaluating
  * 'balloonexpr', etc.
  */
-int text_locked()         {
+int text_locked(void)         {
   if (cmdwin_type != 0)
     return TRUE;
   return textlock != 0;
@@ -1589,7 +1593,7 @@ int text_locked()         {
  * Give an error message for a command that isn't allowed while the cmdline
  * window is open or editing the cmdline in another way.
  */
-void text_locked_msg()          {
+void text_locked_msg(void)          {
   if (cmdwin_type != 0)
     EMSG(_(e_cmdwin));
   else
@@ -1600,7 +1604,7 @@ void text_locked_msg()          {
  * Check if "curbuf_lock" or "allbuf_lock" is set and return TRUE when it is
  * and give an error message.
  */
-int curbuf_locked()         {
+int curbuf_locked(void)         {
   if (curbuf_lock > 0) {
     EMSG(_("E788: Not allowed to edit another buffer now"));
     return TRUE;
@@ -1612,7 +1616,7 @@ int curbuf_locked()         {
  * Check if "allbuf_lock" is set and return TRUE when it is and give an error
  * message.
  */
-int allbuf_locked()         {
+int allbuf_locked(void)         {
   if (allbuf_lock > 0) {
     EMSG(_("E811: Not allowed to change buffer information now"));
     return TRUE;
@@ -1620,8 +1624,7 @@ int allbuf_locked()         {
   return FALSE;
 }
 
-static int cmdline_charsize(idx)
-int idx;
+static int cmdline_charsize(int idx)
 {
   if (cmdline_star > 0)             /* showing '*', always 1 position */
     return 1;
@@ -1632,7 +1635,7 @@ int idx;
  * Compute the offset of the cursor on the command line for the prompt and
  * indent.
  */
-static void set_cmdspos()                 {
+static void set_cmdspos(void)                 {
   if (ccline.cmdfirstc != NUL)
     ccline.cmdspos = 1 + ccline.cmdindent;
   else
@@ -1642,7 +1645,7 @@ static void set_cmdspos()                 {
 /*
  * Compute the screen position for the cursor on the command line.
  */
-static void set_cmdspos_cursor()                 {
+static void set_cmdspos_cursor(void)                 {
   int i, m, c;
 
   set_cmdspos();
@@ -1672,9 +1675,7 @@ static void set_cmdspos_cursor()                 {
  * Check if the character at "idx", which is "cells" wide, is a multi-byte
  * character that doesn't fit, so that a ">" must be displayed.
  */
-static void correct_cmdspos(idx, cells)
-int idx;
-int cells;
+static void correct_cmdspos(int idx, int cells)
 {
   if ((*mb_ptr2len)(ccline.cmdbuff + idx) > 1
       && (*mb_ptr2cells)(ccline.cmdbuff + idx) > 1
@@ -1685,10 +1686,12 @@ int cells;
 /*
  * Get an Ex command line for the ":" command.
  */
-char_u * getexline(c, cookie, indent)
-int c;                          /* normally ':', NUL for ":append" */
-void        *cookie UNUSED;
-int indent;                     /* indent for inside conditionals */
+char_u *
+getexline (
+    int c,                          /* normally ':', NUL for ":append" */
+    void *cookie,
+    int indent                     /* indent for inside conditionals */
+)
 {
   /* When executing a register, remove ':' that's in front of each line. */
   if (exec_from_reg && vpeekc() == ':')
@@ -1702,11 +1705,13 @@ int indent;                     /* indent for inside conditionals */
  * mappings or abbreviations.
  * Returns a string in allocated memory or NULL.
  */
-char_u * getexmodeline(promptc, cookie, indent)
-int promptc;                    /* normally ':', NUL for ":append" and '?' for
+char_u *
+getexmodeline (
+    int promptc,                    /* normally ':', NUL for ":append" and '?' for
                                    :s prompt */
-void        *cookie UNUSED;
-int indent;                     /* indent for inside conditionals */
+    void *cookie,
+    int indent                     /* indent for inside conditionals */
+)
 {
   garray_T line_ga;
   char_u      *pend;
@@ -1932,14 +1937,14 @@ redraw:
 /*
  * Return TRUE if ccline.overstrike is on.
  */
-int cmdline_overstrike()         {
+int cmdline_overstrike(void)         {
   return ccline.overstrike;
 }
 
 /*
  * Return TRUE if the cursor is at the end of the cmdline.
  */
-int cmdline_at_end()         {
+int cmdline_at_end(void)         {
   return ccline.cmdpos >= ccline.cmdlen;
 }
 
@@ -1952,8 +1957,7 @@ int cmdline_at_end()         {
  * Assigns the new buffer to ccline.cmdbuff and ccline.cmdbufflen.
  * Returns the new value of ccline.cmdbuff and ccline.cmdbufflen.
  */
-static void alloc_cmdbuff(len)
-int len;
+static void alloc_cmdbuff(int len)
 {
   /*
    * give some extra space to avoid having to allocate all the time
@@ -1971,8 +1975,7 @@ int len;
  * Re-allocate the command line to length len + something extra.
  * return FAIL for failure, OK otherwise
  */
-static int realloc_cmdbuff(len)
-int len;
+static int realloc_cmdbuff(int len)
 {
   char_u      *p;
 
@@ -2009,7 +2012,7 @@ int len;
 static char_u   *arshape_buf = NULL;
 
 # if defined(EXITFREE) || defined(PROTO)
-void free_cmdline_buf()          {
+void free_cmdline_buf(void)          {
   vim_free(arshape_buf);
 }
 
@@ -2019,9 +2022,7 @@ void free_cmdline_buf()          {
  * Draw part of the cmdline at the current cursor position.  But draw stars
  * when cmdline_star is TRUE.
  */
-static void draw_cmdline(start, len)
-int start;
-int len;
+static void draw_cmdline(int start, int len)
 {
   int i;
 
@@ -2120,9 +2121,7 @@ int len;
  * right when "shift" is TRUE.  Used for CTRL-V, CTRL-K, etc.
  * "c" must be printable (fit in one display cell)!
  */
-void putcmdline(c, shift)
-int c;
-int shift;
+void putcmdline(int c, int shift)
 {
   if (cmd_silent)
     return;
@@ -2137,7 +2136,7 @@ int shift;
 /*
  * Undo a putcmdline(c, FALSE).
  */
-void unputcmdline()          {
+void unputcmdline(void)          {
   if (cmd_silent)
     return;
   msg_no_more = TRUE;
@@ -2160,10 +2159,7 @@ void unputcmdline()          {
  * twice in a row, then 'redraw' should be FALSE and redrawcmd() should be
  * called afterwards.
  */
-int put_on_cmdline(str, len, redraw)
-char_u      *str;
-int len;
-int redraw;
+int put_on_cmdline(char_u *str, int len, int redraw)
 {
   int retval;
   int i;
@@ -2298,8 +2294,7 @@ static int prev_ccline_used = FALSE;
  * and overwrite it.  But get_cmdline_str() may need it, thus make it
  * available globally in prev_ccline.
  */
-static void save_cmdline(ccp)
-struct cmdline_info *ccp;
+static void save_cmdline(struct cmdline_info *ccp)
 {
   if (!prev_ccline_used) {
     vim_memset(&prev_ccline, 0, sizeof(struct cmdline_info));
@@ -2315,8 +2310,7 @@ struct cmdline_info *ccp;
 /*
  * Restore ccline after it has been saved with save_cmdline().
  */
-static void restore_cmdline(ccp)
-struct cmdline_info *ccp;
+static void restore_cmdline(struct cmdline_info *ccp)
 {
   ccline = prev_ccline;
   prev_ccline = *ccp;
@@ -2327,7 +2321,7 @@ struct cmdline_info *ccp;
  * passed to restore_cmdline_alloc() later.
  * Returns NULL when failed.
  */
-char_u * save_cmdline_alloc()              {
+char_u *save_cmdline_alloc(void)              {
   struct cmdline_info *p;
 
   p = (struct cmdline_info *)alloc((unsigned)sizeof(struct cmdline_info));
@@ -2339,8 +2333,7 @@ char_u * save_cmdline_alloc()              {
 /*
  * Restore the command line from the return value of save_cmdline_alloc().
  */
-void restore_cmdline_alloc(p)
-char_u  *p;
+void restore_cmdline_alloc(char_u *p)
 {
   if (p != NULL) {
     restore_cmdline((struct cmdline_info *)p);
@@ -2356,10 +2349,12 @@ char_u  *p;
  *
  * return FAIL for failure, OK otherwise
  */
-static int cmdline_paste(regname, literally, remcr)
-int regname;
-int literally;          /* Insert text literally instead of "as typed" */
-int remcr;              /* remove trailing CR */
+static int 
+cmdline_paste (
+    int regname,
+    int literally,          /* Insert text literally instead of "as typed" */
+    int remcr              /* remove trailing CR */
+)
 {
   long i;
   char_u              *arg;
@@ -2433,9 +2428,7 @@ int remcr;              /* remove trailing CR */
  * When "literally" is FALSE, insert as typed, but don't leave the command
  * line.
  */
-void cmdline_paste_str(s, literally)
-char_u      *s;
-int literally;
+void cmdline_paste_str(char_u *s, int literally)
 {
   int c, cv;
 
@@ -2465,8 +2458,7 @@ int literally;
  * Delete characters on the command line, from "from" to the current
  * position.
  */
-static void cmdline_del(from)
-int from;
+static void cmdline_del(int from)
 {
   mch_memmove(ccline.cmdbuff + from, ccline.cmdbuff + ccline.cmdpos,
       (size_t)(ccline.cmdlen - ccline.cmdpos + 1));
@@ -2478,7 +2470,7 @@ int from;
  * this function is called when the screen size changes and with incremental
  * search
  */
-void redrawcmdline()          {
+void redrawcmdline(void)          {
   if (cmd_silent)
     return;
   need_wait_return = FALSE;
@@ -2487,7 +2479,7 @@ void redrawcmdline()          {
   cursorcmd();
 }
 
-static void redrawcmdprompt()                 {
+static void redrawcmdprompt(void)                 {
   int i;
 
   if (cmd_silent)
@@ -2508,7 +2500,7 @@ static void redrawcmdprompt()                 {
 /*
  * Redraw what is currently on the command line.
  */
-void redrawcmd()          {
+void redrawcmd(void)          {
   if (cmd_silent)
     return;
 
@@ -2541,7 +2533,7 @@ void redrawcmd()          {
   skip_redraw = FALSE;
 }
 
-void compute_cmdrow()          {
+void compute_cmdrow(void)          {
   if (exmode_active || msg_scrolled != 0)
     cmdline_row = Rows - 1;
   else
@@ -2549,7 +2541,7 @@ void compute_cmdrow()          {
                   + W_STATUS_HEIGHT(lastwin);
 }
 
-static void cursorcmd()                 {
+static void cursorcmd(void)                 {
   if (cmd_silent)
     return;
 
@@ -2568,8 +2560,7 @@ static void cursorcmd()                 {
   windgoto(msg_row, msg_col);
 }
 
-void gotocmdline(clr)
-int clr;
+void gotocmdline(int clr)
 {
   msg_start();
   if (cmdmsg_rl)
@@ -2587,8 +2578,7 @@ int clr;
  * When an abbreviation is recognized it is removed from the text with
  * backspaces and the replacement string is inserted, followed by "c".
  */
-static int ccheck_abbr(c)
-int c;
+static int ccheck_abbr(int c)
 {
   if (p_paste || no_abbr)           /* no abbreviations or in paste mode */
     return FALSE;
@@ -2596,9 +2586,7 @@ int c;
   return check_abbr(c, ccline.cmdbuff, ccline.cmdpos, 0);
 }
 
-static int sort_func_compare(s1, s2)
-const void *s1;
-const void *s2;
+static int sort_func_compare(const void *s1, const void *s2)
 {
   char_u *p1 = *(char_u **)s1;
   char_u *p2 = *(char_u **)s2;
@@ -2614,11 +2602,13 @@ const void *s2;
  * For the caller, this means that the character is just passed through like a
  * normal character (instead of being expanded).  This allows :s/^I^D etc.
  */
-static int nextwild(xp, type, options, escape)
-expand_T    *xp;
-int type;
-int options;                    /* extra options for ExpandOne() */
-int escape;                     /* if TRUE, escape the returned matches */
+static int 
+nextwild (
+    expand_T *xp,
+    int type,
+    int options,                    /* extra options for ExpandOne() */
+    int escape                     /* if TRUE, escape the returned matches */
+)
 {
   int i, j;
   char_u      *p1;
@@ -2753,12 +2743,14 @@ int escape;                     /* if TRUE, escape the returned matches */
  *
  * The variables xp->xp_context and xp->xp_backslash must have been set!
  */
-char_u * ExpandOne(xp, str, orig, options, mode)
-expand_T    *xp;
-char_u      *str;
-char_u      *orig;          /* allocated copy of original of expanded string */
-int options;
-int mode;
+char_u *
+ExpandOne (
+    expand_T *xp,
+    char_u *str,
+    char_u *orig,          /* allocated copy of original of expanded string */
+    int options,
+    int mode
+)
 {
   char_u      *ss = NULL;
   static int findex;
@@ -2937,8 +2929,7 @@ int mode;
 /*
  * Prepare an expand structure for use.
  */
-void ExpandInit(xp)
-expand_T    *xp;
+void ExpandInit(expand_T *xp)
 {
   xp->xp_pattern = NULL;
   xp->xp_pattern_len = 0;
@@ -2955,8 +2946,7 @@ expand_T    *xp;
 /*
  * Cleanup an expand structure after use.
  */
-void ExpandCleanup(xp)
-expand_T    *xp;
+void ExpandCleanup(expand_T *xp)
 {
   if (xp->xp_numfiles >= 0) {
     FreeWild(xp->xp_numfiles, xp->xp_files);
@@ -2964,12 +2954,7 @@ expand_T    *xp;
   }
 }
 
-void ExpandEscape(xp, str, numfiles, files, options)
-expand_T    *xp;
-char_u      *str;
-int numfiles;
-char_u      **files;
-int options;
+void ExpandEscape(expand_T *xp, char_u *str, int numfiles, char_u **files, int options)
 {
   int i;
   char_u      *p;
@@ -3048,9 +3033,7 @@ int options;
  * after a Vim command, or, when "shell" is non-zero, a shell command.
  * Returns the result in allocated memory.
  */
-char_u * vim_strsave_fnameescape(fname, shell)
-char_u *fname;
-int shell;
+char_u *vim_strsave_fnameescape(char_u *fname, int shell)
 {
   char_u      *p;
 #ifdef BACKSLASH_IN_FILENAME
@@ -3087,8 +3070,7 @@ int shell;
 /*
  * Put a backslash before the file name in "pp", which is in allocated memory.
  */
-static void escape_fname(pp)
-char_u **pp;
+static void escape_fname(char_u **pp)
 {
   char_u      *p;
 
@@ -3105,10 +3087,7 @@ char_u **pp;
  * For each file name in files[num_files]:
  * If 'orig_pat' starts with "~/", replace the home directory with "~".
  */
-void tilde_replace(orig_pat, num_files, files)
-char_u  *orig_pat;
-int num_files;
-char_u  **files;
+void tilde_replace(char_u *orig_pat, int num_files, char_u **files)
 {
   int i;
   char_u  *p;
@@ -3129,9 +3108,7 @@ char_u  **files;
  * Returns EXPAND_NOTHING when the character that triggered expansion should
  * be inserted like a normal character.
  */
-static int showmatches(xp, wildmenu)
-expand_T    *xp;
-int wildmenu UNUSED;
+static int showmatches(expand_T *xp, int wildmenu)
 {
 #define L_SHOWFILE(m) (showtail ? sm_gettail(files_found[m]) : files_found[m])
   int num_files;
@@ -3285,8 +3262,7 @@ int wildmenu UNUSED;
  * Private gettail for showmatches() (and win_redr_status_matches()):
  * Find tail of file name path, but ignore trailing "/".
  */
-char_u * sm_gettail(s)
-char_u      *s;
+char_u *sm_gettail(char_u *s)
 {
   char_u      *p;
   char_u      *t = s;
@@ -3313,8 +3289,7 @@ char_u      *s;
  * When not completing file names or there is a wildcard in the path FALSE is
  * returned.
  */
-static int expand_showtail(xp)
-expand_T    *xp;
+static int expand_showtail(expand_T *xp)
 {
   char_u      *s;
   char_u      *end;
@@ -3347,10 +3322,12 @@ expand_T    *xp;
  * When expanding other names: The string will be used with regcomp().  Copy
  * the name into allocated memory and prepend "^".
  */
-char_u * addstar(fname, len, context)
-char_u      *fname;
-int len;
-int context;                    /* EXPAND_FILES etc. */
+char_u *
+addstar (
+    char_u *fname,
+    int len,
+    int context                    /* EXPAND_FILES etc. */
+)
 {
   char_u      *retval;
   int i, j;
@@ -3505,8 +3482,7 @@ int context;                    /* EXPAND_FILES etc. */
  *  EXPAND_ENV_VARS	    Complete environment variable names
  *  EXPAND_USER		    Complete user names
  */
-static void set_expand_context(xp)
-expand_T    *xp;
+static void set_expand_context(expand_T *xp)
 {
   /* only expansion for ':', '>' and '=' command-lines */
   if (ccline.cmdfirstc != ':'
@@ -3519,11 +3495,13 @@ expand_T    *xp;
   set_cmd_context(xp, ccline.cmdbuff, ccline.cmdlen, ccline.cmdpos);
 }
 
-void set_cmd_context(xp, str, len, col)
-expand_T    *xp;
-char_u      *str;           /* start of command line */
-int len;                    /* length of command line (excl. NUL) */
-int col;                    /* position of cursor */
+void 
+set_cmd_context (
+    expand_T *xp,
+    char_u *str,           /* start of command line */
+    int len,                    /* length of command line (excl. NUL) */
+    int col                    /* position of cursor */
+)
 {
   int old_char = NUL;
   char_u      *nextcomm;
@@ -3567,12 +3545,14 @@ int col;                    /* position of cursor */
  * key that triggered expansion literally.
  * Returns EXPAND_OK otherwise.
  */
-int expand_cmdline(xp, str, col, matchcount, matches)
-expand_T    *xp;
-char_u      *str;               /* start of command line */
-int col;                        /* position of cursor */
-int         *matchcount;        /* return: nr of matches */
-char_u      ***matches;         /* return: array of pointers to matches */
+int 
+expand_cmdline (
+    expand_T *xp,
+    char_u *str,               /* start of command line */
+    int col,                        /* position of cursor */
+    int *matchcount,        /* return: nr of matches */
+    char_u ***matches         /* return: array of pointers to matches */
+)
 {
   char_u      *file_str = NULL;
   int options = WILD_ADD_SLASH|WILD_SILENT;
@@ -3610,9 +3590,7 @@ char_u      ***matches;         /* return: array of pointers to matches */
  */
 static void cleanup_help_tags __ARGS((int num_file, char_u **file));
 
-static void cleanup_help_tags(num_file, file)
-int num_file;
-char_u      **file;
+static void cleanup_help_tags(int num_file, char_u **file)
 {
   int i, j;
   int len;
@@ -3636,12 +3614,14 @@ char_u      **file;
 /*
  * Do the expansion based on xp->xp_context and "pat".
  */
-static int ExpandFromContext(xp, pat, num_file, file, options)
-expand_T    *xp;
-char_u      *pat;
-int         *num_file;
-char_u      ***file;
-int options;              /* EW_ flags */
+static int 
+ExpandFromContext (
+    expand_T *xp,
+    char_u *pat,
+    int *num_file,
+    char_u ***file,
+    int options              /* EW_ flags */
+)
 {
   regmatch_T regmatch;
   int ret;
@@ -3900,11 +3880,13 @@ int escaped;
  * Complete a shell command.
  * Returns FAIL or OK;
  */
-static int expand_shellcmd(filepat, num_file, file, flagsarg)
-char_u      *filepat;           /* pattern to match with command names */
-int         *num_file;          /* return: number of matches */
-char_u      ***file;            /* return: array with matches */
-int flagsarg;                   /* EW_ flags */
+static int 
+expand_shellcmd (
+    char_u *filepat,           /* pattern to match with command names */
+    int *num_file,          /* return: number of matches */
+    char_u ***file,            /* return: array with matches */
+    int flagsarg                   /* EW_ flags */
+)
 {
   char_u      *pat;
   int i;
@@ -4051,11 +4033,7 @@ char_u      ***file;
 /*
  * Expand names with a function defined by the user.
  */
-static int ExpandUserDefined(xp, regmatch, num_file, file)
-expand_T    *xp;
-regmatch_T  *regmatch;
-int         *num_file;
-char_u      ***file;
+static int ExpandUserDefined(expand_T *xp, regmatch_T *regmatch, int *num_file, char_u ***file)
 {
   char_u      *retstr;
   char_u      *s;
@@ -4101,10 +4079,7 @@ char_u      ***file;
 /*
  * Expand names with a list returned by a function defined by the user.
  */
-static int ExpandUserList(xp, num_file, file)
-expand_T    *xp;
-int         *num_file;
-char_u      ***file;
+static int ExpandUserList(expand_T *xp, int *num_file, char_u ***file)
 {
   list_T      *retlist;
   listitem_T  *li;
@@ -4139,11 +4114,7 @@ char_u      ***file;
  * 'runtimepath'/{dirnames}/{pat}.vim
  * "dirnames" is an array with one or more directory names.
  */
-static int ExpandRTDir(pat, num_file, file, dirnames)
-char_u      *pat;
-int         *num_file;
-char_u      ***file;
-char        *dirnames[];
+static int ExpandRTDir(char_u *pat, int *num_file, char_u ***file, char *dirnames[])
 {
   char_u      *matches;
   char_u      *s;
@@ -4207,10 +4178,7 @@ char        *dirnames[];
  * Returns an allocated string with all matches concatenated, separated by
  * newlines.  Returns NULL for an error or no matches.
  */
-char_u * globpath(path, file, expand_options)
-char_u      *path;
-char_u      *file;
-int expand_options;
+char_u *globpath(char_u *path, char_u *file, int expand_options)
 {
   expand_T xpc;
   char_u      *buf;
@@ -4273,8 +4241,7 @@ int expand_options;
 /*
  * Translate a history character to the associated type number.
  */
-static int hist_char2type(c)
-int c;
+static int hist_char2type(int c)
 {
   if (c == ':')
     return HIST_CMD;
@@ -4307,9 +4274,7 @@ static char *(history_names[]) =
  * Function given to ExpandGeneric() to obtain the possible first
  * arguments of the ":history command.
  */
-static char_u * get_history_arg(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+static char_u *get_history_arg(expand_T *xp, int idx)
 {
   static char_u compl[2] = { NUL, NUL };
   char *short_names = ":=@>?/";
@@ -4331,7 +4296,7 @@ int idx;
  * init_history() - Initialize the command line history.
  * Also used to re-allocate the history when the size changes.
  */
-void init_history()          {
+void init_history(void)          {
   int newlen;               /* new length of history table */
   histentry_T *temp;
   int i;
@@ -4394,8 +4359,7 @@ void init_history()          {
   }
 }
 
-static void clear_hist_entry(hisptr)
-histentry_T *hisptr;
+static void clear_hist_entry(histentry_T *hisptr)
 {
   hisptr->hisnum = 0;
   hisptr->viminfo = FALSE;
@@ -4406,12 +4370,14 @@ histentry_T *hisptr;
  * Check if command line 'str' is already in history.
  * If 'move_to_front' is TRUE, matching entry is moved to end of history.
  */
-static int in_history(type, str, move_to_front, sep, writing)
-int type;
-char_u  *str;
-int move_to_front;              /* Move the entry to the front if it exists */
-int sep;
-int writing;                    /* ignore entries read from viminfo */
+static int 
+in_history (
+    int type,
+    char_u *str,
+    int move_to_front,              /* Move the entry to the front if it exists */
+    int sep,
+    int writing                    /* ignore entries read from viminfo */
+)
 {
   int i;
   int last_i = -1;
@@ -4460,8 +4426,7 @@ int writing;                    /* ignore entries read from viminfo */
  * When "name" is empty, return "cmd" history.
  * Returns -1 for unknown history name.
  */
-int get_histtype(name)
-char_u      *name;
+int get_histtype(char_u *name)
 {
   int i;
   int len = (int)STRLEN(name);
@@ -4487,11 +4452,13 @@ static int last_maptick = -1;           /* last seen maptick */
  * history then it is moved to the front.  "histype" may be one of he HIST_
  * values.
  */
-void add_to_history(histype, new_entry, in_map, sep)
-int histype;
-char_u      *new_entry;
-int in_map;                     /* consider maptick when inside a mapping */
-int sep;                        /* separator character used (search hist) */
+void 
+add_to_history (
+    int histype,
+    char_u *new_entry,
+    int in_map,                     /* consider maptick when inside a mapping */
+    int sep                        /* separator character used (search hist) */
+)
 {
   histentry_T *hisptr;
   int len;
@@ -4543,8 +4510,7 @@ int sep;                        /* separator character used (search hist) */
  * Get identifier of newest history entry.
  * "histype" may be one of the HIST_ values.
  */
-int get_history_idx(histype)
-int histype;
+int get_history_idx(int histype)
 {
   if (hislen == 0 || histype < 0 || histype >= HIST_COUNT
       || hisidx[histype] < 0)
@@ -4559,7 +4525,7 @@ static struct cmdline_info *get_ccline_ptr __ARGS((void));
  * Get pointer to the command line info to use. cmdline_paste() may clear
  * ccline and put the previous value in prev_ccline.
  */
-static struct cmdline_info * get_ccline_ptr()
+static struct cmdline_info *get_ccline_ptr(void)
 {
   if ((State & CMDLINE) == 0)
     return NULL;
@@ -4575,7 +4541,7 @@ static struct cmdline_info * get_ccline_ptr()
  * Only works when the command line is being edited.
  * Returns NULL when something is wrong.
  */
-char_u * get_cmdline_str()              {
+char_u *get_cmdline_str(void)              {
   struct cmdline_info *p = get_ccline_ptr();
 
   if (p == NULL)
@@ -4589,7 +4555,7 @@ char_u * get_cmdline_str()              {
  * Only works when the command line is being edited.
  * Returns -1 when something is wrong.
  */
-int get_cmdline_pos()         {
+int get_cmdline_pos(void)         {
   struct cmdline_info *p = get_ccline_ptr();
 
   if (p == NULL)
@@ -4602,8 +4568,7 @@ int get_cmdline_pos()         {
  * Only works when the command line is being edited.
  * Returns 1 when failed, 0 when OK.
  */
-int set_cmdline_pos(pos)
-int pos;
+int set_cmdline_pos(int pos)
 {
   struct cmdline_info *p = get_ccline_ptr();
 
@@ -4625,7 +4590,7 @@ int pos;
  * Only works when the command line is being edited.
  * Returns NUL when something is wrong.
  */
-int get_cmdline_type()         {
+int get_cmdline_type(void)         {
   struct cmdline_info *p = get_ccline_ptr();
 
   if (p == NULL)
@@ -4641,9 +4606,7 @@ int get_cmdline_type()         {
  *   num < 0: relative position in history wrt newest entry
  * "histype" may be one of the HIST_ values.
  */
-static int calc_hist_idx(histype, num)
-int histype;
-int num;
+static int calc_hist_idx(int histype, int num)
 {
   int i;
   histentry_T *hist;
@@ -4678,9 +4641,7 @@ int num;
  * Get a history entry by its index.
  * "histype" may be one of the HIST_ values.
  */
-char_u * get_history_entry(histype, idx)
-int histype;
-int idx;
+char_u *get_history_entry(int histype, int idx)
 {
   idx = calc_hist_idx(histype, idx);
   if (idx >= 0)
@@ -4693,8 +4654,7 @@ int idx;
  * Clear all entries of a history.
  * "histype" may be one of the HIST_ values.
  */
-int clr_history(histype)
-int histype;
+int clr_history(int histype)
 {
   int i;
   histentry_T *hisptr;
@@ -4716,9 +4676,7 @@ int histype;
  * Remove all entries matching {str} from a history.
  * "histype" may be one of the HIST_ values.
  */
-int del_history_entry(histype, str)
-int histype;
-char_u      *str;
+int del_history_entry(int histype, char_u *str)
 {
   regmatch_T regmatch;
   histentry_T *hisptr;
@@ -4767,9 +4725,7 @@ char_u      *str;
  * Remove an indexed entry from a history.
  * "histype" may be one of the HIST_ values.
  */
-int del_history_idx(histype, idx)
-int histype;
-int idx;
+int del_history_idx(int histype, int idx)
 {
   int i, j;
 
@@ -4802,7 +4758,7 @@ int idx;
  * Very specific function to remove the value in ":set key=val" from the
  * history.
  */
-void remove_key_from_history()          {
+void remove_key_from_history(void)          {
   char_u      *p;
   int i;
 
@@ -4830,10 +4786,7 @@ void remove_key_from_history()          {
  * text lines in a buffer!) from a string.  Used for ":history" and ":clist".
  * Returns OK if parsed successfully, otherwise FAIL.
  */
-int get_list_range(str, num1, num2)
-char_u      **str;
-int         *num1;
-int         *num2;
+int get_list_range(char_u **str, int *num1, int *num2)
 {
   int len;
   int first = FALSE;
@@ -4863,8 +4816,7 @@ int         *num2;
 /*
  * :history command - print a history
  */
-void ex_history(eap)
-exarg_T     *eap;
+void ex_history(exarg_T *eap)
 {
   histentry_T *hist;
   int histype1 = HIST_CMD;
@@ -4956,9 +4908,11 @@ static int hist_type2char __ARGS((int type, int use_question));
 /*
  * Translate a history type number to the associated character.
  */
-static int hist_type2char(type, use_question)
-int type;
-int use_question;                   /* use '?' instead of '/' */
+static int 
+hist_type2char (
+    int type,
+    int use_question                   /* use '?' instead of '/' */
+)
 {
   if (type == HIST_CMD)
     return ':';
@@ -4977,9 +4931,7 @@ int use_question;                   /* use '?' instead of '/' */
  * Prepare for reading the history from the viminfo file.
  * This allocates history arrays to store the read history lines.
  */
-void prepare_viminfo_history(asklen, writing)
-int asklen;
-int writing;
+void prepare_viminfo_history(int asklen, int writing)
 {
   int i;
   int num;
@@ -5017,9 +4969,7 @@ int writing;
  * Accept a line from the viminfo, store it in the history array when it's
  * new.
  */
-int read_viminfo_history(virp, writing)
-vir_T       *virp;
-int writing;
+int read_viminfo_history(vir_T *virp, int writing)
 {
   int type;
   long_u len;
@@ -5061,7 +5011,7 @@ int writing;
 /*
  * Finish reading history lines from viminfo.  Not used when writing viminfo.
  */
-void finish_viminfo_history()          {
+void finish_viminfo_history(void)          {
   int idx;
   int i;
   int type;
@@ -5114,9 +5064,7 @@ void finish_viminfo_history()          {
  * file, data is in viminfo_history[].
  * When "merge" is FALSE just write all history lines.  Used for ":wviminfo!".
  */
-void write_viminfo_history(fp, merge)
-FILE    *fp;
-int merge;
+void write_viminfo_history(FILE *fp, int merge)
 {
   int i;
   int type;
@@ -5202,8 +5150,7 @@ int merge;
  * Write a character at the current cursor+offset position.
  * It is directly written into the command buffer block.
  */
-void cmd_pchar(c, offset)
-int c, offset;
+void cmd_pchar(int c, int offset)
 {
   if (ccline.cmdpos + offset >= ccline.cmdlen || ccline.cmdpos + offset < 0) {
     EMSG(_("E198: cmd_pchar beyond the command length"));
@@ -5213,8 +5160,7 @@ int c, offset;
   ccline.cmdbuff[ccline.cmdlen] = NUL;
 }
 
-int cmd_gchar(offset)
-int offset;
+int cmd_gchar(int offset)
 {
   if (ccline.cmdpos + offset >= ccline.cmdlen || ccline.cmdpos + offset < 0) {
     /*  EMSG(_("cmd_gchar beyond the command length")); */
@@ -5231,7 +5177,7 @@ int offset;
  *	Ctrl_C	 if it is to be abandoned
  *	K_IGNORE if editing continues
  */
-static int ex_window()                {
+static int ex_window(void)                {
   struct cmdline_info save_ccline;
   buf_T               *old_curbuf = curbuf;
   win_T               *old_curwin = curwin;
@@ -5447,9 +5393,7 @@ static int ex_window()                {
  *	endmarker
  * Returns a pointer to allocated memory with {script} or NULL.
  */
-char_u * script_get(eap, cmd)
-exarg_T     *eap;
-char_u      *cmd;
+char_u *script_get(exarg_T *eap, char_u *cmd)
 {
   char_u      *theline;
   char        *end_pattern = NULL;

--- a/src/farsi.c
+++ b/src/farsi.c
@@ -37,8 +37,7 @@ static void lrswapbuf __ARGS((char_u *buf, int len));
 /*
 ** Convert the given Farsi character into a _X or _X_ type
 */
-static int toF_Xor_X_(c)
-int c;
+static int toF_Xor_X_(int c)
 {
   int tempc;
 
@@ -127,8 +126,7 @@ int c;
 /*
 ** Convert the given Farsi character into Farsi capital character .
 */
-int toF_TyA(c)
-int c;
+int toF_TyA(int c)
 {
   switch (c) {
   case ALEF_:
@@ -205,8 +203,7 @@ int c;
 ** That is a character that is combined with the others.
 ** Note: the offset is used only for command line buffer.
 */
-static int F_is_TyB_TyC_TyD(src, offset)
-int src, offset;
+static int F_is_TyB_TyC_TyD(int src, int offset)
 {
   int c;
 
@@ -255,8 +252,7 @@ int src, offset;
 /*
 ** Is the Farsi character one of the terminating only type.
 */
-static int F_is_TyE(c)
-int c;
+static int F_is_TyE(int c)
 {
   switch (c) {
   case ALEF_A:
@@ -277,8 +273,7 @@ int c;
 /*
 ** Is the Farsi character one of the none leading type.
 */
-static int F_is_TyC_TyD(c)
-int c;
+static int F_is_TyC_TyD(int c)
 {
   switch (c) {
   case ALEF_:
@@ -300,8 +295,7 @@ int c;
 /*
 ** Convert a none leading Farsi char into a leading type.
 */
-static int toF_TyB(c)
-int c;
+static int toF_TyB(int c)
 {
   switch (c) {
   case ALEF_:     return ALEF;
@@ -322,8 +316,7 @@ int c;
 /*
 ** Overwrite the current redo and cursor characters + left adjust
 */
-static void put_curr_and_l_to_X(c)
-int c;
+static void put_curr_and_l_to_X(int c)
 {
   int tempc;
 
@@ -353,8 +346,7 @@ int c;
   put_and_redo(c);
 }
 
-static void put_and_redo(c)
-int c;
+static void put_and_redo(int c)
 {
   pchar_cursor(c);
   AppendCharToRedobuff(K_BS);
@@ -364,7 +356,7 @@ int c;
 /*
 ** Change the char. under the cursor to a X_ or X type
 */
-static void chg_c_toX_orX()                 {
+static void chg_c_toX_orX(void)                 {
   int tempc, curc;
 
   switch ((curc = gchar_cursor())) {
@@ -481,7 +473,7 @@ static void chg_c_toX_orX()                 {
 ** Change the char. under the cursor to a _X_ or X_ type
 */
 
-static void chg_c_to_X_orX_()                 {
+static void chg_c_to_X_orX_(void)                 {
   int tempc;
 
   switch (gchar_cursor()) {
@@ -529,7 +521,7 @@ static void chg_c_to_X_orX_()                 {
 /*
 ** Change the char. under the cursor to a _X_ or _X type
 */
-static void chg_c_to_X_or_X ()                 {
+static void chg_c_to_X_or_X(void)                 {
   int tempc;
 
   tempc = gchar_cursor();
@@ -556,7 +548,7 @@ static void chg_c_to_X_or_X ()                 {
 /*
 ** Change the character left to the cursor to a _X_ or X_ type
 */
-static void chg_l_to_X_orX_ ()                 {
+static void chg_l_to_X_orX_(void)                 {
   int tempc;
 
   if (curwin->w_cursor.col != 0 &&
@@ -622,7 +614,7 @@ static void chg_l_to_X_orX_ ()                 {
 ** Change the character left to the cursor to a X or _X type
 */
 
-static void chg_l_toXor_X ()                 {
+static void chg_l_toXor_X(void)                 {
   int tempc;
 
   if (curwin->w_cursor.col != 0 &&
@@ -688,7 +680,7 @@ static void chg_l_toXor_X ()                 {
 ** Change the character right to the cursor to a _X or _X_ type
 */
 
-static void chg_r_to_Xor_X_()                 {
+static void chg_r_to_Xor_X_(void)                 {
   int tempc, c;
 
   if (curwin->w_cursor.col) {
@@ -710,8 +702,7 @@ static void chg_r_to_Xor_X_()                 {
 ** Map Farsi keyboard when in fkmap mode.
 */
 
-int fkmap(c)
-int c;
+int fkmap(int c)
 {
   int tempc;
   static int revins;
@@ -1387,8 +1378,7 @@ int c;
 /*
 ** Convert a none leading Farsi char into a leading type.
 */
-static int toF_leading(c)
-int c;
+static int toF_leading(int c)
 {
   switch (c) {
   case ALEF_:     return ALEF;
@@ -1440,8 +1430,7 @@ int c;
 /*
 ** Convert a given Farsi char into right joining type.
 */
-static int toF_Rjoin(c)
-int c;
+static int toF_Rjoin(int c)
 {
   switch (c) {
   case ALEF:  return ALEF_;
@@ -1495,8 +1484,7 @@ int c;
 /*
 ** Can a given Farsi character join via its left edj.
 */
-static int canF_Ljoin(c)
-int c;
+static int canF_Ljoin(int c)
 {
   switch (c) {
   case _BE:
@@ -1568,8 +1556,7 @@ int c;
 /*
 ** Can a given Farsi character join via its right edj.
 */
-static int canF_Rjoin(c)
-int c;
+static int canF_Rjoin(int c)
 {
   switch (c) {
   case ALEF:
@@ -1595,8 +1582,7 @@ int c;
 /*
 ** is a given Farsi character a terminating type.
 */
-static int F_isterm(c)
-int c;
+static int F_isterm(int c)
 {
   switch (c) {
   case ALEF:
@@ -1621,8 +1607,7 @@ int c;
 /*
 ** Convert the given Farsi character into a ending type .
 */
-static int toF_ending(c)
-int c;
+static int toF_ending(int c)
 {
 
   switch (c) {
@@ -1697,7 +1682,7 @@ int c;
 /*
 ** Convert the Farsi 3342 standard into Farsi VIM.
 */
-void conv_to_pvim()          {
+void conv_to_pvim(void)          {
   char_u      *ptr;
   int lnum, llen, i;
 
@@ -1739,7 +1724,7 @@ void conv_to_pvim()          {
 /*
  * Convert the Farsi VIM into Farsi 3342 standard.
  */
-void conv_to_pstd()          {
+void conv_to_pstd(void)          {
   char_u      *ptr;
   int lnum, llen, i;
 
@@ -1768,9 +1753,7 @@ void conv_to_pstd()          {
 /*
  * left-right swap the characters in buf[len].
  */
-static void lrswapbuf(buf, len)
-char_u      *buf;
-int len;
+static void lrswapbuf(char_u *buf, int len)
 {
   char_u      *s, *e;
   int c;
@@ -1790,8 +1773,7 @@ int len;
 /*
  * swap all the characters in reverse direction
  */
-char_u * lrswap(ibuf)
-char_u      *ibuf;
+char_u *lrswap(char_u *ibuf)
 {
   if (ibuf != NULL && *ibuf != NUL)
     lrswapbuf(ibuf, (int)STRLEN(ibuf));
@@ -1801,9 +1783,7 @@ char_u      *ibuf;
 /*
  * swap all the Farsi characters in reverse direction
  */
-char_u * lrFswap(cmdbuf, len)
-char_u      *cmdbuf;
-int len;
+char_u *lrFswap(char_u *cmdbuf, int len)
 {
   int i, cnt;
 
@@ -1831,8 +1811,7 @@ int len;
  * accordingly.
  * TODO: handle different separator characters.  Use skip_regexp().
  */
-char_u * lrF_sub(ibuf)
-char_u      *ibuf;
+char_u *lrF_sub(char_u *ibuf)
 {
   char_u      *p, *ep;
   int i, cnt;
@@ -1870,8 +1849,7 @@ char_u      *ibuf;
 /*
  * Map Farsi keyboard when in cmd_fkmap mode.
  */
-int cmdl_fkmap(c)
-int c;
+int cmdl_fkmap(int c)
 {
   int tempc;
 
@@ -2124,8 +2102,7 @@ int c;
 /*
  * F_isalpha returns TRUE if 'c' is a Farsi alphabet
  */
-int F_isalpha(c)
-int c;
+int F_isalpha(int c)
 {
   return ( c >= TEE_ && c <= _YE)
          || (c >= ALEF_A && c <= YE)
@@ -2135,8 +2112,7 @@ int c;
 /*
  * F_isdigit returns TRUE if 'c' is a Farsi digit
  */
-int F_isdigit(c)
-int c;
+int F_isdigit(int c)
 {
   return c >= FARSI_0 && c <= FARSI_9;
 }
@@ -2144,14 +2120,12 @@ int c;
 /*
  * F_ischar returns TRUE if 'c' is a Farsi character.
  */
-int F_ischar(c)
-int c;
+int F_ischar(int c)
 {
   return c >= TEE_ && c <= YE_;
 }
 
-void farsi_fkey(cap)
-cmdarg_T    *cap;
+void farsi_fkey(cmdarg_T *cap)
 {
   int c = cap->cmdchar;
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -121,11 +121,7 @@ static void vim_settempdir __ARGS((char_u *tempdir));
 static char *e_auchangedbuf = N_(
     "E812: Autocommands changed buffer or buffer name");
 
-void filemess(buf, name, s, attr)
-buf_T       *buf;
-char_u      *name;
-char_u      *s;
-int attr;
+void filemess(buf_T *buf, char_u *name, char_u *s, int attr)
 {
   int msg_scroll_save;
 
@@ -180,14 +176,16 @@ int attr;
  *
  * return FAIL for failure, OK otherwise
  */
-int readfile(fname, sfname, from, lines_to_skip, lines_to_read, eap, flags)
-char_u      *fname;
-char_u      *sfname;
-linenr_T from;
-linenr_T lines_to_skip;
-linenr_T lines_to_read;
-exarg_T     *eap;                       /* can be NULL! */
-int flags;
+int 
+readfile (
+    char_u *fname,
+    char_u *sfname,
+    linenr_T from,
+    linenr_T lines_to_skip,
+    linenr_T lines_to_read,
+    exarg_T *eap,                       /* can be NULL! */
+    int flags
+)
 {
   int fd = 0;
   int newfile = (flags & READ_NEW);
@@ -2020,8 +2018,7 @@ failed:
  * some shells on some operating systems, e.g., bash on SunOS.
  * Do not accept "/dev/fd/[012]", opening these may hang Vim.
  */
-static int is_dev_fd_file(fname)
-char_u      *fname;
+static int is_dev_fd_file(char_u *fname)
 {
   return STRNCMP(fname, "/dev/fd/", 8) == 0
          && VIM_ISDIGIT(fname[8])
@@ -2037,10 +2034,12 @@ char_u      *fname;
  * line number where we are now.
  * Used for error messages that include a line number.
  */
-static linenr_T readfile_linenr(linecnt, p, endp)
-linenr_T linecnt;               /* line count before reading more bytes */
-char_u      *p;                 /* start of more bytes read */
-char_u      *endp;              /* end of more bytes read */
+static linenr_T 
+readfile_linenr (
+    linenr_T linecnt,               /* line count before reading more bytes */
+    char_u *p,                 /* start of more bytes read */
+    char_u *endp              /* end of more bytes read */
+)
 {
   char_u      *s;
   linenr_T lnum;
@@ -2057,9 +2056,7 @@ char_u      *endp;              /* end of more bytes read */
  * equal to the buffer "buf".  Used for calling readfile().
  * Returns OK or FAIL.
  */
-int prep_exarg(eap, buf)
-exarg_T     *eap;
-buf_T       *buf;
+int prep_exarg(exarg_T *eap, buf_T *buf)
 {
   eap->cmd = alloc((unsigned)(STRLEN(buf->b_p_ff)
                               + STRLEN(buf->b_p_fenc)
@@ -2081,9 +2078,7 @@ buf_T       *buf;
 /*
  * Set default or forced 'fileformat' and 'binary'.
  */
-void set_file_options(set_options, eap)
-int set_options;
-exarg_T *eap;
+void set_file_options(int set_options, exarg_T *eap)
 {
   /* set default 'fileformat' */
   if (set_options) {
@@ -2105,8 +2100,7 @@ exarg_T *eap;
 /*
  * Set forced 'fileencoding'.
  */
-void set_forced_fenc(eap)
-exarg_T *eap;
+void set_forced_fenc(exarg_T *eap)
 {
   if (eap->force_enc != 0) {
     char_u *fenc = enc_canonize(eap->cmd + eap->force_enc);
@@ -2125,8 +2119,7 @@ exarg_T *eap;
  * NULL.
  * When *pp is not set to NULL, the result is in allocated memory.
  */
-static char_u * next_fenc(pp)
-char_u      **pp;
+static char_u *next_fenc(char_u **pp)
 {
   char_u      *p;
   char_u      *r;
@@ -2163,10 +2156,12 @@ char_u      **pp;
  * after reading it).
  * Returns NULL if the conversion failed ("*fdp" is not set) .
  */
-static char_u * readfile_charconvert(fname, fenc, fdp)
-char_u      *fname;             /* name of input file */
-char_u      *fenc;              /* converted from */
-int         *fdp;               /* in/out: file descriptor of file */
+static char_u *
+readfile_charconvert (
+    char_u *fname,             /* name of input file */
+    char_u *fenc,              /* converted from */
+    int *fdp               /* in/out: file descriptor of file */
+)
 {
   char_u      *tmpname;
   char_u      *errmsg = NULL;
@@ -2208,7 +2203,7 @@ int         *fdp;               /* in/out: file descriptor of file */
  * Read marks for the current buffer from the viminfo file, when we support
  * buffer marks and the buffer has a name.
  */
-static void check_marks_read()                 {
+static void check_marks_read(void)                 {
   if (!curbuf->b_marks_read && get_viminfo_parameter('\'') > 0
       && curbuf->b_ffname != NULL)
     read_viminfo(NULL, VIF_WANT_MARKS);
@@ -2223,9 +2218,7 @@ static void check_marks_read()                 {
  * start of the file.
  * Returns -1 when no encryption used.
  */
-static int crypt_method_from_magic(ptr, len)
-char  *ptr;
-int len;
+static int crypt_method_from_magic(char *ptr, int len)
 {
   int i;
 
@@ -2249,16 +2242,16 @@ int len;
  * *filesizep are updated.
  * Return the (new) encryption key, NULL for no encryption.
  */
-static char_u * check_for_cryptkey(cryptkey, ptr, sizep, filesizep, newfile,
-    fname,
-    did_ask)
-char_u      *cryptkey;          /* previous encryption key or NULL */
-char_u      *ptr;               /* pointer to read bytes */
-long        *sizep;             /* length of read bytes */
-off_t       *filesizep;         /* nr of bytes used from file */
-int newfile;                    /* editing a new buffer */
-char_u      *fname;             /* file name to display */
-int         *did_ask;           /* flag: whether already asked for key */
+static char_u *
+check_for_cryptkey (
+    char_u *cryptkey,          /* previous encryption key or NULL */
+    char_u *ptr,               /* pointer to read bytes */
+    long *sizep,             /* length of read bytes */
+    off_t *filesizep,         /* nr of bytes used from file */
+    int newfile,                    /* editing a new buffer */
+    char_u *fname,             /* file name to display */
+    int *did_ask           /* flag: whether already asked for key */
+)
 {
   int method = crypt_method_from_magic((char *)ptr, *sizep);
   int b_p_ro = curbuf->b_p_ro;
@@ -2327,8 +2320,7 @@ int         *did_ask;           /* flag: whether already asked for key */
  * Check for magic number used for encryption.  Applies to the current buffer.
  * If found and decryption is possible returns OK;
  */
-int prepare_crypt_read(fp)
-FILE        *fp;
+int prepare_crypt_read(FILE *fp)
 {
   int method;
   char_u buffer[CRYPT_MAGIC_LEN + CRYPT_SALT_LEN_MAX
@@ -2364,9 +2356,7 @@ FILE        *fp;
  * When out of memory returns NULL.
  * Otherwise calls crypt_push_state(), call crypt_pop_state() later.
  */
-char_u * prepare_crypt_write(buf, lenp)
-buf_T *buf;
-int   *lenp;
+char_u *prepare_crypt_write(buf_T *buf, int *lenp)
 {
   char_u  *header;
   int seed_len = crypt_seed_len[get_crypt_method(buf)];
@@ -2398,10 +2388,12 @@ int   *lenp;
 
 
 #ifdef UNIX
-static void set_file_time(fname, atime, mtime)
-char_u  *fname;
-time_t atime;               /* access time */
-time_t mtime;               /* modification time */
+static void 
+set_file_time (
+    char_u *fname,
+    time_t atime,               /* access time */
+    time_t mtime               /* modification time */
+)
 {
 # if defined(HAVE_UTIME) && defined(HAVE_UTIME_H)
   struct utimbuf buf;
@@ -2427,9 +2419,11 @@ time_t mtime;               /* modification time */
 /*
  * Return TRUE if a file appears to be read-only from the file permissions.
  */
-int check_file_readonly(fname, perm)
-char_u      *fname;             /* full path to file */
-int perm;                       /* known permissions on file */
+int 
+check_file_readonly (
+    char_u *fname,             /* full path to file */
+    int perm                       /* known permissions on file */
+)
 {
 #ifndef USE_MCH_ACCESS
   int fd = 0;
@@ -2465,18 +2459,20 @@ int perm;                       /* known permissions on file */
  *
  * return FAIL for failure, OK otherwise
  */
-int buf_write(buf, fname, sfname, start, end, eap, append, forceit,
-    reset_changed, filtering)
-buf_T           *buf;
-char_u          *fname;
-char_u          *sfname;
-linenr_T start, end;
-exarg_T         *eap;                   /* for forced 'ff' and 'fenc', can be
+int 
+buf_write (
+    buf_T *buf,
+    char_u *fname,
+    char_u *sfname,
+    linenr_T start,
+    linenr_T end,
+    exarg_T *eap,                   /* for forced 'ff' and 'fenc', can be
                                            NULL! */
-int append;                             /* append to the file */
-int forceit;
-int reset_changed;
-int filtering;
+    int append,                             /* append to the file */
+    int forceit,
+    int reset_changed,
+    int filtering
+)
 {
   int fd;
   char_u          *backup = NULL;
@@ -4094,9 +4090,7 @@ nofail:
  * Set the name of the current buffer.  Use when the buffer doesn't have a
  * name and a ":r" or ":w" command with a file name is used.
  */
-static int set_rw_fname(fname, sfname)
-char_u      *fname;
-char_u      *sfname;
+static int set_rw_fname(char_u *fname, char_u *sfname)
 {
   buf_T       *buf = curbuf;
 
@@ -4135,9 +4129,7 @@ char_u      *sfname;
 /*
  * Put file name into IObuff with quotes.
  */
-void msg_add_fname(buf, fname)
-buf_T       *buf;
-char_u      *fname;
+void msg_add_fname(buf_T *buf, char_u *fname)
 {
   if (fname == NULL)
     fname = (char_u *)"-stdin-";
@@ -4150,8 +4142,7 @@ char_u      *fname;
  * Append message for text mode to IObuff.
  * Return TRUE if something appended.
  */
-static int msg_add_fileformat(eol_type)
-int eol_type;
+static int msg_add_fileformat(int eol_type)
 {
 #ifndef USE_CRNL
   if (eol_type == EOL_DOS) {
@@ -4177,10 +4168,7 @@ int eol_type;
 /*
  * Append line and character count to IObuff.
  */
-void msg_add_lines(insert_space, lnum, nchars)
-int insert_space;
-long lnum;
-off_t nchars;
+void msg_add_lines(int insert_space, long lnum, off_t nchars)
 {
   char_u  *p;
 
@@ -4220,7 +4208,7 @@ off_t nchars;
 /*
  * Append message for missing line separator to IObuff.
  */
-static void msg_add_eol()                 {
+static void msg_add_eol(void)                 {
   STRCAT(IObuff,
       shortmess(SHM_LAST) ? _("[noeol]") : _("[Incomplete last line]"));
 }
@@ -4230,9 +4218,7 @@ static void msg_add_eol()                 {
  * The size isn't checked, because using a tool like "gzip" takes care of
  * using the same timestamp but can't set the size.
  */
-static int check_mtime(buf, st)
-buf_T               *buf;
-struct stat         *st;
+static int check_mtime(buf_T *buf, struct stat *st)
 {
   if (buf->b_mtime_read != 0
       && time_differs((long)st->st_mtime, buf->b_mtime_read)) {
@@ -4249,8 +4235,7 @@ struct stat         *st;
   return OK;
 }
 
-static int time_differs(t1, t2)
-long t1, t2;
+static int time_differs(long t1, long t2)
 {
 #if defined(__linux__) || defined(MSDOS) || defined(MSWIN)
   /* On a FAT filesystem, esp. under Linux, there are only 5 bits to store
@@ -4268,8 +4253,7 @@ long t1, t2;
  *
  * Return FAIL for failure, OK otherwise.
  */
-static int buf_write_bytes(ip)
-struct bw_info *ip;
+static int buf_write_bytes(struct bw_info *ip)
 {
   int wlen;
   char_u      *buf = ip->bw_buf;        /* data to write */
@@ -4479,10 +4463,12 @@ struct bw_info *ip;
  * Convert a Unicode character to bytes.
  * Return TRUE for an error, FALSE when it's OK.
  */
-static int ucs2bytes(c, pp, flags)
-unsigned c;                     /* in: character */
-char_u      **pp;               /* in/out: pointer to result */
-int flags;                      /* FIO_ flags */
+static int 
+ucs2bytes (
+    unsigned c,                     /* in: character */
+    char_u **pp,               /* in/out: pointer to result */
+    int flags                      /* FIO_ flags */
+)
 {
   char_u      *p = *pp;
   int error = FALSE;
@@ -4544,8 +4530,7 @@ int flags;                      /* FIO_ flags */
  * Return TRUE if file encoding "fenc" requires conversion from or to
  * 'encoding'.
  */
-static int need_conversion(fenc)
-char_u      *fenc;
+static int need_conversion(char_u *fenc)
 {
   int same_encoding;
   int enc_flags;
@@ -4577,8 +4562,7 @@ char_u      *fenc;
  * internal conversion.
  * if "ptr" is an empty string, use 'encoding'.
  */
-static int get_fio_flags(ptr)
-char_u      *ptr;
+static int get_fio_flags(char_u *ptr)
 {
   int prop;
 
@@ -4618,11 +4602,7 @@ char_u      *ptr;
  * Return the name of the encoding and set "*lenp" to the length.
  * Returns NULL when no BOM found.
  */
-static char_u * check_for_bom(p, size, lenp, flags)
-char_u      *p;
-long size;
-int         *lenp;
-int flags;
+static char_u *check_for_bom(char_u *p, long size, int *lenp, int flags)
 {
   char        *name = NULL;
   int len = 2;
@@ -4663,9 +4643,7 @@ int flags;
  * Generate a BOM in "buf[4]" for encoding "name".
  * Return the length of the BOM (zero when no BOM).
  */
-static int make_bom(buf, name)
-char_u      *buf;
-char_u      *name;
+static int make_bom(char_u *buf, char_u *name)
 {
   int flags;
   char_u      *p;
@@ -4694,8 +4672,7 @@ char_u      *name;
  * directory.
  * Returns "full_path" or pointer into "full_path" if shortened.
  */
-char_u * shorten_fname1(full_path)
-char_u      *full_path;
+char_u *shorten_fname1(char_u *full_path)
 {
   char_u      *dirname;
   char_u      *p = full_path;
@@ -4719,9 +4696,7 @@ char_u      *full_path;
  * Returns NULL if not shorter name possible, pointer into "full_path"
  * otherwise.
  */
-char_u * shorten_fname(full_path, dir_name)
-char_u      *full_path;
-char_u      *dir_name;
+char_u *shorten_fname(char_u *full_path, char_u *dir_name)
 {
   int len;
   char_u      *p;
@@ -4751,8 +4726,7 @@ char_u      *dir_name;
  * For buffers that have buftype "nofile" or "scratch": never change the file
  * name.
  */
-void shorten_fnames(force)
-int force;
+void shorten_fnames(int force)
 {
   char_u dirname[MAXPATHL];
   buf_T       *buf;
@@ -4792,9 +4766,7 @@ int force;
 /*
  * Shorten all filenames in "fnames[count]" by current directory.
  */
-void shorten_filenames(fnames, count)
-char_u      **fnames;
-int count;
+void shorten_filenames(char_u **fnames, int count)
 {
   int i;
   char_u dirname[MAXPATHL];
@@ -4827,9 +4799,12 @@ int count;
  * Space for the returned name is allocated, must be freed later.
  * Returns NULL when out of memory.
  */
-char_u * modname(fname, ext, prepend_dot)
-char_u *fname, *ext;
-int prepend_dot;                /* may prepend a '.' to file name */
+char_u *
+modname (
+    char_u *fname,
+    char_u *ext,
+    int prepend_dot                /* may prepend a '.' to file name */
+)
 {
   return buf_modname(
 #ifdef SHORT_FNAME
@@ -4840,10 +4815,13 @@ int prepend_dot;                /* may prepend a '.' to file name */
       fname, ext, prepend_dot);
 }
 
-char_u * buf_modname(shortname, fname, ext, prepend_dot)
-int shortname;                  /* use 8.3 file name */
-char_u  *fname, *ext;
-int prepend_dot;                /* may prepend a '.' to file name */
+char_u *
+buf_modname (
+    int shortname,                  /* use 8.3 file name */
+    char_u *fname,
+    char_u *ext,
+    int prepend_dot                /* may prepend a '.' to file name */
+)
 {
   char_u      *retval;
   char_u      *s;
@@ -5009,10 +4987,7 @@ int prepend_dot;                /* may prepend a '.' to file name */
  * Like fgets(), but if the file line is too long, it is truncated and the
  * rest of the line is thrown away.  Returns TRUE for end-of-file.
  */
-int vim_fgets(buf, size, fp)
-char_u      *buf;
-int size;
-FILE        *fp;
+int vim_fgets(char_u *buf, int size, FILE *fp)
 {
   char        *eof;
 #define FGETS_SIZE 200
@@ -5046,10 +5021,7 @@ FILE        *fp;
  * Returns TRUE for end-of-file.
  * Only used for the Mac, because it's much slower than vim_fgets().
  */
-int tag_fgets(buf, size, fp)
-char_u      *buf;
-int size;
-FILE        *fp;
+int tag_fgets(char_u *buf, int size, FILE *fp)
 {
   int i = 0;
   int c;
@@ -5085,9 +5057,7 @@ FILE        *fp;
  * function will (attempts to?) copy the file across if rename fails -- webb
  * Return -1 for failure, 0 for success.
  */
-int vim_rename(from, to)
-char_u      *from;
-char_u      *to;
+int vim_rename(char_u *from, char_u *to)
 {
   int fd_in;
   int fd_out;
@@ -5255,8 +5225,10 @@ static int already_warned = FALSE;
  * Returns TRUE if some message was written (screen should be redrawn and
  * cursor positioned).
  */
-int check_timestamps(focus)
-int focus;                      /* called for GUI focus event */
+int 
+check_timestamps (
+    int focus                      /* called for GUI focus event */
+)
 {
   buf_T       *buf;
   int didit = 0;
@@ -5314,9 +5286,7 @@ int focus;                      /* called for GUI focus event */
  * Return OK or FAIL.  When FAIL "tobuf" is incomplete and/or "frombuf" is not
  * empty.
  */
-static int move_lines(frombuf, tobuf)
-buf_T       *frombuf;
-buf_T       *tobuf;
+static int move_lines(buf_T *frombuf, buf_T *tobuf)
 {
   buf_T       *tbuf = curbuf;
   int retval = OK;
@@ -5358,9 +5328,11 @@ buf_T       *tobuf;
  * return 2 if a message has been displayed.
  * return 0 otherwise.
  */
-int buf_check_timestamp(buf, focus)
-buf_T       *buf;
-int focus UNUSED;               /* called for GUI focus event */
+int 
+buf_check_timestamp (
+    buf_T *buf,
+    int focus               /* called for GUI focus event */
+)
 {
   struct stat st;
   int stat_res;
@@ -5582,9 +5554,7 @@ int focus UNUSED;               /* called for GUI focus event */
  * "orig_mode" is buf->b_orig_mode before the need for reloading was detected.
  * buf->b_orig_mode may have been reset already.
  */
-void buf_reload(buf, orig_mode)
-buf_T       *buf;
-int orig_mode;
+void buf_reload(buf_T *buf, int orig_mode)
 {
   exarg_T ea;
   pos_T old_cursor;
@@ -5712,10 +5682,7 @@ int orig_mode;
   /* Careful: autocommands may have made "buf" invalid! */
 }
 
-void buf_store_time(buf, st, fname)
-buf_T       *buf;
-struct stat *st;
-char_u      *fname UNUSED;
+void buf_store_time(buf_T *buf, struct stat *st, char_u *fname)
 {
   buf->b_mtime = (long)st->st_mtime;
   buf->b_orig_size = st->st_size;
@@ -5730,8 +5697,7 @@ char_u      *fname UNUSED;
  * Adjust the line with missing eol, used for the next write.
  * Used for do_filter(), when the input lines for the filter are deleted.
  */
-void write_lnum_adjust(offset)
-linenr_T offset;
+void write_lnum_adjust(linenr_T offset)
 {
   if (curbuf->b_no_eol_lnum != 0)       /* only if there is a missing eol */
     curbuf->b_no_eol_lnum += offset;
@@ -5743,7 +5709,7 @@ static long temp_count = 0;             /* Temp filename counter. */
 /*
  * Delete the temp directory and all files it contains.
  */
-void vim_deltempdir()          {
+void vim_deltempdir(void)          {
   char_u      **files;
   int file_count;
   int i;
@@ -5772,8 +5738,7 @@ void vim_deltempdir()          {
  * it in "vim_tempdir".  This avoids that using ":cd" would confuse us.
  * "tempdir" must be no longer than MAXPATHL.
  */
-static void vim_settempdir(tempdir)
-char_u      *tempdir;
+static void vim_settempdir(char_u *tempdir)
 {
   char_u      *buf;
 
@@ -5796,8 +5761,10 @@ char_u      *tempdir;
  * The returned pointer is to allocated memory.
  * The returned pointer is NULL if no valid name was found.
  */
-char_u  * vim_tempname(extra_char)
-int extra_char UNUSED;          /* char to use in the name instead of '?' */
+char_u *
+vim_tempname (
+    int extra_char          /* char to use in the name instead of '?' */
+)
 {
 #ifdef USE_TMPNAM
   char_u itmp[L_tmpnam];        /* use tmpnam() */
@@ -5945,8 +5912,7 @@ int extra_char UNUSED;          /* char to use in the name instead of '?' */
 /*
  * Convert all backslashes in fname to forward slashes in-place.
  */
-void forward_slash(fname)
-char_u      *fname;
+void forward_slash(char_u *fname)
 {
   char_u      *p;
 
@@ -6183,9 +6149,7 @@ static int autocmd_blocked = 0;         /* block all autocmds */
 /*
  * Show the autocommands for one AutoPat.
  */
-static void show_autocmd(ap, event)
-AutoPat     *ap;
-event_T event;
+static void show_autocmd(AutoPat *ap, event_T event)
 {
   AutoCmd *ac;
 
@@ -6241,8 +6205,7 @@ event_T event;
 /*
  * Mark an autocommand pattern for deletion.
  */
-static void au_remove_pat(ap)
-AutoPat *ap;
+static void au_remove_pat(AutoPat *ap)
 {
   vim_free(ap->pat);
   ap->pat = NULL;
@@ -6253,8 +6216,7 @@ AutoPat *ap;
 /*
  * Mark all commands for a pattern for deletion.
  */
-static void au_remove_cmds(ap)
-AutoPat *ap;
+static void au_remove_cmds(AutoPat *ap)
 {
   AutoCmd *ac;
 
@@ -6269,7 +6231,7 @@ AutoPat *ap;
  * Cleanup autocommands and patterns that have been deleted.
  * This is only done when not executing autocommands.
  */
-static void au_cleanup()                 {
+static void au_cleanup(void)                 {
   AutoPat     *ap, **prev_ap;
   AutoCmd     *ac, **prev_ac;
   event_T event;
@@ -6313,8 +6275,7 @@ static void au_cleanup()                 {
  * Called when buffer is freed, to remove/invalidate related buffer-local
  * autocmds.
  */
-void aubuflocal_remove(buf)
-buf_T       *buf;
+void aubuflocal_remove(buf_T *buf)
 {
   AutoPat     *ap;
   event_T event;
@@ -6347,8 +6308,7 @@ buf_T       *buf;
  * Add an autocmd group name.
  * Return it's ID.  Returns AUGROUP_ERROR (< 0) for error.
  */
-static int au_new_group(name)
-char_u      *name;
+static int au_new_group(char_u *name)
 {
   int i;
 
@@ -6371,8 +6331,7 @@ char_u      *name;
   return i;
 }
 
-static void au_del_group(name)
-char_u      *name;
+static void au_del_group(char_u *name)
 {
   int i;
 
@@ -6389,8 +6348,7 @@ char_u      *name;
  * Find the ID of an autocmd group name.
  * Return it's ID.  Returns AUGROUP_ERROR (< 0) for error.
  */
-static int au_find_group(name)
-char_u      *name;
+static int au_find_group(char_u *name)
 {
   int i;
 
@@ -6403,8 +6361,7 @@ char_u      *name;
 /*
  * Return TRUE if augroup "name" exists.
  */
-int au_has_group(name)
-char_u      *name;
+int au_has_group(char_u *name)
 {
   return au_find_group(name) != AUGROUP_ERROR;
 }
@@ -6412,9 +6369,7 @@ char_u      *name;
 /*
  * ":augroup {name}".
  */
-void do_augroup(arg, del_group)
-char_u      *arg;
-int del_group;
+void do_augroup(char_u *arg, int del_group)
 {
   int i;
 
@@ -6443,7 +6398,7 @@ int del_group;
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_all_autocmds()          {
+void free_all_autocmds(void)          {
   for (current_augroup = -1; current_augroup < augroups.ga_len;
        ++current_augroup)
     do_autocmd((char_u *)"", TRUE);
@@ -6457,9 +6412,7 @@ void free_all_autocmds()          {
  * Return NUM_EVENTS if the event name was not found.
  * Return a pointer to the next event name in "end".
  */
-static event_T event_name2nr(start, end)
-char_u  *start;
-char_u  **end;
+static event_T event_name2nr(char_u *start, char_u **end)
 {
   char_u      *p;
   int i;
@@ -6484,8 +6437,7 @@ char_u  **end;
 /*
  * Return the name for event "event".
  */
-static char_u * event_nr2name(event)
-event_T event;
+static char_u *event_nr2name(event_T event)
 {
   int i;
 
@@ -6498,9 +6450,11 @@ event_T event;
 /*
  * Scan over the events.  "*" stands for all events.
  */
-static char_u * find_end_event(arg, have_group)
-char_u  *arg;
-int have_group;             /* TRUE when group name was found */
+static char_u *
+find_end_event (
+    char_u *arg,
+    int have_group             /* TRUE when group name was found */
+)
 {
   char_u  *pat;
   char_u  *p;
@@ -6528,8 +6482,7 @@ int have_group;             /* TRUE when group name was found */
 /*
  * Return TRUE if "event" is included in 'eventignore'.
  */
-static int event_ignored(event)
-event_T event;
+static int event_ignored(event_T event)
 {
   char_u      *p = p_ei;
 
@@ -6546,7 +6499,7 @@ event_T event;
 /*
  * Return OK when the contents of p_ei is valid, FAIL otherwise.
  */
-int check_ei()         {
+int check_ei(void)         {
   char_u      *p = p_ei;
 
   while (*p) {
@@ -6566,8 +6519,7 @@ int check_ei()         {
  * buffer loaded into the window.  "what" must start with a comma.
  * Returns the old value of 'eventignore' in allocated memory.
  */
-char_u * au_event_disable(what)
-char        *what;
+char_u *au_event_disable(char *what)
 {
   char_u      *new_ei;
   char_u      *save_ei;
@@ -6588,8 +6540,7 @@ char        *what;
   return save_ei;
 }
 
-void au_event_restore(old_ei)
-char_u      *old_ei;
+void au_event_restore(char_u *old_ei)
 {
   if (old_ei != NULL) {
     set_string_option_direct((char_u *)"ei", -1, old_ei,
@@ -6630,9 +6581,7 @@ char_u      *old_ei;
  *
  * Mostly a {group} argument can optionally appear before <event>.
  */
-void do_autocmd(arg, forceit)
-char_u  *arg;
-int forceit;
+void do_autocmd(char_u *arg, int forceit)
 {
   char_u      *pat;
   char_u      *envpat = NULL;
@@ -6740,8 +6689,7 @@ int forceit;
  *
  * Returns the group ID, AUGROUP_ERROR for error (out of memory).
  */
-static int au_get_grouparg(argp)
-char_u      **argp;
+static int au_get_grouparg(char_u **argp)
 {
   char_u      *group_name;
   char_u      *p;
@@ -6770,13 +6718,7 @@ char_u      **argp;
  * If forceit == TRUE delete entries.
  * If group is not AUGROUP_ALL, only use this group.
  */
-static int do_autocmd_event(event, pat, nested, cmd, forceit, group)
-event_T event;
-char_u      *pat;
-int nested;
-char_u      *cmd;
-int forceit;
-int group;
+static int do_autocmd_event(event_T event, char_u *pat, int nested, char_u *cmd, int forceit, int group)
 {
   AutoPat     *ap;
   AutoPat     **prev_ap;
@@ -6991,9 +6933,11 @@ int group;
  * Implementation of ":doautocmd [group] event [fname]".
  * Return OK for success, FAIL for failure;
  */
-int do_doautocmd(arg, do_msg)
-char_u      *arg;
-int do_msg;                 /* give message for no matching autocmds? */
+int 
+do_doautocmd (
+    char_u *arg,
+    int do_msg                 /* give message for no matching autocmds? */
+)
 {
   char_u      *fname;
   int nothing_done = TRUE;
@@ -7038,8 +6982,7 @@ int do_msg;                 /* give message for no matching autocmds? */
 /*
  * ":doautoall": execute autocommands for each loaded buffer.
  */
-void ex_doautoall(eap)
-exarg_T     *eap;
+void ex_doautoall(exarg_T *eap)
 {
   int retval;
   aco_save_T aco;
@@ -7086,8 +7029,7 @@ exarg_T     *eap;
  * return TRUE and advance *argp to after it.
  * Thus return TRUE when do_modelines() should be called.
  */
-int check_nomodeline(argp)
-char_u **argp;
+int check_nomodeline(char_u **argp)
 {
   if (STRNCMP(*argp, "<nomodeline>", 12) == 0) {
     *argp = skipwhite(*argp + 12);
@@ -7103,9 +7045,11 @@ char_u **argp;
  * Set "curbuf" and "curwin" to match "buf".
  * When FEAT_AUTOCMD is not defined another version is used, see below.
  */
-void aucmd_prepbuf(aco, buf)
-aco_save_T  *aco;               /* structure to save values in */
-buf_T       *buf;               /* new curbuf */
+void 
+aucmd_prepbuf (
+    aco_save_T *aco,               /* structure to save values in */
+    buf_T *buf               /* new curbuf */
+)
 {
   win_T       *win;
   int save_ea;
@@ -7187,8 +7131,10 @@ buf_T       *buf;               /* new curbuf */
  * Restore the window as it was (if possible).
  * When FEAT_AUTOCMD is not defined another version is used, see below.
  */
-void aucmd_restbuf(aco)
-aco_save_T  *aco;               /* structure holding saved values */
+void 
+aucmd_restbuf (
+    aco_save_T *aco               /* structure holding saved values */
+)
 {
   int dummy;
 
@@ -7270,12 +7216,14 @@ static int autocmd_nested = FALSE;
  * Execute autocommands for "event" and file name "fname".
  * Return TRUE if some commands were executed.
  */
-int apply_autocmds(event, fname, fname_io, force, buf)
-event_T event;
-char_u      *fname;         /* NULL or empty means use actual file name */
-char_u      *fname_io;      /* fname to use for <afile> on cmdline */
-int force;                  /* when TRUE, ignore autocmd_busy */
-buf_T       *buf;           /* buffer for <abuf> */
+int 
+apply_autocmds (
+    event_T event,
+    char_u *fname,         /* NULL or empty means use actual file name */
+    char_u *fname_io,      /* fname to use for <afile> on cmdline */
+    int force,                  /* when TRUE, ignore autocmd_busy */
+    buf_T *buf           /* buffer for <abuf> */
+)
 {
   return apply_autocmds_group(event, fname, fname_io, force,
       AUGROUP_ALL, buf, NULL);
@@ -7285,13 +7233,7 @@ buf_T       *buf;           /* buffer for <abuf> */
  * Like apply_autocmds(), but with extra "eap" argument.  This takes care of
  * setting v:filearg.
  */
-static int apply_autocmds_exarg(event, fname, fname_io, force, buf, eap)
-event_T event;
-char_u      *fname;
-char_u      *fname_io;
-int force;
-buf_T       *buf;
-exarg_T     *eap;
+static int apply_autocmds_exarg(event_T event, char_u *fname, char_u *fname_io, int force, buf_T *buf, exarg_T *eap)
 {
   return apply_autocmds_group(event, fname, fname_io, force,
       AUGROUP_ALL, buf, eap);
@@ -7303,13 +7245,15 @@ exarg_T     *eap;
  * conditional, no autocommands are executed.  If otherwise the autocommands
  * cause the script to be aborted, retval is set to FAIL.
  */
-int apply_autocmds_retval(event, fname, fname_io, force, buf, retval)
-event_T event;
-char_u      *fname;         /* NULL or empty means use actual file name */
-char_u      *fname_io;      /* fname to use for <afile> on cmdline */
-int force;                  /* when TRUE, ignore autocmd_busy */
-buf_T       *buf;           /* buffer for <abuf> */
-int         *retval;        /* pointer to caller's retval */
+int 
+apply_autocmds_retval (
+    event_T event,
+    char_u *fname,         /* NULL or empty means use actual file name */
+    char_u *fname_io,      /* fname to use for <afile> on cmdline */
+    int force,                  /* when TRUE, ignore autocmd_busy */
+    buf_T *buf,           /* buffer for <abuf> */
+    int *retval        /* pointer to caller's retval */
+)
 {
   int did_cmd;
 
@@ -7328,7 +7272,7 @@ int         *retval;        /* pointer to caller's retval */
 /*
  * Return TRUE when there is a CursorHold autocommand defined.
  */
-int has_cursorhold()         {
+int has_cursorhold(void)         {
   return first_autopat[(int)(get_real_state() == NORMAL_BUSY
                              ? EVENT_CURSORHOLD : EVENT_CURSORHOLDI)] != NULL;
 }
@@ -7336,7 +7280,7 @@ int has_cursorhold()         {
 /*
  * Return TRUE if the CursorHold event can be triggered.
  */
-int trigger_cursorhold()         {
+int trigger_cursorhold(void)         {
   int state;
 
   if (!did_cursorhold
@@ -7355,47 +7299,49 @@ int trigger_cursorhold()         {
 /*
  * Return TRUE when there is a CursorMoved autocommand defined.
  */
-int has_cursormoved()         {
+int has_cursormoved(void)         {
   return first_autopat[(int)EVENT_CURSORMOVED] != NULL;
 }
 
 /*
  * Return TRUE when there is a CursorMovedI autocommand defined.
  */
-int has_cursormovedI()         {
+int has_cursormovedI(void)         {
   return first_autopat[(int)EVENT_CURSORMOVEDI] != NULL;
 }
 
 /*
  * Return TRUE when there is a TextChanged autocommand defined.
  */
-int has_textchanged()         {
+int has_textchanged(void)         {
   return first_autopat[(int)EVENT_TEXTCHANGED] != NULL;
 }
 
 /*
  * Return TRUE when there is a TextChangedI autocommand defined.
  */
-int has_textchangedI()         {
+int has_textchangedI(void)         {
   return first_autopat[(int)EVENT_TEXTCHANGEDI] != NULL;
 }
 
 /*
  * Return TRUE when there is an InsertCharPre autocommand defined.
  */
-int has_insertcharpre()         {
+int has_insertcharpre(void)         {
   return first_autopat[(int)EVENT_INSERTCHARPRE] != NULL;
 }
 
-static int apply_autocmds_group(event, fname, fname_io, force, group, buf, eap)
-event_T event;
-char_u      *fname;         /* NULL or empty means use actual file name */
-char_u      *fname_io;      /* fname to use for <afile> on cmdline, NULL means
+static int 
+apply_autocmds_group (
+    event_T event,
+    char_u *fname,         /* NULL or empty means use actual file name */
+    char_u *fname_io,      /* fname to use for <afile> on cmdline, NULL means
                                use fname */
-int force;                  /* when TRUE, ignore autocmd_busy */
-int group;                  /* group ID, or AUGROUP_ALL */
-buf_T       *buf;           /* buffer for <abuf> */
-exarg_T     *eap;           /* command arguments */
+    int force,                  /* when TRUE, ignore autocmd_busy */
+    int group,                  /* group ID, or AUGROUP_ALL */
+    buf_T *buf,           /* buffer for <abuf> */
+    exarg_T *eap           /* command arguments */
+)
 {
   char_u      *sfname = NULL;   /* short file name */
   char_u      *tail;
@@ -7716,14 +7662,14 @@ static char_u   *old_termresponse = NULL;
  * Block triggering autocommands until unblock_autocmd() is called.
  * Can be used recursively, so long as it's symmetric.
  */
-void block_autocmds()          {
+void block_autocmds(void)          {
   /* Remember the value of v:termresponse. */
   if (autocmd_blocked == 0)
     old_termresponse = get_vim_var_str(VV_TERMRESPONSE);
   ++autocmd_blocked;
 }
 
-void unblock_autocmds()          {
+void unblock_autocmds(void)          {
   --autocmd_blocked;
 
   /* When v:termresponse was set while autocommands were blocked, trigger
@@ -7734,16 +7680,18 @@ void unblock_autocmds()          {
     apply_autocmds(EVENT_TERMRESPONSE, NULL, NULL, FALSE, curbuf);
 }
 
-int is_autocmd_blocked()         {
+int is_autocmd_blocked(void)         {
   return autocmd_blocked != 0;
 }
 
 /*
  * Find next autocommand pattern that matches.
  */
-static void auto_next_pat(apc, stop_at_last)
-AutoPatCmd  *apc;
-int stop_at_last;                   /* stop when 'last' flag is set */
+static void 
+auto_next_pat (
+    AutoPatCmd *apc,
+    int stop_at_last                   /* stop when 'last' flag is set */
+)
 {
   AutoPat     *ap;
   AutoCmd     *cp;
@@ -7801,10 +7749,7 @@ int stop_at_last;                   /* stop when 'last' flag is set */
  * Called by do_cmdline() to get the next line for ":if".
  * Returns allocated string, or NULL for end of autocommands.
  */
-char_u * getnextac(c, cookie, indent)
-int c UNUSED;
-void    *cookie;
-int indent UNUSED;
+char_u *getnextac(int c, void *cookie, int indent)
 {
   AutoPatCmd      *acp = (AutoPatCmd *)cookie;
   char_u          *retval;
@@ -7860,10 +7805,7 @@ int indent UNUSED;
  * To account for buffer-local autocommands, function needs to know
  * in which buffer the file will be opened.
  */
-int has_autocmd(event, sfname, buf)
-event_T event;
-char_u      *sfname;
-buf_T       *buf;
+int has_autocmd(event_T event, char_u *sfname, buf_T *buf)
 {
   AutoPat     *ap;
   char_u      *fname;
@@ -7908,9 +7850,7 @@ buf_T       *buf;
  * Function given to ExpandGeneric() to obtain the list of autocommand group
  * names.
  */
-char_u * get_augroup_name(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_augroup_name(expand_T *xp, int idx)
 {
   if (idx == augroups.ga_len)           /* add "END" add the end */
     return (char_u *)"END";
@@ -7923,10 +7863,12 @@ int idx;
 
 static int include_groups = FALSE;
 
-char_u  * set_context_in_autocmd(xp, arg, doautocmd)
-expand_T    *xp;
-char_u      *arg;
-int doautocmd;                  /* TRUE for :doauto*, FALSE for :autocmd */
+char_u *
+set_context_in_autocmd (
+    expand_T *xp,
+    char_u *arg,
+    int doautocmd                  /* TRUE for :doauto*, FALSE for :autocmd */
+)
 {
   char_u      *p;
   int group;
@@ -7972,9 +7914,7 @@ int doautocmd;                  /* TRUE for :doauto*, FALSE for :autocmd */
 /*
  * Function given to ExpandGeneric() to obtain the list of event names.
  */
-char_u * get_event_name(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_event_name(expand_T *xp, int idx)
 {
   if (idx < augroups.ga_len) {          /* First list group names, if wanted */
     if (!include_groups || AUGROUP_NAME(idx) == NULL)
@@ -7988,8 +7928,7 @@ int idx;
 /*
  * Return TRUE if autocmd is supported.
  */
-int autocmd_supported(name)
-char_u      *name;
+int autocmd_supported(char_u *name)
 {
   char_u *p;
 
@@ -8008,8 +7947,7 @@ char_u      *name;
  *	exists("#Event") or
  *	exists("#Event#pat")
  */
-int au_exists(arg)
-char_u      *arg;
+int au_exists(char_u *arg)
 {
   char_u      *arg_save;
   char_u      *pattern = NULL;
@@ -8098,13 +8036,15 @@ theend:
  * Used for autocommands and 'wildignore'.
  * Returns TRUE if there is a match, FALSE otherwise.
  */
-int match_file_pat(pattern, prog, fname, sfname, tail, allow_dirs)
-char_u      *pattern;                   /* pattern to match with */
-regprog_T   *prog;                      /* pre-compiled regprog or NULL */
-char_u      *fname;                     /* full path of file name */
-char_u      *sfname;                    /* short file name or NULL */
-char_u      *tail;                      /* tail of path */
-int allow_dirs;                         /* allow matching with dir */
+int 
+match_file_pat (
+    char_u *pattern,                   /* pattern to match with */
+    regprog_T *prog,                      /* pre-compiled regprog or NULL */
+    char_u *fname,                     /* full path of file name */
+    char_u *sfname,                    /* short file name or NULL */
+    char_u *tail,                      /* tail of path */
+    int allow_dirs                         /* allow matching with dir */
+)
 {
   regmatch_T regmatch;
   int result = FALSE;
@@ -8185,10 +8125,7 @@ int allow_dirs;                         /* allow matching with dir */
  * "list" is a comma-separated list of patterns, like 'wildignore'.
  * "sfname" is the short file name or NULL, "ffname" the long file name.
  */
-int match_file_list(list, sfname, ffname)
-char_u      *list;
-char_u      *sfname;
-char_u      *ffname;
+int match_file_list(char_u *list, char_u *sfname, char_u *ffname)
 {
   char_u buf[100];
   char_u      *tail;
@@ -8227,11 +8164,13 @@ char_u      *ffname;
  *
  * Returns NULL when out of memory.
  */
-char_u * file_pat_to_reg_pat(pat, pat_end, allow_dirs, no_bslash)
-char_u      *pat;
-char_u      *pat_end;           /* first char after pattern or NULL */
-char        *allow_dirs;        /* Result passed back out in here */
-int no_bslash UNUSED;             /* Don't use a backward slash as pathsep */
+char_u *
+file_pat_to_reg_pat (
+    char_u *pat,
+    char_u *pat_end,           /* first char after pattern or NULL */
+    char *allow_dirs,        /* Result passed back out in here */
+    int no_bslash             /* Don't use a backward slash as pathsep */
+)
 {
   int size;
   char_u      *endp;

--- a/src/fold.c
+++ b/src/fold.c
@@ -104,9 +104,7 @@ static int foldendmarkerlen;
 /*
  * Copy that folding state from window "wp_from" to window "wp_to".
  */
-void copyFoldingState(wp_from, wp_to)
-win_T       *wp_from;
-win_T       *wp_to;
+void copyFoldingState(win_T *wp_from, win_T *wp_to)
 {
   wp_to->w_fold_manual = wp_from->w_fold_manual;
   wp_to->w_foldinvalid = wp_from->w_foldinvalid;
@@ -117,8 +115,7 @@ win_T       *wp_to;
 /*
  * Return TRUE if there may be folded lines in the current window.
  */
-int hasAnyFolding(win)
-win_T       *win;
+int hasAnyFolding(win_T *win)
 {
   /* very simple now, but can become more complex later */
   return win->w_p_fen
@@ -132,22 +129,21 @@ win_T       *win;
  * When returning TRUE, *firstp and *lastp are set to the first and last
  * lnum of the sequence of folded lines (skipped when NULL).
  */
-int hasFolding(lnum, firstp, lastp)
-linenr_T lnum;
-linenr_T    *firstp;
-linenr_T    *lastp;
+int hasFolding(linenr_T lnum, linenr_T *firstp, linenr_T *lastp)
 {
   return hasFoldingWin(curwin, lnum, firstp, lastp, TRUE, NULL);
 }
 
 /* hasFoldingWin() {{{2 */
-int hasFoldingWin(win, lnum, firstp, lastp, cache, infop)
-win_T       *win;
-linenr_T lnum;
-linenr_T    *firstp;
-linenr_T    *lastp;
-int cache;                      /* when TRUE: use cached values of window */
-foldinfo_T  *infop;             /* where to store fold info */
+int 
+hasFoldingWin (
+    win_T *win,
+    linenr_T lnum,
+    linenr_T *firstp,
+    linenr_T *lastp,
+    int cache,                      /* when TRUE: use cached values of window */
+    foldinfo_T *infop             /* where to store fold info */
+)
 {
   int had_folded = FALSE;
   linenr_T first = 0;
@@ -242,8 +238,7 @@ foldinfo_T  *infop;             /* where to store fold info */
 /*
  * Return fold level at line number "lnum" in the current window.
  */
-int foldLevel(lnum)
-linenr_T lnum;
+int foldLevel(linenr_T lnum)
 {
   /* While updating the folds lines between invalid_top and invalid_bot have
    * an undefined fold level.  Otherwise update the folds first. */
@@ -268,9 +263,7 @@ linenr_T lnum;
  * Return FALSE if line is not folded.
  * Return MAYBE if the line is folded when next to a folded line.
  */
-int lineFolded(win, lnum)
-win_T       *win;
-linenr_T lnum;
+int lineFolded(win_T *win, linenr_T lnum)
 {
   return foldedCount(win, lnum, NULL) != 0;
 }
@@ -284,10 +277,7 @@ linenr_T lnum;
  * Returns number of folded lines from "lnum", or 0 if line is not folded.
  * When "infop" is not NULL, fills *infop with the fold level info.
  */
-long foldedCount(win, lnum, infop)
-win_T       *win;
-linenr_T lnum;
-foldinfo_T  *infop;
+long foldedCount(win_T *win, linenr_T lnum, foldinfo_T *infop)
 {
   linenr_T last;
 
@@ -300,8 +290,7 @@ foldinfo_T  *infop;
 /*
  * Return TRUE if 'foldmethod' is "manual"
  */
-int foldmethodIsManual(wp)
-win_T       *wp;
+int foldmethodIsManual(win_T *wp)
 {
   return wp->w_p_fdm[3] == 'u';
 }
@@ -310,8 +299,7 @@ win_T       *wp;
 /*
  * Return TRUE if 'foldmethod' is "indent"
  */
-int foldmethodIsIndent(wp)
-win_T       *wp;
+int foldmethodIsIndent(win_T *wp)
 {
   return wp->w_p_fdm[0] == 'i';
 }
@@ -320,8 +308,7 @@ win_T       *wp;
 /*
  * Return TRUE if 'foldmethod' is "expr"
  */
-int foldmethodIsExpr(wp)
-win_T       *wp;
+int foldmethodIsExpr(win_T *wp)
 {
   return wp->w_p_fdm[1] == 'x';
 }
@@ -330,8 +317,7 @@ win_T       *wp;
 /*
  * Return TRUE if 'foldmethod' is "marker"
  */
-int foldmethodIsMarker(wp)
-win_T       *wp;
+int foldmethodIsMarker(win_T *wp)
 {
   return wp->w_p_fdm[2] == 'r';
 }
@@ -340,8 +326,7 @@ win_T       *wp;
 /*
  * Return TRUE if 'foldmethod' is "syntax"
  */
-int foldmethodIsSyntax(wp)
-win_T       *wp;
+int foldmethodIsSyntax(win_T *wp)
 {
   return wp->w_p_fdm[0] == 's';
 }
@@ -350,8 +335,7 @@ win_T       *wp;
 /*
  * Return TRUE if 'foldmethod' is "diff"
  */
-int foldmethodIsDiff(wp)
-win_T       *wp;
+int foldmethodIsDiff(win_T *wp)
 {
   return wp->w_p_fdm[0] == 'd';
 }
@@ -361,9 +345,7 @@ win_T       *wp;
  * Close fold for current window at line "lnum".
  * Repeat "count" times.
  */
-void closeFold(lnum, count)
-linenr_T lnum;
-long count;
+void closeFold(linenr_T lnum, long count)
 {
   setFoldRepeat(lnum, count, FALSE);
 }
@@ -372,8 +354,7 @@ long count;
 /*
  * Close fold for current window at line "lnum" recursively.
  */
-void closeFoldRecurse(lnum)
-linenr_T lnum;
+void closeFoldRecurse(linenr_T lnum)
 {
   (void)setManualFold(lnum, FALSE, TRUE, NULL);
 }
@@ -383,12 +364,14 @@ linenr_T lnum;
  * Open or Close folds for current window in lines "first" to "last".
  * Used for "zo", "zO", "zc" and "zC" in Visual mode.
  */
-void opFoldRange(first, last, opening, recurse, had_visual)
-linenr_T first;
-linenr_T last;
-int opening;                    /* TRUE to open, FALSE to close */
-int recurse;                    /* TRUE to do it recursively */
-int had_visual;                 /* TRUE when Visual selection used */
+void 
+opFoldRange (
+    linenr_T first,
+    linenr_T last,
+    int opening,                    /* TRUE to open, FALSE to close */
+    int recurse,                    /* TRUE to do it recursively */
+    int had_visual                 /* TRUE when Visual selection used */
+)
 {
   int done = DONE_NOTHING;              /* avoid error messages */
   linenr_T lnum;
@@ -418,9 +401,7 @@ int had_visual;                 /* TRUE when Visual selection used */
  * Open fold for current window at line "lnum".
  * Repeat "count" times.
  */
-void openFold(lnum, count)
-linenr_T lnum;
-long count;
+void openFold(linenr_T lnum, long count)
 {
   setFoldRepeat(lnum, count, TRUE);
 }
@@ -429,8 +410,7 @@ long count;
 /*
  * Open fold for current window at line "lnum" recursively.
  */
-void openFoldRecurse(lnum)
-linenr_T lnum;
+void openFoldRecurse(linenr_T lnum)
 {
   (void)setManualFold(lnum, TRUE, TRUE, NULL);
 }
@@ -439,7 +419,7 @@ linenr_T lnum;
 /*
  * Open folds until the cursor line is not in a closed fold.
  */
-void foldOpenCursor()          {
+void foldOpenCursor(void)          {
   int done;
 
   checkupdate(curwin);
@@ -456,7 +436,7 @@ void foldOpenCursor()          {
 /*
  * Set new foldlevel for current window.
  */
-void newFoldLevel()          {
+void newFoldLevel(void)          {
   newFoldLevelWin(curwin);
 
   if (foldmethodIsDiff(curwin) && curwin->w_p_scb) {
@@ -475,8 +455,7 @@ void newFoldLevel()          {
   }
 }
 
-static void newFoldLevelWin(wp)
-win_T       *wp;
+static void newFoldLevelWin(win_T *wp)
 {
   fold_T      *fp;
   int i;
@@ -498,7 +477,7 @@ win_T       *wp;
 /*
  * Apply 'foldlevel' to all folds that don't contain the cursor.
  */
-void foldCheckClose()          {
+void foldCheckClose(void)          {
   if (*p_fcl != NUL) {  /* can only be "all" right now */
     checkupdate(curwin);
     if (checkCloseRec(&curwin->w_folds, curwin->w_cursor.lnum,
@@ -508,10 +487,7 @@ void foldCheckClose()          {
 }
 
 /* checkCloseRec() {{{2 */
-static int checkCloseRec(gap, lnum, level)
-garray_T    *gap;
-linenr_T lnum;
-int level;
+static int checkCloseRec(garray_T *gap, linenr_T lnum, int level)
 {
   fold_T      *fp;
   int retval = FALSE;
@@ -538,8 +514,7 @@ int level;
  * Return TRUE if it's allowed to manually create or delete a fold.
  * Give an error message and return FALSE if not.
  */
-int foldManualAllowed(create)
-int create;
+int foldManualAllowed(int create)
 {
   if (foldmethodIsManual(curwin) || foldmethodIsMarker(curwin))
     return TRUE;
@@ -555,9 +530,7 @@ int create;
  * Create a fold from line "start" to line "end" (inclusive) in the current
  * window.
  */
-void foldCreate(start, end)
-linenr_T start;
-linenr_T end;
+void foldCreate(linenr_T start, linenr_T end)
 {
   fold_T      *fp;
   garray_T    *gap;
@@ -671,11 +644,13 @@ linenr_T end;
  * When "end" is not 0, delete all folds from "start" to "end".
  * When "recursive" is TRUE delete recursively.
  */
-void deleteFold(start, end, recursive, had_visual)
-linenr_T start;
-linenr_T end;
-int recursive;
-int had_visual;                 /* TRUE when Visual selection used */
+void 
+deleteFold (
+    linenr_T start,
+    linenr_T end,
+    int recursive,
+    int had_visual                 /* TRUE when Visual selection used */
+)
 {
   garray_T    *gap;
   fold_T      *fp;
@@ -757,8 +732,7 @@ int had_visual;                 /* TRUE when Visual selection used */
 /*
  * Remove all folding for window "win".
  */
-void clearFolding(win)
-win_T       *win;
+void clearFolding(win_T *win)
 {
   deleteFoldRecurse(&win->w_folds);
   win->w_foldinvalid = FALSE;
@@ -771,10 +745,7 @@ win_T       *win;
  * calling foldMarkAdjust().
  * The changes in lines from top to bot (inclusive).
  */
-void foldUpdate(wp, top, bot)
-win_T       *wp;
-linenr_T top;
-linenr_T bot;
+void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 {
   fold_T      *fp;
 
@@ -807,8 +778,7 @@ linenr_T bot;
  * The actual updating is postponed until fold info is used, to avoid doing
  * every time a setting is changed or a syntax item is added.
  */
-void foldUpdateAll(win)
-win_T       *win;
+void foldUpdateAll(win_T *win)
 {
   win->w_foldinvalid = TRUE;
   redraw_win_later(win, NOT_VALID);
@@ -820,10 +790,12 @@ win_T       *win;
  * If "updown" is TRUE: move to fold at the same level.
  * If not moved return FAIL.
  */
-int foldMoveTo(updown, dir, count)
-int updown;
-int dir;                    /* FORWARD or BACKWARD */
-long count;
+int 
+foldMoveTo (
+    int updown,
+    int dir,                    /* FORWARD or BACKWARD */
+    long count
+)
 {
   long n;
   int retval = FAIL;
@@ -936,8 +908,7 @@ long count;
 /*
  * Init the fold info in a new window.
  */
-void foldInitWin(new_win)
-win_T       *new_win;
+void foldInitWin(win_T *new_win)
 {
   ga_init2(&new_win->w_folds, (int)sizeof(fold_T), 10);
 }
@@ -949,9 +920,7 @@ win_T       *new_win;
  * line number can be wrong).
  * Returns index of entry or -1 if not found.
  */
-int find_wl_entry(win, lnum)
-win_T       *win;
-linenr_T lnum;
+int find_wl_entry(win_T *win, linenr_T lnum)
 {
   int i;
 
@@ -969,7 +938,7 @@ linenr_T lnum;
 /*
  * Adjust the Visual area to include any fold at the start or end completely.
  */
-void foldAdjustVisual()          {
+void foldAdjustVisual(void)          {
   pos_T       *start, *end;
   char_u      *ptr;
 
@@ -1000,7 +969,7 @@ void foldAdjustVisual()          {
 /*
  * Move the cursor to the first line of a closed fold.
  */
-void foldAdjustCursor()          {
+void foldAdjustCursor(void)          {
   (void)hasFolding(curwin->w_cursor.lnum, &curwin->w_cursor.lnum, NULL);
 }
 
@@ -1011,9 +980,7 @@ void foldAdjustCursor()          {
  *
  * Return FAIL if the operation cannot be completed, otherwise OK.
  */
-void cloneFoldGrowArray(from, to)
-garray_T    *from;
-garray_T    *to;
+void cloneFoldGrowArray(garray_T *from, garray_T *to)
 {
   int i;
   fold_T      *from_p;
@@ -1045,10 +1012,7 @@ garray_T    *to;
  * the first fold below it (careful: it can be beyond the end of the array!).
  * Returns FALSE when there is no fold that contains "lnum".
  */
-static int foldFind(gap, lnum, fpp)
-garray_T    *gap;
-linenr_T lnum;
-fold_T      **fpp;
+static int foldFind(garray_T *gap, linenr_T lnum, fold_T **fpp)
 {
   linenr_T low, high;
   fold_T      *fp;
@@ -1084,9 +1048,7 @@ fold_T      **fpp;
 /*
  * Return fold level at line number "lnum" in window "wp".
  */
-static int foldLevelWin(wp, lnum)
-win_T       *wp;
-linenr_T lnum;
+static int foldLevelWin(win_T *wp, linenr_T lnum)
 {
   fold_T      *fp;
   linenr_T lnum_rel = lnum;
@@ -1111,8 +1073,7 @@ linenr_T lnum;
 /*
  * Check if the folds in window "wp" are invalid and update them if needed.
  */
-static void checkupdate(wp)
-win_T       *wp;
+static void checkupdate(win_T *wp)
 {
   if (wp->w_foldinvalid) {
     foldUpdate(wp, (linenr_T)1, (linenr_T)MAXLNUM);     /* will update all */
@@ -1125,10 +1086,7 @@ win_T       *wp;
  * Open or close fold for current window at line "lnum".
  * Repeat "count" times.
  */
-static void setFoldRepeat(lnum, count, do_open)
-linenr_T lnum;
-long count;
-int do_open;
+static void setFoldRepeat(linenr_T lnum, long count, int do_open)
 {
   int done;
   long n;
@@ -1150,11 +1108,13 @@ int do_open;
  * Open or close the fold in the current window which contains "lnum".
  * Also does this for other windows in diff mode when needed.
  */
-static linenr_T setManualFold(lnum, opening, recurse, donep)
-linenr_T lnum;
-int opening;                /* TRUE when opening, FALSE when closing */
-int recurse;                /* TRUE when closing/opening recursive */
-int         *donep;
+static linenr_T 
+setManualFold (
+    linenr_T lnum,
+    int opening,                /* TRUE when opening, FALSE when closing */
+    int recurse,                /* TRUE when closing/opening recursive */
+    int *donep
+)
 {
   if (foldmethodIsDiff(curwin) && curwin->w_p_scb) {
     win_T       *wp;
@@ -1187,12 +1147,14 @@ int         *donep;
  * Return the line number of the next line that could be closed.
  * It's only valid when "opening" is TRUE!
  */
-static linenr_T setManualFoldWin(wp, lnum, opening, recurse, donep)
-win_T       *wp;
-linenr_T lnum;
-int opening;                /* TRUE when opening, FALSE when closing */
-int recurse;                /* TRUE when closing/opening recursive */
-int         *donep;
+static linenr_T 
+setManualFoldWin (
+    win_T *wp,
+    linenr_T lnum,
+    int opening,                /* TRUE when opening, FALSE when closing */
+    int recurse,                /* TRUE when closing/opening recursive */
+    int *donep
+)
 {
   fold_T      *fp;
   fold_T      *fp2;
@@ -1286,8 +1248,7 @@ int         *donep;
 /*
  * Open all nested folds in fold "fpr" recursively.
  */
-static void foldOpenNested(fpr)
-fold_T      *fpr;
+static void foldOpenNested(fold_T *fpr)
 {
   int i;
   fold_T      *fp;
@@ -1305,10 +1266,7 @@ fold_T      *fpr;
  * When "recursive" is TRUE also delete all the folds contained in it.
  * When "recursive" is FALSE contained folds are moved one level up.
  */
-static void deleteFoldEntry(gap, idx, recursive)
-garray_T    *gap;
-int idx;
-int recursive;
+static void deleteFoldEntry(garray_T *gap, int idx, int recursive)
 {
   fold_T      *fp;
   int i;
@@ -1356,8 +1314,7 @@ int recursive;
 /*
  * Delete nested folds in a fold.
  */
-void deleteFoldRecurse(gap)
-garray_T    *gap;
+void deleteFoldRecurse(garray_T *gap)
 {
   int i;
 
@@ -1370,12 +1327,7 @@ garray_T    *gap;
 /*
  * Update line numbers of folds for inserted/deleted lines.
  */
-void foldMarkAdjust(wp, line1, line2, amount, amount_after)
-win_T       *wp;
-linenr_T line1;
-linenr_T line2;
-long amount;
-long amount_after;
+void foldMarkAdjust(win_T *wp, linenr_T line1, linenr_T line2, long amount, long amount_after)
 {
   /* If deleting marks from line1 to line2, but not deleting all those
    * lines, set line2 so that only deleted lines have their folds removed. */
@@ -1389,12 +1341,7 @@ long amount_after;
 }
 
 /* foldMarkAdjustRecurse() {{{2 */
-static void foldMarkAdjustRecurse(gap, line1, line2, amount, amount_after)
-garray_T    *gap;
-linenr_T line1;
-linenr_T line2;
-long amount;
-long amount_after;
+static void foldMarkAdjustRecurse(garray_T *gap, linenr_T line1, linenr_T line2, long amount, long amount_after)
 {
   fold_T      *fp;
   int i;
@@ -1487,13 +1434,12 @@ long amount_after;
  * Get the lowest 'foldlevel' value that makes the deepest nested fold in the
  * current window open.
  */
-int getDeepestNesting()         {
+int getDeepestNesting(void)         {
   checkupdate(curwin);
   return getDeepestNestingRecurse(&curwin->w_folds);
 }
 
-static int getDeepestNestingRecurse(gap)
-garray_T    *gap;
+static int getDeepestNestingRecurse(garray_T *gap)
 {
   int i;
   int level;
@@ -1514,13 +1460,15 @@ garray_T    *gap;
 /*
  * Check if a fold is closed and update the info needed to check nested folds.
  */
-static int check_closed(win, fp, use_levelp, level, maybe_smallp, lnum_off)
-win_T       *win;
-fold_T      *fp;
-int         *use_levelp;            /* TRUE: outer fold had FD_LEVEL */
-int level;                          /* folding depth */
-int         *maybe_smallp;          /* TRUE: outer this had fd_small == MAYBE */
-linenr_T lnum_off;                  /* line number offset for fp->fd_top */
+static int 
+check_closed (
+    win_T *win,
+    fold_T *fp,
+    int *use_levelp,            /* TRUE: outer fold had FD_LEVEL */
+    int level,                          /* folding depth */
+    int *maybe_smallp,          /* TRUE: outer this had fd_small == MAYBE */
+    linenr_T lnum_off                  /* line number offset for fp->fd_top */
+)
 {
   int closed = FALSE;
 
@@ -1550,10 +1498,12 @@ linenr_T lnum_off;                  /* line number offset for fp->fd_top */
 /*
  * Update fd_small field of fold "fp".
  */
-static void checkSmall(wp, fp, lnum_off)
-win_T       *wp;
-fold_T      *fp;
-linenr_T lnum_off;              /* offset for fp->fd_top */
+static void 
+checkSmall (
+    win_T *wp,
+    fold_T *fp,
+    linenr_T lnum_off              /* offset for fp->fd_top */
+)
 {
   int count;
   int n;
@@ -1582,8 +1532,7 @@ linenr_T lnum_off;              /* offset for fp->fd_top */
 /*
  * Set small flags in "gap" to MAYBE.
  */
-static void setSmallMaybe(gap)
-garray_T    *gap;
+static void setSmallMaybe(garray_T *gap)
 {
   int i;
   fold_T      *fp;
@@ -1598,9 +1547,7 @@ garray_T    *gap;
  * Create a fold from line "start" to line "end" (inclusive) in the current
  * window by adding markers.
  */
-static void foldCreateMarkers(start, end)
-linenr_T start;
-linenr_T end;
+static void foldCreateMarkers(linenr_T start, linenr_T end)
 {
   if (!curbuf->b_p_ma) {
     EMSG(_(e_modifiable));
@@ -1620,10 +1567,7 @@ linenr_T end;
 /*
  * Add "marker[markerlen]" in 'commentstring' to line "lnum".
  */
-static void foldAddMarker(lnum, marker, markerlen)
-linenr_T lnum;
-char_u      *marker;
-int markerlen;
+static void foldAddMarker(linenr_T lnum, char_u *marker, int markerlen)
 {
   char_u      *cms = curbuf->b_p_cms;
   char_u      *line;
@@ -1656,10 +1600,12 @@ int markerlen;
 /*
  * Delete the markers for a fold, causing it to be deleted.
  */
-static void deleteFoldMarkers(fp, recursive, lnum_off)
-fold_T      *fp;
-int recursive;
-linenr_T lnum_off;              /* offset for fp->fd_top */
+static void 
+deleteFoldMarkers (
+    fold_T *fp,
+    int recursive,
+    linenr_T lnum_off              /* offset for fp->fd_top */
+)
 {
   int i;
 
@@ -1679,10 +1625,7 @@ linenr_T lnum_off;              /* offset for fp->fd_top */
  * If the marker is not found, there is no error message.  Could a missing
  * close-marker.
  */
-static void foldDelMarker(lnum, marker, markerlen)
-linenr_T lnum;
-char_u      *marker;
-int markerlen;
+static void foldDelMarker(linenr_T lnum, char_u *marker, int markerlen)
 {
   char_u      *line;
   char_u      *newline;
@@ -1727,11 +1670,7 @@ int markerlen;
  * When 'foldtext' isn't set puts the result in "buf[51]".  Otherwise the
  * result is in allocated memory.
  */
-char_u * get_foldtext(wp, lnum, lnume, foldinfo, buf)
-win_T       *wp;
-linenr_T lnum, lnume;
-foldinfo_T  *foldinfo;
-char_u      *buf;
+char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T *foldinfo, char_u *buf)
 {
   char_u      *text = NULL;
   /* an error occurred when evaluating 'fdt' setting */
@@ -1827,8 +1766,7 @@ char_u      *buf;
 /*
  * Remove 'foldmarker' and 'commentstring' from "str" (in-place).
  */
-void foldtext_cleanup(str)
-char_u      *str;
+void foldtext_cleanup(char_u *str)
 {
   char_u      *cms_start;       /* first part or the whole comment */
   int cms_slen = 0;             /* length of cms_start */
@@ -1943,10 +1881,7 @@ static void foldlevelSyntax __ARGS((fline_T *flp));
  * Update the folding for window "wp", at least from lines "top" to "bot".
  * Return TRUE if any folds did change.
  */
-static void foldUpdateIEMS(wp, top, bot)
-win_T       *wp;
-linenr_T top;
-linenr_T bot;
+static void foldUpdateIEMS(win_T *wp, linenr_T top, linenr_T bot)
 {
   linenr_T start;
   linenr_T end;
@@ -2550,9 +2485,7 @@ int topflags;                   /* flags used by containing fold */
  * Insert a new fold in "gap" at position "i".
  * Returns OK for success, FAIL for failure.
  */
-static int foldInsert(gap, i)
-garray_T    *gap;
-int i;
+static int foldInsert(garray_T *gap, int i)
 {
   fold_T      *fp;
 
@@ -2574,11 +2507,7 @@ int i;
  * The caller must first have taken care of any nested folds from "top" to
  * "bot"!
  */
-static void foldSplit(gap, i, top, bot)
-garray_T    *gap;
-int i;
-linenr_T top;
-linenr_T bot;
+static void foldSplit(garray_T *gap, int i, linenr_T top, linenr_T bot)
 {
   fold_T      *fp;
   fold_T      *fp2;
@@ -2635,10 +2564,7 @@ linenr_T bot;
  * 5: made to start below "bot".
  * 6: not changed
  */
-static void foldRemove(gap, top, bot)
-garray_T    *gap;
-linenr_T top;
-linenr_T bot;
+static void foldRemove(garray_T *gap, linenr_T top, linenr_T bot)
 {
   fold_T      *fp = NULL;
 
@@ -2692,10 +2618,7 @@ linenr_T bot;
  * The resulting fold is "fp1", nested folds are moved from "fp2" to "fp1".
  * Fold entry "fp2" in "gap" is deleted.
  */
-static void foldMerge(fp1, gap, fp2)
-fold_T      *fp1;
-garray_T    *gap;
-fold_T      *fp2;
+static void foldMerge(fold_T *fp1, garray_T *gap, fold_T *fp2)
 {
   fold_T      *fp3;
   fold_T      *fp4;
@@ -2730,8 +2653,7 @@ fold_T      *fp2;
  * Doesn't use any caching.
  * Returns a level of -1 if the foldlevel depends on surrounding lines.
  */
-static void foldlevelIndent(flp)
-fline_T     *flp;
+static void foldlevelIndent(fline_T *flp)
 {
   char_u      *s;
   buf_T       *buf;
@@ -2762,8 +2684,7 @@ fline_T     *flp;
  * Low level function to get the foldlevel for the "diff" method.
  * Doesn't use any caching.
  */
-static void foldlevelDiff(flp)
-fline_T     *flp;
+static void foldlevelDiff(fline_T *flp)
 {
   if (diff_infold(flp->wp, flp->lnum + flp->off))
     flp->lvl = 1;
@@ -2777,8 +2698,7 @@ fline_T     *flp;
  * Doesn't use any caching.
  * Returns a level of -1 if the foldlevel depends on surrounding lines.
  */
-static void foldlevelExpr(flp)
-fline_T     *flp;
+static void foldlevelExpr(fline_T *flp)
 {
   win_T       *win;
   int n;
@@ -2869,8 +2789,7 @@ fline_T     *flp;
  * "foldendmarkerlen".
  * Relies on the option value to have been checked for correctness already.
  */
-static void parseMarker(wp)
-win_T       *wp;
+static void parseMarker(win_T *wp)
 {
   foldendmarker = vim_strchr(wp->w_p_fmr, ',');
   foldstartmarkerlen = (int)(foldendmarker++ - wp->w_p_fmr);
@@ -2887,8 +2806,7 @@ win_T       *wp;
  * Doesn't use any caching.
  * Sets flp->start when a start marker was found.
  */
-static void foldlevelMarker(flp)
-fline_T     *flp;
+static void foldlevelMarker(fline_T *flp)
 {
   char_u      *startmarker;
   int cstart;
@@ -2958,8 +2876,7 @@ fline_T     *flp;
  * Low level function to get the foldlevel for the "syntax" method.
  * Doesn't use any caching.
  */
-static void foldlevelSyntax(flp)
-fline_T     *flp;
+static void foldlevelSyntax(fline_T *flp)
 {
   linenr_T lnum = flp->lnum + flp->off;
   int n;
@@ -2987,9 +2904,7 @@ static int put_fold_open_close __ARGS((FILE *fd, fold_T *fp, linenr_T off));
  * Write commands to "fd" to restore the manual folds in window "wp".
  * Return FAIL if writing fails.
  */
-int put_folds(fd, wp)
-FILE        *fd;
-win_T       *wp;
+int put_folds(FILE *fd, win_T *wp)
 {
   if (foldmethodIsManual(wp)) {
     if (put_line(fd, "silent! normal! zE") == FAIL
@@ -3009,10 +2924,7 @@ win_T       *wp;
  * Write commands to "fd" to recreate manually created folds.
  * Returns FAIL when writing failed.
  */
-static int put_folds_recurse(fd, gap, off)
-FILE        *fd;
-garray_T    *gap;
-linenr_T off;
+static int put_folds_recurse(FILE *fd, garray_T *gap, linenr_T off)
 {
   int i;
   fold_T      *fp;
@@ -3036,11 +2948,7 @@ linenr_T off;
  * Write commands to "fd" to open and close manually opened/closed folds.
  * Returns FAIL when writing failed.
  */
-static int put_foldopen_recurse(fd, wp, gap, off)
-FILE        *fd;
-win_T       *wp;
-garray_T    *gap;
-linenr_T off;
+static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off)
 {
   int i;
   int level;
@@ -3086,10 +2994,7 @@ linenr_T off;
  * Write the open or close command to "fd".
  * Returns FAIL when writing failed.
  */
-static int put_fold_open_close(fd, fp, off)
-FILE        *fd;
-fold_T      *fp;
-linenr_T off;
+static int put_fold_open_close(FILE *fd, fold_T *fp, linenr_T off)
 {
   if (fprintf(fd, "%ld", fp->fd_top + off) < 0
       || put_eol(fd) == FAIL

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -134,8 +134,7 @@ static char_u   *eval_map_expr __ARGS((char_u *str, int c));
 /*
  * Free and clear a buffer.
  */
-void free_buff(buf)
-struct buffheader   *buf;
+void free_buff(struct buffheader *buf)
 {
   struct buffblock    *p, *np;
 
@@ -150,9 +149,11 @@ struct buffheader   *buf;
  * Return the contents of a buffer as a single string.
  * K_SPECIAL and CSI in the returned string are escaped.
  */
-static char_u * get_buffcont(buffer, dozero)
-struct buffheader   *buffer;
-int dozero;                         /* count == zero is not an error */
+static char_u *
+get_buffcont (
+    struct buffheader *buffer,
+    int dozero                         /* count == zero is not an error */
+)
 {
   long_u count = 0;
   char_u          *p = NULL;
@@ -179,7 +180,7 @@ int dozero;                         /* count == zero is not an error */
  * and clear the record buffer.
  * K_SPECIAL and CSI in the returned string are escaped.
  */
-char_u * get_recorded()              {
+char_u *get_recorded(void)              {
   char_u      *p;
   size_t len;
 
@@ -210,7 +211,7 @@ char_u * get_recorded()              {
  * Return the contents of the redo buffer as a single string.
  * K_SPECIAL and CSI in the returned string are escaped.
  */
-char_u * get_inserted()              {
+char_u *get_inserted(void)              {
   return get_buffcont(&redobuff, FALSE);
 }
 
@@ -218,10 +219,12 @@ char_u * get_inserted()              {
  * Add string "s" after the current block of buffer "buf".
  * K_SPECIAL and CSI should have been escaped already.
  */
-static void add_buff(buf, s, slen)
-struct buffheader   *buf;
-char_u              *s;
-long slen;                      /* length of "s" or -1 */
+static void 
+add_buff (
+    struct buffheader *buf,
+    char_u *s,
+    long slen                      /* length of "s" or -1 */
+)
 {
   struct buffblock *p;
   long_u len;
@@ -269,9 +272,7 @@ long slen;                      /* length of "s" or -1 */
 /*
  * Add number "n" to buffer "buf".
  */
-static void add_num_buff(buf, n)
-struct buffheader *buf;
-long n;
+static void add_num_buff(struct buffheader *buf, long n)
 {
   char_u number[32];
 
@@ -283,9 +284,7 @@ long n;
  * Add character 'c' to buffer "buf".
  * Translates special keys, NUL, CSI, K_SPECIAL and multibyte characters.
  */
-static void add_char_buff(buf, c)
-struct buffheader   *buf;
-int c;
+static void add_char_buff(struct buffheader *buf, int c)
 {
   char_u bytes[MB_MAXBYTES + 1];
   int len;
@@ -319,8 +318,7 @@ int c;
  * If advance == TRUE go to the next char.
  * No translation is done K_SPECIAL and CSI are escaped.
  */
-static int read_stuff(advance)
-int advance;
+static int read_stuff(int advance)
 {
   char_u c;
   struct buffblock    *curr;
@@ -344,7 +342,7 @@ int advance;
 /*
  * Prepare the stuff buffer for reading (if it contains something).
  */
-static void start_stuff()                 {
+static void start_stuff(void)                 {
   if (stuffbuff.bh_first.b_next != NULL) {
     stuffbuff.bh_curr = &(stuffbuff.bh_first);
     stuffbuff.bh_space = 0;
@@ -354,15 +352,14 @@ static void start_stuff()                 {
 /*
  * Return TRUE if the stuff buffer is empty.
  */
-int stuff_empty()         {
+int stuff_empty(void)         {
   return stuffbuff.bh_first.b_next == NULL;
 }
 
 /*
  * Set a typeahead character that won't be flushed.
  */
-void typeahead_noflush(c)
-int c;
+void typeahead_noflush(int c)
 {
   typeahead_char = c;
 }
@@ -372,8 +369,7 @@ int c;
  * typeahead buffer (used in case of an error).  If "flush_typeahead" is true,
  * flush all typeahead characters (used when interrupted by a CTRL-C).
  */
-void flush_buffers(flush_typeahead)
-int flush_typeahead;
+void flush_buffers(int flush_typeahead)
 {
   init_typebuf();
 
@@ -406,7 +402,7 @@ int flush_typeahead;
  * The previous contents of the redo buffer is kept in old_redobuffer.
  * This is used for the CTRL-O <.> command in insert mode.
  */
-void ResetRedobuff()          {
+void ResetRedobuff(void)          {
   if (!block_redo) {
     free_buff(&old_redobuff);
     old_redobuff = redobuff;
@@ -418,7 +414,7 @@ void ResetRedobuff()          {
  * Discard the contents of the redo buffer and restore the previous redo
  * buffer.
  */
-void CancelRedo()          {
+void CancelRedo(void)          {
   if (!block_redo) {
     free_buff(&redobuff);
     redobuff = old_redobuff;
@@ -435,7 +431,7 @@ void CancelRedo()          {
  */
 static int save_level = 0;
 
-void saveRedobuff()          {
+void saveRedobuff(void)          {
   char_u      *s;
 
   if (save_level++ == 0) {
@@ -457,7 +453,7 @@ void saveRedobuff()          {
  * Restore redobuff and old_redobuff from save_redobuff and save_old_redobuff.
  * Used after executing autocommands and user functions.
  */
-void restoreRedobuff()          {
+void restoreRedobuff(void)          {
   if (--save_level == 0) {
     free_buff(&redobuff);
     redobuff = save_redobuff;
@@ -470,8 +466,7 @@ void restoreRedobuff()          {
  * Append "s" to the redo buffer.
  * K_SPECIAL and CSI should already have been escaped.
  */
-void AppendToRedobuff(s)
-char_u         *s;
+void AppendToRedobuff(char_u *s)
 {
   if (!block_redo)
     add_buff(&redobuff, s, -1L);
@@ -481,9 +476,11 @@ char_u         *s;
  * Append to Redo buffer literally, escaping special characters with CTRL-V.
  * K_SPECIAL and CSI are escaped as well.
  */
-void AppendToRedobuffLit(str, len)
-char_u      *str;
-int len;                    /* length of "str" or -1 for up to the NUL */
+void 
+AppendToRedobuffLit (
+    char_u *str,
+    int len                    /* length of "str" or -1 for up to the NUL */
+)
 {
   char_u      *s = str;
   int c;
@@ -532,8 +529,7 @@ int len;                    /* length of "str" or -1 for up to the NUL */
  * Append a character to the redo buffer.
  * Translates special keys, NUL, CSI, K_SPECIAL and multibyte characters.
  */
-void AppendCharToRedobuff(c)
-int c;
+void AppendCharToRedobuff(int c)
 {
   if (!block_redo)
     add_char_buff(&redobuff, c);
@@ -542,8 +538,7 @@ int c;
 /*
  * Append a number to the redo buffer.
  */
-void AppendNumberToRedobuff(n)
-long n;
+void AppendNumberToRedobuff(long n)
 {
   if (!block_redo)
     add_num_buff(&redobuff, n);
@@ -553,15 +548,12 @@ long n;
  * Append string "s" to the stuff buffer.
  * CSI and K_SPECIAL must already have been escaped.
  */
-void stuffReadbuff(s)
-char_u      *s;
+void stuffReadbuff(char_u *s)
 {
   add_buff(&stuffbuff, s, -1L);
 }
 
-void stuffReadbuffLen(s, len)
-char_u      *s;
-long len;
+void stuffReadbuffLen(char_u *s, long len)
 {
   add_buff(&stuffbuff, s, len);
 }
@@ -571,8 +563,7 @@ long len;
  * escaping other K_SPECIAL and CSI bytes.
  * Change CR, LF and ESC into a space.
  */
-void stuffReadbuffSpec(s)
-char_u      *s;
+void stuffReadbuffSpec(char_u *s)
 {
   int c;
 
@@ -594,8 +585,7 @@ char_u      *s;
  * Append a character to the stuff buffer.
  * Translates special keys, NUL, CSI, K_SPECIAL and multibyte characters.
  */
-void stuffcharReadbuff(c)
-int c;
+void stuffcharReadbuff(int c)
 {
   add_char_buff(&stuffbuff, c);
 }
@@ -603,8 +593,7 @@ int c;
 /*
  * Append a number to the stuff buffer.
  */
-void stuffnumReadbuff(n)
-long n;
+void stuffnumReadbuff(long n)
 {
   add_num_buff(&stuffbuff, n);
 }
@@ -617,9 +606,7 @@ long n;
  * otherwise.
  * If old is TRUE, use old_redobuff instead of redobuff.
  */
-static int read_redo(init, old_redo)
-int init;
-int old_redo;
+static int read_redo(int init, int old_redo)
 {
   static struct buffblock     *bp;
   static char_u               *p;
@@ -675,8 +662,7 @@ int old_redo;
  * If old_redo is TRUE, use old_redobuff instead of redobuff.
  * The escaped K_SPECIAL and CSI are copied without translation.
  */
-static void copy_redo(old_redo)
-int old_redo;
+static void copy_redo(int old_redo)
 {
   int c;
 
@@ -693,9 +679,7 @@ int old_redo;
  *
  * return FAIL for failure, OK otherwise
  */
-int start_redo(count, old_redo)
-long count;
-int old_redo;
+int start_redo(long count, int old_redo)
 {
   int c;
 
@@ -744,7 +728,7 @@ int old_redo;
  * the redo buffer into the stuffbuff.
  * return FAIL for failure, OK otherwise
  */
-int start_redo_ins()         {
+int start_redo_ins(void)         {
   int c;
 
   if (read_redo(TRUE, FALSE) == FAIL)
@@ -766,7 +750,7 @@ int start_redo_ins()         {
   return OK;
 }
 
-void stop_redo_ins()          {
+void stop_redo_ins(void)          {
   block_redo = FALSE;
 }
 
@@ -775,7 +759,7 @@ void stop_redo_ins()          {
  * alloc() cannot be used here: In out-of-memory situations it would
  * be impossible to type anything.
  */
-static void init_typebuf()                 {
+static void init_typebuf(void)                 {
   if (typebuf.tb_buf == NULL) {
     typebuf.tb_buf = typebuf_init;
     typebuf.tb_noremap = noremapbuf_init;
@@ -805,12 +789,7 @@ static void init_typebuf()                 {
  *
  * return FAIL for failure, OK otherwise
  */
-int ins_typebuf(str, noremap, offset, nottyped, silent)
-char_u      *str;
-int noremap;
-int offset;
-int nottyped;
-int silent;
+int ins_typebuf(char_u *str, int noremap, int offset, int nottyped, int silent)
 {
   char_u      *s1, *s2;
   int newlen;
@@ -931,8 +910,7 @@ int silent;
  * Uses cmd_silent, KeyTyped and KeyNoremap to restore the flags belonging to
  * the char.
  */
-void ins_char_typebuf(c)
-int c;
+void ins_char_typebuf(int c)
 {
   char_u buf[MB_MAXBYTES + 1];
   if (IS_SPECIAL(c)) {
@@ -955,8 +933,10 @@ int c;
  * Or "typebuf.tb_off" may have been changed and we would overwrite characters
  * that was just added.
  */
-int typebuf_changed(tb_change_cnt)
-int tb_change_cnt;              /* old value of typebuf.tb_change_cnt */
+int 
+typebuf_changed (
+    int tb_change_cnt              /* old value of typebuf.tb_change_cnt */
+)
 {
   return tb_change_cnt != 0 && (typebuf.tb_change_cnt != tb_change_cnt
                                 || typebuf_was_filled
@@ -967,23 +947,21 @@ int tb_change_cnt;              /* old value of typebuf.tb_change_cnt */
  * Return TRUE if there are no characters in the typeahead buffer that have
  * not been typed (result from a mapping or come from ":normal").
  */
-int typebuf_typed()         {
+int typebuf_typed(void)         {
   return typebuf.tb_maplen == 0;
 }
 
 /*
  * Return the number of characters that are mapped (or not typed).
  */
-int typebuf_maplen()         {
+int typebuf_maplen(void)         {
   return typebuf.tb_maplen;
 }
 
 /*
  * remove "len" characters from typebuf.tb_buf[typebuf.tb_off + offset]
  */
-void del_typebuf(len, offset)
-int len;
-int offset;
+void del_typebuf(int len, int offset)
 {
   int i;
 
@@ -1053,9 +1031,7 @@ int offset;
  * Write typed characters to script file.
  * If recording is on put the character in the recordbuffer.
  */
-static void gotchars(chars, len)
-char_u      *chars;
-int len;
+static void gotchars(char_u *chars, int len)
 {
   char_u      *s = chars;
   int c;
@@ -1095,7 +1071,7 @@ int len;
  * - While reading a script file.
  * - When no_u_sync is non-zero.
  */
-static void may_sync_undo()                 {
+static void may_sync_undo(void)                 {
   if ((!(State & (INSERT + CMDLINE)) || arrow_used)
       && scriptin[curscript] == NULL)
     u_sync(FALSE);
@@ -1105,7 +1081,7 @@ static void may_sync_undo()                 {
  * Make "typebuf" empty and allocate new buffers.
  * Returns FAIL when out of memory.
  */
-int alloc_typebuf()         {
+int alloc_typebuf(void)         {
   typebuf.tb_buf = alloc(TYPELEN_INIT);
   typebuf.tb_noremap = alloc(TYPELEN_INIT);
   if (typebuf.tb_buf == NULL || typebuf.tb_noremap == NULL) {
@@ -1126,7 +1102,7 @@ int alloc_typebuf()         {
 /*
  * Free the buffers of "typebuf".
  */
-void free_typebuf()          {
+void free_typebuf(void)          {
   if (typebuf.tb_buf == typebuf_init)
     EMSG2(_(e_intern2), "Free typebuf 1");
   else
@@ -1143,7 +1119,7 @@ void free_typebuf()          {
  */
 static typebuf_T saved_typebuf[NSCRIPT];
 
-int save_typebuf()         {
+int save_typebuf(void)         {
   init_typebuf();
   saved_typebuf[curscript] = typebuf;
   /* If out of memory: restore typebuf and close file. */
@@ -1163,8 +1139,7 @@ static int old_mouse_col;       /* mouse_col related to old_char */
 /*
  * Save all three kinds of typeahead, so that the user must type at a prompt.
  */
-void save_typeahead(tp)
-tasave_T    *tp;
+void save_typeahead(tasave_T *tp)
 {
   tp->save_typebuf = typebuf;
   tp->typebuf_valid = (alloc_typebuf() == OK);
@@ -1186,8 +1161,7 @@ tasave_T    *tp;
  * Restore the typeahead to what it was before calling save_typeahead().
  * The allocated memory is freed, can only be called once!
  */
-void restore_typeahead(tp)
-tasave_T    *tp;
+void restore_typeahead(tasave_T *tp)
 {
   if (tp->typebuf_valid) {
     free_typebuf();
@@ -1207,9 +1181,11 @@ tasave_T    *tp;
 /*
  * Open a new script file for the ":source!" command.
  */
-void openscript(name, directly)
-char_u      *name;
-int directly;                   /* when TRUE execute directly */
+void 
+openscript (
+    char_u *name,
+    int directly                   /* when TRUE execute directly */
+)
 {
   if (curscript + 1 == NSCRIPT) {
     EMSG(_(e_nesting));
@@ -1272,7 +1248,7 @@ int directly;                   /* when TRUE execute directly */
 /*
  * Close the currently active input script.
  */
-static void closescript()                 {
+static void closescript(void)                 {
   free_typebuf();
   typebuf = saved_typebuf[curscript];
 
@@ -1283,7 +1259,7 @@ static void closescript()                 {
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void close_all_scripts()          {
+void close_all_scripts(void)          {
   while (scriptin[0] != NULL)
     closescript();
 }
@@ -1293,7 +1269,7 @@ void close_all_scripts()          {
 /*
  * Return TRUE when reading keys from a script file.
  */
-int using_script()         {
+int using_script(void)         {
   return scriptin[curscript] != NULL;
 }
 
@@ -1301,7 +1277,7 @@ int using_script()         {
  * This function is called just before doing a blocking wait.  Thus after
  * waiting 'updatetime' for a character to arrive.
  */
-void before_blocking()          {
+void before_blocking(void)          {
   updatescript(0);
   if (may_garbage_collect)
     garbage_collect();
@@ -1314,8 +1290,7 @@ void before_blocking()          {
  * All the changed memfiles are synced if c == 0 or when the number of typed
  * characters reaches 'updatecount' and 'updatecount' is non-zero.
  */
-void updatescript(c)
-int c;
+void updatescript(int c)
 {
   static int count = 0;
 
@@ -1336,7 +1311,7 @@ int c;
  * Collects the bytes of a multibyte character into the whole character.
  * Returns the modifiers in the global "mod_mask".
  */
-int vgetc()         {
+int vgetc(void)         {
   int c, c2;
   int n;
   char_u buf[MB_MAXBYTES + 1];
@@ -1481,7 +1456,7 @@ int vgetc()         {
  * Like vgetc(), but never return a NUL when called recursively, get a key
  * directly from the user (ignoring typeahead).
  */
-int safe_vgetc()         {
+int safe_vgetc(void)         {
   int c;
 
   c = vgetc();
@@ -1494,7 +1469,7 @@ int safe_vgetc()         {
  * Like safe_vgetc(), but loop to handle K_IGNORE.
  * Also ignore scrollbar events.
  */
-int plain_vgetc()         {
+int plain_vgetc(void)         {
   int c;
 
   do {
@@ -1508,7 +1483,7 @@ int plain_vgetc()         {
  * If the next character is a special character or multi-byte, the returned
  * character is not valid!.
  */
-int vpeekc()         {
+int vpeekc(void)         {
   if (old_char != -1)
     return old_char;
   return vgetorpeek(FALSE);
@@ -1518,7 +1493,7 @@ int vpeekc()         {
  * Like vpeekc(), but don't allow mapping.  Do allow checking for terminal
  * codes.
  */
-int vpeekc_nomap()         {
+int vpeekc_nomap(void)         {
   int c;
 
   ++no_mapping;
@@ -1534,7 +1509,7 @@ int vpeekc_nomap()         {
  * Trick: when no typeahead found, but there is something in the typeahead
  * buffer, it must be an ESC that is recognized as the start of a key code.
  */
-int vpeekc_any()         {
+int vpeekc_any(void)         {
   int c;
 
   c = vpeekc();
@@ -1547,7 +1522,7 @@ int vpeekc_any()         {
  * Call vpeekc() without causing anything to be mapped.
  * Return TRUE if a character is available, FALSE otherwise.
  */
-int char_avail()         {
+int char_avail(void)         {
   int retval;
 
   ++no_mapping;
@@ -1556,8 +1531,10 @@ int char_avail()         {
   return retval != NUL;
 }
 
-void vungetc(c) /* unget one character (can only be done once!) */
-int c;
+void 
+vungetc ( /* unget one character (can only be done once!) */
+    int c
+)
 {
   old_char = c;
   old_mod_mask = mod_mask;
@@ -1588,8 +1565,7 @@ int c;
  * Only returns one byte (of a multi-byte character).
  * K_SPECIAL and CSI may be escaped, need to get two more bytes then.
  */
-static int vgetorpeek(advance)
-int advance;
+static int vgetorpeek(int advance)
 {
   int c, c1;
   int keylen;
@@ -2363,11 +2339,13 @@ int advance;
  *  Return the number of obtained characters.
  *  Return -1 when end of input script reached.
  */
-int inchar(buf, maxlen, wait_time, tb_change_cnt)
-char_u      *buf;
-int maxlen;
-long wait_time;                     /* milli seconds */
-int tb_change_cnt;
+int 
+inchar (
+    char_u *buf,
+    int maxlen,
+    long wait_time,                     /* milli seconds */
+    int tb_change_cnt
+)
 {
   int len = 0;                      /* init for GCC */
   int retesc = FALSE;               /* return ESC with gotint */
@@ -2464,10 +2442,12 @@ int tb_change_cnt;
  * buf[] must have room to triple the number of bytes!
  * Returns the new length.
  */
-int fix_input_buffer(buf, len, script)
-char_u      *buf;
-int len;
-int script;                     /* TRUE when reading from a script */
+int 
+fix_input_buffer (
+    char_u *buf,
+    int len,
+    int script                     /* TRUE when reading from a script */
+)
 {
   int i;
   char_u      *p = buf;
@@ -2505,7 +2485,7 @@ int script;                     /* TRUE when reading from a script */
  * or feedkeys() may insert characters in the typeahead buffer while we are
  * waiting for input to arrive.
  */
-int input_available()         {
+int input_available(void)         {
   return !vim_is_input_buf_empty()
          || typebuf_was_filled
   ;
@@ -2551,11 +2531,13 @@ int input_available()         {
  *	  4 for out of mem
  *	  5 for entry not unique
  */
-int do_map(maptype, arg, mode, abbrev)
-int maptype;
-char_u      *arg;
-int mode;
-int abbrev;                     /* not a mapping but an abbreviation */
+int 
+do_map (
+    int maptype,
+    char_u *arg,
+    int mode,
+    int abbrev                     /* not a mapping but an abbreviation */
+)
 {
   char_u      *keys;
   mapblock_T  *mp, **mpp;
@@ -3020,8 +3002,7 @@ theend:
  * Delete one entry from the abbrlist or maphash[].
  * "mpp" is a pointer to the m_next field of the PREVIOUS entry!
  */
-static void map_free(mpp)
-mapblock_T  **mpp;
+static void map_free(mapblock_T **mpp)
 {
   mapblock_T  *mp;
 
@@ -3036,7 +3017,7 @@ mapblock_T  **mpp;
 /*
  * Initialize maphash[] for first use.
  */
-static void validate_maphash()                 {
+static void validate_maphash(void)                 {
   if (!maphash_valid) {
     vim_memset(maphash, 0, sizeof(maphash));
     maphash_valid = TRUE;
@@ -3046,9 +3027,7 @@ static void validate_maphash()                 {
 /*
  * Get the mapping mode from the command name.
  */
-int get_map_mode(cmdp, forceit)
-char_u      **cmdp;
-int forceit;
+int get_map_mode(char_u **cmdp, int forceit)
 {
   char_u      *p;
   int modec;
@@ -3088,11 +3067,7 @@ int forceit;
  * Clear all mappings or abbreviations.
  * 'abbr' should be FALSE for mappings, TRUE for abbreviations.
  */
-void map_clear(cmdp, arg, forceit, abbr)
-char_u      *cmdp;
-char_u      *arg UNUSED;
-int forceit;
-int abbr;
+void map_clear(char_u *cmdp, char_u *arg, int forceit, int abbr)
 {
   int mode;
   int local;
@@ -3112,11 +3087,13 @@ int abbr;
 /*
  * Clear all mappings in "mode".
  */
-void map_clear_int(buf, mode, local, abbr)
-buf_T       *buf UNUSED;        /* buffer for local mappings */
-int mode;                       /* mode in which to delete */
-int local UNUSED;               /* TRUE for buffer-local mappings */
-int abbr;                       /* TRUE for abbreviations */
+void 
+map_clear_int (
+    buf_T *buf,        /* buffer for local mappings */
+    int mode,                       /* mode in which to delete */
+    int local,               /* TRUE for buffer-local mappings */
+    int abbr                       /* TRUE for abbreviations */
+)
 {
   mapblock_T  *mp, **mpp;
   int hash;
@@ -3171,8 +3148,7 @@ int abbr;                       /* TRUE for abbreviations */
  * Return characters to represent the map mode in an allocated string.
  * Returns NULL when out of memory.
  */
-char_u * map_mode_to_chars(mode)
-int mode;
+char_u *map_mode_to_chars(int mode)
 {
   garray_T mapmode;
 
@@ -3208,9 +3184,11 @@ int mode;
   return (char_u *)mapmode.ga_data;
 }
 
-static void showmap(mp, local)
-mapblock_T  *mp;
-int local;                  /* TRUE for buffer-local map */
+static void 
+showmap (
+    mapblock_T *mp,
+    int local                  /* TRUE for buffer-local map */
+)
 {
   int len = 1;
   char_u      *mapchars;
@@ -3274,10 +3252,7 @@ int local;                  /* TRUE for buffer-local map */
  * Recognize termcap codes in "str".
  * Also checks mappings local to the current buffer.
  */
-int map_to_exists(str, modechars, abbr)
-char_u      *str;
-char_u      *modechars;
-int abbr;
+int map_to_exists(char_u *str, char_u *modechars, int abbr)
 {
   int mode = 0;
   char_u      *rhs;
@@ -3313,10 +3288,7 @@ int abbr;
  * Return TRUE if a map exists that has "str" in the rhs for mode "mode".
  * Also checks mappings local to the current buffer.
  */
-int map_to_exists_mode(rhs, mode, abbr)
-char_u      *rhs;
-int mode;
-int abbr;
+int map_to_exists_mode(char_u *rhs, int mode, int abbr)
 {
   mapblock_T  *mp;
   int hash;
@@ -3363,15 +3335,16 @@ static int expand_buffer = FALSE;
  * Work out what to complete when doing command line completion of mapping
  * or abbreviation names.
  */
-char_u * set_context_in_map_cmd(xp, cmd, arg, forceit, isabbrev, isunmap,
-    cmdidx)
-expand_T    *xp;
-char_u      *cmd;
-char_u      *arg;
-int forceit;                    /* TRUE if '!' given */
-int isabbrev;                   /* TRUE if abbreviation */
-int isunmap;                    /* TRUE if unmap/unabbrev command */
-cmdidx_T cmdidx;
+char_u *
+set_context_in_map_cmd (
+    expand_T *xp,
+    char_u *cmd,
+    char_u *arg,
+    int forceit,                    /* TRUE if '!' given */
+    int isabbrev,                   /* TRUE if abbreviation */
+    int isunmap,                    /* TRUE if unmap/unabbrev command */
+    cmdidx_T cmdidx
+)
 {
   if (forceit && cmdidx != CMD_map && cmdidx != CMD_unmap)
     xp->xp_context = EXPAND_NOTHING;
@@ -3425,10 +3398,7 @@ cmdidx_T cmdidx;
  * For command line expansion of ":[un]map" and ":[un]abbrev" in all modes.
  * Return OK if matches found, FAIL otherwise.
  */
-int ExpandMappings(regmatch, num_file, file)
-regmatch_T  *regmatch;
-int         *num_file;
-char_u      ***file;
+int ExpandMappings(regmatch_T *regmatch, int *num_file, char_u ***file)
 {
   mapblock_T  *mp;
   int hash;
@@ -3551,11 +3521,7 @@ char_u      ***file;
  *
  * return TRUE if there is an abbreviation, FALSE if not
  */
-int check_abbr(c, ptr, col, mincol)
-int c;
-char_u      *ptr;
-int col;
-int mincol;
+int check_abbr(int c, char_u *ptr, int col, int mincol)
 {
   int len;
   int scol;                     /* starting column of the abbr. */
@@ -3703,9 +3669,11 @@ int mincol;
  * Evaluate the RHS of a mapping or abbreviations and take care of escaping
  * special characters.
  */
-static char_u * eval_map_expr(str, c)
-char_u      *str;
-int c;                      /* NUL or typed character for abbreviation */
+static char_u *
+eval_map_expr (
+    char_u *str,
+    int c                      /* NUL or typed character for abbreviation */
+)
 {
   char_u      *res;
   char_u      *p;
@@ -3760,8 +3728,7 @@ int c;                      /* NUL or typed character for abbreviation */
  * can be put in the typeahead buffer.
  * Returns NULL when out of memory.
  */
-char_u * vim_strsave_escape_csi(p)
-char_u *p;
+char_u *vim_strsave_escape_csi(char_u *p)
 {
   char_u      *res;
   char_u      *s, *d;
@@ -3799,8 +3766,7 @@ char_u *p;
  * Remove escaping from CSI and K_SPECIAL characters.  Reverse of
  * vim_strsave_escape_csi().  Works in-place.
  */
-void vim_unescape_csi(p)
-char_u *p;
+void vim_unescape_csi(char_u *p)
 {
   char_u      *s = p, *d = p;
 
@@ -3822,9 +3788,11 @@ char_u *p;
  * Write map commands for the current mappings to an .exrc file.
  * Return FAIL on error, OK otherwise.
  */
-int makemap(fd, buf)
-FILE        *fd;
-buf_T       *buf;           /* buffer for local mappings or NULL */
+int 
+makemap (
+    FILE *fd,
+    buf_T *buf           /* buffer for local mappings or NULL */
+)
 {
   mapblock_T  *mp;
   char_u c1, c2, c3;
@@ -4019,10 +3987,7 @@ buf_T       *buf;           /* buffer for local mappings or NULL */
  *
  * return FAIL for failure, OK otherwise
  */
-int put_escstr(fd, strstart, what)
-FILE        *fd;
-char_u      *strstart;
-int what;
+int put_escstr(FILE *fd, char_u *strstart, int what)
 {
   char_u      *str = strstart;
   int c;
@@ -4118,7 +4083,7 @@ int what;
  * Check all mappings for the presence of special key codes.
  * Used after ":set term=xxx".
  */
-void check_map_keycodes()          {
+void check_map_keycodes(void)          {
   mapblock_T  *mp;
   char_u      *p;
   int i;
@@ -4187,14 +4152,16 @@ void check_map_keycodes()          {
  * Return pointer to rhs of mapping (mapblock->m_str).
  * NULL when no mapping found.
  */
-char_u * check_map(keys, mode, exact, ign_mod, abbr, mp_ptr, local_ptr)
-char_u      *keys;
-int mode;
-int exact;                      /* require exact match */
-int ign_mod;                    /* ignore preceding modifier */
-int abbr;                       /* do abbreviations */
-mapblock_T  **mp_ptr;           /* return: pointer to mapblock or NULL */
-int         *local_ptr;         /* return: buffer-local mapping or NULL */
+char_u *
+check_map (
+    char_u *keys,
+    int mode,
+    int exact,                      /* require exact match */
+    int ign_mod,                    /* ignore preceding modifier */
+    int abbr,                       /* do abbreviations */
+    mapblock_T **mp_ptr,           /* return: pointer to mapblock or NULL */
+    int *local_ptr         /* return: buffer-local mapping or NULL */
+)
 {
   int hash;
   int len, minlen;
@@ -4255,9 +4222,7 @@ int         *local_ptr;         /* return: buffer-local mapping or NULL */
  * Add a mapping "map" for mode "mode".
  * Need to put string in allocated memory, because do_map() will modify it.
  */
-void add_map(map, mode)
-char_u      *map;
-int mode;
+void add_map(char_u *map, int mode)
 {
   char_u      *s;
   char_u      *cpo_save = p_cpo;

--- a/src/hangulin.c
+++ b/src/hangulin.c
@@ -96,9 +96,7 @@ static short_u kind_table_for_3[] =
  * 3 bulsik: (current initial sound, input english) -> compound initial sound.
  */
 
-static int comfcon3(v, c)
-int v;
-int c;
+static int comfcon3(int v, int c)
 {
   if (v == 2 && c == 2)
     return 3;
@@ -117,9 +115,7 @@ int c;
  * 3 bulsik: (current vowel, input english) -> compound vowel.
  */
 
-static int comvow3(v, c)
-int v;
-int c;
+static int comvow3(int v, int c)
 {
   switch (v) {
   case 13:                                              /* ㅗ */
@@ -156,9 +152,7 @@ int c;
  * VIM: V = initial sound, I = medial vowel, M = final consonant.
  */
 
-static int comcon3(k, c)
-int k;
-int c;
+static int comcon3(int k, int c)
 {
   switch (k) {
   case 2:                                               /* ㄱ */
@@ -212,8 +206,7 @@ int c;
 /****** 2 벌식자판을 위한 루틴  (Routines for 2 bulsik keyboard) ******/
 /**********************************************************************/
 
-static int kind_table_for_2(c)
-int c;
+static int kind_table_for_2(int c)
 {
   static char_u table[] =
   {
@@ -235,8 +228,7 @@ int c;
  * (2 bulsik: conversion english char. to initial sound of compound type)
  * 결과: 초성이 아니면 0 (If it is not initial sound, return 0).
  */
-static int fcon(c)
-int c;
+static int fcon(int c)
 {
   static char_u table[] =
   {
@@ -259,8 +251,7 @@ int c;
  * (2 bulsik: conversion english char. to medial vowel)
  * 결과: 중성이 아니면 0 (If it is not medial vowel, return 0).
  */
-static int vow(c)
-int c;
+static int vow(int c)
 {
   static char_u table[] =
   {
@@ -282,8 +273,7 @@ int c;
  * (2 bulsik: conversion english char. to prop)
  * 결과: 받침이 아니면 0 (If not prop, return 0)
  */
-static int lcon(c)
-int c;
+static int lcon(int c)
 {
   static char_u table[] =
   {
@@ -304,9 +294,7 @@ int c;
  * (2 bulsik: conversion (curr. prop, input english) to prop)
  */
 
-static int comcon2(k, c)
-int k;
-int c;
+static int comcon2(int k, int c)
 {
   switch (k) {
   case 2:                                       /* ㄱ */
@@ -359,9 +347,7 @@ int c;
  * vowel)
  */
 
-static int comvow2(v, c)
-int v;
-int c;
+static int comvow2(int v, int c)
 {
   switch (v) {
   case 13:                                              /* ㅗ */
@@ -396,22 +382,21 @@ int c;
   return 0;
 }
 
-int hangul_input_state_get()         {
+int hangul_input_state_get(void)         {
   return hangul_input_state;
 }
 
-void hangul_input_state_set(state)
-int state;
+void hangul_input_state_set(int state)
 {
   hangul_input_state = state;
   hangul_input_clear();
 }
 
-int im_get_status()         {
+int im_get_status(void)         {
   return hangul_input_state_get();
 }
 
-void hangul_input_state_toggle()          {
+void hangul_input_state_toggle(void)          {
   if (hangul_input_state_get()) {
     hangul_input_state_set(0);
     if (composing_hangul) {
@@ -428,9 +413,7 @@ void hangul_input_state_toggle()          {
 
 }
 
-static int hangul_automata2(buf, c)
-char_u  *buf;
-int_u   *c;
+static int hangul_automata2(char_u *buf, int_u *c)
 {
   int t,t2;
 
@@ -570,9 +553,7 @@ int_u   *c;
   return AUTOMATA_ERROR;   /* RrEeAaLlLlYy EeRrRrOoRr */
 }
 
-static int hangul_automata3(buf, c)
-char_u  *buf;
-int_u   *c;
+static int hangul_automata3(char_u *buf, int_u *c)
 {
   int t, t2;
 
@@ -665,7 +646,7 @@ int_u   *c;
   return AUTOMATA_SPECIAL;
 }
 
-void hangul_keyboard_set()          {
+void hangul_keyboard_set(void)          {
   int keyboard;
   char    *s;
 
@@ -683,9 +664,7 @@ void hangul_keyboard_set()          {
   }
 }
 
-int hangul_input_process(s, len)
-char_u  *s;
-int len;
+int hangul_input_process(char_u *s, int len)
 {
   int n;
   unsigned int c;
@@ -746,7 +725,7 @@ int len;
   return len;
 }
 
-void hangul_input_clear()          {
+void hangul_input_clear(void)          {
   sp = 0;
   f = F_NULL;
   m = M_NULL;
@@ -1416,11 +1395,7 @@ static const char_u johab_lcon_to_wan[] =
   0xbb, 0xbc, 0xbd, 0xbe             /* ㅋ, ㅌ, ㅍ, ㅎ */
 };
 
-static void convert_ks_to_3(src, fp, mp, lp)
-const char_u    *src;
-int             *fp;
-int             *mp;
-int             *lp;
+static void convert_ks_to_3(const char_u *src, int *fp, int *mp, int *lp)
 {
   int h = *src;
   int low = *(src + 1);
@@ -1447,11 +1422,7 @@ int             *lp;
   }
 }
 
-static int convert_3_to_ks(fv, mv, lv, des)
-int fv;
-int mv;
-int lv;
-char_u  *des;
+static int convert_3_to_ks(int fv, int mv, int lv, char_u *des)
 {
   char_u key[3];
   register int hi, lo, mi = 0, result, found;

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -151,7 +151,7 @@ static void prt_get_attr __ARGS((int hl_id, prt_text_attr_T* pattr, int modec));
  * Parse 'printoptions' and set the flags in "printer_opts".
  * Returns an error message or NULL;
  */
-char_u * parse_printoptions()              {
+char_u *parse_printoptions(void)              {
   return parse_list_options(p_popt, printer_opts, OPT_PRINT_NUM_OPTIONS);
 }
 
@@ -159,7 +159,7 @@ char_u * parse_printoptions()              {
  * Parse 'printoptions' and set the flags in "printer_opts".
  * Returns an error message or NULL;
  */
-char_u * parse_printmbfont()              {
+char_u *parse_printmbfont(void)              {
   return parse_list_options(p_pmfn, mbfont_opts, OPT_MBFONT_NUM_OPTIONS);
 }
 
@@ -172,10 +172,7 @@ char_u * parse_printmbfont()              {
  * Returns an error message for an illegal option, NULL otherwise.
  * Only used for the printer at the moment...
  */
-static char_u * parse_list_options(option_str, table, table_size)
-char_u              *option_str;
-option_table_T      *table;
-int table_size;
+static char_u *parse_list_options(char_u *option_str, option_table_T *table, int table_size)
 {
   char_u      *stringp;
   char_u      *colonp;
@@ -234,16 +231,14 @@ int table_size;
  * If using a dark background, the colors will probably be too bright to show
  * up well on white paper, so reduce their brightness.
  */
-static long_u darken_rgb(rgb)
-long_u rgb;
+static long_u darken_rgb(long_u rgb)
 {
   return ((rgb >> 17) << 16)
          +   (((rgb & 0xff00) >> 9) << 8)
          +   ((rgb & 0xff) >> 1);
 }
 
-static long_u prt_get_term_color(colorindex)
-int colorindex;
+static long_u prt_get_term_color(int colorindex)
 {
   /* TODO: Should check for xterm with 88 or 256 colors. */
   if (t_colors > 8)
@@ -251,10 +246,7 @@ int colorindex;
   return cterm_color_8[colorindex % 8];
 }
 
-static void prt_get_attr(hl_id, pattr, modec)
-int hl_id;
-prt_text_attr_T     *pattr;
-int modec;
+static void prt_get_attr(int hl_id, prt_text_attr_T *pattr, int modec)
 {
   int colorindex;
   long_u fg_color;
@@ -290,8 +282,7 @@ int modec;
   pattr->bg_color = bg_color;
 }
 
-static void prt_set_fg(fg)
-long_u fg;
+static void prt_set_fg(long_u fg)
 {
   if (fg != curr_fg) {
     curr_fg = fg;
@@ -299,8 +290,7 @@ long_u fg;
   }
 }
 
-static void prt_set_bg(bg)
-long_u bg;
+static void prt_set_bg(long_u bg)
 {
   if (bg != curr_bg) {
     curr_bg = bg;
@@ -308,10 +298,7 @@ long_u bg;
   }
 }
 
-static void prt_set_font(bold, italic, underline)
-int bold;
-int italic;
-int underline;
+static void prt_set_font(int bold, int italic, int underline)
 {
   if (curr_bold != bold
       || curr_italic != italic
@@ -326,10 +313,7 @@ int underline;
 /*
  * Print the line number in the left margin.
  */
-static void prt_line_number(psettings, page_line, lnum)
-prt_settings_T *psettings;
-int page_line;
-linenr_T lnum;
+static void prt_line_number(prt_settings_T *psettings, int page_line, linenr_T lnum)
 {
   int i;
   char_u tbuf[20];
@@ -360,7 +344,7 @@ linenr_T lnum;
 /*
  * Get the currently effective header height.
  */
-int prt_header_height()         {
+int prt_header_height(void)         {
   if (printer_opts[OPT_PRINT_HEADERHEIGHT].present)
     return printer_opts[OPT_PRINT_HEADERHEIGHT].number;
   return 2;
@@ -369,7 +353,7 @@ int prt_header_height()         {
 /*
  * Return TRUE if using a line number for printing.
  */
-int prt_use_number()         {
+int prt_use_number(void)         {
   return printer_opts[OPT_PRINT_NUMBER].present
          && TOLOWER_ASC(printer_opts[OPT_PRINT_NUMBER].string[0]) == 'y';
 }
@@ -378,8 +362,7 @@ int prt_use_number()         {
  * Return the unit used in a margin item in 'printoptions'.
  * Returns PRT_UNIT_NONE if not recognized.
  */
-int prt_get_unit(idx)
-int idx;
+int prt_get_unit(int idx)
 {
   int u = PRT_UNIT_NONE;
   int i;
@@ -397,10 +380,7 @@ int idx;
 /*
  * Print the page header.
  */
-static void prt_header(psettings, pagenum, lnum)
-prt_settings_T  *psettings;
-int pagenum;
-linenr_T lnum UNUSED;
+static void prt_header(prt_settings_T *psettings, int pagenum, linenr_T lnum)
 {
   int width = psettings->chars_per_line;
   int page_line;
@@ -481,16 +461,14 @@ linenr_T lnum UNUSED;
 /*
  * Display a print status message.
  */
-static void prt_message(s)
-char_u      *s;
+static void prt_message(char_u *s)
 {
   screen_fill((int)Rows - 1, (int)Rows, 0, (int)Columns, ' ', ' ', 0);
   screen_puts(s, (int)Rows - 1, 0, hl_attr(HLF_R));
   out_flush();
 }
 
-void ex_hardcopy(eap)
-exarg_T     *eap;
+void ex_hardcopy(exarg_T *eap)
 {
   linenr_T lnum;
   int collated_copies, uncollated_copies;
@@ -726,10 +704,7 @@ print_fail_no_begin:
  * Print one page line.
  * Return the next column to print, or zero if the line is finished.
  */
-static colnr_T hardcopy_line(psettings, page_line, ppos)
-prt_settings_T      *psettings;
-int page_line;
-prt_pos_T           *ppos;
+static colnr_T hardcopy_line(prt_settings_T *psettings, int page_line, prt_pos_T *ppos)
 {
   colnr_T col;
   char_u      *line;
@@ -1337,9 +1312,7 @@ static int prt_half_width;
 static char *prt_ascii_encoding;
 static char_u prt_hexchar[] = "0123456789abcdef";
 
-static void prt_write_file_raw_len(buffer, bytes)
-char_u      *buffer;
-int bytes;
+static void prt_write_file_raw_len(char_u *buffer, int bytes)
 {
   if (!prt_file_error
       && fwrite(buffer, sizeof(char_u), bytes, prt_ps_fd)
@@ -1349,15 +1322,12 @@ int bytes;
   }
 }
 
-static void prt_write_file(buffer)
-char_u      *buffer;
+static void prt_write_file(char_u *buffer)
 {
   prt_write_file_len(buffer, (int)STRLEN(buffer));
 }
 
-static void prt_write_file_len(buffer, bytes)
-char_u      *buffer;
-int bytes;
+static void prt_write_file_len(char_u *buffer, int bytes)
 {
   prt_write_file_raw_len(buffer, bytes);
 }
@@ -1365,8 +1335,7 @@ int bytes;
 /*
  * Write a string.
  */
-static void prt_write_string(s)
-char        *s;
+static void prt_write_string(char *s)
 {
   vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer), "%s", s);
   prt_write_file(prt_line_buffer);
@@ -1375,8 +1344,7 @@ char        *s;
 /*
  * Write an int and a space.
  */
-static void prt_write_int(i)
-int i;
+static void prt_write_int(int i)
 {
   sprintf((char *)prt_line_buffer, "%d ", i);
   prt_write_file(prt_line_buffer);
@@ -1385,8 +1353,7 @@ int i;
 /*
  * Write a boolean and a space.
  */
-static void prt_write_boolean(b)
-int b;
+static void prt_write_boolean(int b)
 {
   sprintf((char *)prt_line_buffer, "%s ", (b ? "T" : "F"));
   prt_write_file(prt_line_buffer);
@@ -1395,11 +1362,7 @@ int b;
 /*
  * Write PostScript to re-encode and define the font.
  */
-static void prt_def_font(new_name, encoding, height, font)
-char        *new_name;
-char        *encoding;
-int height;
-char        *font;
+static void prt_def_font(char *new_name, char *encoding, int height, char *font)
 {
   vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer),
       "/_%s /VIM-%s /%s ref\n", new_name, encoding, font);
@@ -1416,10 +1379,7 @@ char        *font;
 /*
  * Write a line to define the CID font.
  */
-static void prt_def_cidfont(new_name, height, cidfont)
-char        *new_name;
-int height;
-char        *cidfont;
+static void prt_def_cidfont(char *new_name, int height, char *cidfont)
 {
   vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer),
       "/_%s /%s[/%s] vim_composefont\n", new_name, prt_cmap, cidfont);
@@ -1432,9 +1392,7 @@ char        *cidfont;
 /*
  * Write a line to define a duplicate of a CID font
  */
-static void prt_dup_cidfont(original_name, new_name)
-char        *original_name;
-char        *new_name;
+static void prt_dup_cidfont(char *original_name, char *new_name)
 {
   vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer),
       "/%s %s d\n", new_name, original_name);
@@ -1446,11 +1404,7 @@ char        *new_name;
  * the fractional part being in the range [0,10^precision).  The fractional part
  * is also rounded based on the precision + 1'th fractional digit.
  */
-static void prt_real_bits(real, precision, pinteger, pfraction)
-double real;
-int precision;
-int         *pinteger;
-int         *pfraction;
+static void prt_real_bits(double real, int precision, int *pinteger, int *pfraction)
 {
   int i;
   int integer;
@@ -1472,9 +1426,7 @@ int         *pfraction;
  * We use prt_real_bits() as %f in sprintf uses the locale setting to decide
  * what decimal point character to use, but PS always requires a '.'.
  */
-static void prt_write_real(val, prec)
-double val;
-int prec;
+static void prt_write_real(double val, int prec)
 {
   int integer;
   int fraction;
@@ -1501,10 +1453,7 @@ int prec;
 /*
  * Write a line to define a numeric variable.
  */
-static void prt_def_var(name, value, prec)
-char        *name;
-double value;
-int prec;
+static void prt_def_var(char *name, double value, int prec)
 {
   vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer),
       "/%s ", name);
@@ -1517,7 +1466,7 @@ int prec;
 /* Convert size from font space to user space at current font scale */
 #define PRT_PS_FONT_TO_USER(scale, size)    ((size) * ((scale)/1000.0))
 
-static void prt_flush_buffer()                 {
+static void prt_flush_buffer(void)                 {
   if (prt_ps_buffer.ga_len > 0) {
     /* Any background color must be drawn first */
     if (prt_do_bgcol && (prt_new_bgcol != PRCOLOR_WHITE)) {
@@ -1585,9 +1534,7 @@ static void prt_flush_buffer()                 {
   }
 }
 
-static void prt_resource_name(filename, cookie)
-char_u  *filename;
-void    *cookie;
+static void prt_resource_name(char_u *filename, void *cookie)
 {
   char_u *resource_filename = cookie;
 
@@ -1597,9 +1544,7 @@ void    *cookie;
     STRCPY(resource_filename, filename);
 }
 
-static int prt_find_resource(name, resource)
-char        *name;
-struct prt_ps_resource_S *resource;
+static int prt_find_resource(char *name, struct prt_ps_resource_S *resource)
 {
   char_u      *buffer;
   int retval;
@@ -1638,7 +1583,7 @@ struct prt_resfile_buffer_S {
 
 static struct prt_resfile_buffer_S prt_resfile;
 
-static int prt_resfile_next_line()                {
+static int prt_resfile_next_line(void)                {
   int idx;
 
   /* Move to start of next line and then find end of line */
@@ -1660,10 +1605,7 @@ static int prt_resfile_next_line()                {
   return idx < prt_resfile.len;
 }
 
-static int prt_resfile_strncmp(offset, string, len)
-int offset;
-char    *string;
-int len;
+static int prt_resfile_strncmp(int offset, char *string, int len)
 {
   /* Force not equal if string is longer than remainder of line */
   if (len > (prt_resfile.line_end - (prt_resfile.line_start + offset)))
@@ -1673,8 +1615,7 @@ int len;
       string, len);
 }
 
-static int prt_resfile_skip_nonws(offset)
-int offset;
+static int prt_resfile_skip_nonws(int offset)
 {
   int idx;
 
@@ -1687,8 +1628,7 @@ int offset;
   return -1;
 }
 
-static int prt_resfile_skip_ws(offset)
-int offset;
+static int prt_resfile_skip_ws(int offset)
 {
   int idx;
 
@@ -1703,8 +1643,7 @@ int offset;
 
 /* prt_next_dsc() - returns detail on next DSC comment line found.  Returns true
  * if a DSC comment is found, else false */
-static int prt_next_dsc(p_dsc_line)
-struct prt_dsc_line_S *p_dsc_line;
+static int prt_next_dsc(struct prt_dsc_line_S *p_dsc_line)
 {
   int comment;
   int offset;
@@ -1749,8 +1688,7 @@ struct prt_dsc_line_S *p_dsc_line;
 /* Improved hand crafted parser to get the type, title, and version number of a
  * PS resource file so the file details can be added to the DSC header comments.
  */
-static int prt_open_resource(resource)
-struct prt_ps_resource_S *resource;
+static int prt_open_resource(struct prt_ps_resource_S *resource)
 {
   int offset;
   int seen_all;
@@ -1866,9 +1804,7 @@ struct prt_ps_resource_S *resource;
   return TRUE;
 }
 
-static int prt_check_resource(resource, version)
-struct prt_ps_resource_S *resource;
-char_u  *version;
+static int prt_check_resource(struct prt_ps_resource_S *resource, char_u *version)
 {
   /* Version number m.n should match, the revision number does not matter */
   if (STRNCMP(resource->version, version, STRLEN(version))) {
@@ -1881,30 +1817,25 @@ char_u  *version;
   return TRUE;
 }
 
-static void prt_dsc_start()                 {
+static void prt_dsc_start(void)                 {
   prt_write_string("%!PS-Adobe-3.0\n");
 }
 
-static void prt_dsc_noarg(comment)
-char        *comment;
+static void prt_dsc_noarg(char *comment)
 {
   vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer),
       "%%%%%s\n", comment);
   prt_write_file(prt_line_buffer);
 }
 
-static void prt_dsc_textline(comment, text)
-char        *comment;
-char        *text;
+static void prt_dsc_textline(char *comment, char *text)
 {
   vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer),
       "%%%%%s: %s\n", comment, text);
   prt_write_file(prt_line_buffer);
 }
 
-static void prt_dsc_text(comment, text)
-char        *comment;
-char        *text;
+static void prt_dsc_text(char *comment, char *text)
 {
   /* TODO - should scan 'text' for any chars needing escaping! */
   vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer),
@@ -1914,10 +1845,7 @@ char        *text;
 
 #define prt_dsc_atend(c)        prt_dsc_text((c), "atend")
 
-static void prt_dsc_ints(comment, count, ints)
-char        *comment;
-int count;
-int         *ints;
+static void prt_dsc_ints(char *comment, int count, int *ints)
 {
   int i;
 
@@ -1933,10 +1861,12 @@ int         *ints;
   prt_write_string("\n");
 }
 
-static void prt_dsc_resources(comment, type, string)
-char        *comment;           /* if NULL add to previous */
-char        *type;
-char        *string;
+static void 
+prt_dsc_resources (
+    char *comment,           /* if NULL add to previous */
+    char *type,
+    char *string
+)
 {
   if (comment != NULL)
     vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer),
@@ -1951,9 +1881,7 @@ char        *string;
   prt_write_file(prt_line_buffer);
 }
 
-static void prt_dsc_font_resource(resource, ps_font)
-char        *resource;
-struct prt_ps_font_S *ps_font;
+static void prt_dsc_font_resource(char *resource, struct prt_ps_font_S *ps_font)
 {
   int i;
 
@@ -1964,12 +1892,7 @@ struct prt_ps_font_S *ps_font;
       prt_dsc_resources(NULL, "font", ps_font->ps_fontname[i]);
 }
 
-static void prt_dsc_requirements(duplex, tumble, collate, color, num_copies)
-int duplex;
-int tumble;
-int collate;
-int color;
-int num_copies;
+static void prt_dsc_requirements(int duplex, int tumble, int collate, int color, int num_copies)
 {
   /* Only output the comment if we need to.
    * Note: tumble is ignored if we are not duplexing
@@ -1999,13 +1922,7 @@ int num_copies;
   prt_write_string("\n");
 }
 
-static void prt_dsc_docmedia(paper_name, width, height, weight, colour, type)
-char        *paper_name;
-double width;
-double height;
-double weight;
-char        *colour;
-char        *type;
+static void prt_dsc_docmedia(char *paper_name, double width, double height, double weight, char *colour, char *type)
 {
   vim_snprintf((char *)prt_line_buffer, sizeof(prt_line_buffer),
       "%%%%DocumentMedia: %s ", paper_name);
@@ -2025,7 +1942,7 @@ char        *type;
   prt_write_string("\n");
 }
 
-void mch_print_cleanup()          {
+void mch_print_cleanup(void)          {
   if (prt_out_mbyte) {
     int i;
 
@@ -2055,10 +1972,7 @@ void mch_print_cleanup()          {
   }
 }
 
-static float to_device_units(idx, physsize, def_number)
-int idx;
-double physsize;
-int def_number;
+static float to_device_units(int idx, double physsize, int def_number)
 {
   float ret;
   int u;
@@ -2093,13 +2007,7 @@ int def_number;
 /*
  * Calculate margins for given width and height from printoptions settings.
  */
-static void prt_page_margins(width, height, left, right, top, bottom)
-double width;
-double height;
-double      *left;
-double      *right;
-double      *top;
-double      *bottom;
+static void prt_page_margins(double width, double height, double *left, double *right, double *top, double *bottom)
 {
   *left   = to_device_units(OPT_PRINT_LEFT, width, 10);
   *right  = width - to_device_units(OPT_PRINT_RIGHT, width, 5);
@@ -2107,15 +2015,14 @@ double      *bottom;
   *bottom = to_device_units(OPT_PRINT_BOT, height, 5);
 }
 
-static void prt_font_metrics(font_scale)
-int font_scale;
+static void prt_font_metrics(int font_scale)
 {
   prt_line_height = (float)font_scale;
   prt_char_width = (float)PRT_PS_FONT_TO_USER(font_scale, prt_ps_font->wx);
 }
 
 
-static int prt_get_cpl()                {
+static int prt_get_cpl(void)                {
   if (prt_use_number()) {
     prt_number_width = PRINT_NUMBER_WIDTH * prt_char_width;
     /* If we are outputting multi-byte characters then line numbers will be
@@ -2130,10 +2037,7 @@ static int prt_get_cpl()                {
   return (int)((prt_right_margin - prt_left_margin) / prt_char_width);
 }
 
-static int prt_build_cid_fontname(font, name, name_len)
-int font;
-char_u  *name;
-int name_len;
+static int prt_build_cid_fontname(int font, char_u *name, int name_len)
 {
   char    *fontname;
 
@@ -2149,7 +2053,7 @@ int name_len;
 /*
  * Get number of lines of text that fit on a page (excluding the header).
  */
-static int prt_get_lpp()                {
+static int prt_get_lpp(void)                {
   int lpp;
 
   /*
@@ -2177,10 +2081,7 @@ static int prt_get_lpp()                {
   return lpp - prt_header_height();
 }
 
-static int prt_match_encoding(p_encoding, p_cmap, pp_mbenc)
-char                        *p_encoding;
-struct prt_ps_mbfont_S      *p_cmap;
-struct prt_ps_encoding_S    **pp_mbenc;
+static int prt_match_encoding(char *p_encoding, struct prt_ps_mbfont_S *p_cmap, struct prt_ps_encoding_S **pp_mbenc)
 {
   int mbenc;
   int enc_len;
@@ -2200,10 +2101,7 @@ struct prt_ps_encoding_S    **pp_mbenc;
   return FALSE;
 }
 
-static int prt_match_charset(p_charset, p_cmap, pp_mbchar)
-char                    *p_charset;
-struct prt_ps_mbfont_S  *p_cmap;
-struct prt_ps_charset_S **pp_mbchar;
+static int prt_match_charset(char *p_charset, struct prt_ps_mbfont_S *p_cmap, struct prt_ps_charset_S **pp_mbchar)
 {
   int mbchar;
   int char_len;
@@ -2224,10 +2122,7 @@ struct prt_ps_charset_S **pp_mbchar;
   return FALSE;
 }
 
-int mch_print_init(psettings, jobname, forceit)
-prt_settings_T *psettings;
-char_u      *jobname;
-int forceit UNUSED;
+int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
 {
   int i;
   char        *paper_name;
@@ -2510,8 +2405,7 @@ int forceit UNUSED;
   return OK;
 }
 
-static int prt_add_resource(resource)
-struct prt_ps_resource_S *resource;
+static int prt_add_resource(struct prt_ps_resource_S *resource)
 {
   FILE*       fd_resource;
   char_u resource_buffer[512];
@@ -2553,8 +2447,7 @@ struct prt_ps_resource_S *resource;
   return TRUE;
 }
 
-int mch_print_begin(psettings)
-prt_settings_T *psettings;
+int mch_print_begin(prt_settings_T *psettings)
 {
   time_t now;
   int bbox[4];
@@ -2925,8 +2818,7 @@ theend:
   return retval;
 }
 
-void mch_print_end(psettings)
-prt_settings_T *psettings;
+void mch_print_end(prt_settings_T *psettings)
 {
   prt_dsc_noarg("Trailer");
 
@@ -2960,7 +2852,7 @@ prt_settings_T *psettings;
   mch_print_cleanup();
 }
 
-int mch_print_end_page()         {
+int mch_print_end_page(void)         {
   prt_flush_buffer();
 
   prt_write_string("re sp\n");
@@ -2970,8 +2862,7 @@ int mch_print_end_page()         {
   return !prt_file_error;
 }
 
-int mch_print_begin_page(str)
-char_u      *str UNUSED;
+int mch_print_begin_page(char_u *str)
 {
   int page_num[2];
 
@@ -3008,16 +2899,14 @@ char_u      *str UNUSED;
   return !prt_file_error;
 }
 
-int mch_print_blank_page()         {
+int mch_print_blank_page(void)         {
   return mch_print_begin_page(NULL) ? (mch_print_end_page()) : FALSE;
 }
 
 static float prt_pos_x = 0;
 static float prt_pos_y = 0;
 
-void mch_print_start_line(margin, page_line)
-int margin;
-int page_line;
+void mch_print_start_line(int margin, int page_line)
 {
   prt_pos_x = prt_left_margin;
   if (margin)
@@ -3031,9 +2920,7 @@ int page_line;
   prt_half_width = FALSE;
 }
 
-int mch_print_text_out(p, len)
-char_u      *p;
-int len UNUSED;
+int mch_print_text_out(char_u *p, int len)
 {
   int need_break;
   char_u ch;
@@ -3214,10 +3101,7 @@ int len UNUSED;
   return need_break;
 }
 
-void mch_print_set_font(iBold, iItalic, iUnderline)
-int iBold;
-int iItalic;
-int iUnderline;
+void mch_print_set_font(int iBold, int iItalic, int iUnderline)
 {
   int font = 0;
 
@@ -3238,16 +3122,14 @@ int iUnderline;
   }
 }
 
-void mch_print_set_bg(bgcol)
-long_u bgcol;
+void mch_print_set_bg(long_u bgcol)
 {
   prt_bgcol = (int)bgcol;
   prt_attribute_change = TRUE;
   prt_need_bgcol = TRUE;
 }
 
-void mch_print_set_fg(fgcol)
-long_u fgcol;
+void mch_print_set_fg(long_u fgcol)
 {
   if (fgcol != (long_u)prt_fgcol) {
     prt_fgcol = (int)fgcol;

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -40,8 +40,7 @@ static int hash_may_resize __ARGS((hashtab_T *ht, int minitems));
 /*
  * Initialize an empty hash table.
  */
-void hash_init(ht)
-hashtab_T *ht;
+void hash_init(hashtab_T *ht)
 {
   /* This zeroes all "ht_" entries and all the "hi_key" in "ht_smallarray". */
   vim_memset(ht, 0, sizeof(hashtab_T));
@@ -53,8 +52,7 @@ hashtab_T *ht;
  * Free the array of a hash table.  Does not free the items it contains!
  * If "ht" is not freed then you should call hash_init() next!
  */
-void hash_clear(ht)
-hashtab_T *ht;
+void hash_clear(hashtab_T *ht)
 {
   if (ht->ht_array != ht->ht_smallarray)
     vim_free(ht->ht_array);
@@ -65,9 +63,7 @@ hashtab_T *ht;
  * have been allocated.  "off" is the offset from the start of the allocate
  * memory to the location of the key (it's always positive).
  */
-void hash_clear_all(ht, off)
-hashtab_T   *ht;
-int off;
+void hash_clear_all(hashtab_T *ht, int off)
 {
   long todo;
   hashitem_T  *hi;
@@ -90,9 +86,7 @@ int off;
  * WARNING: The returned pointer becomes invalid when the hashtable is changed
  * (adding, setting or removing an item)!
  */
-hashitem_T * hash_find(ht, key)
-hashtab_T   *ht;
-char_u      *key;
+hashitem_T *hash_find(hashtab_T *ht, char_u *key)
 {
   return hash_lookup(ht, key, hash_hash(key));
 }
@@ -100,10 +94,7 @@ char_u      *key;
 /*
  * Like hash_find(), but caller computes "hash".
  */
-hashitem_T * hash_lookup(ht, key, hash)
-hashtab_T   *ht;
-char_u      *key;
-hash_T hash;
+hashitem_T *hash_lookup(hashtab_T *ht, char_u *key, hash_T hash)
 {
   hash_T perturb;
   hashitem_T  *freeitem;
@@ -163,7 +154,7 @@ hash_T hash;
  * Useful when trying different hash algorithms.
  * Called when exiting.
  */
-void hash_debug_results()          {
+void hash_debug_results(void)          {
 #ifdef HT_DEBUG
   fprintf(stderr, "\r\n\r\n\r\n\r\n");
   fprintf(stderr, "Number of hashtable lookups: %ld\r\n", hash_count_lookup);
@@ -177,9 +168,7 @@ void hash_debug_results()          {
  * Add item with key "key" to hashtable "ht".
  * Returns FAIL when out of memory or the key is already present.
  */
-int hash_add(ht, key)
-hashtab_T   *ht;
-char_u      *key;
+int hash_add(hashtab_T *ht, char_u *key)
 {
   hash_T hash = hash_hash(key);
   hashitem_T  *hi;
@@ -198,11 +187,7 @@ char_u      *key;
  * "hi" is invalid after this!
  * Returns OK or FAIL (out of memory).
  */
-int hash_add_item(ht, hi, key, hash)
-hashtab_T   *ht;
-hashitem_T  *hi;
-char_u      *key;
-hash_T hash;
+int hash_add_item(hashtab_T *ht, hashitem_T *hi, char_u *key, hash_T hash)
 {
   /* If resizing failed before and it fails again we can't add an item. */
   if (ht->ht_error && hash_may_resize(ht, 0) == FAIL)
@@ -224,9 +209,7 @@ hash_T hash;
  * hash_lookup().
  * The caller must take care of freeing the item itself.
  */
-void hash_remove(ht, hi)
-hashtab_T   *ht;
-hashitem_T  *hi;
+void hash_remove(hashtab_T *ht, hashitem_T *hi)
 {
   --ht->ht_used;
   hi->hi_key = HI_KEY_REMOVED;
@@ -238,8 +221,7 @@ hashitem_T  *hi;
  * Don't use this when items are to be added!
  * Must call hash_unlock() later.
  */
-void hash_lock(ht)
-hashtab_T   *ht;
+void hash_lock(hashtab_T *ht)
 {
   ++ht->ht_locked;
 }
@@ -250,8 +232,7 @@ hashtab_T   *ht;
  * Table will be resized (shrink) when necessary.
  * This must balance a call to hash_lock().
  */
-void hash_unlock(ht)
-hashtab_T   *ht;
+void hash_unlock(hashtab_T *ht)
 {
   --ht->ht_locked;
   (void)hash_may_resize(ht, 0);
@@ -262,9 +243,11 @@ hashtab_T   *ht;
  * Grow a hashtable when there is not enough empty space.
  * Returns OK or FAIL (out of memory).
  */
-static int hash_may_resize(ht, minitems)
-hashtab_T   *ht;
-int minitems;                           /* minimal number of items */
+static int 
+hash_may_resize (
+    hashtab_T *ht,
+    int minitems                           /* minimal number of items */
+)
 {
   hashitem_T temparray[HT_INIT_SIZE];
   hashitem_T  *oldarray, *newarray;
@@ -395,8 +378,7 @@ int minitems;                           /* minimal number of items */
  * when exiting.  Try that with the current hash algorithm and yours.  The
  * lower the percentage the better.
  */
-hash_T hash_hash(key)
-char_u      *key;
+hash_T hash_hash(char_u *key)
 {
   hash_T hash;
   char_u      *p;

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -83,8 +83,7 @@ static cscmd_T cs_cmds[] =
   { NULL, NULL, NULL, NULL, 0 }
 };
 
-static void cs_usage_msg(x)
-csid_e x;
+static void cs_usage_msg(csid_e x)
 {
   (void)EMSG2(_("E560: Usage: cs[cope] %s"), cs_cmds[(int)x].usage);
 }
@@ -101,9 +100,7 @@ static enum {
  * Function given to ExpandGeneric() to obtain the cscope command
  * expansion.
  */
-char_u * get_cscope_name(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_cscope_name(expand_T *xp, int idx)
 {
   int current_idx;
   int i;
@@ -160,10 +157,7 @@ int idx;
 /*
  * Handle command line completion for :cscope command.
  */
-void set_context_in_cscope_cmd(xp, arg, cmdidx)
-expand_T    *xp;
-char_u      *arg;
-cmdidx_T cmdidx;
+void set_context_in_cscope_cmd(expand_T *xp, char_u *arg, cmdidx_T cmdidx)
 {
   char_u      *p;
 
@@ -199,9 +193,11 @@ cmdidx_T cmdidx;
  * Find the command, print help if invalid, and then call the corresponding
  * command function.
  */
-static void do_cscope_general(eap, make_split)
-exarg_T     *eap;
-int make_split;             /* whether to split window */
+static void 
+do_cscope_general (
+    exarg_T *eap,
+    int make_split             /* whether to split window */
+)
 {
   cscmd_T *cmdp;
 
@@ -230,8 +226,7 @@ int make_split;             /* whether to split window */
 /*
  * PUBLIC: do_cscope
  */
-void do_cscope(eap)
-exarg_T *eap;
+void do_cscope(exarg_T *eap)
 {
   do_cscope_general(eap, FALSE);
 }
@@ -241,8 +236,7 @@ exarg_T *eap;
  *
  * same as do_cscope, but splits window, too.
  */
-void do_scscope(eap)
-exarg_T *eap;
+void do_scscope(exarg_T *eap)
 {
   do_cscope_general(eap, TRUE);
 }
@@ -251,8 +245,7 @@ exarg_T *eap;
  * PUBLIC: do_cstag
  *
  */
-void do_cstag(eap)
-exarg_T *eap;
+void do_cstag(exarg_T *eap)
 {
   int ret = FALSE;
 
@@ -319,9 +312,7 @@ exarg_T *eap;
  *
  * returns TRUE if eof, FALSE otherwise
  */
-int cs_fgets(buf, size)
-char_u      *buf;
-int size;
+int cs_fgets(char_u *buf, int size)
 {
   char *p;
 
@@ -338,7 +329,7 @@ int size;
  *
  * called only from do_tag(), when popping the tag stack
  */
-void cs_free_tags()          {
+void cs_free_tags(void)          {
   cs_manage_matches(NULL, NULL, -1, Free);
 }
 
@@ -347,7 +338,7 @@ void cs_free_tags()          {
  *
  * called from do_tag()
  */
-void cs_print_tags()          {
+void cs_print_tags(void)          {
   cs_manage_matches(NULL, NULL, -1, Print);
 }
 
@@ -378,10 +369,7 @@ void cs_print_tags()          {
  *
  *		Note: All string comparisons are case sensitive!
  */
-int cs_connection(num, dbpath, ppath)
-int num;
-char_u *dbpath;
-char_u *ppath;
+int cs_connection(int num, char_u *dbpath, char_u *ppath)
 {
   int i;
 
@@ -439,8 +427,7 @@ char_u *ppath;
  *
  * MAXPATHL 256
  */
-static int cs_add(eap)
-exarg_T *eap UNUSED;
+static int cs_add(exarg_T *eap)
 {
   char *fname, *ppath, *flags = NULL;
 
@@ -454,8 +441,7 @@ exarg_T *eap UNUSED;
   return cs_add_common(fname, ppath, flags);
 }
 
-static void cs_stat_emsg(fname)
-char *fname;
+static void cs_stat_emsg(char *fname)
 {
   char *stat_emsg = _("E563: stat(%s) error: %d");
   char *buf = (char *)alloc((unsigned)strlen(stat_emsg) + MAXPATHL + 10);
@@ -476,10 +462,12 @@ char *fname;
  * cs_add() and cs_reset().  i really don't like to do this, but this
  * routine uses a number of goto statements.
  */
-static int cs_add_common(arg1, arg2, flags)
-char *arg1;         /* filename - may contain environment variables */
-char *arg2;         /* prepend path - may contain environment variables */
-char *flags;
+static int 
+cs_add_common (
+    char *arg1,         /* filename - may contain environment variables */
+    char *arg2,         /* prepend path - may contain environment variables */
+    char *flags
+)
 {
   struct stat statbuf;
   int ret;
@@ -595,11 +583,11 @@ add_err:
 } /* cs_add_common */
 
 
-static int cs_check_for_connections()                {
+static int cs_check_for_connections(void)                {
   return cs_cnt_connections() > 0;
 } /* cs_check_for_connections */
 
-static int cs_check_for_tags()                {
+static int cs_check_for_tags(void)                {
   return p_tags[0] != NUL && curbuf->b_p_tags != NULL;
 } /* cs_check_for_tags */
 
@@ -608,7 +596,7 @@ static int cs_check_for_tags()                {
  *
  * count the number of cscope connections
  */
-static int cs_cnt_connections()                {
+static int cs_cnt_connections(void)                {
   short i;
   short cnt = 0;
 
@@ -619,8 +607,10 @@ static int cs_cnt_connections()                {
   return cnt;
 } /* cs_cnt_connections */
 
-static void cs_reading_emsg(idx)
-int idx;        /* connection index */
+static void 
+cs_reading_emsg (
+    int idx        /* connection index */
+)
 {
   EMSGN(_("E262: error reading cscope connection %ld"), idx);
 }
@@ -631,8 +621,7 @@ int idx;        /* connection index */
  *
  * count the number of matches for a given cscope connection.
  */
-static int cs_cnt_matches(idx)
-int idx;
+static int cs_cnt_matches(int idx)
 {
   char *stok;
   char *buf;
@@ -689,9 +678,7 @@ int idx;
  *
  * Creates the actual cscope command query from what the user entered.
  */
-static char * cs_create_cmd(csoption, pattern)
-char *csoption;
-char *pattern;
+static char *cs_create_cmd(char *csoption, char *pattern)
 {
   char *cmd;
   short search;
@@ -750,8 +737,7 @@ char *pattern;
  * This piece of code was taken/adapted from nvi.  do we need to add
  * the BSD license notice?
  */
-static int cs_create_connection(i)
-int i;
+static int cs_create_connection(int i)
 {
 #ifdef UNIX
   int to_cs[2], from_cs[2];
@@ -964,8 +950,7 @@ err_closing:
  *
  * returns TRUE if we jump to a tag or abort, FALSE if not.
  */
-static int cs_find(eap)
-exarg_T *eap;
+static int cs_find(exarg_T *eap)
 {
   char *opt, *pat;
   int i;
@@ -1004,13 +989,7 @@ exarg_T *eap;
  *
  * common code for cscope find, shared by cs_find() and do_cstag()
  */
-static int cs_find_common(opt, pat, forceit, verbose, use_ll, cmdline)
-char *opt;
-char *pat;
-int forceit;
-int verbose;
-int use_ll;
-char_u *cmdline;
+static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int use_ll, char_u *cmdline)
 {
   int i;
   char *cmd;
@@ -1191,8 +1170,7 @@ char_u *cmdline;
  *
  * print help
  */
-static int cs_help(eap)
-exarg_T *eap UNUSED;
+static int cs_help(exarg_T *eap)
 {
   cscmd_T *cmdp = cs_cmds;
 
@@ -1227,8 +1205,7 @@ exarg_T *eap UNUSED;
 } /* cs_help */
 
 
-static void clear_csinfo(i)
-int i;
+static void clear_csinfo(int i)
 {
   csinfo[i].fname  = NULL;
   csinfo[i].ppath  = NULL;
@@ -1249,7 +1226,7 @@ int i;
 #ifndef UNIX
 static char *GetWin32Error __ARGS((void));
 
-static char * GetWin32Error()                   {
+static char *GetWin32Error(void)                   {
   char *msg = NULL;
   FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER|FORMAT_MESSAGE_FROM_SYSTEM,
       NULL, GetLastError(), 0, (LPSTR)&msg, 0, NULL);
@@ -1269,11 +1246,7 @@ static char * GetWin32Error()                   {
  *
  * insert a new cscope database filename into the filelist
  */
-static int cs_insert_filelist(fname, ppath, flags, sb)
-char *fname;
-char *ppath;
-char *flags;
-struct stat *sb UNUSED;
+static int cs_insert_filelist(char *fname, char *ppath, char *flags, struct stat *sb)
 {
   short i, j;
 #ifndef UNIX
@@ -1425,8 +1398,7 @@ exarg_T *eap;
  *
  * nuke em
  */
-static int cs_kill(eap)
-exarg_T *eap UNUSED;
+static int cs_kill(exarg_T *eap)
 {
   char *stok;
   short i;
@@ -1473,9 +1445,11 @@ exarg_T *eap UNUSED;
  *
  * Actually kills a specific cscope connection.
  */
-static void cs_kill_execute(i, cname)
-int i;              /* cscope table index */
-char *cname;        /* cscope database name */
+static void 
+cs_kill_execute (
+    int i,              /* cscope table index */
+    char *cname        /* cscope database name */
+)
 {
   if (p_csverbose) {
     msg_clr_eos();
@@ -1506,11 +1480,7 @@ char *cname;        /* cscope database name */
  * would still have to be modified to escape all the special regular expression
  * characters to comply with ctags formatting.
  */
-static char * cs_make_vim_style_matches(fname, slno, search, tagstr)
-char *fname;
-char *slno;
-char *search;
-char *tagstr;
+static char *cs_make_vim_style_matches(char *fname, char *slno, char *search, char *tagstr)
 {
   /* vim style is ctags:
    *
@@ -1563,11 +1533,7 @@ char *tagstr;
  *
  * Print: prints the tags
  */
-static char * cs_manage_matches(matches, contexts, totmatches, cmd)
-char **matches;
-char **contexts;
-int totmatches;
-mcmd_e cmd;
+static char *cs_manage_matches(char **matches, char **contexts, int totmatches, mcmd_e cmd)
 {
   static char **mp = NULL;
   static char **cp = NULL;
@@ -1626,14 +1592,7 @@ mcmd_e cmd;
  *
  * parse cscope output
  */
-static char * cs_parse_results(cnumber, buf, bufsize, context, linenumber,
-    search)
-int cnumber;
-char *buf;
-int bufsize;
-char **context;
-char **linenumber;
-char **search;
+static char *cs_parse_results(int cnumber, char *buf, int bufsize, char **context, char **linenumber, char **search)
 {
   int ch;
   char *p;
@@ -1686,9 +1645,7 @@ char **search;
  *
  * write cscope find results to file
  */
-static void cs_file_results(f, nummatches_a)
-FILE *f;
-int *nummatches_a;
+static void cs_file_results(FILE *f, int *nummatches_a)
 {
   int i, j;
   char *buf;
@@ -1741,15 +1698,7 @@ int *nummatches_a;
  * into ctags format
  * When there are no matches sets "*matches_p" to NULL.
  */
-static void cs_fill_results(tagstr, totmatches, nummatches_a, matches_p,
-    cntxts_p,
-    matched)
-char *tagstr;
-int totmatches;
-int *nummatches_a;
-char ***matches_p;
-char ***cntxts_p;
-int *matched;
+static void cs_fill_results(char *tagstr, int totmatches, int *nummatches_a, char ***matches_p, char ***cntxts_p, int *matched)
 {
   int i, j;
   char *buf;
@@ -1819,8 +1768,7 @@ parse_out:
 
 
 /* get the requested path components */
-static char * cs_pathcomponents(path)
-char        *path;
+static char *cs_pathcomponents(char *path)
 {
   int i;
   char        *s;
@@ -1844,10 +1792,7 @@ char        *path;
  *
  * called from cs_manage_matches()
  */
-static void cs_print_tags_priv(matches, cntxts, num_matches)
-char **matches;
-char **cntxts;
-int num_matches;
+static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
 {
   char        *buf = NULL;
   int bufsize = 0;           /* Track available bufsize */
@@ -1973,8 +1918,7 @@ int num_matches;
  *
  * read a cscope prompt (basically, skip over the ">> ")
  */
-static int cs_read_prompt(i)
-int i;
+static int cs_read_prompt(int i)
 {
   int ch;
   char        *buf = NULL;   /* buffer for possible error message from cscope */
@@ -2065,9 +2009,7 @@ sig_handler SIGDEFARG(sigarg) {
  * Does the actual free'ing for the cs ptr with an optional flag of whether
  * or not to free the filename.  Called by cs_kill and cs_reset.
  */
-static void cs_release_csp(i, freefnpp)
-int i;
-int freefnpp;
+static void cs_release_csp(int i, int freefnpp)
 {
   /*
    * Trying to exit normally (not sure whether it is fit to UNIX cscope
@@ -2185,8 +2127,7 @@ int freefnpp;
  *
  * calls cs_kill on all cscope connections then reinits
  */
-static int cs_reset(eap)
-exarg_T *eap UNUSED;
+static int cs_reset(exarg_T *eap)
 {
   char        **dblist = NULL, **pplist = NULL, **fllist = NULL;
   int i;
@@ -2252,9 +2193,7 @@ exarg_T *eap UNUSED;
  * ships with Solaris 2.6), the output never has the prefix prepended.
  * Contrast this with my development system (Digital Unix), which does.
  */
-static char * cs_resolve_file(i, name)
-int i;
-char *name;
+static char *cs_resolve_file(int i, char *name)
 {
   char        *fullname;
   int len;
@@ -2307,8 +2246,7 @@ char *name;
  *
  * show all cscope connections
  */
-static int cs_show(eap)
-exarg_T *eap UNUSED;
+static int cs_show(exarg_T *eap)
 {
   short i;
   if (cs_cnt_connections() == 0)
@@ -2340,7 +2278,7 @@ exarg_T *eap UNUSED;
  *
  * Only called when VIM exits to quit any cscope sessions.
  */
-void cs_end()          {
+void cs_end(void)          {
   int i;
 
   for (i = 0; i < csinfo_size; i++)

--- a/src/main.c
+++ b/src/main.c
@@ -116,10 +116,7 @@ static char *(main_errors[]) =
 };
 
 #ifndef NO_VIM_MAIN     /* skip this for unittests */
-  int
-main(argc, argv)
-  int argc;
-  char        **argv;
+  int main(int argc, char **argv)
 {
   char_u      *fname = NULL;            /* file name from command line */
   mparm_T params;                       /* various parameters passed between
@@ -539,9 +536,11 @@ main(argc, argv)
  * Also used to handle ":visual" command after ":global": execute Normal mode
  * commands, return when entering Ex mode.  "noexmode" is TRUE then.
  */
-void main_loop(cmdwin, noexmode)
-  int cmdwin;                 /* TRUE when working in the command-line window */
-  int noexmode;               /* TRUE when return on entering Ex mode */
+void 
+main_loop (
+    int cmdwin,                 /* TRUE when working in the command-line window */
+    int noexmode               /* TRUE when return on entering Ex mode */
+)
 {
   oparg_T oa;                                   /* operator arguments */
   int previous_got_int = FALSE;                 /* "got_int" was TRUE */
@@ -748,8 +747,7 @@ void main_loop(cmdwin, noexmode)
 
 
 /* Exit properly */
-void getout(exitval)
-  int exitval;
+void getout(int exitval)
 {
   buf_T       *buf;
   win_T       *wp;
@@ -835,10 +833,12 @@ void getout(exitval)
 /*
  * Get a (optional) count for a Vim argument.
  */
-static int get_number_arg(p, idx, def)
-  char_u      *p;             /* pointer to argument */
-  int         *idx;           /* index in argument, is incremented */
-  int def;                    /* default value */
+static int 
+get_number_arg (
+    char_u *p,             /* pointer to argument */
+    int *idx,           /* index in argument, is incremented */
+    int def                    /* default value */
+)
 {
   if (vim_isdigit(p[*idx])) {
     def = atoi((char *)&(p[*idx]));
@@ -852,7 +852,7 @@ static int get_number_arg(p, idx, def)
 /*
  * Setup to use the current locale (for ctype() and many other things).
  */
-static void init_locale()                 {
+static void init_locale(void)                 {
   setlocale(LC_ALL, "");
 
 # if defined(FEAT_FLOAT) && defined(LC_NUMERIC)
@@ -891,8 +891,7 @@ static void init_locale()                 {
  * If the next characters are "ex" we start in Ex mode.  If it's followed
  * by "im" use improved Ex mode.
  */
-static void parse_command_name(parmp)
-  mparm_T     *parmp;
+static void parse_command_name(mparm_T *parmp)
 {
   char_u      *initstr;
 
@@ -961,8 +960,7 @@ static bool parse_string(input, val, len)
 /*
  * Scan the command line arguments.
  */
-static void command_line_scan(parmp)
-  mparm_T     *parmp;
+static void command_line_scan(mparm_T *parmp)
 {
   int argc = parmp->argc;
   char        **argv = parmp->argv;
@@ -1459,10 +1457,7 @@ scripterror:
  * Many variables are in "params" so that we can pass them to invoked
  * functions without a lot of arguments.  "argc" and "argv" are also
  * copied, so that they can be changed. */
-static void init_params(paramp, argc, argv)
-  mparm_T     *paramp;
-  int argc;
-  char        **argv;
+static void init_params(mparm_T *paramp, int argc, char **argv)
 {
   vim_memset(paramp, 0, sizeof(*paramp));
   paramp->argc = argc;
@@ -1475,8 +1470,7 @@ static void init_params(paramp, argc, argv)
 /*
  * Initialize global startuptime file if "--startuptime" passed as an argument.
  */
-static void init_startuptime(paramp)
-  mparm_T     *paramp;
+static void init_startuptime(mparm_T *paramp)
 {
 #ifdef STARTUPTIME
   int i;
@@ -1495,7 +1489,7 @@ static void init_startuptime(paramp)
  * Allocate space for the generic buffers (needed for set_init_1() and
  * EMSG2()).
  */
-static void allocate_generic_buffers()
+static void allocate_generic_buffers(void)
 {
   if ((IObuff = alloc(IOSIZE)) == NULL
       || (NameBuff = alloc(MAXPATHL)) == NULL)
@@ -1509,8 +1503,7 @@ static void allocate_generic_buffers()
  * (needed for :! to * work). mch_check_win() will also handle the -d or
  * -dev argument.
  */
-static void check_and_set_isatty(paramp)
-  mparm_T     *paramp;
+static void check_and_set_isatty(mparm_T *paramp)
 {
   paramp->stdout_isatty = (mch_check_win(paramp->argc, paramp->argv) != FAIL);
   TIME_MSG("window checked");
@@ -1519,8 +1512,7 @@ static void check_and_set_isatty(paramp)
 /*
  * Get filename from command line, given that there is one.
  */
-static char_u* get_fname(parmp)
-  mparm_T     *parmp;
+static char_u *get_fname(mparm_T *parmp)
 {
 #if (!defined(UNIX) && !defined(__EMX__)) || defined(ARCHIE)
   /*
@@ -1541,8 +1533,7 @@ static char_u* get_fname(parmp)
 /*
  * Decide about window layout for diff mode after reading vimrc.
  */
-static void set_window_layout(paramp)
-  mparm_T     *paramp;
+static void set_window_layout(mparm_T *paramp)
 {
   if (paramp->diff_mode && paramp->window_layout == 0) {
     if (diffopt_horizontal())
@@ -1556,7 +1547,7 @@ static void set_window_layout(paramp)
  * Read all the plugin files.
  * Only when compiled with +eval, since most plugins need it.
  */
-static void load_plugins()
+static void load_plugins(void)
 {
   if (p_lpl) {
     source_runtime((char_u *)"plugin/**/*.vim", TRUE);
@@ -1568,8 +1559,7 @@ static void load_plugins()
  * "-q errorfile": Load the error file now.
  * If the error file can't be read, exit before doing anything else.
  */
-static void handle_quickfix(paramp)
-  mparm_T     *paramp;
+static void handle_quickfix(mparm_T *paramp)
 {
   if (paramp->edit_type == EDIT_QF) {
     if (paramp->use_ef != NULL)
@@ -1588,8 +1578,7 @@ static void handle_quickfix(paramp)
  * Need to jump to the tag before executing the '-c command'.
  * Makes "vim -c '/return' -t main" work.
  */
-static void handle_tag(tagname)
-  char_u      *tagname;
+static void handle_tag(char_u *tagname)
 {
   if (tagname != NULL) {
 #if defined(HAS_SWAP_EXISTS_ACTION)
@@ -1612,8 +1601,7 @@ static void handle_tag(tagname)
  * Print a warning if stdout is not a terminal.
  * When starting in Ex mode and commands come from a file, set Silent mode.
  */
-static void check_tty(parmp)
-  mparm_T     *parmp;
+static void check_tty(mparm_T *parmp)
 {
   int input_isatty;                     /* is active input a terminal? */
 
@@ -1637,7 +1625,7 @@ static void check_tty(parmp)
 /*
  * Read text from stdin.
  */
-static void read_stdin()                 {
+static void read_stdin(void)                 {
   int i;
 
 #if defined(HAS_SWAP_EXISTS_ACTION)
@@ -1667,8 +1655,7 @@ static void read_stdin()                 {
  * Create the requested number of windows and edit buffers in them.
  * Also does recovery if "recoverymode" set.
  */
-static void create_windows(parmp)
-  mparm_T     *parmp UNUSED;
+static void create_windows(mparm_T *parmp)
 {
   int dorewind;
   int done = 0;
@@ -1783,8 +1770,7 @@ static void create_windows(parmp)
  * If opened more than one window, start editing files in the other
  * windows.  make_windows() has already opened the windows.
  */
-static void edit_buffers(parmp)
-  mparm_T     *parmp;
+static void edit_buffers(mparm_T *parmp)
 {
   int arg_idx;                          /* index in argument list */
   int i;
@@ -1886,8 +1872,7 @@ static void edit_buffers(parmp)
 /*
  * Execute the commands from --cmd arguments "cmds[cnt]".
  */
-static void exe_pre_commands(parmp)
-  mparm_T     *parmp;
+static void exe_pre_commands(mparm_T *parmp)
 {
   char_u      **cmds = parmp->pre_commands;
   int cnt = parmp->n_pre_commands;
@@ -1908,8 +1893,7 @@ static void exe_pre_commands(parmp)
 /*
  * Execute "+", "-c" and "-S" arguments.
  */
-static void exe_commands(parmp)
-  mparm_T     *parmp;
+static void exe_commands(mparm_T *parmp)
 {
   int i;
 
@@ -1945,8 +1929,7 @@ static void exe_commands(parmp)
 /*
  * Source startup scripts.
  */
-static void source_startup_scripts(parmp)
-  mparm_T     *parmp;
+static void source_startup_scripts(mparm_T *parmp)
 {
   int i;
 
@@ -2075,7 +2058,7 @@ static void source_startup_scripts(parmp)
 /*
  * Setup to start using the GUI.  Exit with an error when not available.
  */
-static void main_start_gui()                 {
+static void main_start_gui(void)                 {
   mch_errmsg(_(e_nogvim));
   mch_errmsg("\n");
   mch_exit(2);
@@ -2087,9 +2070,11 @@ static void main_start_gui()                 {
  * Get an environment variable, and execute it as Ex commands.
  * Returns FAIL if the environment variable was not executed, OK otherwise.
  */
-int process_env(env, is_viminit)
-  char_u      *env;
-  int is_viminit;             /* when TRUE, called for VIMINIT */
+int 
+process_env (
+    char_u *env,
+    int is_viminit             /* when TRUE, called for VIMINIT */
+)
 {
   char_u      *initstr;
   char_u      *save_sourcing_name;
@@ -2120,8 +2105,7 @@ int process_env(env, is_viminit)
  * Used for ".vimrc" and ".exrc".
  * Use both stat() and lstat() for extra security.
  */
-static int file_owned(fname)
-  char        *fname;
+static int file_owned(char *fname)
 {
   struct stat s;
 # ifdef UNIX
@@ -2141,9 +2125,11 @@ static int file_owned(fname)
 /*
  * Give an error message main_errors["n"] and exit.
  */
-static void mainerr(n, str)
-  int n;                  /* one of the ME_ defines */
-  char_u      *str;       /* extra argument or NULL */
+static void 
+mainerr (
+    int n,                  /* one of the ME_ defines */
+    char_u *str       /* extra argument or NULL */
+)
 {
 #if defined(UNIX) || defined(__EMX__) || defined(VMS)
   reset_signals();              /* kill us with CTRL-C here, if you like */
@@ -2162,8 +2148,7 @@ static void mainerr(n, str)
   mch_exit(1);
 }
 
-void mainerr_arg_missing(str)
-  char_u      *str;
+void mainerr_arg_missing(char_u *str)
 {
   mainerr(ME_ARG_MISSING, str);
 }
@@ -2172,8 +2157,7 @@ void mainerr_arg_missing(str)
 /*
  * print a message with three spaces prepended and '\n' appended.
  */
-static void main_msg(s)
-  char *s;
+static void main_msg(char *s)
 {
   mch_msg("   ");
   mch_msg(s);
@@ -2183,7 +2167,7 @@ static void main_msg(s)
 /*
  * Print messages for "vim -h" or "vim --help" and exit.
  */
-static void usage()                 {
+static void usage(void)                 {
   int i;
   static char *(use[]) =
   {
@@ -2272,7 +2256,7 @@ static void usage()                 {
  * When "Quit" selected, exit Vim.
  * When "Recover" selected, recover the file.
  */
-static void check_swap_exists_action()                 {
+static void check_swap_exists_action(void)                 {
   if (swap_exists_action == SEA_QUIT)
     getout(1);
   handle_swap_exists(NULL);
@@ -2292,8 +2276,7 @@ static struct timeval prev_timeval;
  * Save the previous time before doing something that could nest.
  * set "*tv_rel" to the time elapsed so far.
  */
-void time_push(tv_rel, tv_start)
-  void        *tv_rel, *tv_start;
+void time_push(void *tv_rel, void *tv_start)
 {
   *((struct timeval *)tv_rel) = prev_timeval;
   gettimeofday(&prev_timeval, NULL);
@@ -2314,8 +2297,10 @@ void time_push(tv_rel, tv_start)
  * Note: The arguments are (void *) to avoid trouble with systems that don't
  * have struct timeval.
  */
-void time_pop(tp)
-  void        *tp;        /* actually (struct timeval *) */
+void 
+time_pop (
+    void *tp        /* actually (struct timeval *) */
+)
 {
   prev_timeval.tv_usec -= ((struct timeval *)tp)->tv_usec;
   prev_timeval.tv_sec -= ((struct timeval *)tp)->tv_sec;
@@ -2325,9 +2310,7 @@ void time_pop(tp)
   }
 }
 
-static void time_diff(then, now)
-  struct timeval      *then;
-  struct timeval      *now;
+static void time_diff(struct timeval *then, struct timeval *now)
 {
   long usec;
   long msec;
@@ -2338,10 +2321,12 @@ static void time_diff(then, now)
   fprintf(time_fd, "%03ld.%03ld", msec, usec >= 0 ? usec : usec + 1000L);
 }
 
-void time_msg(mesg, tv_start)
-  char        *mesg;
-  void        *tv_start;      /* only for do_source: start time; actually
+void 
+time_msg (
+    char *mesg,
+    void *tv_start      /* only for do_source: start time; actually
                                  (struct timeval *) */
+)
 {
   static struct timeval start;
   struct timeval now;

--- a/src/mark.c
+++ b/src/mark.c
@@ -38,8 +38,7 @@ static void write_one_filemark __ARGS((FILE *fp, xfmark_T *fm, int c1, int c2));
  * Set named mark "c" at current cursor position.
  * Returns OK on success, FAIL if bad name given.
  */
-int setmark(c)
-int c;
+int setmark(int c)
 {
   return setmark_pos(c, &curwin->w_cursor, curbuf->b_fnum);
 }
@@ -49,10 +48,7 @@ int c;
  * When "c" is upper case use file "fnum".
  * Returns OK on success, FAIL if bad name given.
  */
-int setmark_pos(c, pos, fnum)
-int c;
-pos_T       *pos;
-int fnum;
+int setmark_pos(int c, pos_T *pos, int fnum)
 {
   int i;
 
@@ -120,7 +116,7 @@ int fnum;
  * Set the previous context mark to the current position and add it to the
  * jump list.
  */
-void setpcmark()          {
+void setpcmark(void)          {
   int i;
   xfmark_T    *fm;
 #ifdef JUMPLIST_ROTATE
@@ -172,7 +168,7 @@ void setpcmark()          {
  * context will only be changed if the cursor moved to a different line.
  * If pcmark was deleted (with "dG") the previous mark is restored.
  */
-void checkpcmark()          {
+void checkpcmark(void)          {
   if (curwin->w_prev_pcmark.lnum != 0
       && (equalpos(curwin->w_pcmark, curwin->w_cursor)
           || curwin->w_pcmark.lnum == 0)) {
@@ -184,8 +180,7 @@ void checkpcmark()          {
 /*
  * move "count" positions in the jump list (count may be negative)
  */
-pos_T * movemark(count)
-int count;
+pos_T *movemark(int count)
 {
   pos_T       *pos;
   xfmark_T    *jmp;
@@ -238,8 +233,7 @@ int count;
 /*
  * Move "count" positions in the changelist (count may be negative).
  */
-pos_T * movechangelist(count)
-int count;
+pos_T *movechangelist(int count)
 {
   int n;
 
@@ -272,26 +266,17 @@ int count;
  * - NULL if there is no mark called 'c'.
  * - -1 if mark is in other file and jumped there (only if changefile is TRUE)
  */
-pos_T * getmark_buf(buf, c, changefile)
-buf_T       *buf;
-int c;
-int changefile;
+pos_T *getmark_buf(buf_T *buf, int c, int changefile)
 {
   return getmark_buf_fnum(buf, c, changefile, NULL);
 }
 
-pos_T * getmark(c, changefile)
-int c;
-int changefile;
+pos_T *getmark(int c, int changefile)
 {
   return getmark_buf_fnum(curbuf, c, changefile, NULL);
 }
 
-pos_T * getmark_buf_fnum(buf, c, changefile, fnum)
-buf_T       *buf;
-int c;
-int changefile;
-int         *fnum;
+pos_T *getmark_buf_fnum(buf_T *buf, int c, int changefile, int *fnum)
 {
   pos_T               *posp;
   pos_T               *startp, *endp;
@@ -404,10 +389,12 @@ int         *fnum;
  *
  * Returns pointer to pos_T of the next mark or NULL if no mark is found.
  */
-pos_T * getnextmark(startpos, dir, begin_line)
-pos_T       *startpos;          /* where to start */
-int dir;                /* direction for search */
-int begin_line;
+pos_T *
+getnextmark (
+    pos_T *startpos,          /* where to start */
+    int dir,                /* direction for search */
+    int begin_line
+)
 {
   int i;
   pos_T       *result = NULL;
@@ -446,8 +433,7 @@ int begin_line;
  * This is used for marks obtained from the .viminfo file.  It's postponed
  * until the mark is used to avoid a long startup delay.
  */
-static void fname2fnum(fm)
-xfmark_T    *fm;
+static void fname2fnum(xfmark_T *fm)
 {
   char_u      *p;
 
@@ -483,8 +469,7 @@ xfmark_T    *fm;
  * May replace the name with an fnum.
  * Used for marks that come from the .viminfo file.
  */
-void fmarks_check_names(buf)
-buf_T       *buf;
+void fmarks_check_names(buf_T *buf)
 {
   char_u      *name;
   int i;
@@ -509,10 +494,7 @@ buf_T       *buf;
   vim_free(name);
 }
 
-static void fmarks_check_one(fm, name, buf)
-xfmark_T    *fm;
-char_u      *name;
-buf_T       *buf;
+static void fmarks_check_one(xfmark_T *fm, char_u *name, buf_T *buf)
 {
   if (fm->fmark.fnum == 0
       && fm->fname != NULL
@@ -527,8 +509,7 @@ buf_T       *buf;
  * Check a if a position from a mark is valid.
  * Give and error message and return FAIL if not.
  */
-int check_mark(pos)
-pos_T    *pos;
+int check_mark(pos_T *pos)
 {
   if (pos == NULL) {
     EMSG(_(e_umark));
@@ -553,8 +534,7 @@ pos_T    *pos;
  *
  * Used mainly when trashing the entire buffer during ":e" type commands
  */
-void clrallmarks(buf)
-buf_T       *buf;
+void clrallmarks(buf_T *buf)
 {
   static int i = -1;
 
@@ -581,9 +561,7 @@ buf_T       *buf;
  * When it's in the current buffer, return the text at the mark.
  * Returns an allocated string.
  */
-char_u * fm_getname(fmark, lead_len)
-fmark_T     *fmark;
-int lead_len;
+char_u *fm_getname(fmark_T *fmark, int lead_len)
 {
   if (fmark->fnum == curbuf->b_fnum)                /* current buffer */
     return mark_line(&(fmark->mark), lead_len);
@@ -594,9 +572,7 @@ int lead_len;
  * Return the line at mark "mp".  Truncate to fit in window.
  * The returned string has been allocated.
  */
-static char_u * mark_line(mp, lead_len)
-pos_T       *mp;
-int lead_len;
+static char_u *mark_line(pos_T *mp, int lead_len)
 {
   char_u      *s, *p;
   int len;
@@ -620,8 +596,7 @@ int lead_len;
 /*
  * print the marks
  */
-void do_marks(eap)
-exarg_T     *eap;
+void do_marks(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   int i;
@@ -656,12 +631,14 @@ exarg_T     *eap;
   show_one_mark(-1, arg, NULL, NULL, FALSE);
 }
 
-static void show_one_mark(c, arg, p, name, current)
-int c;
-char_u      *arg;
-pos_T       *p;
-char_u      *name;
-int current;                    /* in current file */
+static void 
+show_one_mark (
+    int c,
+    char_u *arg,
+    pos_T *p,
+    char_u *name,
+    int current                    /* in current file */
+)
 {
   static int did_title = FALSE;
   int mustfree = FALSE;
@@ -706,8 +683,7 @@ int current;                    /* in current file */
 /*
  * ":delmarks[!] [marks]"
  */
-void ex_delmarks(eap)
-exarg_T *eap;
+void ex_delmarks(exarg_T *eap)
 {
   char_u      *p;
   int from, to;
@@ -778,8 +754,7 @@ exarg_T *eap;
 /*
  * print the jumplist
  */
-void ex_jumps(eap)
-exarg_T     *eap UNUSED;
+void ex_jumps(exarg_T *eap)
 {
   int i;
   char_u      *name;
@@ -822,8 +797,7 @@ exarg_T     *eap UNUSED;
 /*
  * print the changelist
  */
-void ex_changes(eap)
-exarg_T     *eap UNUSED;
+void ex_changes(exarg_T *eap)
 {
   int i;
   char_u      *name;
@@ -896,11 +870,7 @@ exarg_T     *eap UNUSED;
  * Example: Insert two lines below 55: mark_adjust(56, MAXLNUM, 2, 0);
  *				   or: mark_adjust(56, 55, MAXLNUM, 2);
  */
-void mark_adjust(line1, line2, amount, amount_after)
-linenr_T line1;
-linenr_T line2;
-long amount;
-long amount_after;
+void mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_after)
 {
   int i;
   int fnum = curbuf->b_fnum;
@@ -1043,11 +1013,7 @@ long amount_after;
  * "lnum_amount" to the line number and add "col_amount" to the column
  * position.
  */
-void mark_col_adjust(lnum, mincol, lnum_amount, col_amount)
-linenr_T lnum;
-colnr_T mincol;
-long lnum_amount;
-long col_amount;
+void mark_col_adjust(linenr_T lnum, colnr_T mincol, long lnum_amount, long col_amount)
 {
   int i;
   int fnum = curbuf->b_fnum;
@@ -1118,7 +1084,7 @@ long col_amount;
  * When deleting lines, this may create duplicate marks in the
  * jumplist. They will be removed here for the current window.
  */
-static void cleanup_jumplist()                 {
+static void cleanup_jumplist(void)                 {
   int i;
   int from, to;
 
@@ -1146,9 +1112,7 @@ static void cleanup_jumplist()                 {
 /*
  * Copy the jumplist from window "from" to window "to".
  */
-void copy_jumplist(from, to)
-win_T       *from;
-win_T       *to;
+void copy_jumplist(win_T *from, win_T *to)
 {
   int i;
 
@@ -1164,8 +1128,7 @@ win_T       *to;
 /*
  * Free items in the jumplist of window "wp".
  */
-void free_jumplist(wp)
-win_T       *wp;
+void free_jumplist(win_T *wp)
 {
   int i;
 
@@ -1173,15 +1136,14 @@ win_T       *wp;
     vim_free(wp->w_jumplist[i].fname);
 }
 
-void set_last_cursor(win)
-win_T       *win;
+void set_last_cursor(win_T *win)
 {
   if (win->w_buffer != NULL)
     win->w_buffer->b_last_cursor = win->w_cursor;
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_all_marks()          {
+void free_all_marks(void)          {
   int i;
 
   for (i = 0; i < NMARKS + EXTRA_MARKS; i++)
@@ -1191,9 +1153,7 @@ void free_all_marks()          {
 
 #endif
 
-int read_viminfo_filemark(virp, force)
-vir_T       *virp;
-int force;
+int read_viminfo_filemark(vir_T *virp, int force)
 {
   char_u      *str;
   xfmark_T    *fm;
@@ -1239,8 +1199,7 @@ int force;
   return vim_fgets(virp->vir_line, LSIZE, virp->vir_fd);
 }
 
-void write_viminfo_filemarks(fp)
-FILE        *fp;
+void write_viminfo_filemarks(FILE *fp)
 {
   int i;
   char_u      *name;
@@ -1295,11 +1254,7 @@ FILE        *fp;
   }
 }
 
-static void write_one_filemark(fp, fm, c1, c2)
-FILE        *fp;
-xfmark_T    *fm;
-int c1;
-int c2;
+static void write_one_filemark(FILE *fp, xfmark_T *fm, int c1, int c2)
 {
   char_u      *name;
 
@@ -1323,8 +1278,7 @@ int c2;
 /*
  * Return TRUE if "name" is on removable media (depending on 'viminfo').
  */
-int removable(name)
-char_u  *name;
+int removable(char_u *name)
 {
   char_u  *p;
   char_u part[51];
@@ -1354,8 +1308,7 @@ static void write_one_mark __ARGS((FILE *fp_out, int c, pos_T *pos));
  * Write all the named marks for all buffers.
  * Return the number of buffers for which marks have been written.
  */
-int write_viminfo_marks(fp_out)
-FILE        *fp_out;
+int write_viminfo_marks(FILE *fp_out)
 {
   int count;
   buf_T       *buf;
@@ -1409,10 +1362,7 @@ FILE        *fp_out;
   return count;
 }
 
-static void write_one_mark(fp_out, c, pos)
-FILE        *fp_out;
-int c;
-pos_T       *pos;
+static void write_one_mark(FILE *fp_out, int c, pos_T *pos)
 {
   if (pos->lnum != 0)
     fprintf(fp_out, "\t%c\t%ld\t%d\n", c, (long)pos->lnum, (int)pos->col);
@@ -1424,12 +1374,7 @@ pos_T       *pos;
  * fp_out == NULL && (flags & VIF_WANT_MARKS): read marks for curbuf only
  * fp_out == NULL && (flags & VIF_GET_OLDFILES | VIF_FORCEIT): fill v:oldfiles
  */
-void copy_viminfo_marks(virp, fp_out, count, eof, flags)
-vir_T       *virp;
-FILE        *fp_out;
-int count;
-int eof;
-int flags;
+void copy_viminfo_marks(vir_T *virp, FILE *fp_out, int count, int eof, int flags)
 {
   char_u      *line = virp->vir_line;
   buf_T       *buf;

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -109,9 +109,7 @@ static int mf_hash_grow __ARGS((mf_hashtab_T *));
  *
  * return value: identifier for this memory block file.
  */
-memfile_T * mf_open(fname, flags)
-char_u      *fname;
-int flags;
+memfile_T *mf_open(char_u *fname, int flags)
 {
   memfile_T           *mfp;
   off_t size;
@@ -203,9 +201,7 @@ int flags;
  *
  * return value: FAIL if file could not be opened, OK otherwise
  */
-int mf_open_file(mfp, fname)
-memfile_T   *mfp;
-char_u      *fname;
+int mf_open_file(memfile_T *mfp, char_u *fname)
 {
   mf_do_open(mfp, fname, O_RDWR|O_CREAT|O_EXCL);   /* try to open the file */
 
@@ -219,9 +215,7 @@ char_u      *fname;
 /*
  * Close a memory file and delete the associated file if 'del_file' is TRUE.
  */
-void mf_close(mfp, del_file)
-memfile_T   *mfp;
-int del_file;
+void mf_close(memfile_T *mfp, int del_file)
 {
   bhdr_T      *hp, *nextp;
 
@@ -251,9 +245,11 @@ int del_file;
 /*
  * Close the swap file for a memfile.  Used when 'swapfile' is reset.
  */
-void mf_close_file(buf, getlines)
-buf_T       *buf;
-int getlines;                   /* get all lines into memory? */
+void 
+mf_close_file (
+    buf_T *buf,
+    int getlines                   /* get all lines into memory? */
+)
 {
   memfile_T   *mfp;
   linenr_T lnum;
@@ -288,9 +284,7 @@ int getlines;                   /* get all lines into memory? */
  * Set new size for a memfile.  Used when block 0 of a swapfile has been read
  * and the size it indicates differs from what was guessed.
  */
-void mf_new_page_size(mfp, new_size)
-memfile_T   *mfp;
-unsigned new_size;
+void mf_new_page_size(memfile_T *mfp, unsigned new_size)
 {
   /* Correct the memory used for block 0 to the new size, because it will be
    * freed with that size later on. */
@@ -303,10 +297,7 @@ unsigned new_size;
  *
  *   negative: TRUE if negative block number desired (data block)
  */
-bhdr_T * mf_new(mfp, negative, page_count)
-memfile_T   *mfp;
-int negative;
-int page_count;
+bhdr_T *mf_new(memfile_T *mfp, int negative, int page_count)
 {
   bhdr_T      *hp;      /* new bhdr_T */
   bhdr_T      *freep;   /* first block in free list */
@@ -384,10 +375,7 @@ int page_count;
  *
  * Note: The caller should first check a negative nr with mf_trans_del()
  */
-bhdr_T * mf_get(mfp, nr, page_count)
-memfile_T   *mfp;
-blocknr_T nr;
-int page_count;
+bhdr_T *mf_get(memfile_T *mfp, blocknr_T nr, int page_count)
 {
   bhdr_T    *hp;
   /* doesn't exist */
@@ -440,11 +428,7 @@ int page_count;
  *
  *  no return value, function cannot fail
  */
-void mf_put(mfp, hp, dirty, infile)
-memfile_T   *mfp;
-bhdr_T      *hp;
-int dirty;
-int infile;
+void mf_put(memfile_T *mfp, bhdr_T *hp, int dirty, int infile)
 {
   int flags;
 
@@ -465,9 +449,7 @@ int infile;
 /*
  * block *hp is no longer in used, may put it in the free list of memfile *mfp
  */
-void mf_free(mfp, hp)
-memfile_T   *mfp;
-bhdr_T      *hp;
+void mf_free(memfile_T *mfp, bhdr_T *hp)
 {
   vim_free(hp->bh_data);        /* free the memory */
   mf_rem_hash(mfp, hp);         /* get *hp out of the hash list */
@@ -502,9 +484,7 @@ static unsigned long fdtofh(int filedescriptor)                          {
  *
  * Return FAIL for failure, OK otherwise
  */
-int mf_sync(mfp, flags)
-memfile_T   *mfp;
-int flags;
+int mf_sync(memfile_T *mfp, int flags)
 {
   int status;
   bhdr_T      *hp;
@@ -603,8 +583,7 @@ int flags;
  * the dirty flag.  These are blocks that need to be written to a newly
  * created swapfile.
  */
-void mf_set_dirty(mfp)
-memfile_T   *mfp;
+void mf_set_dirty(memfile_T *mfp)
 {
   bhdr_T      *hp;
 
@@ -617,9 +596,7 @@ memfile_T   *mfp;
 /*
  * insert block *hp in front of hashlist of memfile *mfp
  */
-static void mf_ins_hash(mfp, hp)
-memfile_T   *mfp;
-bhdr_T      *hp;
+static void mf_ins_hash(memfile_T *mfp, bhdr_T *hp)
 {
   mf_hash_add_item(&mfp->mf_hash, (mf_hashitem_T *)hp);
 }
@@ -627,9 +604,7 @@ bhdr_T      *hp;
 /*
  * remove block *hp from hashlist of memfile list *mfp
  */
-static void mf_rem_hash(mfp, hp)
-memfile_T   *mfp;
-bhdr_T      *hp;
+static void mf_rem_hash(memfile_T *mfp, bhdr_T *hp)
 {
   mf_hash_rem_item(&mfp->mf_hash, (mf_hashitem_T *)hp);
 }
@@ -637,9 +612,7 @@ bhdr_T      *hp;
 /*
  * look in hash lists of memfile *mfp for block header with number 'nr'
  */
-static bhdr_T * mf_find_hash(mfp, nr)
-memfile_T   *mfp;
-blocknr_T nr;
+static bhdr_T *mf_find_hash(memfile_T *mfp, blocknr_T nr)
 {
   return (bhdr_T *)mf_hash_find(&mfp->mf_hash, nr);
 }
@@ -647,9 +620,7 @@ blocknr_T nr;
 /*
  * insert block *hp in front of used list of memfile *mfp
  */
-static void mf_ins_used(mfp, hp)
-memfile_T   *mfp;
-bhdr_T      *hp;
+static void mf_ins_used(memfile_T *mfp, bhdr_T *hp)
 {
   hp->bh_next = mfp->mf_used_first;
   mfp->mf_used_first = hp;
@@ -665,9 +636,7 @@ bhdr_T      *hp;
 /*
  * remove block *hp from used list of memfile *mfp
  */
-static void mf_rem_used(mfp, hp)
-memfile_T   *mfp;
-bhdr_T      *hp;
+static void mf_rem_used(memfile_T *mfp, bhdr_T *hp)
 {
   if (hp->bh_next == NULL)          /* last block in used list */
     mfp->mf_used_last = hp->bh_prev;
@@ -688,9 +657,7 @@ bhdr_T      *hp;
  * Return the block header to the caller, including the memory block, so
  * it can be re-used. Make sure the page_count is right.
  */
-static bhdr_T * mf_release(mfp, page_count)
-memfile_T   *mfp;
-int page_count;
+static bhdr_T *mf_release(memfile_T *mfp, int page_count)
 {
   bhdr_T      *hp;
   int need_release;
@@ -768,7 +735,7 @@ int page_count;
  *
  * return TRUE if any memory was released
  */
-int mf_release_all()         {
+int mf_release_all(void)         {
   buf_T       *buf;
   memfile_T   *mfp;
   bhdr_T      *hp;
@@ -804,9 +771,7 @@ int mf_release_all()         {
 /*
  * Allocate a block header and a block of memory for it
  */
-static bhdr_T * mf_alloc_bhdr(mfp, page_count)
-memfile_T   *mfp;
-int page_count;
+static bhdr_T *mf_alloc_bhdr(memfile_T *mfp, int page_count)
 {
   bhdr_T      *hp;
 
@@ -824,8 +789,7 @@ int page_count;
 /*
  * Free a block header and the block of memory for it
  */
-static void mf_free_bhdr(hp)
-bhdr_T      *hp;
+static void mf_free_bhdr(bhdr_T *hp)
 {
   vim_free(hp->bh_data);
   vim_free(hp);
@@ -834,9 +798,7 @@ bhdr_T      *hp;
 /*
  * insert entry *hp in the free list
  */
-static void mf_ins_free(mfp, hp)
-memfile_T   *mfp;
-bhdr_T      *hp;
+static void mf_ins_free(memfile_T *mfp, bhdr_T *hp)
 {
   hp->bh_next = mfp->mf_free_first;
   mfp->mf_free_first = hp;
@@ -846,8 +808,7 @@ bhdr_T      *hp;
  * remove the first entry from the free list and return a pointer to it
  * Note: caller must check that mfp->mf_free_first is not NULL!
  */
-static bhdr_T * mf_rem_free(mfp)
-memfile_T   *mfp;
+static bhdr_T *mf_rem_free(memfile_T *mfp)
 {
   bhdr_T      *hp;
 
@@ -861,9 +822,7 @@ memfile_T   *mfp;
  *
  * Return FAIL for failure, OK otherwise
  */
-static int mf_read(mfp, hp)
-memfile_T   *mfp;
-bhdr_T      *hp;
+static int mf_read(memfile_T *mfp, bhdr_T *hp)
 {
   off_t offset;
   unsigned page_size;
@@ -896,9 +855,7 @@ bhdr_T      *hp;
  *
  * Return FAIL for failure, OK otherwise
  */
-static int mf_write(mfp, hp)
-memfile_T   *mfp;
-bhdr_T      *hp;
+static int mf_write(memfile_T *mfp, bhdr_T *hp)
 {
   off_t offset;             /* offset in the file */
   blocknr_T nr;             /* block nr which is being written */
@@ -969,11 +926,7 @@ bhdr_T      *hp;
  * Takes care of encryption.
  * Return FAIL or OK.
  */
-static int mf_write_block(mfp, hp, offset, size)
-memfile_T   *mfp;
-bhdr_T      *hp;
-off_t offset UNUSED;
-unsigned size;
+static int mf_write_block(memfile_T *mfp, bhdr_T *hp, off_t offset, unsigned size)
 {
   char_u      *data = hp->bh_data;
   int result = OK;
@@ -999,9 +952,7 @@ unsigned size;
  *
  * Return FAIL for failure, OK otherwise
  */
-static int mf_trans_add(mfp, hp)
-memfile_T   *mfp;
-bhdr_T      *hp;
+static int mf_trans_add(memfile_T *mfp, bhdr_T *hp)
 {
   bhdr_T      *freep;
   blocknr_T new_bnum;
@@ -1057,9 +1008,7 @@ bhdr_T      *hp;
  *
  * Return the positive new number when found, the old number when not found
  */
-blocknr_T mf_trans_del(mfp, old_nr)
-memfile_T   *mfp;
-blocknr_T old_nr;
+blocknr_T mf_trans_del(memfile_T *mfp, blocknr_T old_nr)
 {
   NR_TRANS    *np;
   blocknr_T new_bnum;
@@ -1085,8 +1034,7 @@ blocknr_T old_nr;
  * Only called when creating or renaming the swapfile.	Either way it's a new
  * name so we must work out the full path name.
  */
-void mf_set_ffname(mfp)
-memfile_T   *mfp;
+void mf_set_ffname(memfile_T *mfp)
 {
   mfp->mf_ffname = FullName_save(mfp->mf_fname, FALSE);
 }
@@ -1095,8 +1043,7 @@ memfile_T   *mfp;
  * Make the name of the file used for the memfile a full path.
  * Used before doing a :cd
  */
-void mf_fullname(mfp)
-memfile_T   *mfp;
+void mf_fullname(memfile_T *mfp)
 {
   if (mfp != NULL && mfp->mf_fname != NULL && mfp->mf_ffname != NULL) {
     vim_free(mfp->mf_fname);
@@ -1108,8 +1055,7 @@ memfile_T   *mfp;
 /*
  * return TRUE if there are any translations pending for 'mfp'
  */
-int mf_need_trans(mfp)
-memfile_T   *mfp;
+int mf_need_trans(memfile_T *mfp)
 {
   return mfp->mf_fname != NULL && mfp->mf_neg_count > 0;
 }
@@ -1119,10 +1065,12 @@ memfile_T   *mfp;
  * The "fname" must be in allocated memory, and is consumed (also when an
  * error occurs).
  */
-static void mf_do_open(mfp, fname, flags)
-memfile_T   *mfp;
-char_u      *fname;
-int flags;                      /* flags for open() */
+static void 
+mf_do_open (
+    memfile_T *mfp,
+    char_u *fname,
+    int flags                      /* flags for open() */
+)
 {
 #ifdef HAVE_LSTAT
   struct stat sb;
@@ -1191,8 +1139,7 @@ int flags;                      /* flags for open() */
 /*
  * Initialize an empty hash table.
  */
-static void mf_hash_init(mht)
-mf_hashtab_T *mht;
+static void mf_hash_init(mf_hashtab_T *mht)
 {
   vim_memset(mht, 0, sizeof(mf_hashtab_T));
   mht->mht_buckets = mht->mht_small_buckets;
@@ -1203,8 +1150,7 @@ mf_hashtab_T *mht;
  * Free the array of a hash table.  Does not free the items it contains!
  * The hash table must not be used again without another mf_hash_init() call.
  */
-static void mf_hash_free(mht)
-mf_hashtab_T *mht;
+static void mf_hash_free(mf_hashtab_T *mht)
 {
   if (mht->mht_buckets != mht->mht_small_buckets)
     vim_free(mht->mht_buckets);
@@ -1213,8 +1159,7 @@ mf_hashtab_T *mht;
 /*
  * Free the array of a hash table and all the items it contains.
  */
-static void mf_hash_free_all(mht)
-mf_hashtab_T    *mht;
+static void mf_hash_free_all(mf_hashtab_T *mht)
 {
   long_u idx;
   mf_hashitem_T   *mhi;
@@ -1233,9 +1178,7 @@ mf_hashtab_T    *mht;
  * Find "key" in hashtable "mht".
  * Returns a pointer to a mf_hashitem_T or NULL if the item was not found.
  */
-static mf_hashitem_T * mf_hash_find(mht, key)
-mf_hashtab_T    *mht;
-blocknr_T key;
+static mf_hashitem_T *mf_hash_find(mf_hashtab_T *mht, blocknr_T key)
 {
   mf_hashitem_T   *mhi;
 
@@ -1250,9 +1193,7 @@ blocknr_T key;
  * Add item "mhi" to hashtable "mht".
  * "mhi" must not be NULL.
  */
-static void mf_hash_add_item(mht, mhi)
-mf_hashtab_T    *mht;
-mf_hashitem_T   *mhi;
+static void mf_hash_add_item(mf_hashtab_T *mht, mf_hashitem_T *mhi)
 {
   long_u idx;
 
@@ -1282,9 +1223,7 @@ mf_hashitem_T   *mhi;
  * Remove item "mhi" from hashtable "mht".
  * "mhi" must not be NULL and must have been inserted into "mht".
  */
-static void mf_hash_rem_item(mht, mhi)
-mf_hashtab_T    *mht;
-mf_hashitem_T   *mhi;
+static void mf_hash_rem_item(mf_hashtab_T *mht, mf_hashitem_T *mhi)
 {
   if (mhi->mhi_prev == NULL)
     mht->mht_buckets[mhi->mhi_key & mht->mht_mask] = mhi->mhi_next;
@@ -1305,8 +1244,7 @@ mf_hashitem_T   *mhi;
  * rehash items.
  * Returns FAIL when out of memory.
  */
-static int mf_hash_grow(mht)
-mf_hashtab_T    *mht;
+static int mf_hash_grow(mf_hashtab_T *mht)
 {
   long_u i, j;
   int shift;

--- a/src/memline.c
+++ b/src/memline.c
@@ -255,8 +255,7 @@ static void ml_updatechunk __ARGS((buf_T *buf, long line, long len, int updtype)
  *
  * Return FAIL for failure, OK otherwise.
  */
-int ml_open(buf)
-buf_T       *buf;
+int ml_open(buf_T *buf)
 {
   memfile_T   *mfp;
   bhdr_T      *hp = NULL;
@@ -389,9 +388,7 @@ error:
 /*
  * Prepare encryption for "buf" with block 0 "b0p".
  */
-static void ml_set_b0_crypt(buf, b0p)
-buf_T       *buf;
-ZERO_BL     *b0p;
+static void ml_set_b0_crypt(buf_T *buf, ZERO_BL *b0p)
 {
   if (*buf->b_p_key == NUL)
     b0p->b0_id[1] = BLOCK0_ID1;
@@ -415,10 +412,7 @@ ZERO_BL     *b0p;
  * "old_cm" is the previous 'cryptmethod'.  It is equal to the current
  * 'cryptmethod' when 'key' is changed.
  */
-void ml_set_crypt_key(buf, old_key, old_cm)
-buf_T       *buf;
-char_u      *old_key;
-int old_cm;
+void ml_set_crypt_key(buf_T *buf, char_u *old_key, int old_cm)
 {
   memfile_T   *mfp = buf->b_ml.ml_mfp;
   bhdr_T      *hp;
@@ -533,8 +527,7 @@ int old_cm;
  * ml_setname() is called when the file name of "buf" has been changed.
  * It may rename the swap file.
  */
-void ml_setname(buf)
-buf_T       *buf;
+void ml_setname(buf_T *buf)
 {
   int success = FALSE;
   memfile_T   *mfp;
@@ -615,7 +608,7 @@ buf_T       *buf;
  * been modified.
  * Used when 'updatecount' changes from zero to non-zero.
  */
-void ml_open_files()          {
+void ml_open_files(void)          {
   buf_T       *buf;
 
   for (buf = firstbuf; buf != NULL; buf = buf->b_next)
@@ -628,8 +621,7 @@ void ml_open_files()          {
  * If we are unable to find a file name, mf_fname will be NULL
  * and the memfile will be in memory only (no recovery possible).
  */
-void ml_open_file(buf)
-buf_T       *buf;
+void ml_open_file(buf_T *buf)
 {
   memfile_T   *mfp;
   char_u      *fname;
@@ -696,8 +688,10 @@ buf_T       *buf;
  * If still need to create a swap file, and starting to edit a not-readonly
  * file, or reading into an existing buffer, create a swap file now.
  */
-void check_need_swap(newfile)
-int newfile;                    /* reading file into new buffer */
+void 
+check_need_swap (
+    int newfile                    /* reading file into new buffer */
+)
 {
   if (curbuf->b_may_swap && (!curbuf->b_p_ro || !newfile))
     ml_open_file(curbuf);
@@ -707,9 +701,7 @@ int newfile;                    /* reading file into new buffer */
  * Close memline for buffer 'buf'.
  * If 'del_file' is TRUE, delete the swap file
  */
-void ml_close(buf, del_file)
-buf_T       *buf;
-int del_file;
+void ml_close(buf_T *buf, int del_file)
 {
   if (buf->b_ml.ml_mfp == NULL)                 /* not open */
     return;
@@ -732,8 +724,7 @@ int del_file;
  * When 'del_file' is TRUE, delete the memfiles.
  * But don't delete files that were ":preserve"d when we are POSIX compatible.
  */
-void ml_close_all(del_file)
-int del_file;
+void ml_close_all(int del_file)
 {
   buf_T       *buf;
 
@@ -750,7 +741,7 @@ int del_file;
  * Close all memfiles for not modified buffers.
  * Only use just before exiting!
  */
-void ml_close_notmod()          {
+void ml_close_notmod(void)          {
   buf_T       *buf;
 
   for (buf = firstbuf; buf != NULL; buf = buf->b_next)
@@ -762,8 +753,7 @@ void ml_close_notmod()          {
  * Update the timestamp in the .swp file.
  * Used when the file has been written.
  */
-void ml_timestamp(buf)
-buf_T       *buf;
+void ml_timestamp(buf_T *buf)
 {
   ml_upd_block0(buf, UB_FNAME);
 }
@@ -771,8 +761,7 @@ buf_T       *buf;
 /*
  * Return FAIL when the ID of "b0p" is wrong.
  */
-static int ml_check_b0_id(b0p)
-ZERO_BL     *b0p;
+static int ml_check_b0_id(ZERO_BL *b0p)
 {
   if (b0p->b0_id[0] != BLOCK0_ID0
       || (b0p->b0_id[1] != BLOCK0_ID1
@@ -786,9 +775,7 @@ ZERO_BL     *b0p;
 /*
  * Update the timestamp or the B0_SAME_DIR flag of the .swp file.
  */
-static void ml_upd_block0(buf, what)
-buf_T       *buf;
-upd_block0_T what;
+static void ml_upd_block0(buf_T *buf, upd_block0_T what)
 {
   memfile_T   *mfp;
   bhdr_T      *hp;
@@ -816,9 +803,7 @@ upd_block0_T what;
  * Also set buf->b_mtime.
  * Don't use NameBuff[]!!!
  */
-static void set_b0_fname(b0p, buf)
-ZERO_BL     *b0p;
-buf_T       *buf;
+static void set_b0_fname(ZERO_BL *b0p, buf_T *buf)
 {
   struct stat st;
 
@@ -878,9 +863,7 @@ buf_T       *buf;
  * This is fail safe: if we are not sure the directories are equal the flag is
  * not set.
  */
-static void set_b0_dir_flag(b0p, buf)
-ZERO_BL     *b0p;
-buf_T       *buf;
+static void set_b0_dir_flag(ZERO_BL *b0p, buf_T *buf)
 {
   if (same_directory(buf->b_ml.ml_mfp->mf_fname, buf->b_ffname))
     b0p->b0_flags |= B0_SAME_DIR;
@@ -891,9 +874,7 @@ buf_T       *buf;
 /*
  * When there is room, add the 'fileencoding' to block zero.
  */
-static void add_b0_fenc(b0p, buf)
-ZERO_BL     *b0p;
-buf_T       *buf;
+static void add_b0_fenc(ZERO_BL *b0p, buf_T *buf)
 {
   int n;
   int size = B0_FNAME_SIZE_NOCRYPT;
@@ -919,7 +900,7 @@ buf_T       *buf;
 /*
  * Try to recover curbuf from the .swp file.
  */
-void ml_recover()          {
+void ml_recover(void)          {
   buf_T       *buf = NULL;
   memfile_T   *mfp = NULL;
   char_u      *fname;
@@ -1490,11 +1471,13 @@ theend:
  * - list the swap files when recovering
  * - find the name of the n'th swap file when recovering
  */
-int recover_names(fname, list, nr, fname_out)
-char_u      *fname;             /* base for swap file name */
-int list;                       /* when TRUE, list the swap file names */
-int nr;                         /* when non-zero, return nr'th swap file name */
-char_u      **fname_out;        /* result when "nr" > 0 */
+int 
+recover_names (
+    char_u *fname,             /* base for swap file name */
+    int list,                       /* when TRUE, list the swap file names */
+    int nr,                         /* when non-zero, return nr'th swap file name */
+    char_u **fname_out        /* result when "nr" > 0 */
+)
 {
   int num_names;
   char_u      *(names[6]);
@@ -1694,9 +1677,7 @@ char_u      **fname_out;        /* result when "nr" > 0 */
  * Append the full path to name with path separators made into percent
  * signs, to dir. An unnamed buffer is handled as "" (<currentdir>/"")
  */
-static char_u * make_percent_swname(dir, name)
-char_u      *dir;
-char_u      *name;
+static char_u *make_percent_swname(char_u *dir, char_u *name)
 {
   char_u *d, *s, *f;
 
@@ -1727,8 +1708,7 @@ static int process_still_running;
  * Give information about an existing swap file.
  * Returns timestamp (0 when unknown).
  */
-static time_t swapfile_info(fname)
-char_u      *fname;
+static time_t swapfile_info(char_u *fname)
 {
   struct stat st;
   int fd;
@@ -1817,10 +1797,7 @@ char_u      *fname;
   return x;
 }
 
-static int recov_file_names(names, path, prepend_dot)
-char_u      **names;
-char_u      *path;
-int prepend_dot;
+static int recov_file_names(char_u **names, char_u *path, int prepend_dot)
 {
   int num_names;
 
@@ -1909,9 +1886,7 @@ end:
  * If 'check_char' is TRUE, stop syncing when character becomes available, but
  * always sync at least one block.
  */
-void ml_sync_all(check_file, check_char)
-int check_file;
-int check_char;
+void ml_sync_all(int check_file, int check_char)
 {
   buf_T               *buf;
   struct stat st;
@@ -1956,9 +1931,7 @@ int check_char;
  *
  * when message is TRUE the success of preserving is reported
  */
-void ml_preserve(buf, message)
-buf_T       *buf;
-int message;
+void ml_preserve(buf_T *buf, int message)
 {
   bhdr_T      *hp;
   linenr_T lnum;
@@ -2036,8 +2009,7 @@ theend:
  * On failure an error message is given and IObuff is returned (to avoid
  * having to check for error everywhere).
  */
-char_u  * ml_get(lnum)
-linenr_T lnum;
+char_u *ml_get(linenr_T lnum)
 {
   return ml_get_buf(curbuf, lnum, FALSE);
 }
@@ -2045,8 +2017,7 @@ linenr_T lnum;
 /*
  * Return pointer to position "pos".
  */
-char_u * ml_get_pos(pos)
-pos_T       *pos;
+char_u *ml_get_pos(pos_T *pos)
 {
   return ml_get_buf(curbuf, pos->lnum, FALSE) + pos->col;
 }
@@ -2054,14 +2025,14 @@ pos_T       *pos;
 /*
  * Return pointer to cursor line.
  */
-char_u * ml_get_curline()              {
+char_u *ml_get_curline(void)              {
   return ml_get_buf(curbuf, curwin->w_cursor.lnum, FALSE);
 }
 
 /*
  * Return pointer to cursor position.
  */
-char_u * ml_get_cursor()              {
+char_u *ml_get_cursor(void)              {
   return ml_get_buf(curbuf, curwin->w_cursor.lnum, FALSE) +
          curwin->w_cursor.col;
 }
@@ -2072,10 +2043,12 @@ char_u * ml_get_cursor()              {
  * "will_change": if TRUE mark the buffer dirty (chars in the line will be
  * changed)
  */
-char_u  * ml_get_buf(buf, lnum, will_change)
-buf_T       *buf;
-linenr_T lnum;
-int will_change;                        /* line will be changed */
+char_u *
+ml_get_buf (
+    buf_T *buf,
+    linenr_T lnum,
+    int will_change                        /* line will be changed */
+)
 {
   bhdr_T      *hp;
   DATA_BL     *dp;
@@ -2143,7 +2116,7 @@ errorret:
  * Check if a line that was just obtained by a call to ml_get
  * is in allocated memory.
  */
-int ml_line_alloced()         {
+int ml_line_alloced(void)         {
   return curbuf->b_ml.ml_flags & ML_LINE_DIRTY;
 }
 
@@ -2159,11 +2132,13 @@ int ml_line_alloced()         {
  *
  * return FAIL for failure, OK otherwise
  */
-int ml_append(lnum, line, len, newfile)
-linenr_T lnum;                  /* append after this line (can be 0) */
-char_u      *line;              /* text of the new line */
-colnr_T len;                    /* length of new line, including NUL, or 0 */
-int newfile;                    /* flag, see above */
+int 
+ml_append (
+    linenr_T lnum,                  /* append after this line (can be 0) */
+    char_u *line,              /* text of the new line */
+    colnr_T len,                    /* length of new line, including NUL, or 0 */
+    int newfile                    /* flag, see above */
+)
 {
   /* When starting up, we might still need to create the memfile */
   if (curbuf->b_ml.ml_mfp == NULL && open_buffer(FALSE, NULL, 0) == FAIL)
@@ -2178,12 +2153,14 @@ int newfile;                    /* flag, see above */
  * Like ml_append() but for an arbitrary buffer.  The buffer must already have
  * a memline.
  */
-int ml_append_buf(buf, lnum, line, len, newfile)
-buf_T       *buf;
-linenr_T lnum;                  /* append after this line (can be 0) */
-char_u      *line;              /* text of the new line */
-colnr_T len;                    /* length of new line, including NUL, or 0 */
-int newfile;                    /* flag, see above */
+int 
+ml_append_buf (
+    buf_T *buf,
+    linenr_T lnum,                  /* append after this line (can be 0) */
+    char_u *line,              /* text of the new line */
+    colnr_T len,                    /* length of new line, including NUL, or 0 */
+    int newfile                    /* flag, see above */
+)
 {
   if (buf->b_ml.ml_mfp == NULL)
     return FAIL;
@@ -2193,13 +2170,15 @@ int newfile;                    /* flag, see above */
   return ml_append_int(buf, lnum, line, len, newfile, FALSE);
 }
 
-static int ml_append_int(buf, lnum, line, len, newfile, mark)
-buf_T       *buf;
-linenr_T lnum;                  /* append after this line (can be 0) */
-char_u      *line;              /* text of the new line */
-colnr_T len;                    /* length of line, including NUL, or 0 */
-int newfile;                    /* flag, see above */
-int mark;                       /* mark the new line */
+static int 
+ml_append_int (
+    buf_T *buf,
+    linenr_T lnum,                  /* append after this line (can be 0) */
+    char_u *line,              /* text of the new line */
+    colnr_T len,                    /* length of line, including NUL, or 0 */
+    int newfile,                    /* flag, see above */
+    int mark                       /* mark the new line */
+)
 {
   int i;
   int line_count;               /* number of indexes in current block */
@@ -2656,10 +2635,7 @@ int mark;                       /* mark the new line */
  *
  * return FAIL for failure, OK otherwise
  */
-int ml_replace(lnum, line, copy)
-linenr_T lnum;
-char_u      *line;
-int copy;
+int ml_replace(linenr_T lnum, char_u *line, int copy)
 {
   if (line == NULL)             /* just checking... */
     return FAIL;
@@ -2689,18 +2665,13 @@ int copy;
  *
  * return FAIL for failure, OK otherwise
  */
-int ml_delete(lnum, message)
-linenr_T lnum;
-int message;
+int ml_delete(linenr_T lnum, int message)
 {
   ml_flush_line(curbuf);
   return ml_delete_int(curbuf, lnum, message);
 }
 
-static int ml_delete_int(buf, lnum, message)
-buf_T       *buf;
-linenr_T lnum;
-int message;
+static int ml_delete_int(buf_T *buf, linenr_T lnum, int message)
 {
   bhdr_T      *hp;
   memfile_T   *mfp;
@@ -2842,8 +2813,7 @@ int message;
 /*
  * set the B_MARKED flag for line 'lnum'
  */
-void ml_setmarked(lnum)
-linenr_T lnum;
+void ml_setmarked(linenr_T lnum)
 {
   bhdr_T    *hp;
   DATA_BL *dp;
@@ -2871,7 +2841,7 @@ linenr_T lnum;
 /*
  * find the first line with its B_MARKED flag set
  */
-linenr_T ml_firstmarked()              {
+linenr_T ml_firstmarked(void)              {
   bhdr_T      *hp;
   DATA_BL     *dp;
   linenr_T lnum;
@@ -2911,7 +2881,7 @@ linenr_T ml_firstmarked()              {
 /*
  * clear all DB_MARKED flags
  */
-void ml_clearmarked()          {
+void ml_clearmarked(void)          {
   bhdr_T      *hp;
   DATA_BL     *dp;
   linenr_T lnum;
@@ -2949,8 +2919,7 @@ void ml_clearmarked()          {
 /*
  * flush ml_line if necessary
  */
-static void ml_flush_line(buf)
-buf_T       *buf;
+static void ml_flush_line(buf_T *buf)
 {
   bhdr_T      *hp;
   DATA_BL     *dp;
@@ -3046,10 +3015,7 @@ buf_T       *buf;
 /*
  * create a new, empty, data block
  */
-static bhdr_T * ml_new_data(mfp, negative, page_count)
-memfile_T   *mfp;
-int negative;
-int page_count;
+static bhdr_T *ml_new_data(memfile_T *mfp, int negative, int page_count)
 {
   bhdr_T      *hp;
   DATA_BL     *dp;
@@ -3069,8 +3035,7 @@ int page_count;
 /*
  * create a new, empty, pointer block
  */
-static bhdr_T * ml_new_ptr(mfp)
-memfile_T   *mfp;
+static bhdr_T *ml_new_ptr(memfile_T *mfp)
 {
   bhdr_T      *hp;
   PTR_BL      *pp;
@@ -3102,10 +3067,7 @@ memfile_T   *mfp;
  *
  * return: NULL for failure, pointer to block header otherwise
  */
-static bhdr_T * ml_find_line(buf, lnum, action)
-buf_T       *buf;
-linenr_T lnum;
-int action;
+static bhdr_T *ml_find_line(buf_T *buf, linenr_T lnum, int action)
 {
   DATA_BL     *dp;
   PTR_BL      *pp;
@@ -3286,8 +3248,7 @@ error_noblock:
  *
  * return -1 for failure, number of the new entry otherwise
  */
-static int ml_add_stack(buf)
-buf_T       *buf;
+static int ml_add_stack(buf_T *buf)
 {
   int top;
   infoptr_T   *newstack;
@@ -3323,9 +3284,7 @@ buf_T       *buf;
  *
  * Count is the number of lines added, negative if lines have been deleted.
  */
-static void ml_lineadd(buf, count)
-buf_T       *buf;
-int count;
+static void ml_lineadd(buf_T *buf, int count)
 {
   int idx;
   infoptr_T   *ip;
@@ -3357,9 +3316,7 @@ int count;
  * If it worked returns OK and the resolved link in "buf[MAXPATHL]".
  * Otherwise returns FAIL.
  */
-int resolve_symlink(fname, buf)
-char_u      *fname;
-char_u      *buf;
+int resolve_symlink(char_u *fname, char_u *buf)
 {
   char_u tmp[MAXPATHL];
   int ret;
@@ -3427,11 +3384,7 @@ char_u      *buf;
  * Make swap file name out of the file name and a directory name.
  * Returns pointer to allocated memory or NULL.
  */
-char_u * makeswapname(fname, ffname, buf, dir_name)
-char_u      *fname;
-char_u      *ffname UNUSED;
-buf_T       *buf;
-char_u      *dir_name;
+char_u *makeswapname(char_u *fname, char_u *ffname, buf_T *buf, char_u *dir_name)
 {
   char_u      *r, *s;
   char_u      *fname_res = fname;
@@ -3494,9 +3447,11 @@ char_u      *dir_name;
  *
  * The return value is an allocated string and can be NULL.
  */
-char_u * get_file_in_dir(fname, dname)
-char_u  *fname;
-char_u  *dname;         /* don't use "dirname", it is a global for Alpha */
+char_u *
+get_file_in_dir (
+    char_u *fname,
+    char_u *dname         /* don't use "dirname", it is a global for Alpha */
+)
 {
   char_u      *t;
   char_u      *tail;
@@ -3534,9 +3489,11 @@ static void attention_message __ARGS((buf_T *buf, char_u *fname));
 /*
  * Print the ATTENTION message: info about an existing swap file.
  */
-static void attention_message(buf, fname)
-buf_T   *buf;           /* buffer being edited */
-char_u  *fname;         /* swap file name */
+static void 
+attention_message (
+    buf_T *buf,           /* buffer being edited */
+    char_u *fname         /* swap file name */
+)
 {
   struct stat st;
   time_t x, sx;
@@ -3591,9 +3548,7 @@ static int do_swapexists __ARGS((buf_T *buf, char_u *fname));
  * 5: quit
  * 6: abort
  */
-static int do_swapexists(buf, fname)
-buf_T       *buf;
-char_u      *fname;
+static int do_swapexists(buf_T *buf, char_u *fname)
 {
   set_vim_var_string(VV_SWAPNAME, fname, -1);
   set_vim_var_string(VV_SWAPCHOICE, NULL, -1);
@@ -3629,10 +3584,12 @@ char_u      *fname;
  *	 not being able to open the swap or undo file
  * Note: May trigger SwapExists autocmd, pointers may change!
  */
-static char_u * findswapname(buf, dirp, old_fname)
-buf_T       *buf;
-char_u      **dirp;             /* pointer to list of directories */
-char_u      *old_fname;         /* don't give warning for this file name */
+static char_u *
+findswapname (
+    buf_T *buf,
+    char_u **dirp,             /* pointer to list of directories */
+    char_u *old_fname         /* don't give warning for this file name */
+)
 {
   char_u      *fname;
   int n;
@@ -4030,8 +3987,7 @@ char_u      *old_fname;         /* don't give warning for this file name */
   return fname;
 }
 
-static int b0_magic_wrong(b0p)
-ZERO_BL *b0p;
+static int b0_magic_wrong(ZERO_BL *b0p)
 {
   return b0p->b0_magic_long != (long)B0_MAGIC_LONG
          || b0p->b0_magic_int != (int)B0_MAGIC_INT
@@ -4089,10 +4045,12 @@ ZERO_BL *b0p;
  * versions.
  */
 
-static int fnamecmp_ino(fname_c, fname_s, ino_block0)
-char_u      *fname_c;               /* current file name */
-char_u      *fname_s;               /* file name from swap file */
-long ino_block0;
+static int 
+fnamecmp_ino (
+    char_u *fname_c,               /* current file name */
+    char_u *fname_s,               /* file name from swap file */
+    long ino_block0
+)
 {
   struct stat st;
   ino_t ino_c = 0;                  /* ino of current file */
@@ -4141,9 +4099,7 @@ long ino_block0;
  * Move a long integer into a four byte character array.
  * Used for machine independency in block zero.
  */
-static void long_to_char(n, s)
-long n;
-char_u  *s;
+static void long_to_char(long n, char_u *s)
 {
   s[0] = (char_u)(n & 0xff);
   n = (unsigned)n >> 8;
@@ -4154,8 +4110,7 @@ char_u  *s;
   s[3] = (char_u)(n & 0xff);
 }
 
-static long char_to_long(s)
-char_u  *s;
+static long char_to_long(char_u *s)
 {
   long retval;
 
@@ -4176,8 +4131,7 @@ char_u  *s;
  * - 'fileformat'
  * - 'fileencoding'
  */
-void ml_setflags(buf)
-buf_T       *buf;
+void ml_setflags(buf_T *buf)
 {
   bhdr_T      *hp;
   ZERO_BL     *b0p;
@@ -4203,11 +4157,7 @@ buf_T       *buf;
  * in allocated memory.  Return NULL when out of memory.
  * Otherwise return "data".
  */
-char_u * ml_encrypt_data(mfp, data, offset, size)
-memfile_T   *mfp;
-char_u      *data;
-off_t offset;
-unsigned size;
+char_u *ml_encrypt_data(memfile_T *mfp, char_u *data, off_t offset, unsigned size)
 {
   DATA_BL     *dp = (DATA_BL *)data;
   char_u      *head_end;
@@ -4244,11 +4194,7 @@ unsigned size;
 /*
  * Decrypt the text in "data" if it points to a data block.
  */
-void ml_decrypt_data(mfp, data, offset, size)
-memfile_T   *mfp;
-char_u      *data;
-off_t offset;
-unsigned size;
+void ml_decrypt_data(memfile_T *mfp, char_u *data, off_t offset, unsigned size)
 {
   DATA_BL     *dp = (DATA_BL *)data;
   char_u      *head_end;
@@ -4275,10 +4221,7 @@ unsigned size;
 /*
  * Prepare for encryption/decryption, using the key, seed and offset.
  */
-static void ml_crypt_prepare(mfp, offset, reading)
-memfile_T   *mfp;
-off_t offset;
-int reading;
+static void ml_crypt_prepare(memfile_T *mfp, off_t offset, int reading)
 {
   buf_T       *buf = mfp->mf_buffer;
   char_u salt[50];
@@ -4323,11 +4266,7 @@ int reading;
  * ML_CHNK_DELLINE: Subtract len from parent chunk, possibly deleting it
  * ML_CHNK_UPDLINE: Add len to parent chunk, as a signed entity.
  */
-static void ml_updatechunk(buf, line, len, updtype)
-buf_T       *buf;
-linenr_T line;
-long len;
-int updtype;
+static void ml_updatechunk(buf_T *buf, linenr_T line, long len, int updtype)
 {
   static buf_T        *ml_upd_lastbuf = NULL;
   static linenr_T ml_upd_lastline;
@@ -4533,10 +4472,7 @@ int updtype;
  * Find offset of line if "lnum" > 0
  * return -1 if information is not available
  */
-long ml_find_line_or_offset(buf, lnum, offp)
-buf_T       *buf;
-linenr_T lnum;
-long        *offp;
+long ml_find_line_or_offset(buf_T *buf, linenr_T lnum, long *offp)
 {
   linenr_T curline;
   int curix;
@@ -4652,8 +4588,7 @@ long        *offp;
 /*
  * Goto byte in buffer with offset 'cnt'.
  */
-void goto_byte(cnt)
-long cnt;
+void goto_byte(long cnt)
 {
   long boff = cnt;
   linenr_T lnum;

--- a/src/menu.c
+++ b/src/menu.c
@@ -53,8 +53,10 @@ static char_u e_nomenu[] = N_("E329: No menu \"%s\"");
 /*
  * Do the :menu command and relatives.
  */
-void ex_menu(eap)
-exarg_T     *eap;                   /* Ex command arguments */
+void 
+ex_menu (
+    exarg_T *eap                   /* Ex command arguments */
+)
 {
   char_u      *menu_path;
   int modes;
@@ -262,12 +264,14 @@ theend:
 /*
  * Add the menu with the given name to the menu hierarchy
  */
-static int add_menu_path(menu_path, menuarg, pri_tab, call_data)
-char_u      *menu_path;
-vimmenu_T   *menuarg;           /* passes modes, iconfile, iconidx,
+static int 
+add_menu_path (
+    char_u *menu_path,
+    vimmenu_T *menuarg,           /* passes modes, iconfile, iconidx,
                                    icon_builtin, silent[0], noremap[0] */
-int         *pri_tab;
-char_u      *call_data;
+    int *pri_tab,
+    char_u *call_data
+)
 {
   char_u      *path_name;
   int modes = menuarg->modes;
@@ -506,11 +510,7 @@ erret:
  * Set the (sub)menu with the given name to enabled or disabled.
  * Called recursively.
  */
-static int menu_nable_recurse(menu, name, modes, enable)
-vimmenu_T   *menu;
-char_u      *name;
-int modes;
-int enable;
+static int menu_nable_recurse(vimmenu_T *menu, char_u *name, int modes, int enable)
 {
   char_u      *p;
 
@@ -559,11 +559,13 @@ int enable;
  * Remove the (sub)menu with the given name from the menu hierarchy
  * Called recursively.
  */
-static int remove_menu(menup, name, modes, silent)
-vimmenu_T   **menup;
-char_u      *name;
-int modes;
-int silent;                     /* don't give error messages */
+static int 
+remove_menu (
+    vimmenu_T **menup,
+    char_u *name,
+    int modes,
+    int silent                     /* don't give error messages */
+)
 {
   vimmenu_T   *menu;
   vimmenu_T   *child;
@@ -666,8 +668,7 @@ int silent;                     /* don't give error messages */
 /*
  * Free the given menu structure and remove it from the linked list.
  */
-static void free_menu(menup)
-vimmenu_T   **menup;
+static void free_menu(vimmenu_T **menup)
 {
   int i;
   vimmenu_T   *menu;
@@ -692,9 +693,7 @@ vimmenu_T   **menup;
 /*
  * Free the menu->string with the given index.
  */
-static void free_menu_string(menu, idx)
-vimmenu_T   *menu;
-int idx;
+static void free_menu_string(vimmenu_T *menu, int idx)
 {
   int count = 0;
   int i;
@@ -710,9 +709,7 @@ int idx;
 /*
  * Show the mapping associated with a menu item or hierarchy in a sub-menu.
  */
-static int show_menus(path_name, modes)
-char_u  *path_name;
-int modes;
+static int show_menus(char_u *path_name, int modes)
 {
   char_u      *p;
   char_u      *name;
@@ -765,10 +762,7 @@ int modes;
 /*
  * Recursively show the mappings associated with the menus under the given one
  */
-static void show_menus_recursive(menu, modes, depth)
-vimmenu_T   *menu;
-int modes;
-int depth;
+static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
 {
   int i;
   int bit;
@@ -844,11 +838,7 @@ static int expand_emenu;                /* TRUE for ":emenu" command */
 /*
  * Work out what to complete when doing command line completion of menu names.
  */
-char_u * set_context_in_menu_cmd(xp, cmd, arg, forceit)
-expand_T    *xp;
-char_u      *cmd;
-char_u      *arg;
-int forceit;
+char_u *set_context_in_menu_cmd(expand_T *xp, char_u *cmd, char_u *arg, int forceit)
 {
   char_u      *after_dot;
   char_u      *p;
@@ -952,9 +942,7 @@ int forceit;
  * Function given to ExpandGeneric() to obtain the list of (sub)menus (not
  * entries).
  */
-char_u * get_menu_name(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_menu_name(expand_T *xp, int idx)
 {
   static vimmenu_T    *menu = NULL;
   char_u              *str;
@@ -999,9 +987,7 @@ int idx;
  * Function given to ExpandGeneric() to obtain the list of menus and menu
  * entries.
  */
-char_u * get_menu_names(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_menu_names(expand_T *xp, int idx)
 {
   static vimmenu_T    *menu = NULL;
 #define TBUFFER_LEN 256
@@ -1065,8 +1051,7 @@ int idx;
  * element.  Any \ and ^Vs are removed from the current element.
  * "name" may be modified.
  */
-char_u * menu_name_skip(name)
-char_u  *name;
+char_u *menu_name_skip(char_u *name)
 {
   char_u  *p;
 
@@ -1086,9 +1071,7 @@ char_u  *name;
  * Return TRUE when "name" matches with menu "menu".  The name is compared in
  * two ways: raw menu name and menu name without '&'.  ignore part after a TAB.
  */
-static int menu_name_equal(name, menu)
-char_u      *name;
-vimmenu_T   *menu;
+static int menu_name_equal(char_u *name, vimmenu_T *menu)
 {
   if (menu->en_name != NULL
       && (menu_namecmp(name, menu->en_name)
@@ -1097,9 +1080,7 @@ vimmenu_T   *menu;
   return menu_namecmp(name, menu->name) || menu_namecmp(name, menu->dname);
 }
 
-static int menu_namecmp(name, mname)
-char_u      *name;
-char_u      *mname;
+static int menu_namecmp(char_u *name, char_u *mname)
 {
   int i;
 
@@ -1118,11 +1099,13 @@ char_u      *mname;
  * If "unmenu" is not NULL, then the flag it points to is set according to
  * whether the command is an "unmenu" command.
  */
-static int get_menu_cmd_modes(cmd, forceit, noremap, unmenu)
-char_u  *cmd;
-int forceit;                /* Was there a "!" after the command? */
-int     *noremap;
-int     *unmenu;
+static int 
+get_menu_cmd_modes (
+    char_u *cmd,
+    int forceit,                /* Was there a "!" after the command? */
+    int *noremap,
+    int *unmenu
+)
 {
   int modes;
 
@@ -1179,9 +1162,7 @@ int     *unmenu;
  * Modify a menu name starting with "PopUp" to include the mode character.
  * Returns the name in allocated memory (NULL for failure).
  */
-static char_u * popup_mode_name(name, idx)
-char_u      *name;
-int idx;
+static char_u *popup_mode_name(char_u *name, int idx)
 {
   char_u      *p;
   int len = (int)STRLEN(name);
@@ -1202,10 +1183,7 @@ int idx;
  * If mnemonic != NULL, *mnemonic is set to the character after the first '&'.
  * If actext != NULL, *actext is set to the text after the first TAB.
  */
-static char_u * menu_text(str, mnemonic, actext)
-char_u      *str;
-int         *mnemonic;
-char_u      **actext;
+static char_u *menu_text(char_u *str, int *mnemonic, char_u **actext)
 {
   char_u      *p;
   char_u      *text;
@@ -1251,8 +1229,7 @@ char_u      **actext;
 /*
  * Return TRUE if "name" can be a menu in the MenuBar.
  */
-int menu_is_menubar(name)
-char_u      *name;
+int menu_is_menubar(char_u *name)
 {
   return !menu_is_popup(name)
          && !menu_is_toolbar(name)
@@ -1262,8 +1239,7 @@ char_u      *name;
 /*
  * Return TRUE if "name" is a popup menu name.
  */
-int menu_is_popup(name)
-char_u      *name;
+int menu_is_popup(char_u *name)
 {
   return STRNCMP(name, "PopUp", 5) == 0;
 }
@@ -1272,8 +1248,7 @@ char_u      *name;
 /*
  * Return TRUE if "name" is a toolbar menu name.
  */
-int menu_is_toolbar(name)
-char_u      *name;
+int menu_is_toolbar(char_u *name)
 {
   return STRNCMP(name, "ToolBar", 7) == 0;
 }
@@ -1282,8 +1257,7 @@ char_u      *name;
  * Return TRUE if the name is a menu separator identifier: Starts and ends
  * with '-'
  */
-int menu_is_separator(name)
-char_u *name;
+int menu_is_separator(char_u *name)
 {
   return name[0] == '-' && name[STRLEN(name) - 1] == '-';
 }
@@ -1291,8 +1265,7 @@ char_u *name;
 /*
  * Return TRUE if the menu is hidden:  Starts with ']'
  */
-static int menu_is_hidden(name)
-char_u *name;
+static int menu_is_hidden(char_u *name)
 {
   return (name[0] == ']') || (menu_is_popup(name) && name[5] != NUL);
 }
@@ -1302,8 +1275,7 @@ char_u *name;
 /*
  * Return TRUE if the menu is the tearoff menu.
  */
-static int menu_is_tearoff(name)
-char_u *name UNUSED;
+static int menu_is_tearoff(char_u *name)
 {
   return FALSE;
 }
@@ -1315,8 +1287,7 @@ char_u *name UNUSED;
  * Given a menu descriptor, e.g. "File.New", find it in the menu hierarchy and
  * execute it.
  */
-void ex_emenu(eap)
-exarg_T     *eap;
+void ex_emenu(exarg_T *eap)
 {
   vimmenu_T   *menu;
   char_u      *name;
@@ -1430,8 +1401,7 @@ exarg_T     *eap;
 /*
  * Given a menu descriptor, e.g. "File.New", find it in the menu hierarchy.
  */
-vimmenu_T * gui_find_menu(path_name)
-char_u *path_name;
+vimmenu_T *gui_find_menu(char_u *path_name)
 {
   vimmenu_T   *menu = NULL;
   char_u      *name;
@@ -1499,8 +1469,7 @@ static garray_T menutrans_ga = {0, 0, 0, 0, NULL};
  * This function is also defined without the +multi_lang feature, in which
  * case the commands are ignored.
  */
-void ex_menutranslate(eap)
-exarg_T     *eap UNUSED;
+void ex_menutranslate(exarg_T *eap)
 {
   char_u              *arg = eap->arg;
   menutrans_T         *tp;
@@ -1562,8 +1531,7 @@ exarg_T     *eap UNUSED;
 /*
  * Find the character just after one part of a menu name.
  */
-static char_u * menu_skip_part(p)
-char_u      *p;
+static char_u *menu_skip_part(char_u *p)
 {
   while (*p != NUL && *p != '.' && !vim_iswhite(*p)) {
     if ((*p == '\\' || *p == Ctrl_V) && p[1] != NUL)
@@ -1577,9 +1545,7 @@ char_u      *p;
  * Lookup part of a menu name in the translations.
  * Return a pointer to the translation or NULL if not found.
  */
-static char_u * menutrans_lookup(name, len)
-char_u      *name;
-int len;
+static char_u *menutrans_lookup(char_u *name, int len)
 {
   menutrans_T         *tp = (menutrans_T *)menutrans_ga.ga_data;
   int i;
@@ -1609,8 +1575,7 @@ int len;
 /*
  * Unescape the name in the translate dictionary table.
  */
-static void menu_unescape_name(name)
-char_u      *name;
+static void menu_unescape_name(char_u *name)
 {
   char_u  *p;
 
@@ -1623,8 +1588,7 @@ char_u      *name;
  * Isolate the menu name.
  * Skip the menu name, and translate <Tab> into a real TAB.
  */
-static char_u * menu_translate_tab_and_shift(arg_start)
-char_u      *arg_start;
+static char_u *menu_translate_tab_and_shift(char_u *arg_start)
 {
   char_u      *arg = arg_start;
 

--- a/src/message.c
+++ b/src/message.c
@@ -100,8 +100,7 @@ static int verbose_did_open = FALSE;
  * When terminal not initialized (yet) mch_errmsg(..) is used.
  * return TRUE if wait_return not called
  */
-int msg(s)
-char_u      *s;
+int msg(char_u *s)
 {
   return msg_attr_keep(s, 0, FALSE);
 }
@@ -111,8 +110,7 @@ char_u      *s;
 /*
  * Like msg() but keep it silent when 'verbosefile' is set.
  */
-int verb_msg(s)
-char_u      *s;
+int verb_msg(char_u *s)
 {
   int n;
 
@@ -124,17 +122,17 @@ char_u      *s;
 }
 #endif
 
-int msg_attr(s, attr)
-char_u      *s;
-int attr;
+int msg_attr(char_u *s, int attr)
 {
   return msg_attr_keep(s, attr, FALSE);
 }
 
-int msg_attr_keep(s, attr, keep)
-char_u      *s;
-int attr;
-int keep;                   /* TRUE: set keep_msg if it doesn't scroll */
+int 
+msg_attr_keep (
+    char_u *s,
+    int attr,
+    int keep                   /* TRUE: set keep_msg if it doesn't scroll */
+)
 {
   static int entered = 0;
   int retval;
@@ -189,9 +187,11 @@ int keep;                   /* TRUE: set keep_msg if it doesn't scroll */
  * Truncate a string such that it can be printed without causing a scroll.
  * Returns an allocated string or NULL when no truncating is done.
  */
-char_u * msg_strtrunc(s, force)
-char_u      *s;
-int force;                  /* always truncate */
+char_u *
+msg_strtrunc (
+    char_u *s,
+    int force                  /* always truncate */
+)
 {
   char_u      *buf = NULL;
   int len;
@@ -229,11 +229,7 @@ int force;                  /* always truncate */
  * Truncate a string "s" to "buf" with cell width "room".
  * "s" and "buf" may be equal.
  */
-void trunc_string(s, buf, room, buflen)
-char_u      *s;
-char_u      *buf;
-int room;
-int buflen;
+void trunc_string(char_u *s, char_u *buf, int room, int buflen)
 {
   int half;
   int len;
@@ -331,18 +327,13 @@ int vim_snprintf __ARGS((char *, size_t, char *, long, long, long,
  */
 
 /* VARARGS */
-int smsg(s, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
-char_u      *s;
-long a1, a2, a3, a4, a5, a6, a7, a8, a9, a10;
+int smsg(char_u *s, long a1, long a2, long a3, long a4, long a5, long a6, long a7, long a8, long a9, long a10)
 {
   return smsg_attr(0, s, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
 }
 
 /* VARARGS */
-int smsg_attr(attr, s, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
-int attr;
-char_u      *s;
-long a1, a2, a3, a4, a5, a6, a7, a8, a9, a10;
+int smsg_attr(int attr, char_u *s, long a1, long a2, long a3, long a4, long a5, long a6, long a7, long a8, long a9, long a10)
 {
   vim_snprintf((char *)IObuff, IOSIZE, (char *)s,
       a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
@@ -384,7 +375,7 @@ static char_u   *last_sourcing_name = NULL;
  * Reset the last used sourcing name/lnum.  Makes sure it is displayed again
  * for the next error message;
  */
-void reset_last_sourcing()          {
+void reset_last_sourcing(void)          {
   vim_free(last_sourcing_name);
   last_sourcing_name = NULL;
   last_sourcing_lnum = 0;
@@ -393,7 +384,7 @@ void reset_last_sourcing()          {
 /*
  * Return TRUE if "sourcing_name" differs from "last_sourcing_name".
  */
-static int other_sourcing_name()                {
+static int other_sourcing_name(void)                {
   if (sourcing_name != NULL) {
     if (last_sourcing_name != NULL)
       return STRCMP(sourcing_name, last_sourcing_name) != 0;
@@ -407,7 +398,7 @@ static int other_sourcing_name()                {
  * Returns an allocated string with room for one more character.
  * Returns NULL when no message is to be given.
  */
-static char_u * get_emsg_source()                     {
+static char_u *get_emsg_source(void)                     {
   char_u      *Buf, *p;
 
   if (sourcing_name != NULL && other_sourcing_name()) {
@@ -425,7 +416,7 @@ static char_u * get_emsg_source()                     {
  * Returns an allocated string with room for one more character.
  * Returns NULL when no message is to be given.
  */
-static char_u * get_emsg_lnum()                     {
+static char_u *get_emsg_lnum(void)                     {
   char_u      *Buf, *p;
 
   /* lnum is 0 when executing a command from the command line
@@ -447,8 +438,7 @@ static char_u * get_emsg_lnum()                     {
  * Remember the file name and line number, so that for the next error the info
  * is only displayed if it changed.
  */
-void msg_source(attr)
-int attr;
+void msg_source(int attr)
 {
   char_u      *p;
 
@@ -482,7 +472,7 @@ int attr;
  * If "msg" is in 'debug': do error message but without side effects.
  * If "emsg_skip" is set: never do error messages.
  */
-int emsg_not_now()         {
+int emsg_not_now(void)         {
   if ((emsg_off > 0 && vim_strchr(p_debug, 'm') == NULL
        && vim_strchr(p_debug, 't') == NULL)
       || emsg_skip > 0
@@ -499,8 +489,7 @@ int emsg_not_now()         {
  *
  * return TRUE if wait_return not called
  */
-int emsg(s)
-char_u      *s;
+int emsg(char_u *s)
 {
   int attr;
   char_u      *p;
@@ -598,16 +587,14 @@ char_u      *s;
 /*
  * Print an error message with one "%s" and one string argument.
  */
-int emsg2(s, a1)
-char_u *s, *a1;
+int emsg2(char_u *s, char_u *a1)
 {
   return emsg3(s, a1, NULL);
 }
 
 /* emsg3() and emsgn() are in misc2.c to avoid warnings for the prototypes. */
 
-void emsg_invreg(name)
-int name;
+void emsg_invreg(int name)
 {
   EMSG2(_("E354: Invalid register name: '%s'"), transchar(name));
 }
@@ -618,10 +605,7 @@ int name;
  * Careful: The string may be changed by msg_may_trunc()!
  * Returns a pointer to the printed message, if wait_return() not called.
  */
-char_u * msg_trunc_attr(s, force, attr)
-char_u      *s;
-int force;
-int attr;
+char_u *msg_trunc_attr(char_u *s, int force, int attr)
 {
   int n;
 
@@ -644,9 +628,7 @@ int attr;
  * Return a pointer to where the truncated message starts.
  * Note: May change the message by replacing a character with '<'.
  */
-char_u * msg_may_trunc(force, s)
-int force;
-char_u      *s;
+char_u *msg_may_trunc(int force, char_u *s)
 {
   int n;
   int room;
@@ -673,10 +655,12 @@ char_u      *s;
   return s;
 }
 
-static void add_msg_hist(s, len, attr)
-char_u      *s;
-int len;                        /* -1 for undetermined length */
-int attr;
+static void 
+add_msg_hist (
+    char_u *s,
+    int len,                        /* -1 for undetermined length */
+    int attr
+)
 {
   struct msg_hist *p;
 
@@ -715,7 +699,7 @@ int attr;
  * Delete the first (oldest) message from the history.
  * Returns FAIL if there are no messages.
  */
-int delete_first_msg()         {
+int delete_first_msg(void)         {
   struct msg_hist *p;
 
   if (msg_hist_len <= 0)
@@ -733,8 +717,7 @@ int delete_first_msg()         {
 /*
  * ":messages" command.
  */
-void ex_messages(eap)
-exarg_T     *eap UNUSED;
+void ex_messages(exarg_T *eap)
 {
   struct msg_hist *p;
   char_u          *s;
@@ -758,7 +741,7 @@ exarg_T     *eap UNUSED;
  * Call this after prompting the user.  This will avoid a hit-return message
  * and a delay.
  */
-void msg_end_prompt()          {
+void msg_end_prompt(void)          {
   need_wait_return = FALSE;
   emsg_on_display = FALSE;
   cmdline_row = msg_row;
@@ -773,8 +756,7 @@ void msg_end_prompt()          {
  * if 'redraw' is FALSE, just redraw the screen
  * if 'redraw' is -1, don't redraw at all
  */
-void wait_return(redraw)
-int redraw;
+void wait_return(int redraw)
 {
   int c;
   int oldState;
@@ -977,7 +959,7 @@ int redraw;
 /*
  * Write the hit-return prompt.
  */
-static void hit_return_msg()                 {
+static void hit_return_msg(void)                 {
   int save_p_more = p_more;
 
   p_more = FALSE;       /* don't want see this message when scrolling back */
@@ -995,9 +977,7 @@ static void hit_return_msg()                 {
 /*
  * Set "keep_msg" to "s".  Free the old value and check for NULL pointer.
  */
-void set_keep_msg(s, attr)
-char_u      *s;
-int attr;
+void set_keep_msg(char_u *s, int attr)
 {
   vim_free(keep_msg);
   if (s != NULL && msg_silent == 0)
@@ -1012,7 +992,7 @@ int attr;
  * If there currently is a message being displayed, set "keep_msg" to it, so
  * that it will be displayed again after redraw.
  */
-void set_keep_msg_from_hist()          {
+void set_keep_msg_from_hist(void)          {
   if (keep_msg == NULL && last_msg_hist != NULL && msg_scrolled == 0
       && (State & NORMAL))
     set_keep_msg(last_msg_hist->msg, last_msg_hist->attr);
@@ -1021,7 +1001,7 @@ void set_keep_msg_from_hist()          {
 /*
  * Prepare for outputting characters in the command line.
  */
-void msg_start()          {
+void msg_start(void)          {
   int did_return = FALSE;
 
   if (!msg_silent) {
@@ -1062,20 +1042,17 @@ void msg_start()          {
 /*
  * Note that the current msg position is where messages start.
  */
-void msg_starthere()          {
+void msg_starthere(void)          {
   lines_left = cmdline_row;
   msg_didany = FALSE;
 }
 
-void msg_putchar(c)
-int c;
+void msg_putchar(int c)
 {
   msg_putchar_attr(c, 0);
 }
 
-void msg_putchar_attr(c, attr)
-int c;
-int attr;
+void msg_putchar_attr(int c, int attr)
 {
   char_u buf[MB_MAXBYTES + 1];
 
@@ -1090,8 +1067,7 @@ int attr;
   msg_puts_attr(buf, attr);
 }
 
-void msg_outnum(n)
-long n;
+void msg_outnum(long n)
 {
   char_u buf[20];
 
@@ -1099,21 +1075,17 @@ long n;
   msg_puts(buf);
 }
 
-void msg_home_replace(fname)
-char_u      *fname;
+void msg_home_replace(char_u *fname)
 {
   msg_home_replace_attr(fname, 0);
 }
 
-void msg_home_replace_hl(fname)
-char_u      *fname;
+void msg_home_replace_hl(char_u *fname)
 {
   msg_home_replace_attr(fname, hl_attr(HLF_D));
 }
 
-static void msg_home_replace_attr(fname, attr)
-char_u  *fname;
-int attr;
+static void msg_home_replace_attr(char_u *fname, int attr)
 {
   char_u      *name;
 
@@ -1129,22 +1101,17 @@ int attr;
  * Use attributes 'attr'.
  * Return the number of characters it takes on the screen.
  */
-int msg_outtrans(str)
-char_u          *str;
+int msg_outtrans(char_u *str)
 {
   return msg_outtrans_attr(str, 0);
 }
 
-int msg_outtrans_attr(str, attr)
-char_u      *str;
-int attr;
+int msg_outtrans_attr(char_u *str, int attr)
 {
   return msg_outtrans_len_attr(str, (int)STRLEN(str), attr);
 }
 
-int msg_outtrans_len(str, len)
-char_u      *str;
-int len;
+int msg_outtrans_len(char_u *str, int len)
 {
   return msg_outtrans_len_attr(str, len, 0);
 }
@@ -1153,9 +1120,7 @@ int len;
  * Output one character at "p".  Return pointer to the next character.
  * Handles multi-byte characters.
  */
-char_u * msg_outtrans_one(p, attr)
-char_u      *p;
-int attr;
+char_u *msg_outtrans_one(char_u *p, int attr)
 {
   int l;
 
@@ -1167,10 +1132,7 @@ int attr;
   return p + 1;
 }
 
-int msg_outtrans_len_attr(msgstr, len, attr)
-char_u      *msgstr;
-int len;
-int attr;
+int msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
 {
   int retval = 0;
   char_u      *str = msgstr;
@@ -1243,8 +1205,7 @@ int attr;
   return retval;
 }
 
-void msg_make(arg)
-char_u  *arg;
+void msg_make(char_u *arg)
 {
   int i;
   static char_u *str = (char_u *)"eeffoc", *rs = (char_u *)"Plon#dqg#vxjduB";
@@ -1274,9 +1235,11 @@ char_u  *arg;
  * This function is used to show mappings, where we want to see how to type
  * the character/string -- webb
  */
-int msg_outtrans_special(strstart, from)
-char_u      *strstart;
-int from;               /* TRUE for lhs of a mapping */
+int 
+msg_outtrans_special (
+    char_u *strstart,
+    int from               /* TRUE for lhs of a mapping */
+)
 {
   char_u      *str = strstart;
   int retval = 0;
@@ -1306,9 +1269,11 @@ int from;               /* TRUE for lhs of a mapping */
  * Return the lhs or rhs of a mapping, with the key codes turned into printable
  * strings, in an allocated string.
  */
-char_u * str2special_save(str, is_lhs)
-char_u  *str;
-int is_lhs;          /* TRUE for lhs, FALSE for rhs */
+char_u *
+str2special_save (
+    char_u *str,
+    int is_lhs          /* TRUE for lhs, FALSE for rhs */
+)
 {
   garray_T ga;
   char_u      *p = str;
@@ -1325,9 +1290,11 @@ int is_lhs;          /* TRUE for lhs, FALSE for rhs */
  * Used for translating the lhs or rhs of a mapping to printable chars.
  * Advances "sp" to the next code.
  */
-char_u * str2special(sp, from)
-char_u      **sp;
-int from;               /* TRUE for lhs of mapping */
+char_u *
+str2special (
+    char_u **sp,
+    int from               /* TRUE for lhs of mapping */
+)
 {
   int c;
   static char_u buf[7];
@@ -1390,10 +1357,7 @@ int from;               /* TRUE for lhs of mapping */
 /*
  * Translate a key sequence into special key names.
  */
-void str2specialbuf(sp, buf, len)
-char_u      *sp;
-char_u      *buf;
-int len;
+void str2specialbuf(char_u *sp, char_u *buf, int len)
 {
   char_u      *s;
 
@@ -1408,9 +1372,7 @@ int len;
 /*
  * print line for :print or :list command
  */
-void msg_prt_line(s, list)
-char_u      *s;
-int list;
+void msg_prt_line(char_u *s, int list)
 {
   int c;
   int col = 0;
@@ -1508,10 +1470,7 @@ int list;
  * Use screen_puts() to output one multi-byte character.
  * Return the pointer "s" advanced to the next character.
  */
-static char_u * screen_puts_mbyte(s, l, attr)
-char_u      *s;
-int l;
-int attr;
+static char_u *screen_puts_mbyte(char_u *s, int l, int attr)
 {
   int cw;
 
@@ -1546,14 +1505,12 @@ int attr;
  * Output a string to the screen at position msg_row, msg_col.
  * Update msg_row and msg_col for the next message.
  */
-void msg_puts(s)
-char_u      *s;
+void msg_puts(char_u *s)
 {
   msg_puts_attr(s, 0);
 }
 
-void msg_puts_title(s)
-char_u      *s;
+void msg_puts_title(char_u *s)
 {
   msg_puts_attr(s, hl_attr(HLF_T));
 }
@@ -1563,17 +1520,12 @@ char_u      *s;
  * part in the middle and replace it with "..." when necessary.
  * Does not handle multi-byte characters!
  */
-void msg_puts_long_attr(longstr, attr)
-char_u      *longstr;
-int attr;
+void msg_puts_long_attr(char_u *longstr, int attr)
 {
   msg_puts_long_len_attr(longstr, (int)STRLEN(longstr), attr);
 }
 
-void msg_puts_long_len_attr(longstr, len, attr)
-char_u      *longstr;
-int len;
-int attr;
+void msg_puts_long_len_attr(char_u *longstr, int len, int attr)
 {
   int slen = len;
   int room;
@@ -1590,9 +1542,7 @@ int attr;
 /*
  * Basic function for writing a message with highlight attributes.
  */
-void msg_puts_attr(s, attr)
-char_u      *s;
-int attr;
+void msg_puts_attr(char_u *s, int attr)
 {
   msg_puts_attr_len(s, -1, attr);
 }
@@ -1602,10 +1552,7 @@ int attr;
  * When "maxlen" is -1 there is no maximum length.
  * When "maxlen" is >= 0 the message is not put in the history.
  */
-static void msg_puts_attr_len(str, maxlen, attr)
-char_u      *str;
-int maxlen;
-int attr;
+static void msg_puts_attr_len(char_u *str, int maxlen, int attr)
 {
   /*
    * If redirection is on, also write to the redirection file.
@@ -1651,11 +1598,7 @@ int attr;
  * The display part of msg_puts_attr_len().
  * May be called recursively to display scroll-back text.
  */
-static void msg_puts_display(str, maxlen, attr, recurse)
-char_u      *str;
-int maxlen;
-int attr;
-int recurse;
+static void msg_puts_display(char_u *str, int maxlen, int attr, int recurse)
 {
   char_u      *s = str;
   char_u      *t_s = str;       /* string from "t_s" to "s" is still todo */
@@ -1841,7 +1784,7 @@ int recurse;
 /*
  * Scroll the screen up one line for displaying the next message line.
  */
-static void msg_scroll_up()                 {
+static void msg_scroll_up(void)                 {
   /* scrolling up always works */
   screen_del_lines(0, 0, 1, (int)Rows, TRUE, NULL);
 
@@ -1862,7 +1805,7 @@ static void msg_scroll_up()                 {
 /*
  * Increment "msg_scrolled".
  */
-static void inc_msg_scrolled()                 {
+static void inc_msg_scrolled(void)                 {
   if (*get_vim_var_str(VV_SCROLLSTART) == NUL) {
     char_u      *p = sourcing_name;
     char_u      *tofree = NULL;
@@ -1911,12 +1854,14 @@ static int do_clear_sb_text = FALSE;    /* clear text on next msg */
 /*
  * Store part of a printed message for displaying when scrolling back.
  */
-static void store_sb_text(sb_str, s, attr, sb_col, finish)
-char_u      **sb_str;           /* start of string */
-char_u      *s;                 /* just after string */
-int attr;
-int         *sb_col;
-int finish;                     /* line ends */
+static void 
+store_sb_text (
+    char_u **sb_str,           /* start of string */
+    char_u *s,                 /* just after string */
+    int attr,
+    int *sb_col,
+    int finish                     /* line ends */
+)
 {
   msgchunk_T  *mp;
 
@@ -1953,7 +1898,7 @@ int finish;                     /* line ends */
 /*
  * Finished showing messages, clear the scroll-back text on the next message.
  */
-void may_clear_sb_text()          {
+void may_clear_sb_text(void)          {
   do_clear_sb_text = TRUE;
 }
 
@@ -1961,7 +1906,7 @@ void may_clear_sb_text()          {
  * Clear any text remembered for scrolling back.
  * Called when redrawing the screen.
  */
-void clear_sb_text()          {
+void clear_sb_text(void)          {
   msgchunk_T  *mp;
 
   while (last_msgchunk != NULL) {
@@ -1974,7 +1919,7 @@ void clear_sb_text()          {
 /*
  * "g<" command.
  */
-void show_sb_text()          {
+void show_sb_text(void)          {
   msgchunk_T  *mp;
 
   /* Only show something if there is more than one line, otherwise it looks
@@ -1991,8 +1936,7 @@ void show_sb_text()          {
 /*
  * Move to the start of screen line in already displayed text.
  */
-static msgchunk_T * msg_sb_start(mps)
-msgchunk_T *mps;
+static msgchunk_T *msg_sb_start(msgchunk_T *mps)
 {
   msgchunk_T *mp = mps;
 
@@ -2004,7 +1948,7 @@ msgchunk_T *mps;
 /*
  * Mark the last message chunk as finishing the line.
  */
-void msg_sb_eol()          {
+void msg_sb_eol(void)          {
   if (last_msgchunk != NULL)
     last_msgchunk->sb_eol = TRUE;
 }
@@ -2013,9 +1957,7 @@ void msg_sb_eol()          {
  * Display a screen line from previously displayed text at row "row".
  * Returns a pointer to the text for the next line (can be NULL).
  */
-static msgchunk_T * disp_sb_line(row, smp)
-int row;
-msgchunk_T  *smp;
+static msgchunk_T *disp_sb_line(int row, msgchunk_T *smp)
 {
   msgchunk_T  *mp = smp;
   char_u      *p;
@@ -2037,11 +1979,7 @@ msgchunk_T  *smp;
 /*
  * Output any postponed text for msg_puts_attr_len().
  */
-static void t_puts(t_col, t_s, s, attr)
-int         *t_col;
-char_u      *t_s;
-char_u      *s;
-int attr;
+static void t_puts(int *t_col, char_u *t_s, char_u *s, int attr)
 {
   /* output postponed text */
   msg_didout = TRUE;            /* remember that line is not empty */
@@ -2066,7 +2004,7 @@ int attr;
  * different, e.g. for Win32 console) or we just don't know where the
  * cursor is.
  */
-int msg_use_printf()         {
+int msg_use_printf(void)         {
   return !msg_check_screen()
          || (swapping_screen() && !termcap_active)
   ;
@@ -2075,9 +2013,7 @@ int msg_use_printf()         {
 /*
  * Print a message when there is no valid screen.
  */
-static void msg_puts_printf(str, maxlen)
-char_u      *str;
-int maxlen;
+static void msg_puts_printf(char_u *str, int maxlen)
 {
   char_u      *s = str;
   char_u buf[4];
@@ -2126,8 +2062,7 @@ int maxlen;
  * otherwise it's NUL.
  * Returns TRUE when jumping ahead to "confirm_msg_tail".
  */
-static int do_more_prompt(typed_char)
-int typed_char;
+static int do_more_prompt(int typed_char)
 {
   int used_typed_char = typed_char;
   int oldState = State;
@@ -2332,8 +2267,7 @@ int typed_char;
  * yet.  When stderr can't be used, collect error messages until the GUI has
  * started and they can be displayed in a message box.
  */
-void mch_errmsg(str)
-char        *str;
+void mch_errmsg(char *str)
 {
   int len;
 
@@ -2386,8 +2320,7 @@ char        *str;
  * When there is no tty, collect messages until the GUI has started and they
  * can be displayed in a message box.
  */
-void mch_msg(str)
-char        *str;
+void mch_msg(char *str)
 {
 #if (defined(UNIX) || defined(FEAT_GUI)) && !defined(ALWAYS_USE_GUI)
   /* On Unix use stdout if we have a tty.  This allows "vim -h | more" and
@@ -2411,9 +2344,7 @@ char        *str;
  * Put a character on the screen at the current message position and advance
  * to the next position.  Only for printable ASCII!
  */
-static void msg_screen_putchar(c, attr)
-int c;
-int attr;
+static void msg_screen_putchar(int c, int attr)
 {
   msg_didout = TRUE;            /* remember that line is not empty */
   screen_putchar(c, msg_row, msg_col, attr);
@@ -2430,8 +2361,7 @@ int attr;
   }
 }
 
-void msg_moremsg(full)
-int full;
+void msg_moremsg(int full)
 {
   int attr;
   char_u      *s = (char_u *)_("-- More --");
@@ -2448,7 +2378,7 @@ int full;
  * Repeat the message for the current mode: ASKMORE, EXTERNCMD, CONFIRM or
  * exmode_active.
  */
-void repeat_message()          {
+void repeat_message(void)          {
   if (State == ASKMORE) {
     msg_moremsg(TRUE);          /* display --more-- message again */
     msg_row = Rows - 1;
@@ -2477,7 +2407,7 @@ void repeat_message()          {
  * While starting the GUI the terminal codes will be set for the GUI, but the
  * output goes to the terminal.  Don't use the terminal codes then.
  */
-static int msg_check_screen()                {
+static int msg_check_screen(void)                {
   if (!full_screen || !screen_valid(FALSE))
     return FALSE;
 
@@ -2492,7 +2422,7 @@ static int msg_check_screen()                {
  * Clear from current message position to end of screen.
  * Skip this when ":silent" was used, no need to clear for redirection.
  */
-void msg_clr_eos()          {
+void msg_clr_eos(void)          {
   if (msg_silent == 0)
     msg_clr_eos_force();
 }
@@ -2502,7 +2432,7 @@ void msg_clr_eos()          {
  * Note: msg_col is not updated, so we remember the end of the message
  * for msg_check().
  */
-void msg_clr_eos_force()          {
+void msg_clr_eos_force(void)          {
   if (msg_use_printf()) {
     if (full_screen) {          /* only when termcap codes are valid */
       if (*T_CD)
@@ -2525,7 +2455,7 @@ void msg_clr_eos_force()          {
 /*
  * Clear the command line.
  */
-void msg_clr_cmdline()          {
+void msg_clr_cmdline(void)          {
   msg_row = cmdline_row;
   msg_col = 0;
   msg_clr_eos_force();
@@ -2536,7 +2466,7 @@ void msg_clr_cmdline()          {
  * call wait_return if the message does not fit in the available space
  * return TRUE if wait_return not called.
  */
-int msg_end()         {
+int msg_end(void)         {
   /*
    * If the string is larger than the window,
    * or the ruler option is set and we run into it,
@@ -2555,7 +2485,7 @@ int msg_end()         {
  * If the written message runs into the shown command or ruler, we have to
  * wait for hit-return and redraw the window later.
  */
-void msg_check()          {
+void msg_check(void)          {
   if (msg_row == Rows - 1 && msg_col >= sc_col) {
     need_wait_return = TRUE;
     redraw_cmdline = TRUE;
@@ -2566,9 +2496,7 @@ void msg_check()          {
  * May write a string to the redirection file.
  * When "maxlen" is -1 write the whole string, otherwise up to "maxlen" bytes.
  */
-static void redir_write(str, maxlen)
-char_u      *str;
-int maxlen;
+static void redir_write(char_u *str, int maxlen)
 {
   char_u      *s = str;
   static int cur_col = 0;
@@ -2623,7 +2551,7 @@ int maxlen;
   }
 }
 
-int redirecting()         {
+int redirecting(void)         {
   return redir_fd != NULL || *p_vfile != NUL
          || redir_reg || redir_vname
   ;
@@ -2633,7 +2561,7 @@ int redirecting()         {
  * Before giving verbose message.
  * Must always be called paired with verbose_leave()!
  */
-void verbose_enter()          {
+void verbose_enter(void)          {
   if (*p_vfile != NUL)
     ++msg_silent;
 }
@@ -2642,7 +2570,7 @@ void verbose_enter()          {
  * After giving verbose message.
  * Must always be called paired with verbose_enter()!
  */
-void verbose_leave()          {
+void verbose_leave(void)          {
   if (*p_vfile != NUL)
     if (--msg_silent < 0)
       msg_silent = 0;
@@ -2651,7 +2579,7 @@ void verbose_leave()          {
 /*
  * Like verbose_enter() and set msg_scroll when displaying the message.
  */
-void verbose_enter_scroll()          {
+void verbose_enter_scroll(void)          {
   if (*p_vfile != NUL)
     ++msg_silent;
   else
@@ -2662,7 +2590,7 @@ void verbose_enter_scroll()          {
 /*
  * Like verbose_leave() and set cmdline_row when displaying the message.
  */
-void verbose_leave_scroll()          {
+void verbose_leave_scroll(void)          {
   if (*p_vfile != NUL) {
     if (--msg_silent < 0)
       msg_silent = 0;
@@ -2673,7 +2601,7 @@ void verbose_leave_scroll()          {
 /*
  * Called when 'verbosefile' is set: stop writing to the file.
  */
-void verbose_stop()          {
+void verbose_stop(void)          {
   if (verbose_fd != NULL) {
     fclose(verbose_fd);
     verbose_fd = NULL;
@@ -2685,7 +2613,7 @@ void verbose_stop()          {
  * Open the file 'verbosefile'.
  * Return FAIL or OK.
  */
-int verbose_open()         {
+int verbose_open(void)         {
   if (verbose_fd == NULL && !verbose_did_open) {
     /* Only give the error message once. */
     verbose_did_open = TRUE;
@@ -2703,9 +2631,7 @@ int verbose_open()         {
  * Give a warning message (for searching).
  * Use 'w' highlighting and may repeat the message after redrawing
  */
-void give_warning(message, hl)
-char_u  *message;
-int hl;
+void give_warning(char_u *message, int hl)
 {
   /* Don't do this for ":silent". */
   if (msg_silent != 0)
@@ -2733,8 +2659,7 @@ int hl;
 /*
  * Advance msg cursor to column "col".
  */
-void msg_advance(col)
-int col;
+void msg_advance(int col)
 {
   if (msg_silent != 0) {        /* nothing to advance to */
     msg_col = col;              /* for redirection, may fill it up later */
@@ -2768,16 +2693,18 @@ int col;
  * A '&' in a button name becomes a shortcut, so each '&' should be before a
  * different letter.
  */
-int do_dialog(type, title, message, buttons, dfltbutton, textfield, ex_cmd)
-int type UNUSED;
-char_u      *title UNUSED;
-char_u      *message;
-char_u      *buttons;
-int dfltbutton;
-char_u      *textfield UNUSED;          /* IObuff for inputdialog(), NULL
+int 
+do_dialog (
+    int type,
+    char_u *title,
+    char_u *message,
+    char_u *buttons,
+    int dfltbutton,
+    char_u *textfield,          /* IObuff for inputdialog(), NULL
                                            otherwise */
-int ex_cmd;                 /* when TRUE pressing : accepts default and starts
+    int ex_cmd                 /* when TRUE pressing : accepts default and starts
                                Ex command */
+)
 {
   int oldState;
   int retval = 0;
@@ -2862,10 +2789,12 @@ static int copy_char __ARGS((char_u *from, char_u *to, int lowercase));
  * Copy one character from "*from" to "*to", taking care of multi-byte
  * characters.  Return the length of the character in bytes.
  */
-static int copy_char(from, to, lowercase)
-char_u      *from;
-char_u      *to;
-int lowercase;                  /* make character lower case */
+static int 
+copy_char (
+    char_u *from,
+    char_u *to,
+    int lowercase                  /* make character lower case */
+)
 {
   int len;
   int c;
@@ -2897,10 +2826,7 @@ int lowercase;                  /* make character lower case */
  *
  * Returns an allocated string with hotkeys, or NULL for error.
  */
-static char_u * msg_show_console_dialog(message, buttons, dfltbutton)
-char_u      *message;
-char_u      *buttons;
-int dfltbutton;
+static char_u *msg_show_console_dialog(char_u *message, char_u *buttons, int dfltbutton)
 {
   int len = 0;
 # define HOTK_LEN (has_mbyte ? MB_MAXBYTES : 1)
@@ -3032,7 +2958,7 @@ int dfltbutton;
 /*
  * Display the ":confirm" message.  Also called when screen resized.
  */
-void display_confirm_msg()          {
+void display_confirm_msg(void)          {
   /* avoid that 'q' at the more prompt truncates the message here */
   ++confirm_msg_used;
   if (confirm_msg != NULL)
@@ -3040,11 +2966,7 @@ void display_confirm_msg()          {
   --confirm_msg_used;
 }
 
-int vim_dialog_yesno(type, title, message, dflt)
-int type;
-char_u      *title;
-char_u      *message;
-int dflt;
+int vim_dialog_yesno(int type, char_u *title, char_u *message, int dflt)
 {
   if (do_dialog(type,
           title == NULL ? (char_u *)_("Question") : title,
@@ -3054,11 +2976,7 @@ int dflt;
   return VIM_NO;
 }
 
-int vim_dialog_yesnocancel(type, title, message, dflt)
-int type;
-char_u      *title;
-char_u      *message;
-int dflt;
+int vim_dialog_yesnocancel(int type, char_u *title, char_u *message, int dflt)
 {
   switch (do_dialog(type,
               title == NULL ? (char_u *)_("Question") : title,
@@ -3070,11 +2988,7 @@ int dflt;
   return VIM_CANCEL;
 }
 
-int vim_dialog_yesnoallcancel(type, title, message, dflt)
-int type;
-char_u      *title;
-char_u      *message;
-int dflt;
+int vim_dialog_yesnoallcancel(int type, char_u *title, char_u *message, int dflt)
 {
   switch (do_dialog(type,
               title == NULL ? (char_u *)"Question" : title,
@@ -3101,9 +3015,7 @@ static double tv_float __ARGS((typval_T *tvs, int *idxp));
 /*
  * Get number argument from "idxp" entry in "tvs".  First entry is 1.
  */
-static long tv_nr(tvs, idxp)
-typval_T    *tvs;
-int         *idxp;
+static long tv_nr(typval_T *tvs, int *idxp)
 {
   int idx = *idxp - 1;
   long n = 0;
@@ -3124,9 +3036,7 @@ int         *idxp;
  * Get string argument from "idxp" entry in "tvs".  First entry is 1.
  * Returns NULL for an error.
  */
-static char * tv_str(tvs, idxp)
-typval_T    *tvs;
-int         *idxp;
+static char *tv_str(typval_T *tvs, int *idxp)
 {
   int idx = *idxp - 1;
   char        *s = NULL;
@@ -3143,9 +3053,7 @@ int         *idxp;
 /*
  * Get float argument from "idxp" entry in "tvs".  First entry is 1.
  */
-static double tv_float(tvs, idxp)
-typval_T    *tvs;
-int         *idxp;
+static double tv_float(typval_T *tvs, int *idxp)
 {
   int idx = *idxp - 1;
   double f = 0;
@@ -3230,11 +3138,7 @@ int vim_snprintf_add(char *str, size_t str_m, char *fmt, ...)         {
 
 # else
 /* Like vim_vsnprintf() but append to the string. */
-int vim_snprintf_add(str, str_m, fmt, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
-char        *str;
-size_t str_m;
-char        *fmt;
-long a1, a2, a3, a4, a5, a6, a7, a8, a9, a10;
+int vim_snprintf_add(char *str, size_t str_m, char *fmt, long a1, long a2, long a3, long a4, long a5, long a6, long a7, long a8, long a9, long a10)
 {
   size_t len = STRLEN(str);
   size_t space;

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -25,15 +25,14 @@ static garray_T ga_users;
 /*
  * Count the size (in window cells) of the indent in the current line.
  */
-int get_indent()         {
+int get_indent(void)         {
   return get_indent_str(ml_get_curline(), (int)curbuf->b_p_ts);
 }
 
 /*
  * Count the size (in window cells) of the indent in line "lnum".
  */
-int get_indent_lnum(lnum)
-linenr_T lnum;
+int get_indent_lnum(linenr_T lnum)
 {
   return get_indent_str(ml_get(lnum), (int)curbuf->b_p_ts);
 }
@@ -42,9 +41,7 @@ linenr_T lnum;
  * Count the size (in window cells) of the indent in line "lnum" of buffer
  * "buf".
  */
-int get_indent_buf(buf, lnum)
-buf_T       *buf;
-linenr_T lnum;
+int get_indent_buf(buf_T *buf, linenr_T lnum)
 {
   return get_indent_str(ml_get_buf(buf, lnum, FALSE), (int)buf->b_p_ts);
 }
@@ -53,9 +50,7 @@ linenr_T lnum;
  * count the size (in window cells) of the indent in line "ptr", with
  * 'tabstop' at "ts"
  */
-int get_indent_str(ptr, ts)
-char_u      *ptr;
-int ts;
+int get_indent_str(char_u *ptr, int ts)
 {
   int count = 0;
 
@@ -80,9 +75,11 @@ int ts;
  *	SIN_UNDO:	save line for undo before changing it.
  * Returns TRUE if the line was changed.
  */
-int set_indent(size, flags)
-int size;                           /* measured in spaces */
-int flags;
+int 
+set_indent (
+    int size,                           /* measured in spaces */
+    int flags
+)
 {
   char_u      *p;
   char_u      *newline;
@@ -291,9 +288,7 @@ int flags;
  * Leaves the cursor on the first non-blank in the line.
  * Returns TRUE if the line was changed.
  */
-static int copy_indent(size, src)
-int size;
-char_u      *src;
+static int copy_indent(int size, char_u *src)
 {
   char_u      *p = NULL;
   char_u      *line = NULL;
@@ -385,8 +380,7 @@ char_u      *src;
  * number was found.  Used for 'n' in 'formatoptions': numbered list.
  * Since a pattern is used it can actually handle more than numbers.
  */
-int get_number_indent(lnum)
-linenr_T lnum;
+int get_number_indent(linenr_T lnum)
 {
   colnr_T col;
   pos_T pos;
@@ -427,8 +421,7 @@ static int cin_is_cinword __ARGS((char_u *line));
 /*
  * Return TRUE if the string "line" starts with a word from 'cinwords'.
  */
-static int cin_is_cinword(line)
-char_u      *line;
+static int cin_is_cinword(char_u *line)
 {
   char_u      *cinw;
   char_u      *cinw_buf;
@@ -473,10 +466,12 @@ char_u      *line;
  *
  * Return TRUE for success, FALSE for failure
  */
-int open_line(dir, flags, second_line_indent)
-int dir;                        /* FORWARD or BACKWARD */
-int flags;
-int second_line_indent;
+int 
+open_line (
+    int dir,                        /* FORWARD or BACKWARD */
+    int flags,
+    int second_line_indent
+)
 {
   char_u      *saved_line;              /* copy of the original line */
   char_u      *next_line = NULL;        /* copy of the next line */
@@ -1348,11 +1343,7 @@ theend:
  * If "include_space" is set, include trailing whitespace while calculating the
  * length.
  */
-int get_leader_len(line, flags, backward, include_space)
-char_u      *line;
-char_u      **flags;
-int backward;
-int include_space;
+int get_leader_len(char_u *line, char_u **flags, int backward, int include_space)
 {
   int i, j;
   int result;
@@ -1486,9 +1477,7 @@ int include_space;
  * When "flags" is not null, it is set to point to the flags describing the
  * recognized comment leader.
  */
-int get_last_leader_offset(line, flags)
-char_u      *line;
-char_u      **flags;
+int get_last_leader_offset(char_u *line, char_u **flags)
 {
   int result = -1;
   int i, j;
@@ -1618,32 +1607,34 @@ char_u      **flags;
 /*
  * Return the number of window lines occupied by buffer line "lnum".
  */
-int plines(lnum)
-linenr_T lnum;
+int plines(linenr_T lnum)
 {
   return plines_win(curwin, lnum, TRUE);
 }
 
-int plines_win(wp, lnum, winheight)
-win_T       *wp;
-linenr_T lnum;
-int winheight;                  /* when TRUE limit to window height */
+int 
+plines_win (
+    win_T *wp,
+    linenr_T lnum,
+    int winheight                  /* when TRUE limit to window height */
+)
 {
   /* Check for filler lines above this buffer line.  When folded the result
    * is one line anyway. */
   return plines_win_nofill(wp, lnum, winheight) + diff_check_fill(wp, lnum);
 }
 
-int plines_nofill(lnum)
-linenr_T lnum;
+int plines_nofill(linenr_T lnum)
 {
   return plines_win_nofill(curwin, lnum, TRUE);
 }
 
-int plines_win_nofill(wp, lnum, winheight)
-win_T       *wp;
-linenr_T lnum;
-int winheight;                  /* when TRUE limit to window height */
+int 
+plines_win_nofill (
+    win_T *wp,
+    linenr_T lnum,
+    int winheight                  /* when TRUE limit to window height */
+)
 {
   int lines;
 
@@ -1668,9 +1659,7 @@ int winheight;                  /* when TRUE limit to window height */
  * Return number of window lines physical line "lnum" will occupy in window
  * "wp".  Does not care about folding, 'wrap' or 'diff'.
  */
-int plines_win_nofold(wp, lnum)
-win_T       *wp;
-linenr_T lnum;
+int plines_win_nofold(win_T *wp, linenr_T lnum)
 {
   char_u      *s;
   long col;
@@ -1705,10 +1694,7 @@ linenr_T lnum;
  * Like plines_win(), but only reports the number of physical screen lines
  * used from the start of the line to the given column number.
  */
-int plines_win_col(wp, lnum, column)
-win_T       *wp;
-linenr_T lnum;
-long column;
+int plines_win_col(win_T *wp, linenr_T lnum, long column)
 {
   long col;
   char_u      *s;
@@ -1756,9 +1742,7 @@ long column;
   return lines;
 }
 
-int plines_m_win(wp, first, last)
-win_T       *wp;
-linenr_T first, last;
+int plines_m_win(win_T *wp, linenr_T first, linenr_T last)
 {
   int count = 0;
 
@@ -1786,8 +1770,7 @@ linenr_T first, last;
  * Insert string "p" at the cursor position.  Stops at a NUL byte.
  * Handles Replace mode and multi-byte characters.
  */
-void ins_bytes(p)
-char_u      *p;
+void ins_bytes(char_u *p)
 {
   ins_bytes_len(p, (int)STRLEN(p));
 }
@@ -1798,9 +1781,7 @@ char_u      *p;
  * Insert string "p" with length "len" at the cursor position.
  * Handles Replace mode and multi-byte characters.
  */
-void ins_bytes_len(p, len)
-char_u      *p;
-int len;
+void ins_bytes_len(char_u *p, int len)
 {
   int i;
   int n;
@@ -1827,8 +1808,7 @@ int len;
  * For multi-byte characters we get the whole character, the caller must
  * convert bytes to a character.
  */
-void ins_char(c)
-int c;
+void ins_char(int c)
 {
   char_u buf[MB_MAXBYTES + 1];
   int n;
@@ -1843,9 +1823,7 @@ int c;
   ins_char_bytes(buf, n);
 }
 
-void ins_char_bytes(buf, charlen)
-char_u      *buf;
-int charlen;
+void ins_char_bytes(char_u *buf, int charlen)
 {
   int c = buf[0];
   int newlen;                   /* nr of bytes inserted */
@@ -1979,8 +1957,7 @@ int charlen;
  * Note: Does NOT handle Replace mode.
  * Caller must have prepared for undo.
  */
-void ins_str(s)
-char_u      *s;
+void ins_str(char_u *s)
 {
   char_u      *oldp, *newp;
   int newlen = (int)STRLEN(s);
@@ -2014,8 +1991,7 @@ char_u      *s;
  *
  * return FAIL for failure, OK otherwise
  */
-int del_char(fixpos)
-int fixpos;
+int del_char(int fixpos)
 {
   if (has_mbyte) {
     /* Make sure the cursor is at the start of a character. */
@@ -2030,9 +2006,7 @@ int fixpos;
 /*
  * Like del_bytes(), but delete characters instead of bytes.
  */
-int del_chars(count, fixpos)
-long count;
-int fixpos;
+int del_chars(long count, int fixpos)
 {
   long bytes = 0;
   long i;
@@ -2055,10 +2029,12 @@ int fixpos;
  *
  * return FAIL for failure, OK otherwise
  */
-int del_bytes(count, fixpos_arg, use_delcombine)
-long count;
-int fixpos_arg;
-int use_delcombine UNUSED;                  /* 'delcombine' option applies */
+int 
+del_bytes (
+    long count,
+    int fixpos_arg,
+    int use_delcombine                  /* 'delcombine' option applies */
+)
 {
   char_u      *oldp, *newp;
   colnr_T oldlen;
@@ -2152,8 +2128,10 @@ int use_delcombine UNUSED;                  /* 'delcombine' option applies */
  *
  * return FAIL for failure, OK otherwise
  */
-int truncate_line(fixpos)
-int fixpos;                 /* if TRUE fix the cursor position when done */
+int 
+truncate_line (
+    int fixpos                 /* if TRUE fix the cursor position when done */
+)
 {
   char_u      *newp;
   linenr_T lnum = curwin->w_cursor.lnum;
@@ -2185,9 +2163,11 @@ int fixpos;                 /* if TRUE fix the cursor position when done */
  * Delete "nlines" lines at the cursor.
  * Saves the lines for undo first if "undo" is TRUE.
  */
-void del_lines(nlines, undo)
-long nlines;                    /* number of lines to delete */
-int undo;                       /* if TRUE, prepare for undo */
+void 
+del_lines (
+    long nlines,                    /* number of lines to delete */
+    int undo                       /* if TRUE, prepare for undo */
+)
 {
   long n;
   linenr_T first = curwin->w_cursor.lnum;
@@ -2220,8 +2200,7 @@ int undo;                       /* if TRUE, prepare for undo */
   deleted_lines_mark(first, n);
 }
 
-int gchar_pos(pos)
-pos_T *pos;
+int gchar_pos(pos_T *pos)
 {
   char_u      *ptr = ml_get_pos(pos);
 
@@ -2230,7 +2209,7 @@ pos_T *pos;
   return (int)*ptr;
 }
 
-int gchar_cursor()         {
+int gchar_cursor(void)         {
   if (has_mbyte)
     return (*mb_ptr2char)(ml_get_cursor());
   return (int)*ml_get_cursor();
@@ -2240,8 +2219,7 @@ int gchar_cursor()         {
  * Write a character at the current cursor position.
  * It is directly written into the block.
  */
-void pchar_cursor(c)
-int c;
+void pchar_cursor(int c)
 {
   *(ml_get_buf(curbuf, curwin->w_cursor.lnum, TRUE)
     + curwin->w_cursor.col) = c;
@@ -2253,8 +2231,7 @@ int c;
  * When extra == 1: Return TRUE if the cursor is before the first non-blank in
  *		    the line.
  */
-int inindent(extra)
-int extra;
+int inindent(int extra)
 {
   char_u      *ptr;
   colnr_T col;
@@ -2270,8 +2247,7 @@ int extra;
 /*
  * Skip to next part of an option argument: Skip space and comma.
  */
-char_u * skip_to_option_part(p)
-char_u  *p;
+char_u *skip_to_option_part(char_u *p)
 {
   if (*p == ',')
     ++p;
@@ -2288,7 +2264,7 @@ char_u  *p;
  *
  * Careful: may trigger autocommands that reload the buffer.
  */
-void changed()          {
+void changed(void)          {
 
   if (!curbuf->b_changed) {
     int save_msg_scroll = msg_scroll;
@@ -2323,7 +2299,7 @@ void changed()          {
 /*
  * Internal part of changed(), no user interaction.
  */
-void changed_int()          {
+void changed_int(void)          {
   curbuf->b_changed = TRUE;
   ml_setflags(curbuf);
   check_status(curbuf);
@@ -2344,9 +2320,7 @@ static void changed_common __ARGS((linenr_T lnum, colnr_T col, linenr_T lnume,
  * - invalidates cached values
  * Careful: may trigger autocommands that reload the buffer.
  */
-void changed_bytes(lnum, col)
-linenr_T lnum;
-colnr_T col;
+void changed_bytes(linenr_T lnum, colnr_T col)
 {
   changedOneline(curbuf, lnum);
   changed_common(lnum, col, lnum + 1, 0L);
@@ -2366,9 +2340,7 @@ colnr_T col;
   }
 }
 
-static void changedOneline(buf, lnum)
-buf_T       *buf;
-linenr_T lnum;
+static void changedOneline(buf_T *buf, linenr_T lnum)
 {
   if (buf->b_mod_set) {
     /* find the maximum area that must be redisplayed */
@@ -2390,9 +2362,7 @@ linenr_T lnum;
  * Must be called AFTER the change and after mark_adjust().
  * Takes care of marking the buffer to be redrawn and sets the changed flag.
  */
-void appended_lines(lnum, count)
-linenr_T lnum;
-long count;
+void appended_lines(linenr_T lnum, long count)
 {
   changed_lines(lnum + 1, 0, lnum + 1, count);
 }
@@ -2400,9 +2370,7 @@ long count;
 /*
  * Like appended_lines(), but adjust marks first.
  */
-void appended_lines_mark(lnum, count)
-linenr_T lnum;
-long count;
+void appended_lines_mark(linenr_T lnum, long count)
 {
   mark_adjust(lnum + 1, (linenr_T)MAXLNUM, count, 0L);
   changed_lines(lnum + 1, 0, lnum + 1, count);
@@ -2413,9 +2381,7 @@ long count;
  * Must be called AFTER the change and after mark_adjust().
  * Takes care of marking the buffer to be redrawn and sets the changed flag.
  */
-void deleted_lines(lnum, count)
-linenr_T lnum;
-long count;
+void deleted_lines(linenr_T lnum, long count)
 {
   changed_lines(lnum, 0, lnum + count, -count);
 }
@@ -2425,9 +2391,7 @@ long count;
  * Make sure the cursor is on a valid line before calling, a GUI callback may
  * be triggered to display the cursor.
  */
-void deleted_lines_mark(lnum, count)
-linenr_T lnum;
-long count;
+void deleted_lines_mark(linenr_T lnum, long count)
 {
   mark_adjust(lnum, (linenr_T)(lnum + count - 1), (long)MAXLNUM, -count);
   changed_lines(lnum, 0, lnum + count, -count);
@@ -2445,11 +2409,13 @@ long count;
  * Takes care of calling changed() and updating b_mod_*.
  * Careful: may trigger autocommands that reload the buffer.
  */
-void changed_lines(lnum, col, lnume, xtra)
-linenr_T lnum;              /* first line with change */
-colnr_T col;                /* column in first line with change */
-linenr_T lnume;             /* line below last changed line */
-long xtra;                  /* number of extra lines (negative when deleting) */
+void 
+changed_lines (
+    linenr_T lnum,              /* first line with change */
+    colnr_T col,                /* column in first line with change */
+    linenr_T lnume,             /* line below last changed line */
+    long xtra                  /* number of extra lines (negative when deleting) */
+)
 {
   changed_lines_buf(curbuf, lnum, lnume, xtra);
 
@@ -2473,11 +2439,13 @@ long xtra;                  /* number of extra lines (negative when deleting) */
   changed_common(lnum, col, lnume, xtra);
 }
 
-static void changed_lines_buf(buf, lnum, lnume, xtra)
-buf_T       *buf;
-linenr_T lnum;              /* first line with change */
-linenr_T lnume;             /* line below last changed line */
-long xtra;                  /* number of extra lines (negative when deleting) */
+static void 
+changed_lines_buf (
+    buf_T *buf,
+    linenr_T lnum,              /* first line with change */
+    linenr_T lnume,             /* line below last changed line */
+    long xtra                  /* number of extra lines (negative when deleting) */
+)
 {
   if (buf->b_mod_set) {
     /* find the maximum area that must be redisplayed */
@@ -2506,11 +2474,7 @@ long xtra;                  /* number of extra lines (negative when deleting) */
  * See changed_lines() for the arguments.
  * Careful: may trigger autocommands that reload the buffer.
  */
-static void changed_common(lnum, col, lnume, xtra)
-linenr_T lnum;
-colnr_T col;
-linenr_T lnume;
-long xtra;
+static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, long xtra)
 {
   win_T       *wp;
   tabpage_T   *tp;
@@ -2671,9 +2635,11 @@ long xtra;
 /*
  * unchanged() is called when the changed flag must be reset for buffer 'buf'
  */
-void unchanged(buf, ff)
-buf_T       *buf;
-int ff;                 /* also reset 'fileformat' */
+void 
+unchanged (
+    buf_T *buf,
+    int ff                 /* also reset 'fileformat' */
+)
 {
   if (buf->b_changed || (ff && file_ff_differs(buf, FALSE))) {
     buf->b_changed = 0;
@@ -2691,8 +2657,7 @@ int ff;                 /* also reset 'fileformat' */
  * check_status: called when the status bars for the buffer 'buf'
  *		 need to be updated
  */
-void check_status(buf)
-buf_T       *buf;
+void check_status(buf_T *buf)
 {
   win_T       *wp;
 
@@ -2712,9 +2677,11 @@ buf_T       *buf;
  * will be TRUE.
  * Careful: may trigger autocommands that reload the buffer.
  */
-void change_warning(col)
-int col;                        /* column for message; non-zero when in insert
+void 
+change_warning (
+    int col                        /* column for message; non-zero when in insert
                                    mode and 'showmode' is on */
+)
 {
   static char *w_readonly = N_("W10: Warning: Changing a readonly file");
 
@@ -2759,9 +2726,7 @@ int col;                        /* column for message; non-zero when in insert
  *
  * return the 'y' or 'n'
  */
-int ask_yesno(str, direct)
-char_u  *str;
-int direct;
+int ask_yesno(char_u *str, int direct)
 {
   int r = ' ';
   int save_State = State;
@@ -2801,8 +2766,7 @@ int direct;
 /*
  * Return TRUE if "c" is a mouse key.
  */
-int is_mouse_key(c)
-int c;
+int is_mouse_key(int c)
 {
   return c == K_LEFTMOUSE
          || c == K_LEFTMOUSE_NM
@@ -2835,7 +2799,7 @@ int c;
  * Disadvantage: typeahead is ignored.
  * Translates the interrupt character for unix to ESC.
  */
-int get_keystroke()         {
+int get_keystroke(void)         {
   char_u      *buf = NULL;
   int buflen = 150;
   int maxlen;
@@ -2935,9 +2899,11 @@ int get_keystroke()         {
  * Get a number from the user.
  * When "mouse_used" is not NULL allow using the mouse.
  */
-int get_number(colon, mouse_used)
-int colon;                              /* allow colon to abort */
-int     *mouse_used;
+int 
+get_number (
+    int colon,                              /* allow colon to abort */
+    int *mouse_used
+)
 {
   int n = 0;
   int c;
@@ -2993,8 +2959,7 @@ int     *mouse_used;
  * When "mouse_used" is not NULL allow using the mouse and in that case return
  * the line number.
  */
-int prompt_for_number(mouse_used)
-int         *mouse_used;
+int prompt_for_number(int *mouse_used)
 {
   int i;
   int save_cmdline_row;
@@ -3028,8 +2993,7 @@ int         *mouse_used;
   return i;
 }
 
-void msgmore(n)
-long n;
+void msgmore(long n)
 {
   long pn;
 
@@ -3076,7 +3040,7 @@ long n;
 /*
  * flush map and typeahead buffers and give a warning for an error
  */
-void beep_flush()          {
+void beep_flush(void)          {
   if (emsg_silent == 0) {
     flush_buffers(FALSE);
     vim_beep();
@@ -3086,7 +3050,7 @@ void beep_flush()          {
 /*
  * give a warning for an error
  */
-void vim_beep()          {
+void vim_beep(void)          {
   if (emsg_silent == 0) {
     if (p_vb
         ) {
@@ -3115,7 +3079,7 @@ void vim_beep()          {
  */
 static char_u   *homedir = NULL;
 
-void init_homedir()          {
+void init_homedir(void)          {
   char_u  *var;
 
   /* In case we are called a second time (when 'encoding' changes). */
@@ -3147,11 +3111,11 @@ void init_homedir()          {
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_homedir()          {
+void free_homedir(void)          {
   vim_free(homedir);
 }
 
-void free_users()          {
+void free_users(void)          {
   ga_clear_strings(&ga_users);
 }
 
@@ -3162,8 +3126,7 @@ void free_users()          {
  * This is not very memory efficient, this expects the result to be freed
  * again soon.
  */
-char_u * expand_env_save(src)
-char_u      *src;
+char_u *expand_env_save(char_u *src)
 {
   return expand_env_save_opt(src, FALSE);
 }
@@ -3172,9 +3135,7 @@ char_u      *src;
  * Idem, but when "one" is TRUE handle the string as one file name, only
  * expand "~" at the start.
  */
-char_u * expand_env_save_opt(src, one)
-char_u      *src;
-int one;
+char_u *expand_env_save_opt(char_u *src, int one)
 {
   char_u      *p;
 
@@ -3190,21 +3151,25 @@ int one;
  * Skips over "\ ", "\~" and "\$" (not for Win32 though).
  * If anything fails no expansion is done and dst equals src.
  */
-void expand_env(src, dst, dstlen)
-char_u      *src;               /* input string e.g. "$HOME/vim.hlp" */
-char_u      *dst;               /* where to put the result */
-int dstlen;                     /* maximum length of the result */
+void 
+expand_env (
+    char_u *src,               /* input string e.g. "$HOME/vim.hlp" */
+    char_u *dst,               /* where to put the result */
+    int dstlen                     /* maximum length of the result */
+)
 {
   expand_env_esc(src, dst, dstlen, FALSE, FALSE, NULL);
 }
 
-void expand_env_esc(srcp, dst, dstlen, esc, one, startstr)
-char_u      *srcp;              /* input string e.g. "$HOME/vim.hlp" */
-char_u      *dst;               /* where to put the result */
-int dstlen;                     /* maximum length of the result */
-int esc;                        /* escape spaces in expanded variables */
-int one;                        /* "srcp" is one file name */
-char_u      *startstr;          /* start again after this (can be NULL) */
+void 
+expand_env_esc (
+    char_u *srcp,              /* input string e.g. "$HOME/vim.hlp" */
+    char_u *dst,               /* where to put the result */
+    int dstlen,                     /* maximum length of the result */
+    int esc,                        /* escape spaces in expanded variables */
+    int one,                        /* "srcp" is one file name */
+    char_u *startstr          /* start again after this (can be NULL) */
+)
 {
   char_u      *src;
   char_u      *tail;
@@ -3439,9 +3404,7 @@ char_u      *startstr;          /* start again after this (can be NULL) */
  * "mustfree" is set to TRUE when returned is allocated, it must be
  * initialized to FALSE by the caller.
  */
-char_u * vim_getenv(name, mustfree)
-char_u      *name;
-int         *mustfree;
+char_u *vim_getenv(char_u *name, int *mustfree)
 {
   char_u      *p;
   char_u      *pend;
@@ -3581,8 +3544,7 @@ int         *mustfree;
  * Check if the directory "vimdir/<version>" or "vimdir/runtime" exists.
  * Return NULL if not, return its name in allocated memory otherwise.
  */
-static char_u * vim_version_dir(vimdir)
-char_u      *vimdir;
+static char_u *vim_version_dir(char_u *vimdir)
 {
   char_u      *p;
 
@@ -3603,10 +3565,7 @@ char_u      *vimdir;
  * If the string between "p" and "pend" ends in "name/", return "pend" minus
  * the length of "name/".  Otherwise return "pend".
  */
-static char_u * remove_tail(p, pend, name)
-char_u      *p;
-char_u      *pend;
-char_u      *name;
+static char_u *remove_tail(char_u *p, char_u *pend, char_u *name)
 {
   int len = (int)STRLEN(name) + 1;
   char_u      *newend = pend - len;
@@ -3621,9 +3580,7 @@ char_u      *name;
 /*
  * Our portable version of setenv.
  */
-void vim_setenv(name, val)
-char_u      *name;
-char_u      *val;
+void vim_setenv(char_u *name, char_u *val)
 {
 #ifdef HAVE_SETENV
   mch_setenv((char *)name, (char *)val, 1);
@@ -3657,9 +3614,7 @@ char_u      *val;
 /*
  * Function given to ExpandGeneric() to obtain an environment variable name.
  */
-char_u * get_env_name(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_env_name(expand_T *xp, int idx)
 {
 # if defined(AMIGA) || defined(__MRC__) || defined(__SC__)
   /*
@@ -3694,7 +3649,7 @@ int idx;
  * Find all user names for user completion.
  * Done only once and then cached.
  */
-static void init_users()                 {
+static void init_users(void)                 {
   static int lazy_init_done = FALSE;
 
   if (lazy_init_done)
@@ -3727,9 +3682,7 @@ static void init_users()                 {
 /*
  * Function given to ExpandGeneric() to obtain an user names.
  */
-char_u* get_users(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_users(expand_T *xp, int idx)
 {
   init_users();
   if (idx < ga_users.ga_len)
@@ -3743,8 +3696,7 @@ int idx;
  * 1 if name partially matches the beginning of a user name.
  * 2 is name fully matches a user name.
  */
-int match_user(name)
-char_u* name;
+int match_user(char_u *name)
 {
   int i;
   int n = (int)STRLEN(name);
@@ -3765,13 +3717,15 @@ char_u* name;
  * 'src'.
  * If anything fails (except when out of space) dst equals src.
  */
-void home_replace(buf, src, dst, dstlen, one)
-buf_T       *buf;       /* when not NULL, check for help files */
-char_u      *src;       /* input file name */
-char_u      *dst;       /* where to put the result */
-int dstlen;             /* maximum length of the result */
-int one;                /* if TRUE, only replace one file name, include
+void 
+home_replace (
+    buf_T *buf,       /* when not NULL, check for help files */
+    char_u *src,       /* input file name */
+    char_u *dst,       /* where to put the result */
+    int dstlen,             /* maximum length of the result */
+    int one                /* if TRUE, only replace one file name, include
                            spaces and commas in the file name. */
+)
 {
   size_t dirlen = 0, envlen = 0;
   size_t len;
@@ -3876,9 +3830,11 @@ int one;                /* if TRUE, only replace one file name, include
  * Like home_replace, store the replaced string in allocated memory.
  * When something fails, NULL is returned.
  */
-char_u  * home_replace_save(buf, src)
-buf_T       *buf;       /* when not NULL, check for help files */
-char_u      *src;       /* input file name */
+char_u *
+home_replace_save (
+    buf_T *buf,       /* when not NULL, check for help files */
+    char_u *src       /* input file name */
+)
 {
   char_u      *dst;
   unsigned len;
@@ -3901,9 +3857,12 @@ char_u      *src;       /* input file name */
  * FPC_DIFFX  if one of them doesn't exist.
  * For the first name environment variables are expanded
  */
-int fullpathcmp(s1, s2, checkname)
-char_u *s1, *s2;
-int checkname;                  /* when both don't exist, check file names */
+int 
+fullpathcmp (
+    char_u *s1,
+    char_u *s2,
+    int checkname                  /* when both don't exist, check file names */
+)
 {
 #ifdef UNIX
   char_u exp1[MAXPATHL];
@@ -3971,8 +3930,7 @@ int checkname;                  /* when both don't exist, check file names */
  * When the path ends in a path separator the tail is the NUL after it.
  * Fail safe: never returns NULL.
  */
-char_u * gettail(fname)
-char_u *fname;
+char_u *gettail(char_u *fname)
 {
   char_u  *p1, *p2;
 
@@ -3994,8 +3952,7 @@ static char_u *gettail_dir __ARGS((char_u *fname));
  * "/path/file", "/path/dir/", "/path//dir", "/file"
  *	 ^	       ^	     ^	      ^
  */
-static char_u * gettail_dir(fname)
-char_u *fname;
+static char_u *gettail_dir(char_u *fname)
 {
   char_u      *dir_end = fname;
   char_u      *next_dir_end = fname;
@@ -4023,8 +3980,7 @@ char_u *fname;
  * here leaves the directory name.  Takes care of "c:/" and "//".
  * Always returns a valid pointer.
  */
-char_u * gettail_sep(fname)
-char_u      *fname;
+char_u *gettail_sep(char_u *fname)
 {
   char_u      *p;
   char_u      *t;
@@ -4039,8 +3995,7 @@ char_u      *fname;
 /*
  * get the next path component (just after the next path separator).
  */
-char_u * getnextcomp(fname)
-char_u *fname;
+char_u *getnextcomp(char_u *fname)
 {
   while (*fname && !vim_ispathsep(*fname))
     mb_ptr_adv(fname);
@@ -4054,8 +4009,7 @@ char_u *fname;
  * Unix: after "/"; DOS: after "c:\"; Amiga: after "disk:/"; Mac: no head.
  * If there is no head, path is returned.
  */
-char_u * get_past_head(path)
-char_u  *path;
+char_u *get_past_head(char_u *path)
 {
   char_u  *retval;
 
@@ -4071,8 +4025,7 @@ char_u  *path;
  * Return TRUE if 'c' is a path separator.
  * Note that for MS-Windows this includes the colon.
  */
-int vim_ispathsep(c)
-int c;
+int vim_ispathsep(int c)
 {
 #ifdef UNIX
   return c == '/';          /* UNIX has ':' inside file names */
@@ -4088,8 +4041,7 @@ int c;
 /*
  * Like vim_ispathsep(c), but exclude the colon for MS-Windows.
  */
-int vim_ispathsep_nocolon(c)
-int c;
+int vim_ispathsep_nocolon(int c)
 {
   return vim_ispathsep(c)
 #ifdef BACKSLASH_IN_FILENAME
@@ -4101,8 +4053,7 @@ int c;
 /*
  * return TRUE if 'c' is a path list separator.
  */
-int vim_ispathlistsep(c)
-int c;
+int vim_ispathlistsep(int c)
 {
 #ifdef UNIX
   return c == ':';
@@ -4117,8 +4068,7 @@ int c;
  * Shorten the path of a file from "~/foo/../.bar/fname" to "~/f/../.b/fname"
  * It's done in-place.
  */
-void shorten_dir(str)
-char_u *str;
+void shorten_dir(char_u *str)
 {
   char_u      *tail, *s, *d;
   int skip = FALSE;
@@ -4153,8 +4103,7 @@ char_u *str;
  * Also returns TRUE if there is no directory name.
  * "fname" must be writable!.
  */
-int dir_of_file_exists(fname)
-char_u      *fname;
+int dir_of_file_exists(char_u *fname)
 {
   char_u      *p;
   int c;
@@ -4174,8 +4123,7 @@ char_u      *fname;
  * Versions of fnamecmp() and fnamencmp() that handle '/' and '\' equally
  * and deal with 'fileignorecase'.
  */
-int vim_fnamecmp(x, y)
-char_u      *x, *y;
+int vim_fnamecmp(char_u *x, char_u *y)
 {
 #ifdef BACKSLASH_IN_FILENAME
   return vim_fnamencmp(x, y, MAXPATHL);
@@ -4186,9 +4134,7 @@ char_u      *x, *y;
 #endif
 }
 
-int vim_fnamencmp(x, y, len)
-char_u      *x, *y;
-size_t len;
+int vim_fnamencmp(char_u *x, char_u *y, size_t len)
 {
 #ifdef BACKSLASH_IN_FILENAME
   char_u      *px = x;
@@ -4222,10 +4168,7 @@ size_t len;
  * Concatenate file names fname1 and fname2 into allocated memory.
  * Only add a '/' or '\\' when 'sep' is TRUE and it is necessary.
  */
-char_u  * concat_fnames(fname1, fname2, sep)
-char_u  *fname1;
-char_u  *fname2;
-int sep;
+char_u *concat_fnames(char_u *fname1, char_u *fname2, int sep)
 {
   char_u  *dest;
 
@@ -4243,9 +4186,7 @@ int sep;
  * Concatenate two strings and return the result in allocated memory.
  * Returns NULL when out of memory.
  */
-char_u  * concat_str(str1, str2)
-char_u  *str1;
-char_u  *str2;
+char_u *concat_str(char_u *str1, char_u *str2)
 {
   char_u  *dest;
   size_t l = STRLEN(str1);
@@ -4262,8 +4203,7 @@ char_u  *str2;
  * Add a path separator to a file name, unless it already ends in a path
  * separator.
  */
-void add_pathsep(p)
-char_u      *p;
+void add_pathsep(char_u *p)
 {
   if (*p != NUL && !after_pathsep(p, p + STRLEN(p)))
     STRCAT(p, PATHSEPSTR);
@@ -4273,10 +4213,12 @@ char_u      *p;
  * FullName_save - Make an allocated copy of a full file name.
  * Returns NULL when out of memory.
  */
-char_u  * FullName_save(fname, force)
-char_u      *fname;
-int force;                      /* force expansion, even when it already looks
+char_u *
+FullName_save (
+    char_u *fname,
+    int force                      /* force expansion, even when it already looks
                                  * like a full path name */
+)
 {
   char_u      *buf;
   char_u      *new_fname = NULL;
@@ -4303,12 +4245,14 @@ static pos_T *ind_find_start_comment __ARGS((void));
  * Find the start of a comment, not knowing if we are in a comment right now.
  * Search starts at w_cursor.lnum and goes backwards.
  */
-static pos_T * ind_find_start_comment()                    { /* XXX */
+static pos_T *ind_find_start_comment(void)                    { /* XXX */
   return find_start_comment(curbuf->b_ind_maxcomment);
 }
 
-pos_T * find_start_comment(ind_maxcomment)  /* XXX */
-int ind_maxcomment;
+pos_T *
+find_start_comment (  /* XXX */
+    int ind_maxcomment
+)
 {
   pos_T       *pos;
   char_u      *line;
@@ -4342,8 +4286,7 @@ int ind_maxcomment;
  * Skip to the end of a "string" and a 'c' character.
  * If there is no string or character, return argument unmodified.
  */
-static char_u * skip_string(p)
-char_u  *p;
+static char_u *skip_string(char_u *p)
 {
   int i;
 
@@ -4385,7 +4328,7 @@ char_u  *p;
 /*
  * Do C or expression indenting on the current line.
  */
-void do_c_expr_indent()          {
+void do_c_expr_indent(void)          {
   if (*curbuf->b_p_inde != NUL)
     fixthisline(get_expr_indent);
   else
@@ -4440,8 +4383,7 @@ static int cin_is_cpp_namespace __ARGS((char_u *));
  * Skip over white space and C comments within the line.
  * Also skip over Perl/shell comments if desired.
  */
-static char_u * cin_skipcomment(s)
-char_u      *s;
+static char_u *cin_skipcomment(char_u *s)
 {
   while (*s) {
     char_u *prev_s = s;
@@ -4476,8 +4418,7 @@ char_u      *s;
  * Return TRUE if there is no code at *s.  White space and comments are
  * not considered code.
  */
-static int cin_nocode(s)
-char_u      *s;
+static int cin_nocode(char_u *s)
 {
   return *cin_skipcomment(s) == NUL;
 }
@@ -4485,7 +4426,7 @@ char_u      *s;
 /*
  * Check previous lines for a "//" line comment, skipping over blank lines.
  */
-static pos_T * find_line_comment()                    { /* XXX */
+static pos_T *find_line_comment(void)                    { /* XXX */
   static pos_T pos;
   char_u       *line;
   char_u       *p;
@@ -4507,8 +4448,7 @@ static pos_T * find_line_comment()                    { /* XXX */
 /*
  * Check if string matches "label:"; move to character after ':' if true.
  */
-static int cin_islabel_skip(s)
-char_u      **s;
+static int cin_islabel_skip(char_u **s)
 {
   if (!vim_isIDc(**s))              /* need at least one ID character */
     return FALSE;
@@ -4526,7 +4466,7 @@ char_u      **s;
  * Recognize a label: "label:".
  * Note: curwin->w_cursor must be where we are looking for the label.
  */
-int cin_islabel()         { /* XXX */
+int cin_islabel(void)         { /* XXX */
   char_u      *s;
 
   s = cin_skipcomment(ml_get_curline());
@@ -4621,9 +4561,11 @@ static int cin_isinit(void)                {
 /*
  * Recognize a switch label: "case .*:" or "default:".
  */
-int cin_iscase(s, strict)
-char_u *s;
-int strict;     /* Allow relaxed check of case statement for JS */
+int 
+cin_iscase (
+    char_u *s,
+    int strict     /* Allow relaxed check of case statement for JS */
+)
 {
   s = cin_skipcomment(s);
   if (cin_starts_with(s, "case")) {
@@ -4658,8 +4600,7 @@ int strict;     /* Allow relaxed check of case statement for JS */
 /*
  * Recognize a "default" switch label.
  */
-static int cin_isdefault(s)
-char_u  *s;
+static int cin_isdefault(char_u *s)
 {
   return STRNCMP(s, "default", 7) == 0
          && *(s = cin_skipcomment(s + 7)) == ':'
@@ -4669,8 +4610,7 @@ char_u  *s;
 /*
  * Recognize a "public/private/protected" scope declaration label.
  */
-int cin_isscopedecl(s)
-char_u      *s;
+int cin_isscopedecl(char_u *s)
 {
   int i;
 
@@ -4692,8 +4632,7 @@ char_u      *s;
 /*
  * Recognize a "namespace" scope declaration.
  */
-static int cin_is_cpp_namespace(s)
-char_u      *s;
+static int cin_is_cpp_namespace(char_u *s)
 {
   char_u      *p;
   int has_name = FALSE;
@@ -4726,8 +4665,7 @@ char_u      *s;
  *	  case 234:    a = b;
  *		       ^
  */
-static char_u * after_label(l)
-char_u  *l;
+static char_u *after_label(char_u *l)
 {
   for (; *l; ++l) {
     if (*l == ':') {
@@ -4750,8 +4688,10 @@ char_u  *l;
  * Get indent of line "lnum", skipping a label.
  * Return 0 if there is nothing after the label.
  */
-static int get_indent_nolabel(lnum)     /* XXX */
-linenr_T lnum;
+static int 
+get_indent_nolabel (     /* XXX */
+    linenr_T lnum
+)
 {
   char_u      *l;
   pos_T fp;
@@ -4775,9 +4715,7 @@ linenr_T lnum;
  *   label:	if (asdf && asdfasdf)
  *		^
  */
-static int skip_label(lnum, pp)
-linenr_T lnum;
-char_u      **pp;
+static int skip_label(linenr_T lnum, char_u **pp)
 {
   char_u      *l;
   int amount;
@@ -4809,7 +4747,7 @@ char_u      **pp;
  *  enum bla    c,		indent of "c"
  * Returns zero when it doesn't look like a declaration.
  */
-static int cin_first_id_amount()                {
+static int cin_first_id_amount(void)                {
   char_u      *line, *p, *s;
   int len;
   pos_T fp;
@@ -4856,8 +4794,7 @@ static int cin_first_id_amount()                {
  *	       asdf\
  *	       here";
  */
-static int cin_get_equal_amount(lnum)
-linenr_T lnum;
+static int cin_get_equal_amount(linenr_T lnum)
 {
   char_u      *line;
   char_u      *s;
@@ -4896,8 +4833,7 @@ linenr_T lnum;
 /*
  * Recognize a preprocessor statement: Any line that starts with '#'.
  */
-static int cin_ispreproc(s)
-char_u *s;
+static int cin_ispreproc(char_u *s)
 {
   if (*skipwhite(s) == '#')
     return TRUE;
@@ -4909,9 +4845,7 @@ char_u *s;
  * continuation line of a preprocessor statement.  Decrease "*lnump" to the
  * start and return the line in "*pp".
  */
-static int cin_ispreproc_cont(pp, lnump)
-char_u      **pp;
-linenr_T    *lnump;
+static int cin_ispreproc_cont(char_u **pp, linenr_T *lnump)
 {
   char_u      *line = *pp;
   linenr_T lnum = *lnump;
@@ -4938,8 +4872,7 @@ linenr_T    *lnump;
 /*
  * Recognize the start of a C or C++ comment.
  */
-static int cin_iscomment(p)
-char_u  *p;
+static int cin_iscomment(char_u *p)
 {
   return p[0] == '/' && (p[1] == '*' || p[1] == '/');
 }
@@ -4947,8 +4880,7 @@ char_u  *p;
 /*
  * Recognize the start of a "//" comment.
  */
-static int cin_islinecomment(p)
-char_u *p;
+static int cin_islinecomment(char_u *p)
 {
   return p[0] == '/' && p[1] == '/';
 }
@@ -4962,10 +4894,12 @@ char_u *p;
  * Return the character terminating the line (ending char's have precedence if
  * both apply in order to determine initializations).
  */
-static int cin_isterminated(s, incl_open, incl_comma)
-char_u      *s;
-int incl_open;                  /* include '{' at the end as terminator */
-int incl_comma;                 /* recognize a trailing comma */
+static int 
+cin_isterminated (
+    char_u *s,
+    int incl_open,                  /* include '{' at the end as terminator */
+    int incl_comma                 /* recognize a trailing comma */
+)
 {
   char_u found_start = 0;
   unsigned n_open = 0;
@@ -5011,10 +4945,7 @@ int incl_comma;                 /* recognize a trailing comma */
  * "lnum" is where we start looking.
  * "min_lnum" is the line before which we will not be looking.
  */
-static int cin_isfuncdecl(sp, first_lnum, min_lnum)
-char_u      **sp;
-linenr_T first_lnum;
-linenr_T min_lnum;
+static int cin_isfuncdecl(char_u **sp, linenr_T first_lnum, linenr_T min_lnum)
 {
   char_u      *s;
   linenr_T lnum = first_lnum;
@@ -5099,22 +5030,19 @@ done:
   return retval;
 }
 
-static int cin_isif(p)
-char_u  *p;
+static int cin_isif(char_u *p)
 {
   return STRNCMP(p, "if", 2) == 0 && !vim_isIDc(p[2]);
 }
 
-static int cin_iselse(p)
-char_u  *p;
+static int cin_iselse(char_u *p)
 {
   if (*p == '}')            /* accept "} else" */
     p = cin_skipcomment(p + 1);
   return STRNCMP(p, "else", 4) == 0 && !vim_isIDc(p[4]);
 }
 
-static int cin_isdo(p)
-char_u  *p;
+static int cin_isdo(char_u *p)
 {
   return STRNCMP(p, "do", 2) == 0 && !vim_isIDc(p[2]);
 }
@@ -5124,9 +5052,11 @@ char_u  *p;
  * We only accept a "while (condition) ;", with only white space between the
  * ')' and ';'. The condition may be spread over several lines.
  */
-static int cin_iswhileofdo(p, lnum) /* XXX */
-char_u      *p;
-linenr_T lnum;
+static int 
+cin_iswhileofdo ( /* XXX */
+    char_u *p,
+    linenr_T lnum
+)
 {
   pos_T cursor_save;
   pos_T       *trypos;
@@ -5159,9 +5089,7 @@ linenr_T lnum;
  * Otherwise return !0 and update "*poffset" to point to the place where the
  * string was found.
  */
-static int cin_is_if_for_while_before_offset(line, poffset)
-char_u *line;
-int    *poffset;
+static int cin_is_if_for_while_before_offset(char_u *line, int *poffset)
 {
   int offset = *poffset;
 
@@ -5203,8 +5131,7 @@ probablyFound:
  *	       && bar);  <-- here
  * Adjust the cursor to the line with "while".
  */
-static int cin_iswhileofdo_end(terminated)
-int terminated;
+static int cin_iswhileofdo_end(int terminated)
 {
   char_u      *line;
   char_u      *p;
@@ -5247,8 +5174,7 @@ int terminated;
   return FALSE;
 }
 
-static int cin_isbreak(p)
-char_u  *p;
+static int cin_isbreak(char_u *p)
 {
   return STRNCMP(p, "break", 5) == 0 && !vim_isIDc(p[5]);
 }
@@ -5266,8 +5192,10 @@ char_u  *p;
  *
  * This is a lot of guessing.  Watch out for "cond ? func() : foo".
  */
-static int cin_is_cpp_baseclass(col)
-colnr_T     *col;           /* return: column to align with */
+static int 
+cin_is_cpp_baseclass (
+    colnr_T *col           /* return: column to align with */
+)
 {
   char_u      *s;
   int class_or_struct, lookfor_ctor_init, cpp_base_class;
@@ -5390,8 +5318,7 @@ colnr_T     *col;           /* return: column to align with */
   return cpp_base_class;
 }
 
-static int get_baseclass_amount(col)
-int col;
+static int get_baseclass_amount(int col)
 {
   int amount;
   colnr_T vcol;
@@ -5419,10 +5346,7 @@ int col;
  * white space and comments.  Skip strings and comments.
  * Ignore "ignore" after "find" if it's not NULL.
  */
-static int cin_ends_in(s, find, ignore)
-char_u      *s;
-char_u      *find;
-char_u      *ignore;
+static int cin_ends_in(char_u *s, char_u *find, char_u *ignore)
 {
   char_u      *p = s;
   char_u      *r;
@@ -5446,9 +5370,7 @@ char_u      *ignore;
 /*
  * Return TRUE when "s" starts with "word" and then a non-ID character.
  */
-static int cin_starts_with(s, word)
-char_u *s;
-char *word;
+static int cin_starts_with(char_u *s, char *word)
 {
   int l = (int)STRLEN(word);
 
@@ -5459,8 +5381,7 @@ char *word;
  * Skip strings, chars and comments until at or past "trypos".
  * Return the column found.
  */
-static int cin_skip2pos(trypos)
-pos_T       *trypos;
+static int cin_skip2pos(pos_T *trypos)
 {
   char_u      *line;
   char_u      *p;
@@ -5486,7 +5407,7 @@ pos_T       *trypos;
 /* {	    */
 /* }	    */
 
-static pos_T * find_start_brace()                    { /* XXX */
+static pos_T *find_start_brace(void)                    { /* XXX */
   pos_T cursor_save;
   pos_T       *trypos;
   pos_T       *pos;
@@ -5513,8 +5434,10 @@ static pos_T * find_start_brace()                    { /* XXX */
  * Find the matching '(', failing if it is in a comment.
  * Return NULL if no match found.
  */
-static pos_T * find_match_paren(ind_maxparen) /* XXX */
-int ind_maxparen;
+static pos_T *
+find_match_paren ( /* XXX */
+    int ind_maxparen
+)
 {
   pos_T cursor_save;
   pos_T       *trypos;
@@ -5543,8 +5466,7 @@ int ind_maxparen;
  * matching paren above the cursor line doesn't find a match because of
  * looking a few lines further.
  */
-static int corr_ind_maxparen(startpos)
-pos_T       *startpos;
+static int corr_ind_maxparen(pos_T *startpos)
 {
   long n = (long)startpos->lnum - (long)curwin->w_cursor.lnum;
 
@@ -5557,9 +5479,7 @@ pos_T       *startpos;
  * Set w_cursor.col to the column number of the last unmatched ')' or '{' in
  * line "l".  "l" must point to the start of the line.
  */
-static int find_last_paren(l, start, end)
-char_u      *l;
-int start, end;
+static int find_last_paren(char_u *l, int start, int end)
 {
   int i;
   int retval = FALSE;
@@ -5588,8 +5508,7 @@ int start, end;
  * Parse 'cinoptions' and set the values in "curbuf".
  * Must be called when 'cinoptions', 'shiftwidth' and/or 'tabstop' changes.
  */
-void parse_cino(buf)
-buf_T       *buf;
+void parse_cino(buf_T *buf)
 {
   char_u      *p;
   char_u      *l;
@@ -5797,7 +5716,7 @@ buf_T       *buf;
   }
 }
 
-int get_c_indent()         {
+int get_c_indent(void)         {
   pos_T cur_curpos;
   int amount;
   int scope_amount;
@@ -7483,9 +7402,7 @@ theend:
   return amount;
 }
 
-static int find_match(lookfor, ourscope)
-int lookfor;
-linenr_T ourscope;
+static int find_match(int lookfor, linenr_T ourscope)
 {
   char_u      *look;
   pos_T       *theirscope;
@@ -7590,7 +7507,7 @@ linenr_T ourscope;
 /*
  * Get indent level from 'indentexpr'.
  */
-int get_expr_indent()         {
+int get_expr_indent(void)         {
   int indent;
   pos_T save_pos;
   colnr_T save_curswant;
@@ -7633,8 +7550,7 @@ int get_expr_indent()         {
 
 static int lisp_match __ARGS((char_u *p));
 
-static int lisp_match(p)
-char_u      *p;
+static int lisp_match(char_u *p)
 {
   char_u buf[LSIZE];
   int len;
@@ -7665,7 +7581,7 @@ char_u      *p;
  * Update from Sergey Khorev:
  * I tried to fix the first two issues.
  */
-int get_lisp_indent()         {
+int get_lisp_indent(void)         {
   pos_T       *pos, realpos, paren;
   int amount;
   char_u      *that;
@@ -7824,7 +7740,7 @@ int get_lisp_indent()         {
   return amount;
 }
 
-void prepare_to_exit()          {
+void prepare_to_exit(void)          {
 #if defined(SIGHUP) && defined(SIG_IGN)
   /* Ignore SIGHUP, because a dropped connection causes a read error, which
    * makes Vim exit and then handling SIGHUP causes various reentrance
@@ -7851,7 +7767,7 @@ void prepare_to_exit()          {
  * NOTE: This may be called from deathtrap() in a signal handler, avoid unsafe
  * functions, such as allocating memory.
  */
-void preserve_exit()          {
+void preserve_exit(void)          {
   buf_T       *buf;
 
   prepare_to_exit();
@@ -7886,8 +7802,7 @@ void preserve_exit()          {
 /*
  * return TRUE if "fname" exists.
  */
-int vim_fexists(fname)
-char_u  *fname;
+int vim_fexists(char_u *fname)
 {
   struct stat st;
 
@@ -7909,7 +7824,7 @@ char_u  *fname;
 
 static int breakcheck_count = 0;
 
-void line_breakcheck()          {
+void line_breakcheck(void)          {
   if (++breakcheck_count >= BREAKCHECK_SKIP) {
     breakcheck_count = 0;
     ui_breakcheck();
@@ -7919,7 +7834,7 @@ void line_breakcheck()          {
 /*
  * Like line_breakcheck() but check 10 times less often.
  */
-void fast_breakcheck()          {
+void fast_breakcheck(void)          {
   if (++breakcheck_count >= BREAKCHECK_SKIP * 10) {
     breakcheck_count = 0;
     ui_breakcheck();
@@ -7931,11 +7846,13 @@ void fast_breakcheck()          {
  * Expand items like "%:h" before the expansion.
  * Returns OK or FAIL.
  */
-int expand_wildcards_eval(pat, num_file, file, flags)
-char_u       **pat;             /* pointer to input pattern */
-int           *num_file;        /* resulting number of files */
-char_u      ***file;            /* array of resulting files */
-int flags;                      /* EW_DIR, etc. */
+int 
+expand_wildcards_eval (
+    char_u **pat,             /* pointer to input pattern */
+    int *num_file,        /* resulting number of files */
+    char_u ***file,            /* array of resulting files */
+    int flags                      /* EW_DIR, etc. */
+)
 {
   int ret = FAIL;
   char_u      *eval_pat = NULL;
@@ -7968,12 +7885,14 @@ int flags;                      /* EW_DIR, etc. */
  * 'wildignore'.
  * Returns OK or FAIL.  When FAIL then "num_file" won't be set.
  */
-int expand_wildcards(num_pat, pat, num_file, file, flags)
-int num_pat;                    /* number of input patterns */
-char_u       **pat;             /* array of input patterns */
-int           *num_file;        /* resulting number of files */
-char_u      ***file;            /* array of resulting files */
-int flags;                      /* EW_DIR, etc. */
+int 
+expand_wildcards (
+    int num_pat,                    /* number of input patterns */
+    char_u **pat,             /* array of input patterns */
+    int *num_file,        /* resulting number of files */
+    char_u ***file,            /* array of resulting files */
+    int flags                      /* EW_DIR, etc. */
+)
 {
   int retval;
   int i, j;
@@ -8034,8 +7953,7 @@ int flags;                      /* EW_DIR, etc. */
 /*
  * Return TRUE if "fname" matches with an entry in 'suffixes'.
  */
-int match_suffix(fname)
-char_u      *fname;
+int match_suffix(char_u *fname)
 {
   int fnamelen, setsuflen;
   char_u      *setsuf;
@@ -8079,8 +7997,7 @@ static int expand_backtick __ARGS((garray_T *gap, char_u *pat, int flags));
  */
 static int pstrcmp __ARGS((const void *, const void *));
 
-static int pstrcmp(a, b)
-const void *a, *b;
+static int pstrcmp(const void *a, const void *b)
 {
   return pathcmp(*(char **)a, *(char **)b, -1);
 }
@@ -8093,12 +8010,14 @@ const void *a, *b;
  * Return the number of matches found.
  * NOTE: much of this is identical to dos_expandpath(), keep in sync!
  */
-int unix_expandpath(gap, path, wildoff, flags, didstar)
-garray_T    *gap;
-char_u      *path;
-int wildoff;
-int flags;                      /* EW_* flags */
-int didstar;                    /* expanded "**" once already */
+int 
+unix_expandpath (
+    garray_T *gap,
+    char_u *path,
+    int wildoff,
+    int flags,                      /* EW_* flags */
+    int didstar                    /* expanded "**" once already */
+)
 {
   char_u      *buf;
   char_u      *path_end;
@@ -8291,9 +8210,7 @@ static int expand_in_path __ARGS((garray_T *gap, char_u *pattern, int flags));
  * Moves "*psep" back to the previous path separator in "path".
  * Returns FAIL is "*psep" ends up at the beginning of "path".
  */
-static int find_previous_pathsep(path, psep)
-char_u *path;
-char_u **psep;
+static int find_previous_pathsep(char_u *path, char_u **psep)
 {
   /* skip the current separator */
   if (*psep > path && vim_ispathsep(**psep))
@@ -8313,10 +8230,7 @@ char_u **psep;
  * Returns TRUE if "maybe_unique" is unique wrt other_paths in "gap".
  * "maybe_unique" is the end portion of "((char_u **)gap->ga_data)[i]".
  */
-static int is_unique(maybe_unique, gap, i)
-char_u      *maybe_unique;
-garray_T    *gap;
-int i;
+static int is_unique(char_u *maybe_unique, garray_T *gap, int i)
 {
   int j;
   int candidate_len;
@@ -8351,9 +8265,7 @@ int i;
  * TODO: handle upward search (;) and path limiter (**N) notations by
  * expanding each into their equivalent path(s).
  */
-static void expand_path_option(curdir, gap)
-char_u      *curdir;
-garray_T    *gap;
+static void expand_path_option(char_u *curdir, garray_T *gap)
 {
   char_u      *path_option = *curbuf->b_p_path == NUL
                              ? p_path : curbuf->b_p_path;
@@ -8421,9 +8333,7 @@ garray_T    *gap;
  *   fname: /foo/bar/baz/quux.txt
  * returns:		 ^this
  */
-static char_u * get_path_cutoff(fname, gap)
-char_u *fname;
-garray_T *gap;
+static char_u *get_path_cutoff(char_u *fname, garray_T *gap)
 {
   int i;
   int maxlen = 0;
@@ -8455,9 +8365,7 @@ garray_T *gap;
  * that they are unique with respect to each other while conserving the part
  * that matches the pattern. Beware, this is at least O(n^2) wrt "gap->ga_len".
  */
-static void uniquefy_paths(gap, pattern)
-garray_T    *gap;
-char_u      *pattern;
+static void uniquefy_paths(garray_T *gap, char_u *pattern)
 {
   int i;
   int len;
@@ -8608,10 +8516,12 @@ theend:
  * result in "gap".
  * Returns the total number of matches.
  */
-static int expand_in_path(gap, pattern, flags)
-garray_T    *gap;
-char_u      *pattern;
-int flags;                      /* EW_* flags */
+static int 
+expand_in_path (
+    garray_T *gap,
+    char_u *pattern,
+    int flags                      /* EW_* flags */
+)
 {
   char_u      *curdir;
   garray_T path_ga;
@@ -8665,8 +8575,7 @@ int flags;                      /* EW_* flags */
  * Sort "gap" and remove duplicate entries.  "gap" is expected to contain a
  * list of file names in allocated memory.
  */
-void remove_duplicates(gap)
-garray_T    *gap;
+void remove_duplicates(garray_T *gap)
 {
   int i;
   int j;
@@ -8688,8 +8597,7 @@ static int has_env_var __ARGS((char_u *p));
  * Return TRUE if "p" contains what looks like an environment variable.
  * Allowing for escaping.
  */
-static int has_env_var(p)
-char_u *p;
+static int has_env_var(char_u *p)
 {
   for (; *p; mb_ptr_adv(p)) {
     if (*p == '\\' && p[1] != NUL)
@@ -8709,8 +8617,7 @@ static int has_special_wildchar __ARGS((char_u *p));
  * Return TRUE if "p" contains a special wildcard character.
  * Allowing for escaping.
  */
-static int has_special_wildchar(p)
-char_u  *p;
+static int has_special_wildchar(char_u *p)
 {
   for (; *p; mb_ptr_adv(p)) {
     if (*p == '\\' && p[1] != NUL)
@@ -8733,12 +8640,14 @@ char_u  *p;
  * Return OK when some files found.  "num_file" is set to the number of
  * matches, "file" to the array of matches.  Call FreeWild() later.
  */
-int gen_expand_wildcards(num_pat, pat, num_file, file, flags)
-int num_pat;                    /* number of input patterns */
-char_u      **pat;              /* array of input patterns */
-int         *num_file;          /* resulting number of files */
-char_u      ***file;            /* array of resulting files */
-int flags;                      /* EW_* flags */
+int 
+gen_expand_wildcards (
+    int num_pat,                    /* number of input patterns */
+    char_u **pat,              /* array of input patterns */
+    int *num_file,          /* resulting number of files */
+    char_u ***file,            /* array of resulting files */
+    int flags                      /* EW_* flags */
+)
 {
   int i;
   garray_T ga;
@@ -8868,8 +8777,7 @@ int flags;                      /* EW_* flags */
 /*
  * Return TRUE if we can expand this backtick thing here.
  */
-static int vim_backtick(p)
-char_u      *p;
+static int vim_backtick(char_u *p)
 {
   return *p == '`' && *(p + 1) != NUL && *(p + STRLEN(p) - 1) == '`';
 }
@@ -8879,10 +8787,12 @@ char_u      *p;
  * Currently only works when pat[] starts and ends with a `.
  * Returns number of file names found.
  */
-static int expand_backtick(gap, pat, flags)
-garray_T    *gap;
-char_u      *pat;
-int flags;              /* EW_* flags */
+static int 
+expand_backtick (
+    garray_T *gap,
+    char_u *pat,
+    int flags              /* EW_* flags */
+)
 {
   char_u      *p;
   char_u      *cmd;
@@ -8935,10 +8845,12 @@ int flags;              /* EW_* flags */
  * EW_NOTFOUND	add even when it doesn't exist
  * EW_ADDSLASH	add slash after directory name
  */
-void addfile(gap, f, flags)
-garray_T    *gap;
-char_u      *f;         /* filename */
-int flags;
+void 
+addfile (
+    garray_T *gap,
+    char_u *f,         /* filename */
+    int flags
+)
 {
   char_u      *p;
   int isdir;
@@ -8996,10 +8908,12 @@ int flags;
  * Get the stdout of an external command.
  * Returns an allocated string, or NULL for error.
  */
-char_u * get_cmd_output(cmd, infile, flags)
-char_u      *cmd;
-char_u      *infile;            /* optional input file name */
-int flags;                      /* can be SHELL_SILENT */
+char_u *
+get_cmd_output (
+    char_u *cmd,
+    char_u *infile,            /* optional input file name */
+    int flags                      /* can be SHELL_SILENT */
+)
 {
   char_u      *tempname;
   char_u      *command;
@@ -9075,9 +8989,7 @@ done:
  * Free the list of files returned by expand_wildcards() or other expansion
  * functions.
  */
-void FreeWild(count, files)
-int count;
-char_u  **files;
+void FreeWild(int count, char_u **files)
 {
   if (count <= 0 || files == NULL)
     return;
@@ -9091,7 +9003,7 @@ char_u  **files;
  * Don't do this when still processing a command or a mapping.
  * Don't do this when inside a ":normal" command.
  */
-int goto_im()         {
+int goto_im(void)         {
   return p_im && stuff_empty() && typebuf_typed();
 }
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -22,7 +22,7 @@ static int coladvance2 __ARGS((pos_T *pos, int addspaces, int finetune,
 /*
  * Return TRUE if in the current mode we need to use virtual.
  */
-int virtual_active()         {
+int virtual_active(void)         {
   /* While an operator is being executed we return "virtual_op", because
    * VIsual_active has already been reset, thus we can't check for "block"
    * being used. */
@@ -36,7 +36,7 @@ int virtual_active()         {
 /*
  * Get the screen position of the cursor.
  */
-int getviscol()         {
+int getviscol(void)         {
   colnr_T x;
 
   getvvcol(curwin, &curwin->w_cursor, &x, NULL, NULL);
@@ -46,9 +46,7 @@ int getviscol()         {
 /*
  * Get the screen position of character col with a coladd in the cursor line.
  */
-int getviscol2(col, coladd)
-colnr_T col;
-colnr_T coladd;
+int getviscol2(colnr_T col, colnr_T coladd)
 {
   colnr_T x;
   pos_T pos;
@@ -65,8 +63,7 @@ colnr_T coladd;
  * cursor in that column.
  * The caller must have saved the cursor line for undo!
  */
-int coladvance_force(wcol)
-colnr_T wcol;
+int coladvance_force(colnr_T wcol)
 {
   int rc = coladvance2(&curwin->w_cursor, TRUE, FALSE, wcol);
 
@@ -89,8 +86,7 @@ colnr_T wcol;
  *
  * return OK if desired column is reached, FAIL if not
  */
-int coladvance(wcol)
-colnr_T wcol;
+int coladvance(colnr_T wcol)
 {
   int rc = getvpos(&curwin->w_cursor, wcol);
 
@@ -108,18 +104,18 @@ colnr_T wcol;
  * Return in "pos" the position of the cursor advanced to screen column "wcol".
  * return OK if desired column is reached, FAIL if not
  */
-int getvpos(pos, wcol)
-pos_T   *pos;
-colnr_T wcol;
+int getvpos(pos_T *pos, colnr_T wcol)
 {
   return coladvance2(pos, FALSE, virtual_active(), wcol);
 }
 
-static int coladvance2(pos, addspaces, finetune, wcol)
-pos_T       *pos;
-int addspaces;                  /* change the text to achieve our goal? */
-int finetune;                   /* change char offset for the exact column */
-colnr_T wcol;                   /* column to move to */
+static int 
+coladvance2 (
+    pos_T *pos,
+    int addspaces,                  /* change the text to achieve our goal? */
+    int finetune,                   /* change char offset for the exact column */
+    colnr_T wcol                   /* column to move to */
+)
 {
   int idx;
   char_u      *ptr;
@@ -286,7 +282,7 @@ colnr_T wcol;                   /* column to move to */
 /*
  * Increment the cursor position.  See inc() for return values.
  */
-int inc_cursor()         {
+int inc_cursor(void)         {
   return inc(&curwin->w_cursor);
 }
 
@@ -297,8 +293,7 @@ int inc_cursor()         {
  * Return -1 when at the end of file.
  * Return 0 otherwise.
  */
-int inc(lp)
-pos_T  *lp;
+int inc(pos_T *lp)
 {
   char_u  *p = ml_get_pos(lp);
 
@@ -325,8 +320,7 @@ pos_T  *lp;
 /*
  * incl(lp): same as inc(), but skip the NUL at the end of non-empty lines
  */
-int incl(lp)
-pos_T    *lp;
+int incl(pos_T *lp)
 {
   int r;
 
@@ -341,12 +335,11 @@ pos_T    *lp;
  * Decrement the line pointer 'p' crossing line boundaries as necessary.
  * Return 1 when crossing a line, -1 when at start of file, 0 otherwise.
  */
-int dec_cursor()         {
+int dec_cursor(void)         {
   return dec(&curwin->w_cursor);
 }
 
-int dec(lp)
-pos_T  *lp;
+int dec(pos_T *lp)
 {
   char_u      *p;
 
@@ -373,8 +366,7 @@ pos_T  *lp;
 /*
  * decl(lp): same as dec(), but skip the NUL at the end of non-empty lines
  */
-int decl(lp)
-pos_T    *lp;
+int decl(pos_T *lp)
 {
   int r;
 
@@ -388,9 +380,11 @@ pos_T    *lp;
  * difference between line number and cursor position. Only look for lines that
  * can be visible, folded lines don't count.
  */
-linenr_T get_cursor_rel_lnum(wp, lnum)
-win_T       *wp;
-linenr_T lnum;                      /* line number to get the result for */
+linenr_T 
+get_cursor_rel_lnum (
+    win_T *wp,
+    linenr_T lnum                      /* line number to get the result for */
+)
 {
   linenr_T cursor = wp->w_cursor.lnum;
   linenr_T retval = 0;
@@ -427,7 +421,7 @@ linenr_T lnum;                      /* line number to get the result for */
 /*
  * Make sure curwin->w_cursor.lnum is valid.
  */
-void check_cursor_lnum()          {
+void check_cursor_lnum(void)          {
   if (curwin->w_cursor.lnum > curbuf->b_ml.ml_line_count) {
     /* If there is a closed fold at the end of the file, put the cursor in
      * its first line.  Otherwise in the last line. */
@@ -442,15 +436,14 @@ void check_cursor_lnum()          {
 /*
  * Make sure curwin->w_cursor.col is valid.
  */
-void check_cursor_col()          {
+void check_cursor_col(void)          {
   check_cursor_col_win(curwin);
 }
 
 /*
  * Make sure win->w_cursor.col is valid.
  */
-void check_cursor_col_win(win)
-win_T *win;
+void check_cursor_col_win(win_T *win)
 {
   colnr_T len;
   colnr_T oldcol = win->w_cursor.col;
@@ -495,7 +488,7 @@ win_T *win;
 /*
  * make sure curwin->w_cursor in on a valid character
  */
-void check_cursor()          {
+void check_cursor(void)          {
   check_cursor_lnum();
   check_cursor_col();
 }
@@ -504,7 +497,7 @@ void check_cursor()          {
  * Make sure curwin->w_cursor is not on the NUL at the end of the line.
  * Allow it when in Visual mode and 'selection' is not "old".
  */
-void adjust_cursor_col()          {
+void adjust_cursor_col(void)          {
   if (curwin->w_cursor.col > 0
       && (!VIsual_active || *p_sel == 'o')
       && gchar_cursor() == NUL)
@@ -515,7 +508,7 @@ void adjust_cursor_col()          {
  * When curwin->w_leftcol has changed, adjust the cursor position.
  * Return TRUE if the cursor was moved.
  */
-int leftcol_changed()         {
+int leftcol_changed(void)         {
   long lastcol;
   colnr_T s, e;
   int retval = FALSE;
@@ -579,21 +572,17 @@ static void mem_pre_alloc_l __ARGS((long_u *sizep));
 static void mem_post_alloc __ARGS((void **pp, size_t size));
 static void mem_pre_free __ARGS((void **pp));
 
-static void mem_pre_alloc_s(sizep)
-size_t *sizep;
+static void mem_pre_alloc_s(size_t *sizep)
 {
   *sizep += sizeof(size_t);
 }
 
-static void mem_pre_alloc_l(sizep)
-long_u *sizep;
+static void mem_pre_alloc_l(long_u *sizep)
 {
   *sizep += sizeof(size_t);
 }
 
-static void mem_post_alloc(pp, size)
-void **pp;
-size_t size;
+static void mem_post_alloc(void **pp, size_t size)
 {
   if (*pp == NULL)
     return;
@@ -610,8 +599,7 @@ size_t size;
   *pp = (void *)((char *)*pp + sizeof(size_t));
 }
 
-static void mem_pre_free(pp)
-void **pp;
+static void mem_pre_free(void **pp)
 {
   long_u size;
 
@@ -628,7 +616,7 @@ void **pp;
 /*
  * called on exit via atexit()
  */
-void vim_mem_profile_dump()          {
+void vim_mem_profile_dump(void)          {
   int i, j;
 
   printf("\r\n");
@@ -673,8 +661,7 @@ void vim_mem_profile_dump()          {
  * Note: if unsigned is 16 bits we can only allocate up to 64K with alloc().
  * Use lalloc for larger blocks.
  */
-char_u * alloc(size)
-unsigned size;
+char_u *alloc(unsigned size)
 {
   return lalloc((long_u)size, TRUE);
 }
@@ -682,8 +669,7 @@ unsigned size;
 /*
  * Allocate memory and set all bytes to zero.
  */
-char_u * alloc_clear(size)
-unsigned size;
+char_u *alloc_clear(unsigned size)
 {
   char_u *p;
 
@@ -696,8 +682,7 @@ unsigned size;
 /*
  * alloc() with check for maximum line length
  */
-char_u * alloc_check(size)
-unsigned size;
+char_u *alloc_check(unsigned size)
 {
 #if !defined(UNIX) && !defined(__EMX__)
   if (sizeof(int) == 2 && size > 0x7fff) {
@@ -713,9 +698,7 @@ unsigned size;
 /*
  * Allocate memory like lalloc() and set all bytes to zero.
  */
-char_u * lalloc_clear(size, message)
-long_u size;
-int message;
+char_u *lalloc_clear(long_u size, int message)
 {
   char_u *p;
 
@@ -729,9 +712,7 @@ int message;
  * Low level memory allocation function.
  * This is used often, KEEP IT FAST!
  */
-char_u * lalloc(size, message)
-long_u size;
-int message;
+char_u *lalloc(long_u size, int message)
 {
   char_u      *p;                   /* pointer to new storage space */
   static int releasing = FALSE;     /* don't do mf_release_all() recursive */
@@ -817,9 +798,7 @@ theend:
 /*
  * realloc() with memory profiling.
  */
-void * mem_realloc(ptr, size)
-void *ptr;
-size_t size;
+void *mem_realloc(void *ptr, size_t size)
 {
   void *p;
 
@@ -838,8 +817,7 @@ size_t size;
  * Avoid repeating the error message many times (they take 1 second each).
  * Did_outofmem_msg is reset when a character is read.
  */
-void do_outofmem_msg(size)
-long_u size;
+void do_outofmem_msg(long_u size)
 {
   if (!did_outofmem_msg) {
     /* Don't hide this message */
@@ -864,7 +842,7 @@ static void free_findfile __ARGS((void));
  * surprised if Vim crashes...
  * Some things can't be freed, esp. things local to a library function.
  */
-void free_all_mem()          {
+void free_all_mem(void)          {
   buf_T       *buf, *nextbuf;
   static int entered = FALSE;
 
@@ -1008,8 +986,7 @@ void free_all_mem()          {
 /*
  * Copy "string" into newly allocated memory.
  */
-char_u * vim_strsave(string)
-char_u      *string;
+char_u *vim_strsave(char_u *string)
 {
   char_u      *p;
   unsigned len;
@@ -1027,9 +1004,7 @@ char_u      *string;
  * The allocated memory always has size "len + 1", also when "string" is
  * shorter.
  */
-char_u * vim_strnsave(string, len)
-char_u      *string;
-int len;
+char_u *vim_strnsave(char_u *string, int len)
 {
   char_u      *p;
 
@@ -1045,9 +1020,7 @@ int len;
  * Same as vim_strsave(), but any characters found in esc_chars are preceded
  * by a backslash.
  */
-char_u * vim_strsave_escaped(string, esc_chars)
-char_u      *string;
-char_u      *esc_chars;
+char_u *vim_strsave_escaped(char_u *string, char_u *esc_chars)
 {
   return vim_strsave_escaped_ext(string, esc_chars, '\\', FALSE);
 }
@@ -1057,11 +1030,7 @@ char_u      *esc_chars;
  * characters where rem_backslash() would remove the backslash.
  * Escape the characters with "cc".
  */
-char_u * vim_strsave_escaped_ext(string, esc_chars, cc, bsl)
-char_u      *string;
-char_u      *esc_chars;
-int cc;
-int bsl;
+char_u *vim_strsave_escaped_ext(char_u *string, char_u *esc_chars, int cc, int bsl)
 {
   char_u      *p;
   char_u      *p2;
@@ -1106,7 +1075,7 @@ int bsl;
 /*
  * Return TRUE when 'shell' has "csh" in the tail.
  */
-int csh_like_shell()         {
+int csh_like_shell(void)         {
   return strstr((char *)gettail(p_sh), "csh") != NULL;
 }
 
@@ -1119,9 +1088,7 @@ int csh_like_shell()         {
  * with "<" like "<cfile>".
  * Returns the result in allocated memory, NULL if we have run out.
  */
-char_u * vim_strsave_shellescape(string, do_special)
-char_u      *string;
-int do_special;
+char_u *vim_strsave_shellescape(char_u *string, int do_special)
 {
   unsigned length;
   char_u      *p;
@@ -1198,8 +1165,7 @@ int do_special;
  * Like vim_strsave(), but make all characters uppercase.
  * This uses ASCII lower-to-upper case translation, language independent.
  */
-char_u * vim_strsave_up(string)
-char_u      *string;
+char_u *vim_strsave_up(char_u *string)
 {
   char_u *p1;
 
@@ -1212,9 +1178,7 @@ char_u      *string;
  * Like vim_strnsave(), but make all characters uppercase.
  * This uses ASCII lower-to-upper case translation, language independent.
  */
-char_u * vim_strnsave_up(string, len)
-char_u      *string;
-int len;
+char_u *vim_strnsave_up(char_u *string, int len)
 {
   char_u *p1;
 
@@ -1226,8 +1190,7 @@ int len;
 /*
  * ASCII lower-to-upper case translation, language independent.
  */
-void vim_strup(p)
-char_u      *p;
+void vim_strup(char_u *p)
 {
   char_u  *p2;
   int c;
@@ -1244,8 +1207,7 @@ char_u      *p;
  * Handles multi-byte characters as well as possible.
  * Returns NULL when out of memory.
  */
-char_u * strup_save(orig)
-char_u      *orig;
+char_u *strup_save(char_u *orig)
 {
   char_u      *p;
   char_u      *res;
@@ -1295,9 +1257,7 @@ char_u      *orig;
 /*
  * copy a space a number of times
  */
-void copy_spaces(ptr, count)
-char_u      *ptr;
-size_t count;
+void copy_spaces(char_u *ptr, size_t count)
 {
   size_t i = count;
   char_u      *p = ptr;
@@ -1310,10 +1270,7 @@ size_t count;
  * Copy a character a number of times.
  * Does not work for multi-byte characters!
  */
-void copy_chars(ptr, count, c)
-char_u      *ptr;
-size_t count;
-int c;
+void copy_chars(char_u *ptr, size_t count, int c)
 {
   size_t i = count;
   char_u      *p = ptr;
@@ -1325,8 +1282,7 @@ int c;
 /*
  * delete spaces at the end of a string
  */
-void del_trailing_spaces(ptr)
-char_u      *ptr;
+void del_trailing_spaces(char_u *ptr)
 {
   char_u      *q;
 
@@ -1339,10 +1295,7 @@ char_u      *ptr;
  * Like strncpy(), but always terminate the result with one NUL.
  * "to" must be "len + 1" long!
  */
-void vim_strncpy(to, from, len)
-char_u      *to;
-char_u      *from;
-size_t len;
+void vim_strncpy(char_u *to, char_u *from, size_t len)
 {
   STRNCPY(to, from, len);
   to[len] = NUL;
@@ -1352,10 +1305,7 @@ size_t len;
  * Like strcat(), but make sure the result fits in "tosize" bytes and is
  * always NUL terminated.
  */
-void vim_strcat(to, from, tosize)
-char_u      *to;
-char_u      *from;
-size_t tosize;
+void vim_strcat(char_u *to, char_u *from, size_t tosize)
 {
   size_t tolen = STRLEN(to);
   size_t fromlen = STRLEN(from);
@@ -1374,11 +1324,7 @@ size_t tosize;
  * "*option" is advanced to the next part.
  * The length is returned.
  */
-int copy_option_part(option, buf, maxlen, sep_chars)
-char_u      **option;
-char_u      *buf;
-int maxlen;
-char        *sep_chars;
+int copy_option_part(char_u **option, char_u *buf, int maxlen, char *sep_chars)
 {
   int len = 0;
   char_u  *p = *option;
@@ -1411,8 +1357,7 @@ char        *sep_chars;
  * Also skip free() when exiting for sure, this helps when we caught a deadly
  * signal that was caused by a crash in free().
  */
-void vim_free(x)
-void *x;
+void vim_free(void *x)
 {
   if (x != NULL && !really_exiting) {
 #ifdef MEM_PROFILE
@@ -1490,9 +1435,7 @@ size_t len;
  * Doesn't work for multi-byte characters.
  * return 0 for match, < 0 for smaller, > 0 for bigger
  */
-int vim_stricmp(s1, s2)
-char        *s1;
-char        *s2;
+int vim_stricmp(char *s1, char *s2)
 {
   int i;
 
@@ -1515,10 +1458,7 @@ char        *s2;
  * Doesn't work for multi-byte characters.
  * return 0 for match, < 0 for smaller, > 0 for bigger
  */
-int vim_strnicmp(s1, s2, len)
-char        *s1;
-char        *s2;
-size_t len;
+int vim_strnicmp(char *s1, char *s2, size_t len)
 {
   int i;
 
@@ -1541,9 +1481,7 @@ size_t len;
  * with characters from 128 to 255 correctly.  It also doesn't return a
  * pointer to the NUL at the end of the string.
  */
-char_u  * vim_strchr(string, c)
-char_u      *string;
-int c;
+char_u *vim_strchr(char_u *string, int c)
 {
   char_u      *p;
   int b;
@@ -1589,9 +1527,7 @@ int c;
  * strings with characters above 128 correctly. It also doesn't return a
  * pointer to the NUL at the end of the string.
  */
-char_u  * vim_strbyte(string, c)
-char_u      *string;
-int c;
+char_u *vim_strbyte(char_u *string, int c)
 {
   char_u      *p = string;
 
@@ -1608,9 +1544,7 @@ int c;
  * Return NULL if not found.
  * Does not handle multi-byte char for "c"!
  */
-char_u  * vim_strrchr(string, c)
-char_u      *string;
-int c;
+char_u *vim_strrchr(char_u *string, int c)
 {
   char_u      *retval = NULL;
   char_u      *p = string;
@@ -1631,9 +1565,7 @@ int c;
 #  ifdef vim_strpbrk
 #   undef vim_strpbrk
 #  endif
-char_u * vim_strpbrk(s, charset)
-char_u      *s;
-char_u      *charset;
+char_u *vim_strpbrk(char_u *s, char_u *charset)
 {
   while (*s) {
     if (vim_strchr(charset, *s) != NULL)
@@ -1648,8 +1580,7 @@ char_u      *charset;
  * Vim has its own isspace() function, because on some machines isspace()
  * can't handle characters above 128.
  */
-int vim_isspace(x)
-int x;
+int vim_isspace(int x)
 {
   return (x >= 9 && x <= 13) || x == ' ';
 }
@@ -1661,8 +1592,7 @@ int x;
 /*
  * Clear an allocated growing array.
  */
-void ga_clear(gap)
-garray_T *gap;
+void ga_clear(garray_T *gap)
 {
   vim_free(gap->ga_data);
   ga_init(gap);
@@ -1671,8 +1601,7 @@ garray_T *gap;
 /*
  * Clear a growing array that contains a list of strings.
  */
-void ga_clear_strings(gap)
-garray_T *gap;
+void ga_clear_strings(garray_T *gap)
 {
   int i;
 
@@ -1685,18 +1614,14 @@ garray_T *gap;
  * Initialize a growing array.	Don't forget to set ga_itemsize and
  * ga_growsize!  Or use ga_init2().
  */
-void ga_init(gap)
-garray_T *gap;
+void ga_init(garray_T *gap)
 {
   gap->ga_data = NULL;
   gap->ga_maxlen = 0;
   gap->ga_len = 0;
 }
 
-void ga_init2(gap, itemsize, growsize)
-garray_T    *gap;
-int itemsize;
-int growsize;
+void ga_init2(garray_T *gap, int itemsize, int growsize)
 {
   ga_init(gap);
   gap->ga_itemsize = itemsize;
@@ -1707,9 +1632,7 @@ int growsize;
  * Make room in growing array "gap" for at least "n" items.
  * Return FAIL for failure, OK otherwise.
  */
-int ga_grow(gap, n)
-garray_T    *gap;
-int n;
+int ga_grow(garray_T *gap, int n)
 {
   size_t old_len;
   size_t new_len;
@@ -1736,8 +1659,7 @@ int n;
  * strings with a separating comma.
  * Returns NULL when out of memory.
  */
-char_u * ga_concat_strings(gap)
-garray_T *gap;
+char_u *ga_concat_strings(garray_T *gap)
 {
   int i;
   int len = 0;
@@ -1762,9 +1684,7 @@ garray_T *gap;
  * Concatenate a string to a growarray which contains characters.
  * Note: Does NOT copy the NUL at the end!
  */
-void ga_concat(gap, s)
-garray_T    *gap;
-char_u      *s;
+void ga_concat(garray_T *gap, char_u *s)
 {
   int len = (int)STRLEN(s);
 
@@ -1777,9 +1697,7 @@ char_u      *s;
 /*
  * Append one byte to a growarray which contains bytes.
  */
-void ga_append(gap, c)
-garray_T    *gap;
-int c;
+void ga_append(garray_T *gap, int c)
 {
   if (ga_grow(gap, 1) == OK) {
     *((char *)gap->ga_data + gap->ga_len) = c;
@@ -1791,8 +1709,7 @@ int c;
 /*
  * Append the text in "gap" below the cursor line and clear "gap".
  */
-void append_ga_line(gap)
-garray_T    *gap;
+void append_ga_line(garray_T *gap)
 {
   /* Remove trailing CR. */
   if (gap->ga_len > 0
@@ -2120,8 +2037,7 @@ static struct mousetable {
  * Return the modifier mask bit (MOD_MASK_*) which corresponds to the given
  * modifier name ('S' for Shift, 'C' for Ctrl etc).
  */
-int name_to_mod_mask(c)
-int c;
+int name_to_mod_mask(int c)
 {
   int i;
 
@@ -2136,9 +2052,7 @@ int c;
  * Check if if there is a special key code for "key" that includes the
  * modifiers specified.
  */
-int simplify_key(key, modifiers)
-int key;
-int     *modifiers;
+int simplify_key(int key, int *modifiers)
 {
   int i;
   int key0;
@@ -2167,8 +2081,7 @@ int     *modifiers;
 /*
  * Change <xHome> to <Home>, <xUp> to <Up>, etc.
  */
-int handle_x_keys(key)
-int key;
+int handle_x_keys(int key)
 {
   switch (key) {
   case K_XUP:     return K_UP;
@@ -2195,9 +2108,7 @@ int key;
  * Return a string which contains the name of the given key when the given
  * modifiers are down.
  */
-char_u * get_special_key_name(c, modifiers)
-int c;
-int modifiers;
+char_u *get_special_key_name(int c, int modifiers)
 {
   static char_u string[MAX_KEY_NAME_LEN + 1];
 
@@ -2293,10 +2204,12 @@ int modifiers;
  * If there is a match, srcp is advanced to after the <> name.
  * dst[] must be big enough to hold the result (up to six characters)!
  */
-int trans_special(srcp, dst, keycode)
-char_u      **srcp;
-char_u      *dst;
-int keycode;             /* prefer key code, e.g. K_DEL instead of DEL */
+int 
+trans_special (
+    char_u **srcp,
+    char_u *dst,
+    int keycode             /* prefer key code, e.g. K_DEL instead of DEL */
+)
 {
   int modifiers = 0;
   int key;
@@ -2332,11 +2245,13 @@ int keycode;             /* prefer key code, e.g. K_DEL instead of DEL */
  * srcp is advanced to after the <> name.
  * returns 0 if there is no match.
  */
-int find_special_key(srcp, modp, keycode, keep_x_key)
-char_u      **srcp;
-int         *modp;
-int keycode;                 /* prefer key code, e.g. K_DEL instead of DEL */
-int keep_x_key;              /* don't translate xHome to Home key */
+int 
+find_special_key (
+    char_u **srcp,
+    int *modp,
+    int keycode,                 /* prefer key code, e.g. K_DEL instead of DEL */
+    int keep_x_key              /* don't translate xHome to Home key */
+)
 {
   char_u      *last_dash;
   char_u      *end_of_name;
@@ -2453,9 +2368,7 @@ int keep_x_key;              /* don't translate xHome to Home key */
  * Try to include modifiers in the key.
  * Changes "Shift-a" to 'A', "Alt-A" to 0xc0, etc.
  */
-int extract_modifiers(key, modp)
-int key;
-int     *modp;
+int extract_modifiers(int key, int *modp)
 {
   int modifiers = *modp;
 
@@ -2487,8 +2400,7 @@ int     *modp;
  * Try to find key "c" in the special key table.
  * Return the index when found, -1 when not found.
  */
-int find_special_key_in_table(c)
-int c;
+int find_special_key_in_table(int c)
 {
   int i;
 
@@ -2507,8 +2419,7 @@ int c;
  * termcap name.
  * Return the key code, or 0 if not found.
  */
-int get_special_key_code(name)
-char_u  *name;
+int get_special_key_code(char_u *name)
 {
   char_u  *table_name;
   char_u string[3];
@@ -2535,8 +2446,7 @@ char_u  *name;
   return 0;
 }
 
-char_u * get_key_name(i)
-int i;
+char_u *get_key_name(int i)
 {
   if (i >= (int)KEY_NAMES_TABLE_LEN)
     return NULL;
@@ -2547,10 +2457,7 @@ int i;
  * Look up the given mouse code to return the relevant information in the other
  * arguments.  Return which button is down or was released.
  */
-int get_mouse_button(code, is_click, is_drag)
-int code;
-int     *is_click;
-int     *is_drag;
+int get_mouse_button(int code, int *is_click, int *is_drag)
 {
   int i;
 
@@ -2568,10 +2475,12 @@ int     *is_drag;
  * the given information about which mouse button is down, and whether the
  * mouse was clicked, dragged or released.
  */
-int get_pseudo_mouse_code(button, is_click, is_drag)
-int button;             /* eg MOUSE_LEFT */
-int is_click;
-int is_drag;
+int 
+get_pseudo_mouse_code (
+    int button,             /* eg MOUSE_LEFT */
+    int is_click,
+    int is_drag
+)
 {
   int i;
 
@@ -2587,8 +2496,7 @@ int is_drag;
 /*
  * Return the current end-of-line type: EOL_DOS, EOL_UNIX or EOL_MAC.
  */
-int get_fileformat(buf)
-buf_T       *buf;
+int get_fileformat(buf_T *buf)
 {
   int c = *buf->b_p_ff;
 
@@ -2603,9 +2511,11 @@ buf_T       *buf;
  * Like get_fileformat(), but override 'fileformat' with "p" for "++opt=val"
  * argument.
  */
-int get_fileformat_force(buf, eap)
-buf_T       *buf;
-exarg_T     *eap;           /* can be NULL! */
+int 
+get_fileformat_force (
+    buf_T *buf,
+    exarg_T *eap           /* can be NULL! */
+)
 {
   int c;
 
@@ -2629,9 +2539,11 @@ exarg_T     *eap;           /* can be NULL! */
  * Sets both 'textmode' and 'fileformat'.
  * Note: Does _not_ set global value of 'textmode'!
  */
-void set_fileformat(t, opt_flags)
-int t;
-int opt_flags;                  /* OPT_LOCAL and/or OPT_GLOBAL */
+void 
+set_fileformat (
+    int t,
+    int opt_flags                  /* OPT_LOCAL and/or OPT_GLOBAL */
+)
 {
   char        *p = NULL;
 
@@ -2662,7 +2574,7 @@ int opt_flags;                  /* OPT_LOCAL and/or OPT_GLOBAL */
 /*
  * Return the default fileformat from 'fileformats'.
  */
-int default_fileformat()         {
+int default_fileformat(void)         {
   switch (*p_ffs) {
   case 'm':   return EOL_MAC;
   case 'd':   return EOL_DOS;
@@ -2673,9 +2585,7 @@ int default_fileformat()         {
 /*
  * Call shell.	Calls mch_call_shell, with 'shellxquote' added.
  */
-int call_shell(cmd, opt)
-char_u      *cmd;
-int opt;
+int call_shell(char_u *cmd, int opt)
 {
   char_u      *ncmd;
   int retval;
@@ -2744,7 +2654,7 @@ int opt;
  * VISUAL, SELECTMODE and OP_PENDING State are never set, they are equal to
  * NORMAL State with a condition.  This function returns the real State.
  */
-int get_real_state()         {
+int get_real_state(void)         {
   if (State & NORMAL) {
     if (VIsual_active) {
       if (VIsual_select)
@@ -2761,9 +2671,7 @@ int get_real_state()         {
  * Takes care of multi-byte characters.
  * "b" must point to the start of the file name
  */
-int after_pathsep(b, p)
-char_u      *b;
-char_u      *p;
+int after_pathsep(char_u *b, char_u *p)
 {
   return p > b && vim_ispathsep(p[-1])
          && (!has_mbyte || (*mb_head_off)(b, p - 1) == 0);
@@ -2773,9 +2681,7 @@ char_u      *p;
  * Return TRUE if file names "f1" and "f2" are in the same directory.
  * "f1" may be a short name, "f2" must be a full path.
  */
-int same_directory(f1, f2)
-char_u      *f1;
-char_u      *f2;
+int same_directory(char_u *f1, char_u *f2)
 {
   char_u ffname[MAXPATHL];
   char_u      *t1;
@@ -2802,8 +2708,7 @@ char_u      *f2;
  * Caller must call shorten_fnames()!
  * Return OK or FAIL.
  */
-int vim_chdirfile(fname)
-char_u      *fname;
+int vim_chdirfile(char_u *fname)
 {
   char_u dir[MAXPATHL];
 
@@ -2819,8 +2724,7 @@ char_u      *fname;
  * Used for systems where stat() ignores a trailing slash on a file name.
  * The Vim code assumes a trailing slash is only ignored for a directory.
  */
-int illegal_slash(name)
-char *name;
+int illegal_slash(char *name)
 {
   if (name[0] == NUL)
     return FALSE;           /* no file name is not illegal */
@@ -2868,8 +2772,7 @@ cursorentry_T shape_table[SHAPE_IDX_COUNT] =
  * ("what" is SHAPE_MOUSE).
  * Returns error message for an illegal option, NULL otherwise.
  */
-char_u * parse_shape_opt(what)
-int what;
+char_u *parse_shape_opt(int what)
 {
   char_u      *modep;
   char_u      *colonp;
@@ -3045,8 +2948,7 @@ int what;
  * Return the index into shape_table[] for the current mode.
  * When "mouse" is TRUE, consider indexes valid for the mouse pointer.
  */
-int get_shape_idx(mouse)
-int mouse;
+int get_shape_idx(int mouse)
 {
   if (!mouse && State == SHOWMATCH)
     return SHAPE_IDX_SM;
@@ -3106,7 +3008,7 @@ static ulg crc_32_tab[256];
 /*
  * Fill the CRC table.
  */
-static void make_crc_tab()                 {
+static void make_crc_tab(void)                 {
   ulg s,t,v;
   static int done = FALSE;
 
@@ -3154,8 +3056,7 @@ static int saved_crypt_method;
  * 0 for "zip", the old method.  Also for any non-valid value.
  * 1 for "blowfish".
  */
-int crypt_method_from_string(s)
-char_u  *s;
+int crypt_method_from_string(char_u *s)
 {
   return *s == 'b' ? 1 : 0;
 }
@@ -3163,8 +3064,7 @@ char_u  *s;
 /*
  * Get the crypt method for buffer "buf" as a number.
  */
-int get_crypt_method(buf)
-buf_T *buf;
+int get_crypt_method(buf_T *buf)
 {
   return crypt_method_from_string(*buf->b_p_cm == NUL ? p_cm : buf->b_p_cm);
 }
@@ -3173,9 +3073,7 @@ buf_T *buf;
  * Set the crypt method for buffer "buf" to "method" using the int value as
  * returned by crypt_method_from_string().
  */
-void set_crypt_method(buf, method)
-buf_T   *buf;
-int method;
+void set_crypt_method(buf_T *buf, int method)
 {
   free_string_option(buf->b_p_cm);
   buf->b_p_cm = vim_strsave((char_u *)(method == 0 ? "zip" : "blowfish"));
@@ -3186,7 +3084,7 @@ int method;
  * the state.
  * Must always be called symmetrically with crypt_pop_state().
  */
-void crypt_push_state()          {
+void crypt_push_state(void)          {
   if (crypt_busy == 1) {
     /* save the state */
     if (use_crypt_method == 0) {
@@ -3206,7 +3104,7 @@ void crypt_push_state()          {
  * the saved state.
  * Must always be called symmetrically with crypt_push_state().
  */
-void crypt_pop_state()          {
+void crypt_pop_state(void)          {
   --crypt_busy;
   if (crypt_busy == 1) {
     use_crypt_method = saved_crypt_method;
@@ -3223,10 +3121,7 @@ void crypt_pop_state()          {
  * Encrypt "from[len]" into "to[len]".
  * "from" and "to" can be equal to encrypt in place.
  */
-void crypt_encode(from, len, to)
-char_u      *from;
-size_t len;
-char_u      *to;
+void crypt_encode(char_u *from, size_t len, char_u *to)
 {
   size_t i;
   int ztemp, t;
@@ -3245,9 +3140,7 @@ char_u      *to;
 /*
  * Decrypt "ptr[len]" in place.
  */
-void crypt_decode(ptr, len)
-char_u      *ptr;
-long len;
+void crypt_decode(char_u *ptr, long len)
 {
   char_u *p;
 
@@ -3268,8 +3161,10 @@ long len;
  * the given password.
  * If "passwd" is NULL or empty, don't do anything.
  */
-void crypt_init_keys(passwd)
-char_u *passwd;                 /* password string with which to modify keys */
+void 
+crypt_init_keys (
+    char_u *passwd                 /* password string with which to modify keys */
+)
 {
   if (passwd != NULL && *passwd != NUL) {
     if (use_crypt_method == 0) {
@@ -3291,8 +3186,7 @@ char_u *passwd;                 /* password string with which to modify keys */
  * Free an allocated crypt key.  Clear the text to make sure it doesn't stay
  * in memory anywhere.
  */
-void free_crypt_key(key)
-char_u *key;
+void free_crypt_key(char_u *key)
 {
   char_u *p;
 
@@ -3310,9 +3204,11 @@ char_u *key;
  * When "store" is FALSE, the typed key is returned in allocated memory.
  * Returns NULL on failure.
  */
-char_u * get_crypt_key(store, twice)
-int store;
-int twice;                  /* Ask for the key twice. */
+char_u *
+get_crypt_key (
+    int store,
+    int twice                  /* Ask for the key twice. */
+)
 {
   char_u      *p1, *p2 = NULL;
   int round;
@@ -3599,19 +3495,18 @@ static char_u e_pathtoolong[] = N_("E854: path too long for completion");
  * This function silently ignores a few errors, vim_findfile() will have
  * limited functionality then.
  */
-void * vim_findfile_init(path, filename, stopdirs, level, free_visited,
-    find_what,
-    search_ctx_arg, tagfile,
-    rel_fname)
-char_u      *path;
-char_u      *filename;
-char_u      *stopdirs UNUSED;
-int level;
-int free_visited;
-int find_what;
-void        *search_ctx_arg;
-int tagfile;                    /* expanding names of tags files */
-char_u      *rel_fname;         /* file name to use for "." */
+void *
+vim_findfile_init (
+    char_u *path,
+    char_u *filename,
+    char_u *stopdirs,
+    int level,
+    int free_visited,
+    int find_what,
+    void *search_ctx_arg,
+    int tagfile,                    /* expanding names of tags files */
+    char_u *rel_fname         /* file name to use for "." */
+)
 {
   char_u              *wc_part;
   ff_stack_T          *sptr;
@@ -3911,8 +3806,7 @@ error_return:
 /*
  * Get the stopdir string.  Check that ';' is not escaped.
  */
-char_u * vim_findfile_stopdir(buf)
-char_u      *buf;
+char_u *vim_findfile_stopdir(char_u *buf)
 {
   char_u      *r_ptr = buf;
 
@@ -3936,8 +3830,7 @@ char_u      *buf;
 /*
  * Clean up the given search context. Can handle a NULL pointer.
  */
-void vim_findfile_cleanup(ctx)
-void        *ctx;
+void vim_findfile_cleanup(void *ctx)
 {
   if (ctx == NULL)
     return;
@@ -3959,8 +3852,7 @@ void        *ctx;
  * stack with a list (don't forget to leave partly searched directories on the
  * top of the list).
  */
-char_u * vim_findfile(search_ctx_arg)
-void        *search_ctx_arg;
+char_u *vim_findfile(void *search_ctx_arg)
 {
   char_u      *file_path;
   char_u      *rest_of_wildcards;
@@ -4344,8 +4236,7 @@ void        *search_ctx_arg;
  * Free the list of lists of visited files and directories
  * Can handle it if the passed search_context is NULL;
  */
-void vim_findfile_free_visited(search_ctx_arg)
-void        *search_ctx_arg;
+void vim_findfile_free_visited(void *search_ctx_arg)
 {
   ff_search_ctx_T *search_ctx;
 
@@ -4357,8 +4248,7 @@ void        *search_ctx_arg;
   vim_findfile_free_visited_list(&search_ctx->ffsc_dir_visited_lists_list);
 }
 
-static void vim_findfile_free_visited_list(list_headp)
-ff_visited_list_hdr_T       **list_headp;
+static void vim_findfile_free_visited_list(ff_visited_list_hdr_T **list_headp)
 {
   ff_visited_list_hdr_T *vp;
 
@@ -4373,8 +4263,7 @@ ff_visited_list_hdr_T       **list_headp;
   *list_headp = NULL;
 }
 
-static void ff_free_visited_list(vl)
-ff_visited_T *vl;
+static void ff_free_visited_list(ff_visited_T *vl)
 {
   ff_visited_T *vp;
 
@@ -4391,9 +4280,7 @@ ff_visited_T *vl;
  * Returns the already visited list for the given filename. If none is found it
  * allocates a new one.
  */
-static ff_visited_list_hdr_T* ff_get_visited_list(filename, list_headp)
-char_u                      *filename;
-ff_visited_list_hdr_T       **list_headp;
+static ff_visited_list_hdr_T *ff_get_visited_list(char_u *filename, ff_visited_list_hdr_T **list_headp)
 {
   ff_visited_list_hdr_T  *retptr = NULL;
 
@@ -4456,9 +4343,7 @@ ff_visited_list_hdr_T       **list_headp;
  *  - the only differences are in the counters behind a '**', so
  *    '**\20' is equal to '**\24'
  */
-static int ff_wc_equal(s1, s2)
-char_u      *s1;
-char_u      *s2;
+static int ff_wc_equal(char_u *s1, char_u *s2)
 {
   int i;
   int prev1 = NUL;
@@ -4495,11 +4380,7 @@ char_u      *s2;
  *	 -> return TRUE - Better the file is found several times instead of
  *	    never.
  */
-static int ff_check_visited(visited_list, fname
-    , wc_path)
-ff_visited_T        **visited_list;
-char_u              *fname;
-char_u              *wc_path;
+static int ff_check_visited(ff_visited_T **visited_list, char_u *fname, char_u *wc_path)
 {
   ff_visited_T        *vp;
 #ifdef UNIX
@@ -4576,13 +4457,7 @@ char_u              *wc_path;
 /*
  * create stack element from given path pieces
  */
-static ff_stack_T * ff_create_stack_element(fix_part,
-    wc_part,
-    level, star_star_empty)
-char_u      *fix_part;
-char_u      *wc_part;
-int level;
-int star_star_empty;
+static ff_stack_T *ff_create_stack_element(char_u *fix_part, char_u *wc_part, int level, int star_star_empty)
 {
   ff_stack_T  *new;
 
@@ -4620,9 +4495,7 @@ int star_star_empty;
 /*
  * Push a dir on the directory stack.
  */
-static void ff_push(search_ctx, stack_ptr)
-ff_search_ctx_T *search_ctx;
-ff_stack_T      *stack_ptr;
+static void ff_push(ff_search_ctx_T *search_ctx, ff_stack_T *stack_ptr)
 {
   /* check for NULL pointer, not to return an error to the user, but
    * to prevent a crash */
@@ -4636,8 +4509,7 @@ ff_stack_T      *stack_ptr;
  * Pop a dir from the directory stack.
  * Returns NULL if stack is empty.
  */
-static ff_stack_T * ff_pop(search_ctx)
-ff_search_ctx_T *search_ctx;
+static ff_stack_T *ff_pop(ff_search_ctx_T *search_ctx)
 {
   ff_stack_T  *sptr;
 
@@ -4651,8 +4523,7 @@ ff_search_ctx_T *search_ctx;
 /*
  * free the given stack element
  */
-static void ff_free_stack_element(stack_ptr)
-ff_stack_T  *stack_ptr;
+static void ff_free_stack_element(ff_stack_T *stack_ptr)
 {
   /* vim_free handles possible NULL pointers */
   vim_free(stack_ptr->ffs_fix_path);
@@ -4667,8 +4538,7 @@ ff_stack_T  *stack_ptr;
 /*
  * Clear the search context, but NOT the visited list.
  */
-static void ff_clear(search_ctx)
-ff_search_ctx_T *search_ctx;
+static void ff_clear(ff_search_ctx_T *search_ctx)
 {
   ff_stack_T   *sptr;
 
@@ -4704,10 +4574,7 @@ ff_search_ctx_T *search_ctx;
  * check if the given path is in the stopdirs
  * returns TRUE if yes else FALSE
  */
-static int ff_path_in_stoplist(path, path_len, stopdirs_v)
-char_u      *path;
-int path_len;
-char_u      **stopdirs_v;
+static int ff_path_in_stoplist(char_u *path, int path_len, char_u **stopdirs_v)
 {
   int i = 0;
 
@@ -4761,12 +4628,14 @@ char_u      **stopdirs_v;
  * Returns an allocated string for the file name.  NULL for error.
  *
  */
-char_u * find_file_in_path(ptr, len, options, first, rel_fname)
-char_u      *ptr;               /* file name */
-int len;                        /* length of file name */
-int options;
-int first;                      /* use count'th matching file name */
-char_u      *rel_fname;         /* file name searching relative to */
+char_u *
+find_file_in_path (
+    char_u *ptr,               /* file name */
+    int len,                        /* length of file name */
+    int options,
+    int first,                      /* use count'th matching file name */
+    char_u *rel_fname         /* file name searching relative to */
+)
 {
   return find_file_in_path_option(ptr, len, options, first,
       *curbuf->b_p_path == NUL ? p_path : curbuf->b_p_path,
@@ -4777,7 +4646,7 @@ static char_u   *ff_file_to_find = NULL;
 static void     *fdip_search_ctx = NULL;
 
 #if defined(EXITFREE)
-static void free_findfile()                 {
+static void free_findfile(void)                 {
   vim_free(ff_file_to_find);
   vim_findfile_cleanup(fdip_search_ctx);
 }
@@ -4794,27 +4663,29 @@ static void free_findfile()                 {
  *
  * Returns an allocated string for the file name.  NULL for error.
  */
-char_u * find_directory_in_path(ptr, len, options, rel_fname)
-char_u      *ptr;               /* file name */
-int len;                        /* length of file name */
-int options;
-char_u      *rel_fname;         /* file name searching relative to */
+char_u *
+find_directory_in_path (
+    char_u *ptr,               /* file name */
+    int len,                        /* length of file name */
+    int options,
+    char_u *rel_fname         /* file name searching relative to */
+)
 {
   return find_file_in_path_option(ptr, len, options, TRUE, p_cdpath,
       FINDFILE_DIR, rel_fname, (char_u *)"");
 }
 
-char_u * find_file_in_path_option(ptr, len, options, first, path_option,
-    find_what, rel_fname,
-    suffixes)
-char_u      *ptr;               /* file name */
-int len;                        /* length of file name */
-int options;
-int first;                      /* use count'th matching file name */
-char_u      *path_option;       /* p_path or p_cdpath */
-int find_what;                  /* FINDFILE_FILE, _DIR or _BOTH */
-char_u      *rel_fname;         /* file name we are looking relative to. */
-char_u      *suffixes;          /* list of suffixes, 'suffixesadd' option */
+char_u *
+find_file_in_path_option (
+    char_u *ptr,               /* file name */
+    int len,                        /* length of file name */
+    int options,
+    int first,                      /* use count'th matching file name */
+    char_u *path_option,       /* p_path or p_cdpath */
+    int find_what,                  /* FINDFILE_FILE, _DIR or _BOTH */
+    char_u *rel_fname,         /* file name we are looking relative to. */
+    char_u *suffixes          /* list of suffixes, 'suffixesadd' option */
+)
 {
   static char_u       *dir;
   static int did_findfile_init = FALSE;
@@ -4973,8 +4844,7 @@ theend:
  * Change directory to "new_dir".  If FEAT_SEARCHPATH is defined, search
  * 'cdpath' for relative directory names, otherwise just mch_chdir().
  */
-int vim_chdir(new_dir)
-char_u      *new_dir;
+int vim_chdir(char_u *new_dir)
 {
   char_u      *dir_name;
   int r;
@@ -4995,9 +4865,7 @@ char_u      *new_dir;
  * cache the result.
  * Returns OK or FAIL.
  */
-int get_user_name(buf, len)
-char_u      *buf;
-int len;
+int get_user_name(char_u *buf, int len)
 {
   if (username == NULL) {
     if (mch_get_user_name(buf, len) == FAIL)
@@ -5053,16 +4921,12 @@ int (*cmp)__ARGS((const void *, const void *));
 static int
 sort_compare __ARGS((const void *s1, const void *s2));
 
-static int sort_compare(s1, s2)
-const void  *s1;
-const void  *s2;
+static int sort_compare(const void *s1, const void *s2)
 {
   return STRCMP(*(char **)s1, *(char **)s2);
 }
 
-void sort_strings(files, count)
-char_u      **files;
-int count;
+void sort_strings(char_u **files, int count)
 {
   qsort((void *)files, (size_t)count, sizeof(char_u *), sort_compare);
 }
@@ -5073,9 +4937,7 @@ int count;
  * If "maxlen" >= 0 compare "p[maxlen]" to "q[maxlen]"
  * Return value like strcmp(p, q), but consider path separators.
  */
-int pathcmp(p, q, maxlen)
-const char *p, *q;
-int maxlen;
+int pathcmp(const char *p, const char *q, int maxlen)
 {
   int i;
   int c1, c2;
@@ -5174,8 +5036,7 @@ static int findenv __ARGS((char *name));  /* look for a name in the env. */
 static int newenv __ARGS((void));       /* copy env. from stack to heap */
 static int moreenv __ARGS((void));      /* incr. size of env. */
 
-int putenv(string)
-const char *string;
+int putenv(const char *string)
 {
   int i;
   char    *p;
@@ -5208,8 +5069,7 @@ const char *string;
   return 0;
 }
 
-static int findenv(name)
-char *name;
+static int findenv(char *name)
 {
   char    *namechar, *envchar;
   int i, found;
@@ -5227,7 +5087,7 @@ char *name;
   return found ? i - 1 : -1;
 }
 
-static int newenv()                {
+static int newenv(void)                {
   char    **env, *elem;
   int i, esize;
 
@@ -5252,7 +5112,7 @@ static int newenv()                {
   return 0;
 }
 
-static int moreenv()                {
+static int moreenv(void)                {
   int esize;
   char    **env;
 
@@ -5266,8 +5126,7 @@ static int moreenv()                {
 }
 
 # ifdef USE_VIMPTY_GETENV
-char_u * vimpty_getenv(string)
-const char_u *string;
+char_u *vimpty_getenv(const char_u *string)
 {
   int i;
   char_u *p;
@@ -5291,8 +5150,7 @@ const char_u *string;
  * Return 0 for not writable, 1 for writable file, 2 for a dir which we have
  * rights to write into.
  */
-int filewritable(fname)
-char_u      *fname;
+int filewritable(char_u *fname)
 {
   int retval = 0;
 #if defined(UNIX) || defined(VMS)
@@ -5319,8 +5177,7 @@ char_u      *fname;
  * Print an error message with one or two "%s" and one or two string arguments.
  * This is not in message.c to avoid a warning for prototypes.
  */
-int emsg3(s, a1, a2)
-char_u *s, *a1, *a2;
+int emsg3(char_u *s, char_u *a1, char_u *a2)
 {
   if (emsg_not_now())
     return TRUE;                /* no error messages at the moment */
@@ -5336,9 +5193,7 @@ char_u *s, *a1, *a2;
  * Print an error message with one "%ld" and one long int argument.
  * This is not in message.c to avoid a warning for prototypes.
  */
-int emsgn(s, n)
-char_u      *s;
-long n;
+int emsgn(char_u *s, long n)
 {
   if (emsg_not_now())
     return TRUE;                /* no error messages at the moment */
@@ -5349,8 +5204,7 @@ long n;
 /*
  * Read 2 bytes from "fd" and turn them into an int, MSB first.
  */
-int get2c(fd)
-FILE        *fd;
+int get2c(FILE *fd)
 {
   int n;
 
@@ -5362,8 +5216,7 @@ FILE        *fd;
 /*
  * Read 3 bytes from "fd" and turn them into an int, MSB first.
  */
-int get3c(fd)
-FILE        *fd;
+int get3c(FILE *fd)
 {
   int n;
 
@@ -5376,8 +5229,7 @@ FILE        *fd;
 /*
  * Read 4 bytes from "fd" and turn them into an int, MSB first.
  */
-int get4c(fd)
-FILE        *fd;
+int get4c(FILE *fd)
 {
   /* Use unsigned rather than int otherwise result is undefined
    * when left-shift sets the MSB. */
@@ -5393,8 +5245,7 @@ FILE        *fd;
 /*
  * Read 8 bytes from "fd" and turn them into a time_t, MSB first.
  */
-time_t get8ctime(fd)
-FILE        *fd;
+time_t get8ctime(FILE *fd)
 {
   time_t n = 0;
   int i;
@@ -5408,9 +5259,7 @@ FILE        *fd;
  * Read a string of length "cnt" from "fd" into allocated memory.
  * Returns NULL when out of memory or unable to read that many bytes.
  */
-char_u * read_string(fd, cnt)
-FILE        *fd;
-int cnt;
+char_u *read_string(FILE *fd, int cnt)
 {
   char_u      *str;
   int i;
@@ -5436,10 +5285,7 @@ int cnt;
 /*
  * Write a number to file "fd", MSB first, in "len" bytes.
  */
-int put_bytes(fd, nr, len)
-FILE    *fd;
-long_u nr;
-int len;
+int put_bytes(FILE *fd, long_u nr, int len)
 {
   int i;
 
@@ -5453,9 +5299,7 @@ int len;
 /*
  * Write time_t to file "fd" in 8 bytes.
  */
-void put_time(fd, the_time)
-FILE        *fd;
-time_t the_time;
+void put_time(FILE *fd, time_t the_time)
 {
   int c;
   int i;
@@ -5491,8 +5335,7 @@ time_t the_time;
  * Return TRUE if string "s" contains a non-ASCII character (128 or higher).
  * When "s" is NULL FALSE is returned.
  */
-int has_non_ascii(s)
-char_u      *s;
+int has_non_ascii(char_u *s)
 {
   char_u      *p;
 

--- a/src/move.c
+++ b/src/move.c
@@ -42,8 +42,7 @@ static void max_topfill __ARGS((void));
  * Compute wp->w_botline for the current wp->w_topline.  Can be called after
  * wp->w_topline changed.
  */
-static void comp_botline(wp)
-win_T       *wp;
+static void comp_botline(win_T *wp)
 {
   int n;
   linenr_T lnum;
@@ -99,7 +98,7 @@ win_T       *wp;
  * Update curwin->w_topline and redraw if necessary.
  * Used to update the screen before printing a message.
  */
-void update_topline_redraw()          {
+void update_topline_redraw(void)          {
   update_topline();
   if (must_redraw)
     update_screen(0);
@@ -108,7 +107,7 @@ void update_topline_redraw()          {
 /*
  * Update curwin->w_topline to move the cursor onto the screen.
  */
-void update_topline()          {
+void update_topline(void)          {
   long line_count;
   int halfheight;
   int n;
@@ -296,7 +295,7 @@ void update_topline()          {
  * When 'scrolljump' is positive use it as-is.
  * When 'scrolljump' is negative use it as a percentage of the window height.
  */
-static int scrolljump_value()                {
+static int scrolljump_value(void)                {
   if (p_sj >= 0)
     return (int)p_sj;
   return (curwin->w_height * -p_sj) / 100;
@@ -306,7 +305,7 @@ static int scrolljump_value()                {
  * Return TRUE when there are not 'scrolloff' lines above the cursor for the
  * current window.
  */
-static int check_top_offset()                {
+static int check_top_offset(void)                {
   lineoff_T loff;
   int n;
 
@@ -332,7 +331,7 @@ static int check_top_offset()                {
   return FALSE;
 }
 
-void update_curswant()          {
+void update_curswant(void)          {
   if (curwin->w_set_curswant) {
     validate_virtcol();
     curwin->w_curswant = curwin->w_virtcol;
@@ -343,8 +342,7 @@ void update_curswant()          {
 /*
  * Check if the cursor has moved.  Set the w_valid flag accordingly.
  */
-void check_cursor_moved(wp)
-win_T       *wp;
+void check_cursor_moved(win_T *wp)
 {
   if (wp->w_cursor.lnum != wp->w_valid_cursor.lnum) {
     wp->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL
@@ -367,12 +365,11 @@ win_T       *wp;
  * the cursor position, botline and topline to be recomputed and the window to
  * be redrawn.  E.g, when changing the 'wrap' option or folding.
  */
-void changed_window_setting()          {
+void changed_window_setting(void)          {
   changed_window_setting_win(curwin);
 }
 
-void changed_window_setting_win(wp)
-win_T       *wp;
+void changed_window_setting_win(win_T *wp)
 {
   wp->w_lines_valid = 0;
   changed_line_abv_curs_win(wp);
@@ -383,9 +380,7 @@ win_T       *wp;
 /*
  * Set wp->w_topline to a certain number.
  */
-void set_topline(wp, lnum)
-win_T       *wp;
-linenr_T lnum;
+void set_topline(win_T *wp, linenr_T lnum)
 {
   /* go to first of folded lines */
   (void)hasFoldingWin(wp, lnum, &lnum, NULL, TRUE, NULL);
@@ -404,13 +399,12 @@ linenr_T lnum;
  * characters) has changed, and the change is before the cursor.
  * Need to take care of w_botline separately!
  */
-void changed_cline_bef_curs()          {
+void changed_cline_bef_curs(void)          {
   curwin->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL
                        |VALID_CHEIGHT|VALID_TOPLINE);
 }
 
-void changed_cline_bef_curs_win(wp)
-win_T       *wp;
+void changed_cline_bef_curs_win(win_T *wp)
 {
   wp->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL
                    |VALID_CHEIGHT|VALID_TOPLINE);
@@ -421,13 +415,12 @@ win_T       *wp;
  * the cursor have changed.
  * Need to take care of w_botline separately!
  */
-void changed_line_abv_curs()          {
+void changed_line_abv_curs(void)          {
   curwin->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL|VALID_CROW
                        |VALID_CHEIGHT|VALID_TOPLINE);
 }
 
-void changed_line_abv_curs_win(wp)
-win_T       *wp;
+void changed_line_abv_curs_win(win_T *wp)
 {
   wp->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL|VALID_CROW
                    |VALID_CHEIGHT|VALID_TOPLINE);
@@ -436,7 +429,7 @@ win_T       *wp;
 /*
  * Make sure the value of curwin->w_botline is valid.
  */
-void validate_botline()          {
+void validate_botline(void)          {
   if (!(curwin->w_valid & VALID_BOTLINE))
     comp_botline(curwin);
 }
@@ -444,8 +437,7 @@ void validate_botline()          {
 /*
  * Make sure the value of wp->w_botline is valid.
  */
-static void validate_botline_win(wp)
-win_T       *wp;
+static void validate_botline_win(win_T *wp)
 {
   if (!(wp->w_valid & VALID_BOTLINE))
     comp_botline(wp);
@@ -454,18 +446,16 @@ win_T       *wp;
 /*
  * Mark curwin->w_botline as invalid (because of some change in the buffer).
  */
-void invalidate_botline()          {
+void invalidate_botline(void)          {
   curwin->w_valid &= ~(VALID_BOTLINE|VALID_BOTLINE_AP);
 }
 
-void invalidate_botline_win(wp)
-win_T       *wp;
+void invalidate_botline_win(win_T *wp)
 {
   wp->w_valid &= ~(VALID_BOTLINE|VALID_BOTLINE_AP);
 }
 
-void approximate_botline_win(wp)
-win_T       *wp;
+void approximate_botline_win(win_T *wp)
 {
   wp->w_valid &= ~VALID_BOTLINE;
 }
@@ -473,7 +463,7 @@ win_T       *wp;
 /*
  * Return TRUE if curwin->w_wrow and curwin->w_wcol are valid.
  */
-int cursor_valid()         {
+int cursor_valid(void)         {
   check_cursor_moved(curwin);
   return (curwin->w_valid & (VALID_WROW|VALID_WCOL)) ==
          (VALID_WROW|VALID_WCOL);
@@ -483,7 +473,7 @@ int cursor_valid()         {
  * Validate cursor position.  Makes sure w_wrow and w_wcol are valid.
  * w_topline must be valid, you may need to call update_topline() first!
  */
-void validate_cursor()          {
+void validate_cursor(void)          {
   check_cursor_moved(curwin);
   if ((curwin->w_valid & (VALID_WCOL|VALID_WROW)) != (VALID_WCOL|VALID_WROW))
     curs_columns(TRUE);
@@ -495,9 +485,11 @@ void validate_cursor()          {
  *
  * Returns OK when cursor is in the window, FAIL when it isn't.
  */
-static void curs_rows(wp, do_botline)
-win_T       *wp;
-int do_botline;                         /* also compute w_botline */
+static void 
+curs_rows (
+    win_T *wp,
+    int do_botline                         /* also compute w_botline */
+)
 {
   linenr_T lnum;
   int i;
@@ -585,15 +577,14 @@ int do_botline;                         /* also compute w_botline */
 /*
  * Validate curwin->w_virtcol only.
  */
-void validate_virtcol()          {
+void validate_virtcol(void)          {
   validate_virtcol_win(curwin);
 }
 
 /*
  * Validate wp->w_virtcol only.
  */
-void validate_virtcol_win(wp)
-win_T       *wp;
+void validate_virtcol_win(win_T *wp)
 {
   check_cursor_moved(wp);
   if (!(wp->w_valid & VALID_VIRTCOL)) {
@@ -609,7 +600,7 @@ win_T       *wp;
 /*
  * Validate curwin->w_cline_height only.
  */
-static void validate_cheight()                 {
+static void validate_cheight(void)                 {
   check_cursor_moved(curwin);
   if (!(curwin->w_valid & VALID_CHEIGHT)) {
     if (curwin->w_cursor.lnum == curwin->w_topline)
@@ -625,7 +616,7 @@ static void validate_cheight()                 {
 /*
  * Validate w_wcol and w_virtcol only.
  */
-void validate_cursor_col()          {
+void validate_cursor_col(void)          {
   colnr_T off;
   colnr_T col;
   int width;
@@ -657,8 +648,7 @@ void validate_cursor_col()          {
  * Compute offset of a window, occupied by absolute or relative line number,
  * fold column and sign column (these don't move when scrolling horizontally).
  */
-int win_col_off(wp)
-win_T       *wp;
+int win_col_off(win_T *wp)
 {
   return ((wp->w_p_nu || wp->w_p_rnu) ? number_width(wp) + 1 : 0)
          + (cmdwin_type == 0 || wp != curwin ? 0 : 1)
@@ -666,7 +656,7 @@ win_T       *wp;
   ;
 }
 
-int curwin_col_off()         {
+int curwin_col_off(void)         {
   return win_col_off(curwin);
 }
 
@@ -675,15 +665,14 @@ int curwin_col_off()         {
  * wrapped line.  It's 8 if 'number' or 'relativenumber' is on and 'n' is in
  * 'cpoptions'.
  */
-int win_col_off2(wp)
-win_T       *wp;
+int win_col_off2(win_T *wp)
 {
   if ((wp->w_p_nu || wp->w_p_rnu) && vim_strchr(p_cpo, CPO_NUMCOL) != NULL)
     return number_width(wp) + 1;
   return 0;
 }
 
-int curwin_col_off2()         {
+int curwin_col_off2(void)         {
   return win_col_off2(curwin);
 }
 
@@ -692,8 +681,10 @@ int curwin_col_off2()         {
  * Also updates curwin->w_wrow and curwin->w_cline_row.
  * Also updates curwin->w_leftcol.
  */
-void curs_columns(may_scroll)
-int may_scroll;                 /* when TRUE, may scroll horizontally */
+void 
+curs_columns (
+    int may_scroll                 /* when TRUE, may scroll horizontally */
+)
 {
   int diff;
   int extra;                    /* offset for first screen line */
@@ -920,9 +911,11 @@ int may_scroll;                 /* when TRUE, may scroll horizontally */
 /*
  * Scroll the current window down by "line_count" logical lines.  "CTRL-Y"
  */
-void scrolldown(line_count, byfold)
-long line_count;
-int byfold UNUSED;              /* TRUE: count a closed fold as one line */
+void 
+scrolldown (
+    long line_count,
+    int byfold              /* TRUE: count a closed fold as one line */
+)
 {
   long done = 0;                /* total # of physical lines done */
   int wrow;
@@ -999,9 +992,11 @@ int byfold UNUSED;              /* TRUE: count a closed fold as one line */
 /*
  * Scroll the current window up by "line_count" logical lines.  "CTRL-E"
  */
-void scrollup(line_count, byfold)
-long line_count;
-int byfold UNUSED;              /* TRUE: count a closed fold as one line */
+void 
+scrollup (
+    long line_count,
+    int byfold              /* TRUE: count a closed fold as one line */
+)
 {
   linenr_T lnum;
 
@@ -1055,9 +1050,11 @@ int byfold UNUSED;              /* TRUE: count a closed fold as one line */
 /*
  * Don't end up with too many filler lines in the window.
  */
-void check_topfill(wp, down)
-win_T       *wp;
-int down;               /* when TRUE scroll down when not enough space */
+void 
+check_topfill (
+    win_T *wp,
+    int down               /* when TRUE scroll down when not enough space */
+)
 {
   int n;
 
@@ -1080,7 +1077,7 @@ int down;               /* when TRUE scroll down when not enough space */
  * Use as many filler lines as possible for w_topline.  Make sure w_topline
  * is still visible.
  */
-static void max_topfill()                 {
+static void max_topfill(void)                 {
   int n;
 
   n = plines_nofill(curwin->w_topline);
@@ -1097,7 +1094,7 @@ static void max_topfill()                 {
  * Scroll the screen one line down, but don't do it if it would move the
  * cursor off the screen.
  */
-void scrolldown_clamp()          {
+void scrolldown_clamp(void)          {
   int end_row;
   int can_fill = (curwin->w_topfill
                   < diff_check_fill(curwin, curwin->w_topline));
@@ -1145,7 +1142,7 @@ void scrolldown_clamp()          {
  * Scroll the screen one line up, but don't do it if it would move the cursor
  * off the screen.
  */
-void scrollup_clamp()          {
+void scrollup_clamp(void)          {
   int start_row;
 
   if (curwin->w_topline == curbuf->b_ml.ml_line_count
@@ -1186,8 +1183,7 @@ void scrollup_clamp()          {
  * Returns the height of the added line in "lp->height".
  * Lines above the first one are incredibly high: MAXCOL.
  */
-static void topline_back(lp)
-lineoff_T   *lp;
+static void topline_back(lineoff_T *lp)
 {
   if (lp->fill < diff_check_fill(curwin, lp->lnum)) {
     /* Add a filler line. */
@@ -1213,8 +1209,7 @@ lineoff_T   *lp;
  * Returns the height of the added line in "lp->height".
  * Lines below the last one are incredibly high.
  */
-static void botline_forw(lp)
-lineoff_T   *lp;
+static void botline_forw(lineoff_T *lp)
 {
   if (lp->fill < diff_check_fill(curwin, lp->lnum + 1)) {
     /* Add a filler line. */
@@ -1239,8 +1234,7 @@ lineoff_T   *lp;
  * lines above loff.lnum + 1.  This keeps pointing to the same line.
  * When there are no filler lines nothing changes.
  */
-static void botline_topline(lp)
-lineoff_T   *lp;
+static void botline_topline(lineoff_T *lp)
 {
   if (lp->fill > 0) {
     ++lp->lnum;
@@ -1253,8 +1247,7 @@ lineoff_T   *lp;
  * lines below loff.lnum - 1.  This keeps pointing to the same line.
  * When there are no filler lines nothing changes.
  */
-static void topline_botline(lp)
-lineoff_T   *lp;
+static void topline_botline(lineoff_T *lp)
 {
   if (lp->fill > 0) {
     lp->fill = diff_check_fill(curwin, lp->lnum) - lp->fill + 1;
@@ -1267,9 +1260,7 @@ lineoff_T   *lp;
  * Scroll at least "min_scroll" lines.
  * If "always" is TRUE, always set topline (for "zt").
  */
-void scroll_cursor_top(min_scroll, always)
-int min_scroll;
-int always;
+void scroll_cursor_top(int min_scroll, int always)
 {
   int scrolled = 0;
   int extra = 0;
@@ -1383,9 +1374,7 @@ int always;
  * Set w_empty_rows and w_filler_rows for window "wp", having used up "used"
  * screen lines for text lines.
  */
-void set_empty_rows(wp, used)
-win_T       *wp;
-int used;
+void set_empty_rows(win_T *wp, int used)
 {
   wp->w_filler_rows = 0;
   if (used == 0)
@@ -1410,9 +1399,7 @@ int used;
  * If "set_topbot" is TRUE, set topline and botline first (for "zb").
  * This is messy stuff!!!
  */
-void scroll_cursor_bot(min_scroll, set_topbot)
-int min_scroll;
-int set_topbot;
+void scroll_cursor_bot(int min_scroll, int set_topbot)
 {
   int used;
   int scrolled = 0;
@@ -1586,8 +1573,7 @@ int set_topbot;
  * Recompute topline to put the cursor halfway the window
  * If "atend" is TRUE, also put it halfway at the end of the file.
  */
-void scroll_cursor_halfway(atend)
-int atend;
+void scroll_cursor_halfway(int atend)
 {
   int above = 0;
   linenr_T topline;
@@ -1645,7 +1631,7 @@ int atend;
  * If not possible, put it at the same position as scroll_cursor_halfway().
  * When called topline must be valid!
  */
-void cursor_correct()          {
+void cursor_correct(void)          {
   int above = 0;                    /* screen lines above topline */
   linenr_T topline;
   int below = 0;                    /* screen lines below botline */
@@ -1748,9 +1734,7 @@ static void get_scroll_overlap __ARGS((lineoff_T *lp, int dir));
  *
  * return FAIL for failure, OK otherwise
  */
-int onepage(dir, count)
-int dir;
-long count;
+int onepage(int dir, long count)
 {
   long n;
   int retval = OK;
@@ -1936,9 +1920,7 @@ long count;
  *  -------------		l3 second text line
  *  l3				   etc.
  */
-static void get_scroll_overlap(lp, dir)
-lineoff_T   *lp;
-int dir;
+static void get_scroll_overlap(lineoff_T *lp, int dir)
 {
   int h1, h2, h3, h4;
   int min_height = curwin->w_height - 2;
@@ -1991,9 +1973,7 @@ int dir;
 /*
  * Scroll 'scroll' lines up or down.
  */
-void halfpage(flag, Prenum)
-int flag;
-linenr_T Prenum;
+void halfpage(int flag, linenr_T Prenum)
 {
   long scrolled = 0;
   int i;
@@ -2153,7 +2133,7 @@ linenr_T Prenum;
   redraw_later(VALID);
 }
 
-void do_check_cursorbind()          {
+void do_check_cursorbind(void)          {
   linenr_T line = curwin->w_cursor.lnum;
   colnr_T col = curwin->w_cursor.col;
   colnr_T coladd = curwin->w_cursor.coladd;

--- a/src/normal.c
+++ b/src/normal.c
@@ -384,9 +384,7 @@ static int nv_max_linear;
  * Compare functions for qsort() below, that checks the command character
  * through the index in nv_cmd_idx[].
  */
-static int nv_compare(s1, s2)
-const void  *s1;
-const void  *s2;
+static int nv_compare(const void *s1, const void *s2)
 {
   int c1, c2;
 
@@ -403,7 +401,7 @@ const void  *s2;
 /*
  * Initialize the nv_cmd_idx[] table.
  */
-void init_normal_cmds()          {
+void init_normal_cmds(void)          {
   int i;
 
   /* Fill the index table with a one to one relation. */
@@ -424,8 +422,7 @@ void init_normal_cmds()          {
  * Search for a command in the commands table.
  * Returns -1 for invalid command.
  */
-static int find_command(cmdchar)
-int cmdchar;
+static int find_command(int cmdchar)
 {
   int i;
   int idx;
@@ -470,9 +467,11 @@ int cmdchar;
 /*
  * Execute a command in Normal mode.
  */
-void normal_cmd(oap, toplevel)
-oparg_T     *oap;
-int toplevel UNUSED;                    /* TRUE when called from main() */
+void 
+normal_cmd (
+    oparg_T *oap,
+    int toplevel                    /* TRUE when called from main() */
+)
 {
   cmdarg_T ca;                          /* command arguments */
   int c;
@@ -1140,9 +1139,7 @@ normal_end:
  * Set v:count and v:count1 according to "cap".
  * Set v:prevcount only when "set_prevcount" is TRUE.
  */
-static void set_vcount_ca(cap, set_prevcount)
-cmdarg_T    *cap;
-int         *set_prevcount;
+static void set_vcount_ca(cmdarg_T *cap, int *set_prevcount)
 {
   long count = cap->count0;
 
@@ -1156,10 +1153,7 @@ int         *set_prevcount;
 /*
  * Handle an operator after visual mode or when the movement is finished
  */
-void do_pending_operator(cap, old_col, gui_yank)
-cmdarg_T    *cap;
-int old_col;
-int gui_yank;
+void do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 {
   oparg_T     *oap = cap->oap;
   pos_T old_cursor;
@@ -1782,8 +1776,7 @@ int gui_yank;
 /*
  * Handle indent and format operators and visual mode ":".
  */
-static void op_colon(oap)
-oparg_T     *oap;
+static void op_colon(oparg_T *oap)
 {
   stuffcharReadbuff(':');
   if (oap->is_VIsual)
@@ -1830,8 +1823,7 @@ oparg_T     *oap;
 /*
  * Handle the "g@" operator: call 'operatorfunc'.
  */
-static void op_function(oap)
-oparg_T     *oap UNUSED;
+static void op_function(oparg_T *oap)
 {
   char_u      *(argv[1]);
   int save_virtual_op = virtual_op;
@@ -1899,12 +1891,14 @@ oparg_T     *oap UNUSED;
  *
  * Return TRUE if start_arrow() should be called for edit mode.
  */
-int do_mouse(oap, c, dir, count, fixindent)
-oparg_T     *oap;               /* operator argument, can be NULL */
-int c;                          /* K_LEFTMOUSE, etc */
-int dir;                        /* Direction to 'put' if necessary */
-long count;
-int fixindent;                  /* PUT_FIXINDENT if fixing indent necessary */
+int 
+do_mouse (
+    oparg_T *oap,               /* operator argument, can be NULL */
+    int c,                          /* K_LEFTMOUSE, etc */
+    int dir,                        /* Direction to 'put' if necessary */
+    long count,
+    int fixindent                  /* PUT_FIXINDENT if fixing indent necessary */
+)
 {
   static int do_always = FALSE;         /* ignore 'mouse' setting next time */
   static int got_click = FALSE;         /* got a click some time back */
@@ -2574,8 +2568,7 @@ int fixindent;                  /* PUT_FIXINDENT if fixing indent necessary */
 /*
  * Move "pos" back to the start of the word it's in.
  */
-static void find_start_of_word(pos)
-pos_T       *pos;
+static void find_start_of_word(pos_T *pos)
 {
   char_u      *line;
   int cclass;
@@ -2597,8 +2590,7 @@ pos_T       *pos;
  * Move "pos" forward to the end of the word it's in.
  * When 'selection' is "exclusive", the position is just after the word.
  */
-static void find_end_of_word(pos)
-pos_T       *pos;
+static void find_end_of_word(pos_T *pos)
 {
   char_u      *line;
   int cclass;
@@ -2628,8 +2620,7 @@ pos_T       *pos;
  * 2: normal word character
  * >2: multi-byte word character.
  */
-static int get_mouse_class(p)
-char_u      *p;
+static int get_mouse_class(char_u *p)
 {
   int c;
 
@@ -2658,7 +2649,7 @@ char_u      *p;
  * Check if  highlighting for visual mode is possible, give a warning message
  * if not.
  */
-void check_visual_highlight()          {
+void check_visual_highlight(void)          {
   static int did_check = FALSE;
 
   if (full_screen) {
@@ -2673,7 +2664,7 @@ void check_visual_highlight()          {
  * This function should ALWAYS be called to end Visual mode, except from
  * do_pending_operator().
  */
-void end_visual_mode()          {
+void end_visual_mode(void)          {
 
   VIsual_active = FALSE;
   setmouse();
@@ -2699,7 +2690,7 @@ void end_visual_mode()          {
 /*
  * Reset VIsual_active and VIsual_reselect.
  */
-void reset_VIsual_and_resel()          {
+void reset_VIsual_and_resel(void)          {
   if (VIsual_active) {
     end_visual_mode();
     redraw_curbuf_later(INVERTED);      /* delete the inversion later */
@@ -2710,7 +2701,7 @@ void reset_VIsual_and_resel()          {
 /*
  * Reset VIsual_active and VIsual_reselect if it's set.
  */
-void reset_VIsual()          {
+void reset_VIsual(void)          {
   if (VIsual_active) {
     end_visual_mode();
     redraw_curbuf_later(INVERTED);      /* delete the inversion later */
@@ -2739,9 +2730,7 @@ void reset_VIsual()          {
  * If a string is found, a pointer to the string is put in "*string".  This
  * string is not always NUL terminated.
  */
-int find_ident_under_cursor(string, find_type)
-char_u      **string;
-int find_type;
+int find_ident_under_cursor(char_u **string, int find_type)
 {
   return find_ident_at_pos(curwin, curwin->w_cursor.lnum,
       curwin->w_cursor.col, string, find_type);
@@ -2751,12 +2740,7 @@ int find_type;
  * Like find_ident_under_cursor(), but for any window and any position.
  * However: Uses 'iskeyword' from the current window!.
  */
-int find_ident_at_pos(wp, lnum, startcol, string, find_type)
-win_T       *wp;
-linenr_T lnum;
-colnr_T startcol;
-char_u      **string;
-int find_type;
+int find_ident_at_pos(win_T *wp, linenr_T lnum, colnr_T startcol, char_u **string, int find_type)
 {
   char_u      *ptr;
   int col = 0;                      /* init to shut up GCC */
@@ -2870,8 +2854,7 @@ int find_type;
 /*
  * Prepare for redo of a normal command.
  */
-static void prep_redo_cmd(cap)
-cmdarg_T  *cap;
+static void prep_redo_cmd(cmdarg_T *cap)
 {
   prep_redo(cap->oap->regname, cap->count0,
       NUL, cap->cmdchar, NUL, NUL, cap->nchar);
@@ -2881,14 +2864,7 @@ cmdarg_T  *cap;
  * Prepare for redo of any command.
  * Note that only the last argument can be a multi-byte char.
  */
-static void prep_redo(regname, num, cmd1, cmd2, cmd3, cmd4, cmd5)
-int regname;
-long num;
-int cmd1;
-int cmd2;
-int cmd3;
-int cmd4;
-int cmd5;
+static void prep_redo(int regname, long num, int cmd1, int cmd2, int cmd3, int cmd4, int cmd5)
 {
   ResetRedobuff();
   if (regname != 0) {   /* yank from specified buffer */
@@ -2915,8 +2891,7 @@ int cmd5;
  *
  * return TRUE if operator was active
  */
-static int checkclearop(oap)
-oparg_T     *oap;
+static int checkclearop(oparg_T *oap)
 {
   if (oap->op_type == OP_NOP)
     return FALSE;
@@ -2929,8 +2904,7 @@ oparg_T     *oap;
  *
  * Return TRUE if operator or Visual was active.
  */
-static int checkclearopq(oap)
-oparg_T     *oap;
+static int checkclearopq(oparg_T *oap)
 {
   if (oap->op_type == OP_NOP
       && !VIsual_active
@@ -2940,8 +2914,7 @@ oparg_T     *oap;
   return TRUE;
 }
 
-static void clearop(oap)
-oparg_T     *oap;
+static void clearop(oparg_T *oap)
 {
   oap->op_type = OP_NOP;
   oap->regname = 0;
@@ -2949,8 +2922,7 @@ oparg_T     *oap;
   oap->use_reg_one = FALSE;
 }
 
-static void clearopbeep(oap)
-oparg_T     *oap;
+static void clearopbeep(oparg_T *oap)
 {
   clearop(oap);
   beep_flush();
@@ -2959,8 +2931,7 @@ oparg_T     *oap;
 /*
  * Remove the shift modifier from a special key.
  */
-static void unshift_special(cap)
-cmdarg_T    *cap;
+static void unshift_special(cmdarg_T *cap)
 {
   switch (cap->cmdchar) {
   case K_S_RIGHT: cap->cmdchar = K_RIGHT; break;
@@ -2985,7 +2956,7 @@ static int showcmd_visual = FALSE;
 
 static void display_showcmd __ARGS((void));
 
-void clear_showcmd()          {
+void clear_showcmd(void)          {
   if (!p_sc)
     return;
 
@@ -3066,8 +3037,7 @@ void clear_showcmd()          {
  * Add 'c' to string of shown command chars.
  * Return TRUE if output has been written (and setcursor() has been called).
  */
-int add_to_showcmd(c)
-int c;
+int add_to_showcmd(int c)
 {
   char_u      *p;
   int old_len;
@@ -3119,8 +3089,7 @@ int c;
   return TRUE;
 }
 
-void add_to_showcmd_c(c)
-int c;
+void add_to_showcmd_c(int c)
 {
   if (!add_to_showcmd(c))
     setcursor();
@@ -3129,8 +3098,7 @@ int c;
 /*
  * Delete 'len' characters from the end of the shown command.
  */
-static void del_from_showcmd(len)
-int len;
+static void del_from_showcmd(int len)
 {
   int old_len;
 
@@ -3150,12 +3118,12 @@ int len;
  * push_showcmd() and pop_showcmd() are used when waiting for the user to type
  * something and there is a partial mapping.
  */
-void push_showcmd()          {
+void push_showcmd(void)          {
   if (p_sc)
     STRCPY(old_showcmd_buf, showcmd_buf);
 }
 
-void pop_showcmd()          {
+void pop_showcmd(void)          {
   if (!p_sc)
     return;
 
@@ -3164,7 +3132,7 @@ void pop_showcmd()          {
   display_showcmd();
 }
 
-static void display_showcmd()                 {
+static void display_showcmd(void)                 {
   int len;
 
   cursor_off();
@@ -3191,8 +3159,7 @@ static void display_showcmd()                 {
  * When "check" is TRUE, take care of scroll-binding after the window has
  * scrolled.  Called from normal_cmd() and edit().
  */
-void do_check_scrollbind(check)
-int check;
+void do_check_scrollbind(int check)
 {
   static win_T        *old_curwin = NULL;
   static linenr_T old_topline = 0;
@@ -3248,9 +3215,7 @@ int check;
  * number of rows by which the current window has changed
  * (1998-11-02 16:21:01  R. Edward Ralston <eralston@computer.org>)
  */
-void check_scrollbind(topline_diff, leftcol_diff)
-linenr_T topline_diff;
-long leftcol_diff;
+void check_scrollbind(linenr_T topline_diff, long leftcol_diff)
 {
   int want_ver;
   int want_hor;
@@ -3327,8 +3292,7 @@ long leftcol_diff;
  * Used for CTRL-Q and CTRL-S to avoid problems with terminals that use
  * xon/xoff.
  */
-static void nv_ignore(cap)
-cmdarg_T    *cap;
+static void nv_ignore(cmdarg_T *cap)
 {
   cap->retval |= CA_COMMAND_BUSY;       /* don't call edit() now */
 }
@@ -3337,16 +3301,14 @@ cmdarg_T    *cap;
  * Command character that doesn't do anything, but unlike nv_ignore() does
  * start edit().  Used for "startinsert" executed while starting up.
  */
-static void nv_nop(cap)
-cmdarg_T    *cap UNUSED;
+static void nv_nop(cmdarg_T *cap)
 {
 }
 
 /*
  * Command character doesn't exist.
  */
-static void nv_error(cap)
-cmdarg_T    *cap;
+static void nv_error(cmdarg_T *cap)
 {
   clearopbeep(cap->oap);
 }
@@ -3354,8 +3316,7 @@ cmdarg_T    *cap;
 /*
  * <Help> and <F1> commands.
  */
-static void nv_help(cap)
-cmdarg_T    *cap;
+static void nv_help(cmdarg_T *cap)
 {
   if (!checkclearopq(cap->oap))
     ex_help(NULL);
@@ -3364,8 +3325,7 @@ cmdarg_T    *cap;
 /*
  * CTRL-A and CTRL-X: Add or subtract from letter or number under cursor.
  */
-static void nv_addsub(cap)
-cmdarg_T    *cap;
+static void nv_addsub(cmdarg_T *cap)
 {
   if (!checkclearopq(cap->oap)
       && do_addsub((int)cap->cmdchar, cap->count1) == OK)
@@ -3375,8 +3335,7 @@ cmdarg_T    *cap;
 /*
  * CTRL-F, CTRL-B, etc: Scroll page up or down.
  */
-static void nv_page(cap)
-cmdarg_T    *cap;
+static void nv_page(cmdarg_T *cap)
 {
   if (!checkclearop(cap->oap)) {
     if (mod_mask & MOD_MASK_CTRL) {
@@ -3393,10 +3352,12 @@ cmdarg_T    *cap;
 /*
  * Implementation of "gd" and "gD" command.
  */
-static void nv_gd(oap, nchar, thisblock)
-oparg_T     *oap;
-int nchar;
-int thisblock;                  /* 1 for "1gd" and "1gD" */
+static void 
+nv_gd (
+    oparg_T *oap,
+    int nchar,
+    int thisblock                  /* 1 for "1gd" and "1gD" */
+)
 {
   int len;
   char_u      *ptr;
@@ -3415,12 +3376,14 @@ int thisblock;                  /* 1 for "1gd" and "1gD" */
  * When "thisblock" is TRUE check the {} block scope.
  * Return FAIL when not found.
  */
-int find_decl(ptr, len, locally, thisblock, searchflags)
-char_u      *ptr;
-int len;
-int locally;
-int thisblock;
-int searchflags;                /* flags passed to searchit() */
+int 
+find_decl (
+    char_u *ptr,
+    int len,
+    int locally,
+    int thisblock,
+    int searchflags                /* flags passed to searchit() */
+)
 {
   char_u      *pat;
   pos_T old_pos;
@@ -3532,10 +3495,7 @@ int searchflags;                /* flags passed to searchit() */
  *
  * Return OK if able to move cursor, FAIL otherwise.
  */
-static int nv_screengo(oap, dir, dist)
-oparg_T     *oap;
-int dir;
-long dist;
+static int nv_screengo(oparg_T *oap, int dir, long dist)
 {
   int linelen = linetabsize(ml_get_curline());
   int retval = OK;
@@ -3660,8 +3620,7 @@ long dist;
  * K_MOUSEUP (cap->arg == 1) or K_MOUSEDOWN (cap->arg == 0) or
  * K_MOUSELEFT (cap->arg == -1) or K_MOUSERIGHT (cap->arg == -2)
  */
-static void nv_mousescroll(cap)
-cmdarg_T    *cap;
+static void nv_mousescroll(cmdarg_T *cap)
 {
   win_T *old_curwin = curwin;
 
@@ -3695,8 +3654,7 @@ cmdarg_T    *cap;
 /*
  * Mouse clicks and drags.
  */
-static void nv_mouse(cap)
-cmdarg_T    *cap;
+static void nv_mouse(cmdarg_T *cap)
 {
   (void)do_mouse(cap->oap, cap->cmdchar, BACKWARD, cap->count1, 0);
 }
@@ -3705,8 +3663,7 @@ cmdarg_T    *cap;
  * Handle CTRL-E and CTRL-Y commands: scroll a line up or down.
  * cap->arg must be TRUE for CTRL-E.
  */
-static void nv_scroll_line(cap)
-cmdarg_T    *cap;
+static void nv_scroll_line(cmdarg_T *cap)
 {
   if (!checkclearop(cap->oap))
     scroll_redraw(cap->arg, cap->count1);
@@ -3715,9 +3672,7 @@ cmdarg_T    *cap;
 /*
  * Scroll "count" lines up or down, and redraw.
  */
-void scroll_redraw(up, count)
-int up;
-long count;
+void scroll_redraw(int up, long count)
 {
   linenr_T prev_topline = curwin->w_topline;
   int prev_topfill = curwin->w_topfill;
@@ -3764,8 +3719,7 @@ long count;
 /*
  * Commands that start with "z".
  */
-static void nv_zet(cap)
-cmdarg_T  *cap;
+static void nv_zet(cmdarg_T *cap)
 {
   long n;
   colnr_T col;
@@ -4191,8 +4145,7 @@ dozet:
 /*
  * "Q" command.
  */
-static void nv_exmode(cap)
-cmdarg_T    *cap;
+static void nv_exmode(cmdarg_T *cap)
 {
   /*
    * Ignore 'Q' in Visual mode, just give a beep.
@@ -4206,8 +4159,7 @@ cmdarg_T    *cap;
 /*
  * Handle a ":" command.
  */
-static void nv_colon(cap)
-cmdarg_T  *cap;
+static void nv_colon(cmdarg_T *cap)
 {
   int old_p_im;
   int cmd_result;
@@ -4264,8 +4216,7 @@ cmdarg_T  *cap;
 /*
  * Handle CTRL-G command.
  */
-static void nv_ctrlg(cap)
-cmdarg_T *cap;
+static void nv_ctrlg(cmdarg_T *cap)
 {
   if (VIsual_active) {  /* toggle Selection/Visual mode */
     VIsual_select = !VIsual_select;
@@ -4278,8 +4229,7 @@ cmdarg_T *cap;
 /*
  * Handle CTRL-H <Backspace> command.
  */
-static void nv_ctrlh(cap)
-cmdarg_T *cap;
+static void nv_ctrlh(cmdarg_T *cap)
 {
   if (VIsual_active && VIsual_select) {
     cap->cmdchar = 'x';         /* BS key behaves like 'x' in Select mode */
@@ -4291,8 +4241,7 @@ cmdarg_T *cap;
 /*
  * CTRL-L: clear screen and redraw.
  */
-static void nv_clear(cap)
-cmdarg_T    *cap;
+static void nv_clear(cmdarg_T *cap)
 {
   if (!checkclearop(cap->oap)) {
     /* Clear all syntax states to force resyncing. */
@@ -4305,8 +4254,7 @@ cmdarg_T    *cap;
  * CTRL-O: In Select mode: switch to Visual mode for one command.
  * Otherwise: Go to older pcmark.
  */
-static void nv_ctrlo(cap)
-cmdarg_T    *cap;
+static void nv_ctrlo(cmdarg_T *cap)
 {
   if (VIsual_active && VIsual_select) {
     VIsual_select = FALSE;
@@ -4321,8 +4269,7 @@ cmdarg_T    *cap;
 /*
  * CTRL-^ command, short for ":e #"
  */
-static void nv_hat(cap)
-cmdarg_T    *cap;
+static void nv_hat(cmdarg_T *cap)
 {
   if (!checkclearopq(cap->oap))
     (void)buflist_getfile((int)cap->count0, (linenr_T)0,
@@ -4332,8 +4279,7 @@ cmdarg_T    *cap;
 /*
  * "Z" commands.
  */
-static void nv_Zet(cap)
-cmdarg_T *cap;
+static void nv_Zet(cmdarg_T *cap)
 {
   if (!checkclearopq(cap->oap)) {
     switch (cap->nchar) {
@@ -4353,9 +4299,7 @@ cmdarg_T *cap;
 /*
  * Call nv_ident() as if "c1" was used, with "c2" as next character.
  */
-void do_nv_ident(c1, c2)
-int c1;
-int c2;
+void do_nv_ident(int c1, int c2)
 {
   oparg_T oa;
   cmdarg_T ca;
@@ -4376,8 +4320,7 @@ int c2;
  * [g] '#'	? to current identifier or string
  *  g  ']'	:tselect for current identifier
  */
-static void nv_ident(cap)
-cmdarg_T    *cap;
+static void nv_ident(cmdarg_T *cap)
 {
   char_u      *ptr = NULL;
   char_u      *buf;
@@ -4581,10 +4524,12 @@ cmdarg_T    *cap;
  * Get visually selected text, within one line only.
  * Returns FAIL if more than one line selected.
  */
-int get_visual_text(cap, pp, lenp)
-cmdarg_T    *cap;
-char_u      **pp;           /* return: start of selected text */
-int         *lenp;          /* return: length of selected text */
+int 
+get_visual_text (
+    cmdarg_T *cap,
+    char_u **pp,           /* return: start of selected text */
+    int *lenp          /* return: length of selected text */
+)
 {
   if (VIsual_mode != 'V')
     unadjust_for_sel();
@@ -4615,8 +4560,7 @@ int         *lenp;          /* return: length of selected text */
 /*
  * CTRL-T: backwards in tag stack
  */
-static void nv_tagpop(cap)
-cmdarg_T    *cap;
+static void nv_tagpop(cmdarg_T *cap)
 {
   if (!checkclearopq(cap->oap))
     do_tag((char_u *)"", DT_POP, (int)cap->count1, FALSE, TRUE);
@@ -4625,8 +4569,7 @@ cmdarg_T    *cap;
 /*
  * Handle scrolling command 'H', 'L' and 'M'.
  */
-static void nv_scroll(cap)
-cmdarg_T  *cap;
+static void nv_scroll(cmdarg_T *cap)
 {
   int used = 0;
   long n;
@@ -4700,8 +4643,7 @@ cmdarg_T  *cap;
 /*
  * Cursor right commands.
  */
-static void nv_right(cap)
-cmdarg_T    *cap;
+static void nv_right(cmdarg_T *cap)
 {
   long n;
   int PAST_LINE;
@@ -4789,8 +4731,7 @@ cmdarg_T    *cap;
  *
  * Returns TRUE when operator end should not be adjusted.
  */
-static void nv_left(cap)
-cmdarg_T    *cap;
+static void nv_left(cmdarg_T *cap)
 {
   long n;
 
@@ -4850,8 +4791,7 @@ cmdarg_T    *cap;
  * Cursor up commands.
  * cap->arg is TRUE for "-": Move cursor to first non-blank.
  */
-static void nv_up(cap)
-cmdarg_T    *cap;
+static void nv_up(cmdarg_T *cap)
 {
   if (mod_mask & MOD_MASK_SHIFT) {
     /* <S-Up> is page up */
@@ -4870,8 +4810,7 @@ cmdarg_T    *cap;
  * Cursor down commands.
  * cap->arg is TRUE for CR and "+": Move cursor to first non-blank.
  */
-static void nv_down(cap)
-cmdarg_T    *cap;
+static void nv_down(cmdarg_T *cap)
 {
   if (mod_mask & MOD_MASK_SHIFT) {
     /* <S-Down> is page down */
@@ -4901,8 +4840,7 @@ cmdarg_T    *cap;
 /*
  * Grab the file name under the cursor and edit it.
  */
-static void nv_gotofile(cap)
-cmdarg_T    *cap;
+static void nv_gotofile(cmdarg_T *cap)
 {
   char_u      *ptr;
   linenr_T lnum = -1;
@@ -4939,8 +4877,7 @@ cmdarg_T    *cap;
 /*
  * <End> command: to end of current line or last line.
  */
-static void nv_end(cap)
-cmdarg_T    *cap;
+static void nv_end(cmdarg_T *cap)
 {
   if (cap->arg || (mod_mask & MOD_MASK_CTRL)) { /* CTRL-END = goto last line */
     cap->arg = TRUE;
@@ -4953,8 +4890,7 @@ cmdarg_T    *cap;
 /*
  * Handle the "$" command.
  */
-static void nv_dollar(cap)
-cmdarg_T    *cap;
+static void nv_dollar(cmdarg_T *cap)
 {
   cap->oap->motion_type = MCHAR;
   cap->oap->inclusive = TRUE;
@@ -4975,8 +4911,7 @@ cmdarg_T    *cap;
  * Implementation of '?' and '/' commands.
  * If cap->arg is TRUE don't set PC mark.
  */
-static void nv_search(cap)
-cmdarg_T        *cap;
+static void nv_search(cmdarg_T *cap)
 {
   oparg_T     *oap = cap->oap;
 
@@ -5003,8 +4938,7 @@ cmdarg_T        *cap;
  * Handle "N" and "n" commands.
  * cap->arg is SEARCH_REV for "N", 0 for "n".
  */
-static void nv_next(cap)
-cmdarg_T    *cap;
+static void nv_next(cmdarg_T *cap)
 {
   normal_search(cap, 0, NULL, SEARCH_MARK | cap->arg);
 }
@@ -5013,11 +4947,13 @@ cmdarg_T    *cap;
  * Search for "pat" in direction "dir" ('/' or '?', 0 for repeat).
  * Uses only cap->count1 and cap->oap from "cap".
  */
-static void normal_search(cap, dir, pat, opt)
-cmdarg_T    *cap;
-int dir;
-char_u      *pat;
-int opt;                        /* extra flags for do_search() */
+static void 
+normal_search (
+    cmdarg_T *cap,
+    int dir,
+    char_u *pat,
+    int opt                        /* extra flags for do_search() */
+)
 {
   int i;
 
@@ -5049,8 +4985,7 @@ int opt;                        /* extra flags for do_search() */
  * ',' and FALSE for ';'.
  * cap->nchar is NUL for ',' and ';' (repeat the search)
  */
-static void nv_csearch(cap)
-cmdarg_T    *cap;
+static void nv_csearch(cmdarg_T *cap)
 {
   int t_cmd;
 
@@ -5083,8 +5018,7 @@ cmdarg_T    *cap;
  * "[" and "]" commands.
  * cap->arg is BACKWARD for "[" and FORWARD for "]".
  */
-static void nv_brackets(cap)
-cmdarg_T    *cap;
+static void nv_brackets(cmdarg_T *cap)
 {
   pos_T new_pos = INIT_POS_T(0, 0, 0);
   pos_T prev_pos;
@@ -5342,8 +5276,7 @@ cmdarg_T    *cap;
 /*
  * Handle Normal mode "%" command.
  */
-static void nv_percent(cap)
-cmdarg_T    *cap;
+static void nv_percent(cmdarg_T *cap)
 {
   pos_T       *pos;
   linenr_T lnum = curwin->w_cursor.lnum;
@@ -5391,8 +5324,7 @@ cmdarg_T    *cap;
  * Handle "(" and ")" commands.
  * cap->arg is BACKWARD for "(" and FORWARD for ")".
  */
-static void nv_brace(cap)
-cmdarg_T    *cap;
+static void nv_brace(cmdarg_T *cap)
 {
   cap->oap->motion_type = MCHAR;
   cap->oap->use_reg_one = TRUE;
@@ -5414,8 +5346,7 @@ cmdarg_T    *cap;
 /*
  * "m" command: Mark a position.
  */
-static void nv_mark(cap)
-cmdarg_T    *cap;
+static void nv_mark(cmdarg_T *cap)
 {
   if (!checkclearop(cap->oap)) {
     if (setmark(cap->nchar) == FAIL)
@@ -5427,8 +5358,7 @@ cmdarg_T    *cap;
  * "{" and "}" commands.
  * cmd->arg is BACKWARD for "{" and FORWARD for "}".
  */
-static void nv_findpar(cap)
-cmdarg_T    *cap;
+static void nv_findpar(cmdarg_T *cap)
 {
   cap->oap->motion_type = MCHAR;
   cap->oap->inclusive = FALSE;
@@ -5446,8 +5376,7 @@ cmdarg_T    *cap;
 /*
  * "u" command: Undo or make lower case.
  */
-static void nv_undo(cap)
-cmdarg_T    *cap;
+static void nv_undo(cmdarg_T *cap)
 {
   if (cap->oap->op_type == OP_LOWER
       || VIsual_active
@@ -5463,8 +5392,7 @@ cmdarg_T    *cap;
 /*
  * <Undo> command.
  */
-static void nv_kundo(cap)
-cmdarg_T    *cap;
+static void nv_kundo(cmdarg_T *cap)
 {
   if (!checkclearopq(cap->oap)) {
     u_undo((int)cap->count1);
@@ -5475,8 +5403,7 @@ cmdarg_T    *cap;
 /*
  * Handle the "r" command.
  */
-static void nv_replace(cap)
-cmdarg_T    *cap;
+static void nv_replace(cmdarg_T *cap)
 {
   char_u      *ptr;
   int had_ctrl_v;
@@ -5646,8 +5573,7 @@ cmdarg_T    *cap;
  * 'o': Exchange start and end of Visual area.
  * 'O': same, but in block mode exchange left and right corners.
  */
-static void v_swap_corners(cmdchar)
-int cmdchar;
+static void v_swap_corners(int cmdchar)
 {
   pos_T old_cursor;
   colnr_T left, right;
@@ -5691,8 +5617,7 @@ int cmdchar;
 /*
  * "R" (cap->arg is FALSE) and "gR" (cap->arg is TRUE).
  */
-static void nv_Replace(cap)
-cmdarg_T        *cap;
+static void nv_Replace(cmdarg_T *cap)
 {
   if (VIsual_active) {          /* "R" is replace lines */
     cap->cmdchar = 'c';
@@ -5714,8 +5639,7 @@ cmdarg_T        *cap;
 /*
  * "gr".
  */
-static void nv_vreplace(cap)
-cmdarg_T    *cap;
+static void nv_vreplace(cmdarg_T *cap)
 {
   if (VIsual_active) {
     cap->cmdchar = 'r';
@@ -5739,8 +5663,7 @@ cmdarg_T    *cap;
 /*
  * Swap case for "~" command, when it does not work like an operator.
  */
-static void n_swapchar(cap)
-cmdarg_T    *cap;
+static void n_swapchar(cmdarg_T *cap)
 {
   long n;
   pos_T startpos;
@@ -5794,10 +5717,7 @@ cmdarg_T    *cap;
 /*
  * Move cursor to mark.
  */
-static void nv_cursormark(cap, flag, pos)
-cmdarg_T    *cap;
-int flag;
-pos_T       *pos;
+static void nv_cursormark(cmdarg_T *cap, int flag, pos_T *pos)
 {
   if (check_mark(pos) == FAIL)
     clearop(cap->oap);
@@ -5823,8 +5743,7 @@ pos_T       *pos;
 /*
  * Handle commands that are operators in Visual mode.
  */
-static void v_visop(cap)
-cmdarg_T    *cap;
+static void v_visop(cmdarg_T *cap)
 {
   static char_u trans[] = "YyDdCcxdXdAAIIrr";
 
@@ -5844,8 +5763,7 @@ cmdarg_T    *cap;
 /*
  * "s" and "S" commands.
  */
-static void nv_subst(cap)
-cmdarg_T    *cap;
+static void nv_subst(cmdarg_T *cap)
 {
   if (VIsual_active) {  /* "vs" and "vS" are the same as "vc" */
     if (cap->cmdchar == 'S') {
@@ -5861,8 +5779,7 @@ cmdarg_T    *cap;
 /*
  * Abbreviated commands.
  */
-static void nv_abbrev(cap)
-cmdarg_T    *cap;
+static void nv_abbrev(cmdarg_T *cap)
 {
   if (cap->cmdchar == K_DEL || cap->cmdchar == K_KDEL)
     cap->cmdchar = 'x';                 /* DEL key behaves like 'x' */
@@ -5877,8 +5794,7 @@ cmdarg_T    *cap;
 /*
  * Translate a command into another command.
  */
-static void nv_optrans(cap)
-cmdarg_T    *cap;
+static void nv_optrans(cmdarg_T *cap)
 {
   static char_u *(ar[8]) = {(char_u *)"dl", (char_u *)"dh",
                             (char_u *)"d$", (char_u *)"c$",
@@ -5911,8 +5827,7 @@ cmdarg_T    *cap;
  * "'" and "`" commands.  Also for "g'" and "g`".
  * cap->arg is TRUE for "'" and "g'".
  */
-static void nv_gomark(cap)
-cmdarg_T    *cap;
+static void nv_gomark(cmdarg_T *cap)
 {
   pos_T       *pos;
   int c;
@@ -5947,8 +5862,7 @@ cmdarg_T    *cap;
 /*
  * Handle CTRL-O, CTRL-I, "g;" and "g," commands.
  */
-static void nv_pcmark(cap)
-cmdarg_T    *cap;
+static void nv_pcmark(cmdarg_T *cap)
 {
   pos_T       *pos;
   linenr_T lnum = curwin->w_cursor.lnum;
@@ -5984,8 +5898,7 @@ cmdarg_T    *cap;
 /*
  * Handle '"' command.
  */
-static void nv_regname(cap)
-cmdarg_T    *cap;
+static void nv_regname(cmdarg_T *cap)
 {
   if (checkclearop(cap->oap))
     return;
@@ -6005,8 +5918,7 @@ cmdarg_T    *cap;
  * is TRUE.
  * Handle CTRL-Q just like CTRL-V.
  */
-static void nv_visual(cap)
-cmdarg_T    *cap;
+static void nv_visual(cmdarg_T *cap)
 {
   if (cap->cmdchar == Ctrl_Q)
     cap->cmdchar = Ctrl_V;
@@ -6095,7 +6007,7 @@ cmdarg_T    *cap;
 /*
  * Start selection for Shift-movement keys.
  */
-void start_selection()          {
+void start_selection(void)          {
   /* if 'selectmode' contains "key", start Select mode */
   may_start_select('k');
   n_start_visual_mode('v');
@@ -6104,8 +6016,7 @@ void start_selection()          {
 /*
  * Start Select mode, if "c" is in 'selectmode' and not in a mapping or menu.
  */
-void may_start_select(c)
-int c;
+void may_start_select(int c)
 {
   VIsual_select = (stuff_empty() && typebuf_typed()
                    && (vim_strchr(p_slm, c) != NULL));
@@ -6115,8 +6026,7 @@ int c;
  * Start Visual mode "c".
  * Should set VIsual_select before calling this.
  */
-static void n_start_visual_mode(c)
-int c;
+static void n_start_visual_mode(int c)
 {
   /* Check for redraw before changing the state. */
   conceal_check_cursur_line();
@@ -6154,8 +6064,7 @@ int c;
 /*
  * CTRL-W: Window commands
  */
-static void nv_window(cap)
-cmdarg_T    *cap;
+static void nv_window(cmdarg_T *cap)
 {
   if (!checkclearop(cap->oap))
     do_window(cap->nchar, cap->count0, NUL);     /* everything is in window.c */
@@ -6164,8 +6073,7 @@ cmdarg_T    *cap;
 /*
  * CTRL-Z: Suspend
  */
-static void nv_suspend(cap)
-cmdarg_T    *cap;
+static void nv_suspend(cmdarg_T *cap)
 {
   clearop(cap->oap);
   if (VIsual_active)
@@ -6176,8 +6084,7 @@ cmdarg_T    *cap;
 /*
  * Commands starting with "g".
  */
-static void nv_g_cmd(cap)
-cmdarg_T    *cap;
+static void nv_g_cmd(cmdarg_T *cap)
 {
   oparg_T     *oap = cap->oap;
   pos_T tpos;
@@ -6692,8 +6599,7 @@ cmdarg_T    *cap;
 /*
  * Handle "o" and "O" commands.
  */
-static void n_opencmd(cap)
-cmdarg_T    *cap;
+static void n_opencmd(cmdarg_T *cap)
 {
   linenr_T oldline = curwin->w_cursor.lnum;
 
@@ -6727,8 +6633,7 @@ cmdarg_T    *cap;
 /*
  * "." command: redo last change.
  */
-static void nv_dot(cap)
-cmdarg_T    *cap;
+static void nv_dot(cmdarg_T *cap)
 {
   if (!checkclearopq(cap->oap)) {
     /*
@@ -6744,8 +6649,7 @@ cmdarg_T    *cap;
 /*
  * CTRL-R: undo undo
  */
-static void nv_redo(cap)
-cmdarg_T    *cap;
+static void nv_redo(cmdarg_T *cap)
 {
   if (!checkclearopq(cap->oap)) {
     u_redo((int)cap->count1);
@@ -6756,8 +6660,7 @@ cmdarg_T    *cap;
 /*
  * Handle "U" command.
  */
-static void nv_Undo(cap)
-cmdarg_T    *cap;
+static void nv_Undo(cmdarg_T *cap)
 {
   /* In Visual mode and typing "gUU" triggers an operator */
   if (cap->oap->op_type == OP_UPPER
@@ -6777,8 +6680,7 @@ cmdarg_T    *cap;
  * '~' command: If tilde is not an operator and Visual is off: swap case of a
  * single character.
  */
-static void nv_tilde(cap)
-cmdarg_T    *cap;
+static void nv_tilde(cmdarg_T *cap)
 {
   if (!p_to
       && !VIsual_active
@@ -6792,8 +6694,7 @@ cmdarg_T    *cap;
  * Handle an operator command.
  * The actual work is done by do_pending_operator().
  */
-static void nv_operator(cap)
-cmdarg_T    *cap;
+static void nv_operator(cmdarg_T *cap)
 {
   int op_type;
 
@@ -6811,8 +6712,7 @@ cmdarg_T    *cap;
 /*
  * Set v:operator to the characters for "optype".
  */
-static void set_op_var(optype)
-int optype;
+static void set_op_var(int optype)
 {
   char_u opchars[3];
 
@@ -6835,8 +6735,7 @@ int optype;
  * are really an alternate form of "d_" and "y_".  It does accept a count, so
  * "d3_" works to delete 3 lines.
  */
-static void nv_lineop(cap)
-cmdarg_T    *cap;
+static void nv_lineop(cmdarg_T *cap)
 {
   cap->oap->motion_type = MLINE;
   if (cursor_down(cap->count1 - 1L, cap->oap->op_type == OP_NOP) == FAIL)
@@ -6854,8 +6753,7 @@ cmdarg_T    *cap;
 /*
  * <Home> command.
  */
-static void nv_home(cap)
-cmdarg_T    *cap;
+static void nv_home(cmdarg_T *cap)
 {
   /* CTRL-HOME is like "gg" */
   if (mod_mask & MOD_MASK_CTRL)
@@ -6871,8 +6769,7 @@ cmdarg_T    *cap;
 /*
  * "|" command.
  */
-static void nv_pipe(cap)
-cmdarg_T *cap;
+static void nv_pipe(cmdarg_T *cap)
 {
   cap->oap->motion_type = MCHAR;
   cap->oap->inclusive = FALSE;
@@ -6891,8 +6788,7 @@ cmdarg_T *cap;
  * Handle back-word command "b" and "B".
  * cap->arg is 1 for "B"
  */
-static void nv_bck_word(cap)
-cmdarg_T    *cap;
+static void nv_bck_word(cmdarg_T *cap)
 {
   cap->oap->motion_type = MCHAR;
   cap->oap->inclusive = FALSE;
@@ -6907,8 +6803,7 @@ cmdarg_T    *cap;
  * Handle word motion commands "e", "E", "w" and "W".
  * cap->arg is TRUE for "E" and "W".
  */
-static void nv_wordcmd(cap)
-cmdarg_T    *cap;
+static void nv_wordcmd(cmdarg_T *cap)
 {
   int n;
   int word_end;
@@ -6987,8 +6882,7 @@ cmdarg_T    *cap;
  * end of the line, may move it back to the last character and make the motion
  * inclusive.
  */
-static void adjust_cursor(oap)
-oparg_T *oap;
+static void adjust_cursor(oparg_T *oap)
 {
   /* The cursor cannot remain on the NUL when:
    * - the column is > 0
@@ -7011,8 +6905,7 @@ oparg_T *oap;
  * "0" and "^" commands.
  * cap->arg is the argument for beginline().
  */
-static void nv_beginline(cap)
-cmdarg_T    *cap;
+static void nv_beginline(cmdarg_T *cap)
 {
   cap->oap->motion_type = MCHAR;
   cap->oap->inclusive = FALSE;
@@ -7026,8 +6919,7 @@ cmdarg_T    *cap;
 /*
  * In exclusive Visual mode, may include the last character.
  */
-static void adjust_for_sel(cap)
-cmdarg_T    *cap;
+static void adjust_for_sel(cmdarg_T *cap)
 {
   if (VIsual_active && cap->oap->inclusive && *p_sel == 'e'
       && gchar_cursor() != NUL && lt(VIsual, curwin->w_cursor)) {
@@ -7044,7 +6936,7 @@ cmdarg_T    *cap;
  * Should check VIsual_mode before calling this.
  * Returns TRUE when backed up to the previous line.
  */
-static int unadjust_for_sel()                {
+static int unadjust_for_sel(void)                {
   pos_T       *pp;
 
   if (*p_sel == 'e' && !equalpos(VIsual, curwin->w_cursor)) {
@@ -7069,8 +6961,7 @@ static int unadjust_for_sel()                {
 /*
  * SELECT key in Normal or Visual mode: end of Select mode mapping.
  */
-static void nv_select(cap)
-cmdarg_T    *cap;
+static void nv_select(cmdarg_T *cap)
 {
   if (VIsual_active)
     VIsual_select = TRUE;
@@ -7086,8 +6977,7 @@ cmdarg_T    *cap;
  * "G", "gg", CTRL-END, CTRL-HOME.
  * cap->arg is TRUE for "G".
  */
-static void nv_goto(cap)
-cmdarg_T    *cap;
+static void nv_goto(cmdarg_T *cap)
 {
   linenr_T lnum;
 
@@ -7114,8 +7004,7 @@ cmdarg_T    *cap;
 /*
  * CTRL-\ in Normal mode.
  */
-static void nv_normal(cap)
-cmdarg_T    *cap;
+static void nv_normal(cmdarg_T *cap)
 {
   if (cap->nchar == Ctrl_N || cap->nchar == Ctrl_G) {
     clearop(cap->oap);
@@ -7139,8 +7028,7 @@ cmdarg_T    *cap;
  * ESC in Normal mode: beep, but don't flush buffers.
  * Don't even beep if we are canceling a command.
  */
-static void nv_esc(cap)
-cmdarg_T    *cap;
+static void nv_esc(cmdarg_T *cap)
 {
   int no_reason;
 
@@ -7188,8 +7076,7 @@ cmdarg_T    *cap;
 /*
  * Handle "A", "a", "I", "i" and <Insert> commands.
  */
-static void nv_edit(cap)
-cmdarg_T *cap;
+static void nv_edit(cmdarg_T *cap)
 {
   /* <Insert> is equal to "i" */
   if (cap->cmdchar == K_INS || cap->cmdchar == K_KINS)
@@ -7262,11 +7149,13 @@ cmdarg_T *cap;
 /*
  * Invoke edit() and take care of "restart_edit" and the return value.
  */
-static void invoke_edit(cap, repl, cmd, startln)
-cmdarg_T    *cap;
-int repl;                       /* "r" or "gr" command */
-int cmd;
-int startln;
+static void 
+invoke_edit (
+    cmdarg_T *cap,
+    int repl,                       /* "r" or "gr" command */
+    int cmd,
+    int startln
+)
 {
   int restart_edit_save = 0;
 
@@ -7291,8 +7180,7 @@ int startln;
 /*
  * "a" or "i" while an operator is pending or in Visual mode: object motion.
  */
-static void nv_object(cap)
-cmdarg_T    *cap;
+static void nv_object(cmdarg_T *cap)
 {
   int flag;
   int include;
@@ -7363,8 +7251,7 @@ cmdarg_T    *cap;
  * "q" command: Start/stop recording.
  * "q:", "q/", "q?": edit command-line in command-line window.
  */
-static void nv_record(cap)
-cmdarg_T    *cap;
+static void nv_record(cmdarg_T *cap)
 {
   if (cap->oap->op_type == OP_FORMAT) {
     /* "gqq" is the same as "gqgq": format line */
@@ -7386,8 +7273,7 @@ cmdarg_T    *cap;
 /*
  * Handle the "@r" command.
  */
-static void nv_at(cap)
-cmdarg_T    *cap;
+static void nv_at(cmdarg_T *cap)
 {
   if (checkclearop(cap->oap))
     return;
@@ -7407,8 +7293,7 @@ cmdarg_T    *cap;
 /*
  * Handle the CTRL-U and CTRL-D commands.
  */
-static void nv_halfpage(cap)
-cmdarg_T    *cap;
+static void nv_halfpage(cmdarg_T *cap)
 {
   if ((cap->cmdchar == Ctrl_U && curwin->w_cursor.lnum == 1)
       || (cap->cmdchar == Ctrl_D
@@ -7421,8 +7306,7 @@ cmdarg_T    *cap;
 /*
  * Handle "J" or "gJ" command.
  */
-static void nv_join(cap)
-cmdarg_T *cap;
+static void nv_join(cmdarg_T *cap)
 {
   if (VIsual_active)    /* join the visual lines */
     nv_operator(cap);
@@ -7443,8 +7327,7 @@ cmdarg_T *cap;
 /*
  * "P", "gP", "p" and "gp" commands.
  */
-static void nv_put(cap)
-cmdarg_T  *cap;
+static void nv_put(cmdarg_T *cap)
 {
   int regname = 0;
   void        *reg1 = NULL, *reg2 = NULL;
@@ -7555,8 +7438,7 @@ cmdarg_T  *cap;
 /*
  * "o" and "O" commands.
  */
-static void nv_open(cap)
-cmdarg_T    *cap;
+static void nv_open(cmdarg_T *cap)
 {
   /* "do" is ":diffget" */
   if (cap->oap->op_type == OP_DELETE && cap->cmdchar == 'o') {
@@ -7576,8 +7458,7 @@ cmdarg_T    *cap;
  * When waiting for a character for 'updatetime' K_CURSORHOLD is put in the
  * input buffer.  "did_cursorhold" is set to avoid retriggering.
  */
-static void nv_cursorhold(cap)
-cmdarg_T    *cap;
+static void nv_cursorhold(cmdarg_T *cap)
 {
   apply_autocmds(EVENT_CURSORHOLD, NULL, NULL, FALSE, curbuf);
   did_cursorhold = TRUE;

--- a/src/ops.c
+++ b/src/ops.c
@@ -130,9 +130,7 @@ static char opchars[][3] =
  * Translate a command name into an operator type.
  * Must only be called with a valid operator name!
  */
-int get_op_type(char1, char2)
-int char1;
-int char2;
+int get_op_type(int char1, int char2)
 {
   int i;
 
@@ -149,8 +147,7 @@ int char2;
 /*
  * Return TRUE if operator "op" always works on whole lines.
  */
-int op_on_lines(op)
-int op;
+int op_on_lines(int op)
 {
   return opchars[op][2];
 }
@@ -159,8 +156,7 @@ int op;
  * Get first operator command character.
  * Returns 'g' or 'z' if there is another command character.
  */
-int get_op_char(optype)
-int optype;
+int get_op_char(int optype)
 {
   return opchars[optype][0];
 }
@@ -168,8 +164,7 @@ int optype;
 /*
  * Get second operator command character.
  */
-int get_extra_op_char(optype)
-int optype;
+int get_extra_op_char(int optype)
 {
   return opchars[optype][1];
 }
@@ -177,10 +172,7 @@ int optype;
 /*
  * op_shift - handle a shift operation
  */
-void op_shift(oap, curs_top, amount)
-oparg_T         *oap;
-int curs_top;
-int amount;
+void op_shift(oparg_T *oap, int curs_top, int amount)
 {
   long i;
   int first_char;
@@ -257,11 +249,13 @@ int amount;
  * shift the current line one shiftwidth left (if left != 0) or right
  * leaves cursor on first blank in the line
  */
-void shift_line(left, round, amount, call_changed_bytes)
-int left;
-int round;
-int amount;
-int call_changed_bytes;         /* call changed_bytes() */
+void 
+shift_line (
+    int left,
+    int round,
+    int amount,
+    int call_changed_bytes         /* call changed_bytes() */
+)
 {
   int count;
   int i, j;
@@ -301,9 +295,7 @@ int call_changed_bytes;         /* call changed_bytes() */
  * Shift one line of the current block one shiftwidth right or left.
  * Leaves cursor on first character in block.
  */
-static void shift_block(oap, amount)
-oparg_T     *oap;
-int amount;
+static void shift_block(oparg_T *oap, int amount)
 {
   int left = (oap->op_type == OP_LSHIFT);
   int oldstate = State;
@@ -466,11 +458,7 @@ int amount;
  * Insert string "s" (b_insert ? before : after) block :AKelly
  * Caller must prepare for undo.
  */
-static void block_insert(oap, s, b_insert, bdp)
-oparg_T             *oap;
-char_u              *s;
-int b_insert;
-struct block_def    *bdp;
+static void block_insert(oparg_T *oap, char_u *s, int b_insert, struct block_def *bdp)
 {
   int p_ts;
   int count = 0;                /* extra spaces to replace a cut TAB */
@@ -643,7 +631,7 @@ static char_u   *expr_line = NULL;
  * Get an expression for the "\"=expr1" or "CTRL-R =expr1"
  * Returns '=' when OK, NUL otherwise.
  */
-int get_expr_register()         {
+int get_expr_register(void)         {
   char_u      *new_line;
 
   new_line = getcmdline('=', 0L, 0);
@@ -660,8 +648,7 @@ int get_expr_register()         {
  * Set the expression for the '=' register.
  * Argument must be an allocated string.
  */
-void set_expr_line(new_line)
-char_u      *new_line;
+void set_expr_line(char_u *new_line)
 {
   vim_free(expr_line);
   expr_line = new_line;
@@ -671,7 +658,7 @@ char_u      *new_line;
  * Get the result of the '=' register expression.
  * Returns a pointer to allocated memory, or NULL for failure.
  */
-char_u * get_expr_line()              {
+char_u *get_expr_line(void)              {
   char_u      *expr_copy;
   char_u      *rv;
   static int nested = 0;
@@ -700,7 +687,7 @@ char_u * get_expr_line()              {
 /*
  * Get the '=' register expression itself, without evaluating it.
  */
-char_u * get_expr_line_src()              {
+char_u *get_expr_line_src(void)              {
   if (expr_line == NULL)
     return NULL;
   return vim_strsave(expr_line);
@@ -710,9 +697,11 @@ char_u * get_expr_line_src()              {
  * Check if 'regname' is a valid name of a yank register.
  * Note: There is no check for 0 (default register), caller should do this
  */
-int valid_yank_reg(regname, writing)
-int regname;
-int writing;                /* if TRUE check for writable registers */
+int 
+valid_yank_reg (
+    int regname,
+    int writing                /* if TRUE check for writable registers */
+)
 {
   if (       (regname > 0 && ASCII_ISALNUM(regname))
              || (!writing && vim_strchr((char_u *)
@@ -734,9 +723,7 @@ int writing;                /* if TRUE check for writable registers */
  * If regname is 0 and writing, use register 0
  * If regname is 0 and reading, use previous register
  */
-void get_yank_register(regname, writing)
-int regname;
-int writing;
+void get_yank_register(int regname, int writing)
 {
   int i;
 
@@ -767,9 +754,11 @@ int writing;
  * Obtain the contents of a "normal" register. The register is made empty.
  * The returned pointer has allocated memory, use put_register() later.
  */
-void * get_register(name, copy)
-int name;
-int copy;               /* make a copy, if FALSE make register empty. */
+void *
+get_register (
+    int name,
+    int copy               /* make a copy, if FALSE make register empty. */
+)
 {
   struct yankreg      *reg;
   int i;
@@ -799,9 +788,7 @@ int copy;               /* make a copy, if FALSE make register empty. */
 /*
  * Put "reg" into register "name".  Free any previous contents and "reg".
  */
-void put_register(name, reg)
-int name;
-void        *reg;
+void put_register(int name, void *reg)
 {
   get_yank_register(name, 0);
   free_yank_all();
@@ -810,8 +797,7 @@ void        *reg;
 
 }
 
-void free_register(reg)
-void        *reg;
+void free_register(void *reg)
 {
   struct yankreg tmp;
 
@@ -825,8 +811,7 @@ void        *reg;
 /*
  * return TRUE if the current yank register has type MLINE
  */
-int yank_register_mline(regname)
-int regname;
+int yank_register_mline(int regname)
 {
   if (regname != 0 && !valid_yank_reg(regname, FALSE))
     return FALSE;
@@ -841,8 +826,7 @@ int regname;
  *
  * Return FAIL for failure, OK otherwise.
  */
-int do_record(c)
-int c;
+int do_record(int c)
 {
   char_u          *p;
   static int regname;
@@ -896,9 +880,7 @@ int c;
  *
  * return FAIL for failure, OK otherwise
  */
-static int stuff_yank(regname, p)
-int regname;
-char_u      *p;
+static int stuff_yank(int regname, char_u *p)
 {
   char_u      *lp;
   char_u      **pp;
@@ -946,11 +928,13 @@ static int execreg_lastc = NUL;
  *
  * return FAIL for failure, OK otherwise
  */
-int do_execreg(regname, colon, addcr, silent)
-int regname;
-int colon;                      /* insert ':' before each line */
-int addcr;                      /* always add '\n' to end of line */
-int silent;                     /* set "silent" flag in typeahead buffer */
+int 
+do_execreg (
+    int regname,
+    int colon,                      /* insert ':' before each line */
+    int addcr,                      /* always add '\n' to end of line */
+    int silent                     /* set "silent" flag in typeahead buffer */
+)
 {
   long i;
   char_u      *p;
@@ -1052,8 +1036,7 @@ int silent;                     /* set "silent" flag in typeahead buffer */
  * If "restart_edit" is not zero, put it in the typeahead buffer, so that it's
  * used only after other typeahead has been processed.
  */
-static void put_reedit_in_typebuf(silent)
-int silent;
+static void put_reedit_in_typebuf(int silent)
 {
   char_u buf[3];
 
@@ -1077,11 +1060,13 @@ int silent;
  * When "esc" is TRUE it is to be taken literally: Escape CSI characters and
  * no remapping.
  */
-static int put_in_typebuf(s, esc, colon, silent)
-char_u      *s;
-int esc;
-int colon;                  /* add ':' before the line */
-int silent;
+static int 
+put_in_typebuf (
+    char_u *s,
+    int esc,
+    int colon,                  /* add ':' before the line */
+    int silent
+)
 {
   int retval = OK;
 
@@ -1114,9 +1099,11 @@ int silent;
  *
  * return FAIL for failure, OK otherwise
  */
-int insert_reg(regname, literally)
-int regname;
-int literally;                  /* insert literally, not as if typed */
+int 
+insert_reg (
+    int regname,
+    int literally                  /* insert literally, not as if typed */
+)
 {
   long i;
   int retval = OK;
@@ -1169,9 +1156,7 @@ int literally;                  /* insert literally, not as if typed */
  * Stuff a string into the typeahead buffer, such that edit() will insert it
  * literally ("literally" TRUE) or interpret is as typed characters.
  */
-static void stuffescaped(arg, literally)
-char_u      *arg;
-int literally;
+static void stuffescaped(char_u *arg, int literally)
 {
   int c;
   char_u      *start;
@@ -1206,11 +1191,13 @@ int literally;
  * If "regname" is a special register, return TRUE and store a pointer to its
  * value in "argp".
  */
-int get_spec_reg(regname, argp, allocated, errmsg)
-int regname;
-char_u      **argp;
-int         *allocated;         /* return: TRUE when value was allocated */
-int errmsg;                     /* give error message when failing */
+int 
+get_spec_reg (
+    int regname,
+    char_u **argp,
+    int *allocated,         /* return: TRUE when value was allocated */
+    int errmsg                     /* give error message when failing */
+)
 {
   int cnt;
 
@@ -1287,10 +1274,12 @@ int errmsg;                     /* give error message when failing */
  *
  * return FAIL for failure, OK otherwise
  */
-int cmdline_paste_reg(regname, literally, remcr)
-int regname;
-int literally;          /* Insert text literally instead of "as typed" */
-int remcr;              /* don't add trailing CR */
+int 
+cmdline_paste_reg (
+    int regname,
+    int literally,          /* Insert text literally instead of "as typed" */
+    int remcr              /* don't add trailing CR */
+)
 {
   long i;
 
@@ -1325,8 +1314,7 @@ int remcr;              /* don't add trailing CR */
  *
  * Return FAIL if undo failed, OK otherwise.
  */
-int op_delete(oap)
-oparg_T   *oap;
+int op_delete(oparg_T *oap)
 {
   int n;
   linenr_T lnum;
@@ -1667,8 +1655,7 @@ setmarks:
  * Adjust end of operating area for ending on a multi-byte character.
  * Used for deletion.
  */
-static void mb_adjust_opend(oap)
-oparg_T     *oap;
+static void mb_adjust_opend(oparg_T *oap)
 {
   char_u      *p;
 
@@ -1681,9 +1668,7 @@ oparg_T     *oap;
 /*
  * Replace a whole area with one character.
  */
-int op_replace(oap, c)
-oparg_T   *oap;
-int c;
+int op_replace(oparg_T *oap, int c)
 {
   int n, numc;
   int num_chars;
@@ -1885,8 +1870,7 @@ static int swapchars __ARGS((int op_type, pos_T *pos, int length));
 /*
  * Handle the (non-standard vi) tilde operator.  Also for "gu", "gU" and "g?".
  */
-void op_tilde(oap)
-oparg_T     *oap;
+void op_tilde(oparg_T *oap)
 {
   pos_T pos;
   struct block_def bd;
@@ -1961,10 +1945,7 @@ oparg_T     *oap;
  * Also works correctly when the number of bytes changes.
  * Returns TRUE if some character was changed.
  */
-static int swapchars(op_type, pos, length)
-int op_type;
-pos_T       *pos;
-int length;
+static int swapchars(int op_type, pos_T *pos, int length)
 {
   int todo;
   int did_change = 0;
@@ -1991,9 +1972,7 @@ int length;
  * else swap case of character at 'pos'
  * returns TRUE when something actually changed.
  */
-int swapchar(op_type, pos)
-int op_type;
-pos_T    *pos;
+int swapchar(int op_type, pos_T *pos)
 {
   int c;
   int nc;
@@ -2050,9 +2029,7 @@ pos_T    *pos;
 /*
  * op_insert - Insert and append operators for Visual mode.
  */
-void op_insert(oap, count1)
-oparg_T     *oap;
-long count1;
+void op_insert(oparg_T *oap, long count1)
 {
   long ins_len, pre_textlen = 0;
   char_u              *firstline, *ins_text;
@@ -2198,8 +2175,7 @@ long count1;
  *
  * return TRUE if edit() returns because of a CTRL-O command
  */
-int op_change(oap)
-oparg_T     *oap;
+int op_change(oparg_T *oap)
 {
   colnr_T l;
   int retval;
@@ -2318,7 +2294,7 @@ oparg_T     *oap;
 /*
  * set all the yank registers to empty (called from main())
  */
-void init_yank()          {
+void init_yank(void)          {
   int i;
 
   for (i = 0; i < NUM_REGISTERS; ++i)
@@ -2326,7 +2302,7 @@ void init_yank()          {
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void clear_registers()          {
+void clear_registers(void)          {
   int i;
 
   for (i = 0; i < NUM_REGISTERS; ++i) {
@@ -2342,8 +2318,7 @@ void clear_registers()          {
  * Free "n" lines from the current yank register.
  * Called for normal freeing and in case of error.
  */
-static void free_yank(n)
-long n;
+static void free_yank(long n)
 {
   if (y_current->y_array != NULL) {
     long i;
@@ -2356,7 +2331,7 @@ long n;
   }
 }
 
-static void free_yank_all()                 {
+static void free_yank_all(void)                 {
   free_yank(y_current->y_size);
 }
 
@@ -2368,10 +2343,7 @@ static void free_yank_all()                 {
  *
  * Return FAIL for failure, OK otherwise.
  */
-int op_yank(oap, deleting, mess)
-oparg_T   *oap;
-int deleting;
-int mess;
+int op_yank(oparg_T *oap, int deleting, int mess)
 {
   long y_idx;                           /* index in y_array[] */
   struct yankreg      *curr;            /* copy of y_current */
@@ -2604,9 +2576,7 @@ fail:           /* free the allocated lines */
   return FAIL;
 }
 
-static int yank_copy_line(bd, y_idx)
-struct block_def    *bd;
-long y_idx;
+static int yank_copy_line(struct block_def *bd, long y_idx)
 {
   char_u      *pnew;
 
@@ -2632,11 +2602,13 @@ long y_idx;
  *	    PUT_CURSEND		leave cursor after end of new text
  *	    PUT_LINE		force linewise put (":put")
  */
-void do_put(regname, dir, count, flags)
-int regname;
-int dir;                        /* BACKWARD for 'P', FORWARD for 'p' */
-long count;
-int flags;
+void 
+do_put (
+    int regname,
+    int dir,                        /* BACKWARD for 'P', FORWARD for 'p' */
+    long count,
+    int flags
+)
 {
   char_u      *ptr;
   char_u      *newp, *oldp;
@@ -3197,7 +3169,7 @@ end:
  * When the cursor is on the NUL past the end of the line and it should not be
  * there move it left.
  */
-void adjust_cursor_eol()          {
+void adjust_cursor_eol(void)          {
   if (curwin->w_cursor.col > 0
       && gchar_cursor() == NUL
       && (ve_flags & VE_ONEMORE) == 0
@@ -3218,7 +3190,7 @@ void adjust_cursor_eol()          {
 /*
  * Return TRUE if lines starting with '#' should be left aligned.
  */
-int preprocs_left()         {
+int preprocs_left(void)         {
   return
     (curbuf->b_p_si && !curbuf->b_p_cin) ||
     (curbuf->b_p_cin && in_cinkeys('#', ' ', TRUE)
@@ -3227,8 +3199,7 @@ int preprocs_left()         {
 }
 
 /* Return the character name of the register with the given number */
-int get_register_name(num)
-int num;
+int get_register_name(int num)
 {
   if (num == -1)
     return '"';
@@ -3244,8 +3215,7 @@ int num;
 /*
  * ":dis" and ":registers": Display the contents of the yank registers.
  */
-void ex_display(eap)
-exarg_T     *eap;
+void ex_display(exarg_T *eap)
 {
   int i, n;
   long j;
@@ -3374,9 +3344,11 @@ exarg_T     *eap;
  * display a string for do_dis()
  * truncate at end of screen line
  */
-static void dis_msg(p, skip_esc)
-char_u      *p;
-int skip_esc;                       /* if TRUE, ignore trailing ESC */
+static void 
+dis_msg (
+    char_u *p,
+    int skip_esc                       /* if TRUE, ignore trailing ESC */
+)
 {
   int n;
   int l;
@@ -3406,11 +3378,7 @@ int skip_esc;                       /* if TRUE, ignore trailing ESC */
  * is_comment - will indicate whether the current line ends with an unclosed
  *		comment.
  */
-static char_u * skip_comment(line, process, include_space, is_comment)
-char_u   *line;
-int process;
-int include_space;
-int      *is_comment;
+static char_u *skip_comment(char_u *line, int process, int include_space, int *is_comment)
 {
   char_u *comment_flags = NULL;
   int lead_len;
@@ -3470,11 +3438,7 @@ int      *is_comment;
  *
  * return FAIL for failure, OK otherwise
  */
-int do_join(count, insert_space, save_undo, use_formatoptions)
-long count;
-int insert_space;
-int save_undo;
-int use_formatoptions UNUSED;
+int do_join(long count, int insert_space, int save_undo, int use_formatoptions)
 {
   char_u      *curr = NULL;
   char_u      *curr_start = NULL;
@@ -3652,13 +3616,7 @@ theend:
  * the first line.  White-space is ignored.  Note that the whole of
  * 'leader1' must match 'leader2_len' characters from 'leader2' -- webb
  */
-static int same_leader(lnum, leader1_len, leader1_flags, leader2_len,
-    leader2_flags)
-linenr_T lnum;
-int leader1_len;
-char_u  *leader1_flags;
-int leader2_len;
-char_u  *leader2_flags;
+static int same_leader(linenr_T lnum, int leader1_len, char_u *leader1_flags, int leader2_len, char_u *leader2_flags)
 {
   int idx1 = 0, idx2 = 0;
   char_u  *p;
@@ -3719,9 +3677,11 @@ char_u  *leader2_flags;
 /*
  * Implementation of the format operator 'gq'.
  */
-void op_format(oap, keep_cursor)
-oparg_T     *oap;
-int keep_cursor;                        /* keep cursor on same text char */
+void 
+op_format (
+    oparg_T *oap,
+    int keep_cursor                        /* keep cursor on same text char */
+)
 {
   long old_line_count = curbuf->b_ml.ml_line_count;
 
@@ -3787,8 +3747,7 @@ int keep_cursor;                        /* keep cursor on same text char */
 /*
  * Implementation of the format operator 'gq' for when using 'formatexpr'.
  */
-void op_formatexpr(oap)
-oparg_T     *oap;
+void op_formatexpr(oparg_T *oap)
 {
   if (oap->is_VIsual)
     /* When there is no change: need to remove the Visual selection */
@@ -3800,10 +3759,12 @@ oparg_T     *oap;
     op_format(oap, FALSE);
 }
 
-int fex_format(lnum, count, c)
-linenr_T lnum;
-long count;
-int c;                  /* character to be inserted */
+int 
+fex_format (
+    linenr_T lnum,
+    long count,
+    int c                  /* character to be inserted */
+)
 {
   int use_sandbox = was_set_insecurely((char_u *)"formatexpr",
       OPT_LOCAL);
@@ -3837,9 +3798,11 @@ int c;                  /* character to be inserted */
  * Lines after the cursor line are saved for undo, caller must have saved the
  * first line.
  */
-void format_lines(line_count, avoid_fex)
-linenr_T line_count;
-int avoid_fex;                          /* don't use 'formatexpr' */
+void 
+format_lines (
+    linenr_T line_count,
+    int avoid_fex                          /* don't use 'formatexpr' */
+)
 {
   int max_len;
   int is_not_par;                       /* current line not part of parag. */
@@ -4056,8 +4019,7 @@ int avoid_fex;                          /* don't use 'formatexpr' */
 /*
  * Return TRUE if line "lnum" ends in a white character.
  */
-static int ends_in_white(lnum)
-linenr_T lnum;
+static int ends_in_white(linenr_T lnum)
 {
   char_u      *s = ml_get(lnum);
   size_t l;
@@ -4078,11 +4040,7 @@ linenr_T lnum;
  * previous line.  A new paragraph starts after a blank line, or when the
  * comment leader changes -- webb.
  */
-static int fmt_check_par(lnum, leader_len, leader_flags, do_comments)
-linenr_T lnum;
-int         *leader_len;
-char_u      **leader_flags;
-int do_comments;
+static int fmt_check_par(linenr_T lnum, int *leader_len, char_u **leader_flags, int do_comments)
 {
   char_u      *flags = NULL;        /* init for GCC */
   char_u      *ptr;
@@ -4111,8 +4069,7 @@ int do_comments;
  * Return TRUE when a paragraph starts in line "lnum".  Return FALSE when the
  * previous line is in the same paragraph.  Used for auto-formatting.
  */
-int paragraph_start(lnum)
-linenr_T lnum;
+int paragraph_start(linenr_T lnum)
 {
   char_u      *p;
   int leader_len = 0;                   /* leader len of current line */
@@ -4165,11 +4122,7 @@ linenr_T lnum;
  * - start/endspaces is the number of columns of the first/last yanked char
  *   that are to be yanked.
  */
-static void block_prep(oap, bdp, lnum, is_del)
-oparg_T             *oap;
-struct block_def    *bdp;
-linenr_T lnum;
-int is_del;
+static void block_prep(oparg_T *oap, struct block_def *bdp, linenr_T lnum, int is_del)
 {
   int incr = 0;
   char_u      *pend;
@@ -4281,8 +4234,7 @@ int is_del;
 
 static void reverse_line __ARGS((char_u *s));
 
-static void reverse_line(s)
-char_u *s;
+static void reverse_line(char_u *s)
 {
   int i, j;
   char_u c;
@@ -4304,9 +4256,7 @@ char_u *s;
  *
  * return FAIL for failure, OK otherwise
  */
-int do_addsub(command, Prenum1)
-int command;
-linenr_T Prenum1;
+int do_addsub(int command, linenr_T Prenum1)
 {
   int col;
   char_u      *buf1;
@@ -4530,9 +4480,7 @@ linenr_T Prenum1;
   return OK;
 }
 
-int read_viminfo_register(virp, force)
-vir_T       *virp;
-int force;
+int read_viminfo_register(vir_T *virp, int force)
 {
   int eof;
   int do_it = TRUE;
@@ -4622,8 +4570,7 @@ int force;
   return eof;
 }
 
-void write_viminfo_registers(fp)
-FILE    *fp;
+void write_viminfo_registers(FILE *fp)
 {
   int i, j;
   char_u  *type;
@@ -4710,9 +4657,7 @@ FILE    *fp;
  * Used for getregtype()
  * Returns MAUTO for error.
  */
-char_u get_reg_type(regname, reglen)
-int regname;
-long    *reglen;
+char_u get_reg_type(int regname, long *reglen)
 {
   switch (regname) {
   case '%':                     /* file name */
@@ -4748,10 +4693,12 @@ long    *reglen;
  * Used for "@r" in expressions and for getreg().
  * Returns NULL for error.
  */
-char_u * get_reg_contents(regname, allowexpr, expr_src)
-int regname;
-int allowexpr;                  /* allow "=" register */
-int expr_src;                   /* get expression for "=" register */
+char_u *
+get_reg_contents (
+    int regname,
+    int allowexpr,                  /* allow "=" register */
+    int expr_src                   /* get expression for "=" register */
+)
 {
   long i;
   char_u      *retval;
@@ -4835,22 +4782,12 @@ int expr_src;                   /* get expression for "=" register */
  * Careful: 'str' is modified, you may have to use a copy!
  * If "str" ends in '\n' or '\r', use linewise, otherwise use characterwise.
  */
-void write_reg_contents(name, str, maxlen, must_append)
-int name;
-char_u      *str;
-int maxlen;
-int must_append;
+void write_reg_contents(int name, char_u *str, int maxlen, int must_append)
 {
   write_reg_contents_ex(name, str, maxlen, must_append, MAUTO, 0L);
 }
 
-void write_reg_contents_ex(name, str, maxlen, must_append, yank_type, block_len)
-int name;
-char_u      *str;
-int maxlen;
-int must_append;
-int yank_type;
-long block_len;
+void write_reg_contents_ex(int name, char_u *str, int maxlen, int must_append, int yank_type, long block_len)
 {
   struct yankreg  *old_y_previous, *old_y_current;
   long len;
@@ -4910,12 +4847,14 @@ long block_len;
  * Put a string into a register.  When the register is not empty, the string
  * is appended.
  */
-static void str_to_reg(y_ptr, yank_type, str, len, blocklen)
-struct yankreg      *y_ptr;             /* pointer to yank register */
-int yank_type;                          /* MCHAR, MLINE, MBLOCK, MAUTO */
-char_u              *str;               /* string to put in register */
-long len;                               /* length of string */
-long blocklen;                          /* width of Visual block */
+static void 
+str_to_reg (
+    struct yankreg *y_ptr,             /* pointer to yank register */
+    int yank_type,                          /* MCHAR, MLINE, MBLOCK, MAUTO */
+    char_u *str,               /* string to put in register */
+    long len,                               /* length of string */
+    long blocklen                          /* width of Visual block */
+)
 {
   int type;                             /* MCHAR, MLINE or MBLOCK */
   int lnum;
@@ -5010,8 +4949,7 @@ long blocklen;                          /* width of Visual block */
     y_ptr->y_width = 0;
 }
 
-void clear_oparg(oap)
-oparg_T     *oap;
+void clear_oparg(oparg_T *oap)
 {
   vim_memset(oap, 0, sizeof(oparg_T));
 }
@@ -5034,12 +4972,7 @@ static long line_count_info __ARGS((char_u *line, long *wc, long *cc,
  *  case, eol_size will be added to the character count to account for
  *  the size of the EOL character.
  */
-static long line_count_info(line, wc, cc, limit, eol_size)
-char_u      *line;
-long        *wc;
-long        *cc;
-long limit;
-int eol_size;
+static long line_count_info(char_u *line, long *wc, long *cc, long limit, int eol_size)
 {
   long i;
   long words = 0;
@@ -5076,7 +5009,7 @@ int eol_size;
  * In Visual mode, give some info about the selected region.  (In this case,
  * the *_count_cursor variables store running totals for the selection.)
  */
-void cursor_pos_info()          {
+void cursor_pos_info(void)          {
   char_u      *p;
   char_u buf1[50];
   char_u buf2[40];

--- a/src/option.c
+++ b/src/option.c
@@ -1921,7 +1921,7 @@ static int check_opt_wim __ARGS((void));
  *
  * Called only once from main(), just after creating the first buffer.
  */
-void set_init_1()          {
+void set_init_1(void)          {
   char_u      *p;
   int opt_idx;
   long_u n;
@@ -2212,10 +2212,12 @@ void set_init_1()          {
  * Set an option to its default value.
  * This does not take care of side effects!
  */
-static void set_option_default(opt_idx, opt_flags, compatible)
-int opt_idx;
-int opt_flags;                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
-int compatible;                 /* use Vi default value */
+static void 
+set_option_default (
+    int opt_idx,
+    int opt_flags,                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
+    int compatible                 /* use Vi default value */
+)
 {
   char_u      *varp;            /* pointer to variable for current option */
   int dvi;                      /* index in def_val[] */
@@ -2275,8 +2277,10 @@ int compatible;                 /* use Vi default value */
 /*
  * Set all options (except terminal options) to their default value.
  */
-static void set_options_default(opt_flags)
-int opt_flags;                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
+static void 
+set_options_default (
+    int opt_flags                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
+)
 {
   int i;
   win_T       *wp;
@@ -2295,9 +2299,7 @@ int opt_flags;                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
  * Set the Vi-default value of a string option.
  * Used for 'sh', 'backupskip' and 'term'.
  */
-void set_string_default(name, val)
-char        *name;
-char_u      *val;
+void set_string_default(char *name, char_u *val)
 {
   char_u      *p;
   int opt_idx;
@@ -2318,9 +2320,7 @@ char_u      *val;
  * Set the Vi-default value of a number option.
  * Used for 'lines' and 'columns'.
  */
-void set_number_default(name, val)
-char        *name;
-long val;
+void set_number_default(char *name, long val)
 {
   int opt_idx;
 
@@ -2333,7 +2333,7 @@ long val;
 /*
  * Free all options.
  */
-void free_all_options()          {
+void free_all_options(void)          {
   int i;
 
   for (i = 0; !istermoption(&options[i]); i++) {
@@ -2357,7 +2357,7 @@ void free_all_options()          {
  * Initialize the options, part two: After getting Rows and Columns and
  * setting 'term'.
  */
-void set_init_2()          {
+void set_init_2(void)          {
   int idx;
 
   /*
@@ -2411,7 +2411,7 @@ void set_init_2()          {
  * values separated by semicolons; we want the last value in either
  * case. If this value is 0-6 or 8, our background is dark.
  */
-static char_u * term_bg_default()                     {
+static char_u *term_bg_default(void)                     {
   char_u      *p;
 
   if (STRCMP(T_NAME, "linux") == 0
@@ -2429,7 +2429,7 @@ static char_u * term_bg_default()                     {
 /*
  * Initialize the options, part three: After reading the .vimrc
  */
-void set_init_3()          {
+void set_init_3(void)          {
 #if defined(UNIX) || defined(OS2) || defined(WIN3264)
   /*
    * Set 'shellpipe' and 'shellredir', depending on the 'shell' option.
@@ -2520,8 +2520,7 @@ void set_init_3()          {
  * When 'helplang' is still at its default value, set it to "lang".
  * Only the first two characters of "lang" are used.
  */
-void set_helplang_default(lang)
-char_u      *lang;
+void set_helplang_default(char_u *lang)
 {
   int idx;
 
@@ -2554,7 +2553,7 @@ char_u      *lang;
  * they can be reset.  This reduces startup time when using X on a remote
  * machine.
  */
-void set_title_defaults()          {
+void set_title_defaults(void)          {
   int idx1;
   long val;
 
@@ -2592,9 +2591,11 @@ void set_title_defaults()          {
  *
  * returns FAIL if an error is detected, OK otherwise
  */
-int do_set(arg, opt_flags)
-char_u      *arg;               /* option string (may be written to!) */
-int opt_flags;
+int 
+do_set (
+    char_u *arg,               /* option string (may be written to!) */
+    int opt_flags
+)
 {
   int opt_idx;
   char_u      *errmsg;
@@ -3339,10 +3340,12 @@ theend:
  * Call this when an option has been given a new value through a user command.
  * Sets the P_WAS_SET flag and takes care of the P_INSECURE flag.
  */
-static void did_set_option(opt_idx, opt_flags, new_value)
-int opt_idx;
-int opt_flags;              /* possibly with OPT_MODELINE */
-int new_value;              /* value was replaced completely */
+static void 
+did_set_option (
+    int opt_idx,
+    int opt_flags,              /* possibly with OPT_MODELINE */
+    int new_value              /* value was replaced completely */
+)
 {
   long_u      *p;
 
@@ -3362,9 +3365,7 @@ int new_value;              /* value was replaced completely */
     *p = *p & ~P_INSECURE;
 }
 
-static char_u * illegal_char(errbuf, c)
-char_u      *errbuf;
-int c;
+static char_u *illegal_char(char_u *errbuf, int c)
 {
   if (errbuf == NULL)
     return (char_u *)"";
@@ -3377,8 +3378,7 @@ int c;
  * Convert a key name or string into a key value.
  * Used for 'wildchar' and 'cedit' options.
  */
-static int string_to_key(arg)
-char_u      *arg;
+static int string_to_key(char_u *arg)
 {
   if (*arg == '<')
     return find_key_option(arg + 1);
@@ -3391,7 +3391,7 @@ char_u      *arg;
  * Check value of 'cedit' and set cedit_key.
  * Returns NULL if value is OK, error message otherwise.
  */
-static char_u * check_cedit()                     {
+static char_u *check_cedit(void)                     {
   int n;
 
   if (*p_cedit == NUL)
@@ -3411,8 +3411,10 @@ static char_u * check_cedit()                     {
  * When switching the title or icon off, call mch_restore_title() to get
  * the old value back.
  */
-static void did_set_title(icon)
-int icon;                   /* Did set icon instead of title */
+static void 
+did_set_title (
+    int icon                   /* Did set icon instead of title */
+)
 {
   if (starting != NO_SCREEN
       ) {
@@ -3430,10 +3432,12 @@ int icon;                   /* Did set icon instead of title */
 /*
  * set_options_bin -  called when 'bin' changes value.
  */
-void set_options_bin(oldval, newval, opt_flags)
-int oldval;
-int newval;
-int opt_flags;                  /* OPT_LOCAL and/or OPT_GLOBAL */
+void 
+set_options_bin (
+    int oldval,
+    int newval,
+    int opt_flags                  /* OPT_LOCAL and/or OPT_GLOBAL */
+)
 {
   /*
    * The option values that are changed when 'bin' changes are
@@ -3491,8 +3495,7 @@ int opt_flags;                  /* OPT_LOCAL and/or OPT_GLOBAL */
  * If the parameter is not specified in the string or there is no following
  * number, return -1.
  */
-int get_viminfo_parameter(type)
-int type;
+int get_viminfo_parameter(int type)
 {
   char_u  *p;
 
@@ -3507,8 +3510,7 @@ int type;
  * '/') in the 'viminfo' option and return a pointer to the string after it.
  * Return NULL if the parameter is not specified in the string.
  */
-char_u * find_viminfo_parameter(type)
-int type;
+char_u *find_viminfo_parameter(int type)
 {
   char_u  *p;
 
@@ -3530,9 +3532,7 @@ int type;
  * If "val" is NULL expand the current value of the option.
  * Return pointer to NameBuff, or NULL when not expanded.
  */
-static char_u * option_expand(opt_idx, val)
-int opt_idx;
-char_u      *val;
+static char_u *option_expand(int opt_idx, char_u *val)
 {
   /* if option doesn't need expansion nothing to do */
   if (!(options[opt_idx].flags & P_EXPAND) || options[opt_idx].var == NULL)
@@ -3566,7 +3566,7 @@ char_u      *val;
  * After setting various option values: recompute variables that depend on
  * option values.
  */
-static void didset_options()                 {
+static void didset_options(void)                 {
   /* initialize the table for 'iskeyword' et.al. */
   (void)init_chartab();
 
@@ -3590,7 +3590,7 @@ static void didset_options()                 {
 /*
  * Check for string options that are NULL (normally only termcap options).
  */
-void check_options()          {
+void check_options(void)          {
   int opt_idx;
 
   for (opt_idx = 0; options[opt_idx].fullname != NULL; opt_idx++)
@@ -3601,8 +3601,7 @@ void check_options()          {
 /*
  * Check string options in a buffer for NULL value.
  */
-void check_buf_options(buf)
-buf_T       *buf;
+void check_buf_options(buf_T *buf)
 {
   check_string_option(&buf->b_p_bh);
   check_string_option(&buf->b_p_bt);
@@ -3656,23 +3655,20 @@ buf_T       *buf;
  * check_options().
  * Does NOT check for P_ALLOCED flag!
  */
-void free_string_option(p)
-char_u      *p;
+void free_string_option(char_u *p)
 {
   if (p != empty_option)
     vim_free(p);
 }
 
-void clear_string_option(pp)
-char_u      **pp;
+void clear_string_option(char_u **pp)
 {
   if (*pp != empty_option)
     vim_free(*pp);
   *pp = empty_option;
 }
 
-static void check_string_option(pp)
-char_u      **pp;
+static void check_string_option(char_u **pp)
 {
   if (*pp == NULL)
     *pp = empty_option;
@@ -3681,8 +3677,7 @@ char_u      **pp;
 /*
  * Mark a terminal option as allocated, found by a pointer into term_strings[].
  */
-void set_term_option_alloced(p)
-char_u **p;
+void set_term_option_alloced(char_u **p)
 {
   int opt_idx;
 
@@ -3699,9 +3694,7 @@ char_u **p;
  * Return FALSE when it wasn't.
  * Return -1 for an unknown option.
  */
-int was_set_insecurely(opt, opt_flags)
-char_u  *opt;
-int opt_flags;
+int was_set_insecurely(char_u *opt, int opt_flags)
 {
   int idx = findoption(opt);
   long_u  *flagp;
@@ -3718,9 +3711,7 @@ int opt_flags;
  * Get a pointer to the flags used for the P_INSECURE flag of option
  * "opt_idx".  For some local options a local flags field is used.
  */
-static long_u * insecure_flag(opt_idx, opt_flags)
-int opt_idx;
-int opt_flags;
+static long_u *insecure_flag(int opt_idx, int opt_flags)
 {
   if (opt_flags & OPT_LOCAL)
     switch ((int)options[opt_idx].indir) {
@@ -3741,7 +3732,7 @@ static void redraw_titles __ARGS((void));
 /*
  * Redraw the window title and/or tab page text later.
  */
-static void redraw_titles() {
+static void redraw_titles(void) {
   need_maketitle = TRUE;
   redraw_tabline = TRUE;
 }
@@ -3753,12 +3744,14 @@ static void redraw_titles() {
  * When "set_sid" is zero set the scriptID to current_SID.  When "set_sid" is
  * SID_NONE don't set the scriptID.  Otherwise set the scriptID to "set_sid".
  */
-void set_string_option_direct(name, opt_idx, val, opt_flags, set_sid)
-char_u      *name;
-int opt_idx;
-char_u      *val;
-int opt_flags;                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
-int set_sid UNUSED;
+void 
+set_string_option_direct (
+    char_u *name,
+    int opt_idx,
+    char_u *val,
+    int opt_flags,                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
+    int set_sid
+)
 {
   char_u      *s;
   char_u      **varp;
@@ -3805,9 +3798,11 @@ int set_sid UNUSED;
 /*
  * Set global value for string option when it's a local option.
  */
-static void set_string_option_global(opt_idx, varp)
-int opt_idx;                    /* option index */
-char_u      **varp;             /* pointer to option variable */
+static void 
+set_string_option_global (
+    int opt_idx,                    /* option index */
+    char_u **varp             /* pointer to option variable */
+)
 {
   char_u      **p, *s;
 
@@ -3829,10 +3824,12 @@ char_u      **varp;             /* pointer to option variable */
  *
  * Returns NULL on success or error message on error.
  */
-static char_u * set_string_option(opt_idx, value, opt_flags)
-int opt_idx;
-char_u      *value;
-int opt_flags;                  /* OPT_LOCAL and/or OPT_GLOBAL */
+static char_u *
+set_string_option (
+    int opt_idx,
+    char_u *value,
+    int opt_flags                  /* OPT_LOCAL and/or OPT_GLOBAL */
+)
 {
   char_u      *s;
   char_u      **varp;
@@ -3862,15 +3859,15 @@ int opt_flags;                  /* OPT_LOCAL and/or OPT_GLOBAL */
  * Handle string options that need some action to perform when changed.
  * Returns NULL for success, or an error message for an error.
  */
-static char_u * did_set_string_option(opt_idx, varp, new_value_alloced, oldval,
-    errbuf,
-    opt_flags)
-int opt_idx;                            /* index in options[] table */
-char_u      **varp;                     /* pointer to the option variable */
-int new_value_alloced;                  /* new value was allocated */
-char_u      *oldval;                    /* previous value of the option */
-char_u      *errbuf;                    /* buffer for errors, or NULL */
-int opt_flags;                          /* OPT_LOCAL and/or OPT_GLOBAL */
+static char_u *
+did_set_string_option (
+    int opt_idx,                            /* index in options[] table */
+    char_u **varp,                     /* pointer to the option variable */
+    int new_value_alloced,                  /* new value was allocated */
+    char_u *oldval,                    /* previous value of the option */
+    char_u *errbuf,                    /* buffer for errors, or NULL */
+    int opt_flags                          /* OPT_LOCAL and/or OPT_GLOBAL */
+)
 {
   char_u      *errmsg = NULL;
   char_u      *s, *p;
@@ -4817,9 +4814,7 @@ int opt_flags;                          /* OPT_LOCAL and/or OPT_GLOBAL */
 /*
  * Simple int comparison function for use with qsort()
  */
-static int int_cmp(a, b)
-const void *a;
-const void *b;
+static int int_cmp(const void *a, const void *b)
 {
   return *(const int *)a - *(const int *)b;
 }
@@ -4828,8 +4823,7 @@ const void *b;
  * Handle setting 'colorcolumn' or 'textwidth' in window "wp".
  * Returns error message, NULL if it's OK.
  */
-char_u * check_colorcolumn(wp)
-win_T       *wp;
+char_u *check_colorcolumn(win_T *wp)
 {
   char_u      *s;
   int col;
@@ -4893,8 +4887,7 @@ skip:
  * Handle setting 'listchars' or 'fillchars'.
  * Returns error message, NULL if it's OK.
  */
-static char_u * set_chars_option(varp)
-char_u      **varp;
+static char_u *set_chars_option(char_u **varp)
 {
   int round, i, len, entries;
   char_u      *p, *s;
@@ -4991,8 +4984,7 @@ char_u      **varp;
  * Check validity of options with the 'statusline' format.
  * Return error message or NULL.
  */
-char_u * check_stl_option(s)
-char_u      *s;
+char_u *check_stl_option(char_u *s)
 {
   int itemcnt = 0;
   int groupdepth = 0;
@@ -5055,8 +5047,7 @@ char_u      *s;
  * Set curbuf->b_cap_prog to the regexp program for 'spellcapcheck'.
  * Return error message when failed, NULL when OK.
  */
-static char_u * compile_cap_prog(synblock)
-synblock_T *synblock;
+static char_u *compile_cap_prog(synblock_T *synblock)
 {
   regprog_T   *rp = synblock->b_cap_prog;
   char_u      *re;
@@ -5084,10 +5075,7 @@ synblock_T *synblock;
  * Set the scriptID for an option, taking care of setting the buffer- or
  * window-local value.
  */
-static void set_option_scriptID_idx(opt_idx, opt_flags, id)
-int opt_idx;
-int opt_flags;
-int id;
+static void set_option_scriptID_idx(int opt_idx, int opt_flags, int id)
 {
   int both = (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0;
   int indir = (int)options[opt_idx].indir;
@@ -5108,11 +5096,13 @@ int id;
  * Set the value of a boolean option, and take care of side effects.
  * Returns NULL for success, or an error message for an error.
  */
-static char_u * set_bool_option(opt_idx, varp, value, opt_flags)
-int opt_idx;                            /* index in options[] table */
-char_u      *varp;                      /* pointer to the option variable */
-int value;                              /* new value */
-int opt_flags;                          /* OPT_LOCAL and/or OPT_GLOBAL */
+static char_u *
+set_bool_option (
+    int opt_idx,                            /* index in options[] table */
+    char_u *varp,                      /* pointer to the option variable */
+    int value,                              /* new value */
+    int opt_flags                          /* OPT_LOCAL and/or OPT_GLOBAL */
+)
 {
   int old_value = *(int *)varp;
 
@@ -5496,15 +5486,16 @@ int opt_flags;                          /* OPT_LOCAL and/or OPT_GLOBAL */
  * Set the value of a number option, and take care of side effects.
  * Returns NULL for success, or an error message for an error.
  */
-static char_u * set_num_option(opt_idx, varp, value, errbuf, errbuflen,
-    opt_flags)
-int opt_idx;                            /* index in options[] table */
-char_u      *varp;                      /* pointer to the option variable */
-long value;                             /* new value */
-char_u      *errbuf;                    /* buffer for error messages */
-size_t errbuflen;                       /* length of "errbuf" */
-int opt_flags;                          /* OPT_LOCAL, OPT_GLOBAL and
+static char_u *
+set_num_option (
+    int opt_idx,                            /* index in options[] table */
+    char_u *varp,                      /* pointer to the option variable */
+    long value,                             /* new value */
+    char_u *errbuf,                    /* buffer for error messages */
+    size_t errbuflen,                       /* length of "errbuf" */
+    int opt_flags                          /* OPT_LOCAL, OPT_GLOBAL and
                                            OPT_MODELINE */
+)
 {
   char_u      *errmsg = NULL;
   long old_value = *(long *)varp;
@@ -5867,8 +5858,7 @@ int opt_flags;                          /* OPT_LOCAL, OPT_GLOBAL and
 /*
  * Called after an option changed: check if something needs to be redrawn.
  */
-static void check_redraw(flags)
-long_u flags;
+static void check_redraw(long_u flags)
 {
   /* Careful: P_RCLR and P_RALL are a combination of other P_ flags */
   int doclear = (flags & P_RCLR) == P_RCLR;
@@ -5891,8 +5881,7 @@ long_u flags;
  * Find index for option 'arg'.
  * Return -1 if not found.
  */
-static int findoption(arg)
-char_u *arg;
+static int findoption(char_u *arg)
 {
   int opt_idx;
   char            *s, *p;
@@ -5956,11 +5945,13 @@ char_u *arg;
  *	     hidden String option: -2.
  *		   unknown option: -3.
  */
-int get_option_value(name, numval, stringval, opt_flags)
-char_u      *name;
-long        *numval;
-char_u      **stringval;            /* NULL when only checking existence */
-int opt_flags;
+int 
+get_option_value (
+    char_u *name,
+    long *numval,
+    char_u **stringval,            /* NULL when only checking existence */
+    int opt_flags
+)
 {
   int opt_idx;
   char_u      *varp;
@@ -6007,11 +5998,13 @@ int opt_flags;
  *
  * Returns NULL on success or error message on error.
  */
-char_u * set_option_value(name, number, string, opt_flags)
-char_u      *name;
-long number;
-char_u      *string;
-int opt_flags;                  /* OPT_LOCAL or 0 (both) */
+char_u *
+set_option_value (
+    char_u *name,
+    long number,
+    char_u *string,
+    int opt_flags                  /* OPT_LOCAL or 0 (both) */
+)
 {
   int opt_idx;
   char_u      *varp;
@@ -6067,8 +6060,7 @@ int opt_flags;                  /* OPT_LOCAL or 0 (both) */
  * Get the terminal code for a terminal option.
  * Returns NULL when not found.
  */
-char_u * get_term_code(tname)
-char_u      *tname;
+char_u *get_term_code(char_u *tname)
 {
   int opt_idx;
   char_u  *varp;
@@ -6085,7 +6077,7 @@ char_u      *tname;
   return find_termcode(tname + 2);
 }
 
-char_u * get_highlight_default()              {
+char_u *get_highlight_default(void)              {
   int i;
 
   i = findoption((char_u *)"hl");
@@ -6094,7 +6086,7 @@ char_u * get_highlight_default()              {
   return (char_u *)NULL;
 }
 
-char_u * get_encoding_default()              {
+char_u *get_encoding_default(void)              {
   int i;
 
   i = findoption((char_u *)"enc");
@@ -6106,8 +6098,7 @@ char_u * get_encoding_default()              {
 /*
  * Translate a string like "t_xx", "<t_xx>" or "<S-Tab>" to a key number.
  */
-static int find_key_option(arg)
-char_u *arg;
+static int find_key_option(char_u *arg)
 {
   int key;
   int modifiers;
@@ -6133,9 +6124,11 @@ char_u *arg;
  * if 'all' == 1: show all normal options
  * if 'all' == 2: show all terminal options
  */
-static void showoptions(all, opt_flags)
-int all;
-int opt_flags;                  /* OPT_LOCAL and/or OPT_GLOBAL */
+static void 
+showoptions (
+    int all,
+    int opt_flags                  /* OPT_LOCAL and/or OPT_GLOBAL */
+)
 {
   struct vimoption    *p;
   int col;
@@ -6231,9 +6224,7 @@ int opt_flags;                  /* OPT_LOCAL and/or OPT_GLOBAL */
 /*
  * Return TRUE if option "p" has its default value.
  */
-static int optval_default(p, varp)
-struct vimoption    *p;
-char_u              *varp;
+static int optval_default(struct vimoption *p, char_u *varp)
 {
   int dvi;
 
@@ -6254,9 +6245,11 @@ char_u              *varp;
  * showoneopt: show the value of one option
  * must not be called with a hidden option!
  */
-static void showoneopt(p, opt_flags)
-struct vimoption    *p;
-int opt_flags;                          /* OPT_LOCAL or OPT_GLOBAL */
+static void 
+showoneopt (
+    struct vimoption *p,
+    int opt_flags                          /* OPT_LOCAL or OPT_GLOBAL */
+)
 {
   char_u      *varp;
   int save_silent = silent_mode;
@@ -6308,10 +6301,7 @@ int opt_flags;                          /* OPT_LOCAL or OPT_GLOBAL */
  *
  * Return FAIL on error, OK otherwise.
  */
-int makeset(fd, opt_flags, local_only)
-FILE        *fd;
-int opt_flags;
-int local_only;
+int makeset(FILE *fd, int opt_flags, int local_only)
 {
   struct vimoption    *p;
   char_u              *varp;                    /* currently used value */
@@ -6413,8 +6403,7 @@ int local_only;
  * Generate set commands for the local fold options only.  Used when
  * 'sessionoptions' or 'viewoptions' contains "folds" but not "options".
  */
-int makefoldset(fd)
-FILE        *fd;
+int makefoldset(FILE *fd)
 {
   if (put_setstring(fd, "setlocal", "fdm", &curwin->w_p_fdm, FALSE) == FAIL
       || put_setstring(fd, "setlocal", "fde", &curwin->w_p_fde, FALSE)
@@ -6433,12 +6422,7 @@ FILE        *fd;
   return OK;
 }
 
-static int put_setstring(fd, cmd, name, valuep, expand)
-FILE        *fd;
-char        *cmd;
-char        *name;
-char_u      **valuep;
-int expand;
+static int put_setstring(FILE *fd, char *cmd, char *name, char_u **valuep, int expand)
 {
   char_u      *s;
   char_u      *buf;
@@ -6472,11 +6456,7 @@ int expand;
   return OK;
 }
 
-static int put_setnum(fd, cmd, name, valuep)
-FILE        *fd;
-char        *cmd;
-char        *name;
-long        *valuep;
+static int put_setnum(FILE *fd, char *cmd, char *name, long *valuep)
 {
   long wc;
 
@@ -6493,11 +6473,7 @@ long        *valuep;
   return OK;
 }
 
-static int put_setbool(fd, cmd, name, value)
-FILE        *fd;
-char        *cmd;
-char        *name;
-int value;
+static int put_setbool(FILE *fd, char *cmd, char *name, int value)
 {
   if (value < 0)        /* global/local option using global value */
     return OK;
@@ -6512,7 +6488,7 @@ int value;
  * If the option has been allocated, free the memory.
  * Terminal options are never hidden or indirect.
  */
-void clear_termoptions()          {
+void clear_termoptions(void)          {
   /*
    * Reset a few things before clearing the old options. This may cause
    * outputting a few things that the terminal doesn't understand, but the
@@ -6525,7 +6501,7 @@ void clear_termoptions()          {
   free_termoptions();
 }
 
-void free_termoptions()          {
+void free_termoptions(void)          {
   struct vimoption   *p;
 
   for (p = &options[0]; p->fullname != NULL; p++)
@@ -6546,8 +6522,7 @@ void free_termoptions()          {
  * Set the string to empty_option and clear allocated flag.
  * "var" points to the option value.
  */
-void free_one_termoption(var)
-char_u *var;
+void free_one_termoption(char_u *var)
 {
   struct vimoption   *p;
 
@@ -6565,7 +6540,7 @@ char_u *var;
  * Set the terminal option defaults to the current value.
  * Used after setting the terminal name.
  */
-void set_term_defaults()          {
+void set_term_defaults(void)          {
   struct vimoption   *p;
 
   for (p = &options[0]; p->fullname != NULL; p++) {
@@ -6586,8 +6561,7 @@ void set_term_defaults()          {
 /*
  * return TRUE if 'p' starts with 't_'
  */
-static int istermoption(p)
-struct vimoption *p;
+static int istermoption(struct vimoption *p)
 {
   return p->fullname[0] == 't' && p->fullname[1] == '_';
 }
@@ -6601,7 +6575,7 @@ struct vimoption *p;
 
 #define COL_RULER 17        /* columns needed by standard ruler */
 
-void comp_col()          {
+void comp_col(void)          {
   int last_has_status = (p_ls == 2 || (p_ls == 1 && firstwin != lastwin));
 
   sc_col = 0;
@@ -6628,9 +6602,7 @@ void comp_col()          {
 /*
  * Unset local option value, similar to ":set opt<".
  */
-void unset_global_local_option(name, from)
-char_u      *name;
-void        *from;
+void unset_global_local_option(char_u *name, void *from)
 {
   struct vimoption *p;
   int opt_idx;
@@ -6692,9 +6664,7 @@ void        *from;
 /*
  * Get pointer to option variable, depending on local or global scope.
  */
-static char_u * get_varp_scope(p, opt_flags)
-struct vimoption    *p;
-int opt_flags;
+static char_u *get_varp_scope(struct vimoption *p, int opt_flags)
 {
   if ((opt_flags & OPT_GLOBAL) && p->indir != PV_NONE) {
     if (p->var == VAR_WIN)
@@ -6727,8 +6697,7 @@ int opt_flags;
 /*
  * Get pointer to option variable.
  */
-static char_u * get_varp(p)
-struct vimoption    *p;
+static char_u *get_varp(struct vimoption *p)
 {
   /* hidden option, always return NULL */
   if (p->var == NULL)
@@ -6871,7 +6840,7 @@ struct vimoption    *p;
 /*
  * Get the value of 'equalprg', either the buffer-local one or the global one.
  */
-char_u * get_equalprg()              {
+char_u *get_equalprg(void)              {
   if (*curbuf->b_p_ep == NUL)
     return p_ep;
   return curbuf->b_p_ep;
@@ -6881,9 +6850,7 @@ char_u * get_equalprg()              {
  * Copy options from one window to another.
  * Used when splitting a window.
  */
-void win_copy_options(wp_from, wp_to)
-win_T       *wp_from;
-win_T       *wp_to;
+void win_copy_options(win_T *wp_from, win_T *wp_to)
 {
   copy_winopt(&wp_from->w_onebuf_opt, &wp_to->w_onebuf_opt);
   copy_winopt(&wp_from->w_allbuf_opt, &wp_to->w_allbuf_opt);
@@ -6897,9 +6864,7 @@ win_T       *wp_to;
  * The 'scroll' option is not copied, because it depends on the window height.
  * The 'previewwindow' option is reset, there can be only one preview window.
  */
-void copy_winopt(from, to)
-winopt_T    *from;
-winopt_T    *to;
+void copy_winopt(winopt_T *from, winopt_T *to)
 {
   to->wo_arab = from->wo_arab;
   to->wo_list = from->wo_list;
@@ -6945,8 +6910,7 @@ winopt_T    *to;
 /*
  * Check string options in a window for a NULL value.
  */
-void check_win_options(win)
-win_T       *win;
+void check_win_options(win_T *win)
 {
   check_winopt(&win->w_onebuf_opt);
   check_winopt(&win->w_allbuf_opt);
@@ -6955,8 +6919,7 @@ win_T       *win;
 /*
  * Check for NULL pointers in a winopt_T and replace them with empty_option.
  */
-void check_winopt(wop)
-winopt_T    *wop UNUSED;
+void check_winopt(winopt_T *wop)
 {
   check_string_option(&wop->wo_fdi);
   check_string_option(&wop->wo_fdm);
@@ -6973,8 +6936,7 @@ winopt_T    *wop UNUSED;
 /*
  * Free the allocated memory inside a winopt_T.
  */
-void clear_winopt(wop)
-winopt_T    *wop UNUSED;
+void clear_winopt(winopt_T *wop)
 {
   clear_string_option(&wop->wo_fdi);
   clear_string_option(&wop->wo_fdm);
@@ -6997,9 +6959,7 @@ winopt_T    *wop UNUSED;
  *		appropriate.
  * BCO_NOHELP	Don't copy the values to a help buffer.
  */
-void buf_copy_options(buf, flags)
-buf_T       *buf;
-int flags;
+void buf_copy_options(buf_T *buf, int flags)
 {
   int should_copy = TRUE;
   char_u      *save_p_isk = NULL;           /* init for GCC */
@@ -7175,7 +7135,7 @@ int flags;
 /*
  * Reset the 'modifiable' option and its default value.
  */
-void reset_modifiable()          {
+void reset_modifiable(void)          {
   int opt_idx;
 
   curbuf->b_p_ma = FALSE;
@@ -7188,14 +7148,14 @@ void reset_modifiable()          {
 /*
  * Set the global value for 'iminsert' to the local value.
  */
-void set_iminsert_global()          {
+void set_iminsert_global(void)          {
   p_iminsert = curbuf->b_p_iminsert;
 }
 
 /*
  * Set the global value for 'imsearch' to the local value.
  */
-void set_imsearch_global()          {
+void set_imsearch_global(void)          {
   p_imsearch = curbuf->b_p_imsearch;
 }
 
@@ -7203,10 +7163,12 @@ static int expand_option_idx = -1;
 static char_u expand_option_name[5] = {'t', '_', NUL, NUL, NUL};
 static int expand_option_flags = 0;
 
-void set_context_in_set_cmd(xp, arg, opt_flags)
-expand_T    *xp;
-char_u      *arg;
-int opt_flags;                  /* OPT_GLOBAL and/or OPT_LOCAL */
+void 
+set_context_in_set_cmd (
+    expand_T *xp,
+    char_u *arg,
+    int opt_flags                  /* OPT_GLOBAL and/or OPT_LOCAL */
+)
 {
   int nextchar;
   long_u flags = 0;             /* init for GCC */
@@ -7373,11 +7335,7 @@ int opt_flags;                  /* OPT_GLOBAL and/or OPT_LOCAL */
   return;
 }
 
-int ExpandSettings(xp, regmatch, num_file, file)
-expand_T    *xp;
-regmatch_T  *regmatch;
-int         *num_file;
-char_u      ***file;
+int ExpandSettings(expand_T *xp, regmatch_T *regmatch, int *num_file, char_u ***file)
 {
   int num_normal = 0;               /* Nr of matching non-term-code settings */
   int num_term = 0;                 /* Nr of matching terminal code settings */
@@ -7517,9 +7475,7 @@ char_u      ***file;
   return OK;
 }
 
-int ExpandOldSetting(num_file, file)
-int     *num_file;
-char_u  ***file;
+int ExpandOldSetting(int *num_file, char_u ***file)
 {
   char_u  *var = NULL;          /* init for GCC */
   char_u  *buf;
@@ -7576,9 +7532,11 @@ char_u  ***file;
  * Get the value for the numeric or string option *opp in a nice format into
  * NameBuff[].  Must not be called with a hidden option!
  */
-static void option_value2string(opp, opt_flags)
-struct vimoption    *opp;
-int opt_flags;                          /* OPT_GLOBAL and/or OPT_LOCAL */
+static void 
+option_value2string (
+    struct vimoption *opp,
+    int opt_flags                          /* OPT_GLOBAL and/or OPT_LOCAL */
+)
 {
   char_u      *varp;
 
@@ -7615,9 +7573,7 @@ int opt_flags;                          /* OPT_GLOBAL and/or OPT_LOCAL */
  * printed as a keyname.
  * "*wcp" is set to the value of the option if it's 'wildchar' or 'wildcharm'.
  */
-static int wc_use_keyname(varp, wcp)
-char_u      *varp;
-long        *wcp;
+static int wc_use_keyname(char_u *varp, long *wcp)
 {
   if (((long *)varp == &p_wc) || ((long *)varp == &p_wcm)) {
     *wcp = *(long *)varp;
@@ -7655,9 +7611,7 @@ static void langmap_set_entry __ARGS((int from, int to));
  * Search for an entry in "langmap_mapga" for "from".  If found set the "to"
  * field.  If not found insert a new entry at the appropriate location.
  */
-static void langmap_set_entry(from, to)
-int from;
-int to;
+static void langmap_set_entry(int from, int to)
 {
   langmap_entry_T *entries = (langmap_entry_T *)(langmap_mapga.ga_data);
   int a = 0;
@@ -7693,8 +7647,7 @@ int to;
 /*
  * Apply 'langmap' to multi-byte character "c" and return the result.
  */
-int langmap_adjust_mb(c)
-int c;
+int langmap_adjust_mb(int c)
 {
   langmap_entry_T *entries = (langmap_entry_T *)(langmap_mapga.ga_data);
   int a = 0;
@@ -7714,7 +7667,7 @@ int c;
   return c;    /* no entry found, return "c" unmodified */
 }
 
-static void langmap_init()                 {
+static void langmap_init(void)                 {
   int i;
 
   for (i = 0; i < 256; i++)
@@ -7726,7 +7679,7 @@ static void langmap_init()                 {
  * Called when langmap option is set; the language map can be
  * changed at any time!
  */
-static void langmap_set()                 {
+static void langmap_set(void)                 {
   char_u  *p;
   char_u  *p2;
   int from, to;
@@ -7804,8 +7757,7 @@ static void langmap_set()                 {
  * Return TRUE if format option 'x' is in effect.
  * Take care of no formatting when 'paste' is set.
  */
-int has_format_option(x)
-int x;
+int has_format_option(int x)
 {
   if (p_paste)
     return FALSE;
@@ -7816,8 +7768,7 @@ int x;
  * Return TRUE if "x" is present in 'shortmess' option, or
  * 'shortmess' contains 'a' and "x" is present in SHM_A.
  */
-int shortmess(x)
-int x;
+int shortmess(int x)
 {
   return p_shm != NULL &&
          (   vim_strchr(p_shm, x) != NULL
@@ -7828,7 +7779,7 @@ int x;
 /*
  * paste_option_changed() - Called after p_paste was set or reset.
  */
-static void paste_option_changed()                 {
+static void paste_option_changed(void)                 {
   static int old_p_paste = FALSE;
   static int save_sm = 0;
   static int save_ru = 0;
@@ -7924,9 +7875,7 @@ static void paste_option_changed()                 {
  * Don't do this if the 'compatible' option has been set or reset before.
  * When "fname" is not NULL, use it to set $"envname" when it wasn't set yet.
  */
-void vimrc_found(fname, envname)
-char_u      *fname;
-char_u      *envname;
+void vimrc_found(char_u *fname, char_u *envname)
 {
   int opt_idx;
   int dofree = FALSE;
@@ -7957,8 +7906,7 @@ char_u      *envname;
 /*
  * Set 'compatible' on or off.  Called for "-C" and "-N" command line arg.
  */
-void change_compatible(on)
-int on;
+void change_compatible(int on)
 {
   int opt_idx;
 
@@ -7975,8 +7923,7 @@ int on;
  * Return TRUE when option "name" has been set.
  * Only works correctly for global options.
  */
-int option_was_set(name)
-char_u      *name;
+int option_was_set(char_u *name)
 {
   int idx;
 
@@ -7991,8 +7938,7 @@ char_u      *name;
 /*
  * Reset the flag indicating option "name" was set.
  */
-void reset_option_was_set(name)
-char_u      *name;
+void reset_option_was_set(char_u *name)
 {
   int idx = findoption(name);
 
@@ -8008,7 +7954,7 @@ char_u      *name;
  * When 'compatible' is unset: Set all options that have a different default
  * for Vim (without the P_VI_DEF flag) to that default.
  */
-static void compatible_set()                 {
+static void compatible_set(void)                 {
   int opt_idx;
 
   for (opt_idx = 0; !istermoption(&options[opt_idx]); opt_idx++)
@@ -8021,7 +7967,7 @@ static void compatible_set()                 {
 /*
  * fill_breakat_flags() -- called when 'breakat' changes value.
  */
-static void fill_breakat_flags()                 {
+static void fill_breakat_flags(void)                 {
   char_u      *p;
   int i;
 
@@ -8039,10 +7985,12 @@ static void fill_breakat_flags()                 {
  * Return OK for correct value, FAIL otherwise.
  * Empty is always OK.
  */
-static int check_opt_strings(val, values, list)
-char_u      *val;
-char        **values;
-int list;                   /* when TRUE: accept a list of values */
+static int 
+check_opt_strings (
+    char_u *val,
+    char **values,
+    int list                   /* when TRUE: accept a list of values */
+)
 {
   return opt_strings_flags(val, values, NULL, list);
 }
@@ -8054,11 +8002,13 @@ int list;                   /* when TRUE: accept a list of values */
  * Return OK for correct value, FAIL otherwise.
  * Empty is always OK.
  */
-static int opt_strings_flags(val, values, flagp, list)
-char_u      *val;               /* new value */
-char        **values;           /* array of valid string values */
-unsigned    *flagp;
-int list;                       /* when TRUE: accept a list of values */
+static int 
+opt_strings_flags (
+    char_u *val,               /* new value */
+    char **values,           /* array of valid string values */
+    unsigned *flagp,
+    int list                       /* when TRUE: accept a list of values */
+)
 {
   int i;
   int len;
@@ -8087,7 +8037,7 @@ int list;                       /* when TRUE: accept a list of values */
 /*
  * Read the 'wildmode' option, fill wim_flags[].
  */
-static int check_opt_wim()                {
+static int check_opt_wim(void)                {
   char_u new_wim_flags[4];
   char_u      *p;
   int i;
@@ -8134,8 +8084,10 @@ static int check_opt_wim()                {
 /*
  * Check if backspacing over something is allowed.
  */
-int can_bs(what)
-int what;                   /* BS_INDENT, BS_EOL or BS_START */
+int 
+can_bs (
+    int what                   /* BS_INDENT, BS_EOL or BS_START */
+)
 {
   switch (*p_bs) {
   case '2':       return TRUE;
@@ -8149,8 +8101,7 @@ int what;                   /* BS_INDENT, BS_EOL or BS_START */
  * Save the current values of 'fileformat' and 'fileencoding', so that we know
  * the file must be considered changed when the value is different.
  */
-void save_file_ff(buf)
-buf_T       *buf;
+void save_file_ff(buf_T *buf)
 {
   buf->b_start_ffc = *buf->b_p_ff;
   buf->b_start_eol = buf->b_p_eol;
@@ -8172,9 +8123,7 @@ buf_T       *buf;
  * When "ignore_empty" is true don't consider a new, empty buffer to be
  * changed.
  */
-int file_ff_differs(buf, ignore_empty)
-buf_T       *buf;
-int ignore_empty;
+int file_ff_differs(buf_T *buf, int ignore_empty)
 {
   /* In a buffer that was never loaded the options are not valid. */
   if (buf->b_flags & BF_NEVERLOADED)
@@ -8198,8 +8147,7 @@ int ignore_empty;
 /*
  * return OK if "p" is a valid fileformat name, FAIL otherwise.
  */
-int check_ff_value(p)
-char_u      *p;
+int check_ff_value(char_u *p)
 {
   return check_opt_strings(p, p_ff_values, FALSE);
 }
@@ -8208,8 +8156,7 @@ char_u      *p;
  * Return the effective shiftwidth value for current buffer, using the
  * 'tabstop' value when 'shiftwidth' is zero.
  */
-long get_sw_value(buf)
-buf_T *buf;
+long get_sw_value(buf_T *buf)
 {
   return buf->b_p_sw ? buf->b_p_sw : buf->b_p_ts;
 }
@@ -8218,7 +8165,7 @@ buf_T *buf;
  * Return the effective softtabstop value for the current buffer, using the
  * 'tabstop' value when 'softtabstop' is negative.
  */
-long get_sts_value()          {
+long get_sts_value(void)          {
   return curbuf->b_p_sts < 0 ? get_sw_value(curbuf) : curbuf->b_p_sts;
 }
 
@@ -8228,11 +8175,7 @@ long get_sts_value()          {
  * the opposite character.  Set "*backwards" to the direction.
  * When "switchit" is TRUE swap the direction.
  */
-void find_mps_values(initc, findc, backwards, switchit)
-int     *initc;
-int     *findc;
-int     *backwards;
-int switchit;
+void find_mps_values(int *initc, int *findc, int *backwards, int switchit)
 {
   char_u      *ptr;
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -221,8 +221,7 @@ static struct signalinfo {
   {-1,            "Unknown!", FALSE}
 };
 
-int mch_chdir(path)
-char *path;
+int mch_chdir(char *path)
 {
   if (p_verbose >= 5) {
     verbose_enter();
@@ -235,9 +234,7 @@ char *path;
 /*
  * Write s[len] to the screen.
  */
-void mch_write(s, len)
-char_u      *s;
-int len;
+void mch_write(char_u *s, int len)
 {
   ignored = (int)write(1, (char *)s, len);
   if (p_wd)             /* Unix is too fast, slow down a bit more */
@@ -252,74 +249,75 @@ int len;
  * If wtime == n wait a short time for characters.
  * If wtime == -1 wait forever for characters.
  */
-int mch_inchar(buf, maxlen, wtime, tb_change_cnt)
-char_u      *buf;
-int maxlen;
-long wtime;                 /* don't use "time", MIPS cannot handle it */
-int tb_change_cnt;
+int mch_inchar(
+        char_u      *buf,
+        int maxlen,
+        long wtime,                 /* don't use "time", MIPS cannot handle it */
+        int tb_change_cnt
+        )
 {
-  int len;
+    int len;
 
 
-  /* Check if window changed size while we were busy, perhaps the ":set
-   * columns=99" command was used. */
-  while (do_resize)
-    handle_resize();
-
-  if (wtime >= 0) {
-    while (WaitForChar(wtime) == 0) {           /* no character available */
-      if (!do_resize)           /* return if not interrupted by resize */
-        return 0;
-      handle_resize();
-    }
-  } else   {    /* wtime == -1 */
-    /*
-     * If there is no character available within 'updatetime' seconds
-     * flush all the swap files to disk.
-     * Also done when interrupted by SIGWINCH.
-     */
-    if (WaitForChar(p_ut) == 0) {
-      if (trigger_cursorhold() && maxlen >= 3
-          && !typebuf_changed(tb_change_cnt)) {
-        buf[0] = K_SPECIAL;
-        buf[1] = KS_EXTRA;
-        buf[2] = (int)KE_CURSORHOLD;
-        return 3;
-      }
-      before_blocking();
-    }
-  }
-
-  for (;; ) {   /* repeat until we got a character */
-    while (do_resize)        /* window changed size */
-      handle_resize();
-
-    /*
-     * We want to be interrupted by the winch signal
-     * or by an event on the monitored file descriptors.
-     */
-    if (WaitForChar(-1L) == 0) {
-      if (do_resize)                /* interrupted by SIGWINCH signal */
+    /* Check if window changed size while we were busy, perhaps the ":set
+     * columns=99" command was used. */
+    while (do_resize)
         handle_resize();
-      return 0;
+
+    if (wtime >= 0) {
+        while (WaitForChar(wtime) == 0) {           /* no character available */
+            if (!do_resize)           /* return if not interrupted by resize */
+                return 0;
+            handle_resize();
+        }
+    } else   {    /* wtime == -1 */
+        /*
+         * If there is no character available within 'updatetime' seconds
+         * flush all the swap files to disk.
+         * Also done when interrupted by SIGWINCH.
+         */
+        if (WaitForChar(p_ut) == 0) {
+            if (trigger_cursorhold() && maxlen >= 3
+                    && !typebuf_changed(tb_change_cnt)) {
+                buf[0] = K_SPECIAL;
+                buf[1] = KS_EXTRA;
+                buf[2] = (int)KE_CURSORHOLD;
+                return 3;
+            }
+            before_blocking();
+        }
     }
 
-    /* If input was put directly in typeahead buffer bail out here. */
-    if (typebuf_changed(tb_change_cnt))
-      return 0;
+    for (;; ) {   /* repeat until we got a character */
+        while (do_resize)        /* window changed size */
+            handle_resize();
 
-    /*
-     * For some terminals we only get one character at a time.
-     * We want the get all available characters, so we could keep on
-     * trying until none is available
-     * For some other terminals this is quite slow, that's why we don't do
-     * it.
-     */
-    len = read_from_input_buf(buf, (long)maxlen);
-    if (len > 0) {
-      return len;
+        /*
+         * We want to be interrupted by the winch signal
+         * or by an event on the monitored file descriptors.
+         */
+        if (WaitForChar(-1L) == 0) {
+            if (do_resize)                /* interrupted by SIGWINCH signal */
+                handle_resize();
+            return 0;
+        }
+
+        /* If input was put directly in typeahead buffer bail out here. */
+        if (typebuf_changed(tb_change_cnt))
+            return 0;
+
+        /*
+         * For some terminals we only get one character at a time.
+         * We want the get all available characters, so we could keep on
+         * trying until none is available
+         * For some other terminals this is quite slow, that's why we don't do
+         * it.
+         */
+        len = read_from_input_buf(buf, (long)maxlen);
+        if (len > 0) {
+            return len;
+        }
     }
-  }
 }
 
 static void handle_resize()                 {
@@ -349,8 +347,7 @@ int mch_char_avail()         {
  * Return total amount of memory available in Kbyte.
  * Doesn't change when memory has been allocated.
  */
-long_u mch_total_mem(special)
-int special UNUSED;
+long_u mch_total_mem(int special)
 {
   long_u mem = 0;
   long_u shiftright = 10;         /* how much to shift "mem" right for Kbyte */
@@ -430,9 +427,7 @@ int special UNUSED;
 }
 #endif
 
-void mch_delay(msec, ignoreinput)
-long msec;
-int ignoreinput;
+void mch_delay(long msec, int ignoreinput)
 {
   int old_tmode;
 
@@ -508,8 +503,7 @@ static int stack_grows_downwards;
  * Find out if the stack grows upwards or downwards.
  * "p" points to a variable on the stack of the caller.
  */
-static void check_stack_growth(p)
-char        *p;
+static void check_stack_growth(char *p)
 {
   int i;
 
@@ -577,8 +571,7 @@ static void get_stack_limit()                 {
  * Return FAIL when running out of stack space.
  * "p" must point to any variable local to the caller that's on the stack.
  */
-int mch_stackcheck(p)
-char        *p;
+int mch_stackcheck(char *p)
 {
   if (stack_limit != NULL) {
     if (stack_grows_downwards) {
@@ -1005,9 +998,10 @@ void reset_signals()          {
 #endif
 }
 
-static void catch_signals(func_deadly, func_other)
-RETSIGTYPE (*func_deadly)();
-RETSIGTYPE (*func_other)();
+static void catch_signals(
+        RETSIGTYPE (*func_deadly)(),
+        RETSIGTYPE (*func_other)()
+        )
 {
   int i;
 
@@ -1056,8 +1050,7 @@ RETSIGTYPE (*func_other)();
  *			     signal
  * Returns TRUE when Vim should exit.
  */
-int vim_handle_signal(sig)
-int sig;
+int vim_handle_signal(int sig)
 {
   static int got_signal = 0;
   static int blocked = TRUE;
@@ -1088,9 +1081,7 @@ int sig;
 /*
  * Check_win checks whether we have an interactive stdout.
  */
-int mch_check_win(argc, argv)
-int argc UNUSED;
-char    **argv UNUSED;
+int mch_check_win(int argc, char **argv)
 {
   if (isatty(1))
     return OK;
@@ -1106,14 +1097,12 @@ int mch_input_isatty()         {
   return FALSE;
 }
 
-static int get_x11_title(test_only)
-int test_only UNUSED;
+static int get_x11_title(int test_only)
 {
   return FALSE;
 }
 
-static int get_x11_icon(test_only)
-int test_only;
+static int get_x11_icon(int test_only)
 {
   if (!test_only) {
     if (STRNCMP(T_NAME, "builtin_", 8) == 0)
@@ -1136,9 +1125,7 @@ int mch_can_restore_icon()         {
 /*
  * Set the window title and icon.
  */
-void mch_settitle(title, icon)
-char_u *title;
-char_u *icon;
+void mch_settitle(char_u *title, char_u *icon)
 {
   int type = 0;
   static int recursive = 0;
@@ -1195,8 +1182,7 @@ char_u *icon;
  *  2  only restore icon
  *  3  restore title and icon
  */
-void mch_restore_title(which)
-int which;
+void mch_restore_title(int which)
 {
   /* only restore the title or icon when it has been set */
   mch_settitle(((which & 1) && did_set_title) ?
@@ -1209,8 +1195,7 @@ int which;
  * Return TRUE if "name" looks like some xterm name.
  * Seiichi Sato mentioned that "mlterm" works like xterm.
  */
-int vim_is_xterm(name)
-char_u *name;
+int vim_is_xterm(char_u *name)
 {
   if (name == NULL)
     return FALSE;
@@ -1227,8 +1212,7 @@ char_u *name;
  * known to support the xterm-style mouse protocol.
  * Relies on term_is_xterm having been set to its correct value.
  */
-int use_xterm_like_mouse(name)
-char_u *name;
+int use_xterm_like_mouse(char_u *name)
 {
   return name != NULL
          && (term_is_xterm || STRNICMP(name, "screen", 6) == 0);
@@ -1253,8 +1237,7 @@ int use_xterm_mouse()         {
   return 0;
 }
 
-int vim_is_iris(name)
-char_u  *name;
+int vim_is_iris(char_u *name)
 {
   if (name == NULL)
     return FALSE;
@@ -1262,8 +1245,7 @@ char_u  *name;
          || STRCMP(name, "builtin_iris-ansi") == 0;
 }
 
-int vim_is_vt300(name)
-char_u  *name;
+int vim_is_vt300(char_u *name)
 {
   if (name == NULL)
     return FALSE;              /* actually all ANSI comp. terminals should be here  */
@@ -1277,8 +1259,7 @@ char_u  *name;
  * Return TRUE if "name" is a terminal for which 'ttyfast' should be set.
  * This should include all windowed terminal emulators.
  */
-int vim_is_fastterm(name)
-char_u  *name;
+int vim_is_fastterm(char_u *name)
 {
   if (name == NULL)
     return FALSE;
@@ -1294,9 +1275,7 @@ char_u  *name;
  * Insert user name in s[len].
  * Return OK if a name found.
  */
-int mch_get_user_name(s, len)
-char_u  *s;
-int len;
+int mch_get_user_name(char_u *s, int len)
 {
   return mch_get_uname(getuid(), s, len);
 }
@@ -1305,10 +1284,7 @@ int len;
  * Insert user name for "uid" in s[len].
  * Return OK if a name found.
  */
-int mch_get_uname(uid, s, len)
-uid_t uid;
-char_u      *s;
-int len;
+int mch_get_uname(uid_t uid, char_u *s, int len)
 {
 #if defined(HAVE_PWD_H) && defined(HAVE_GETPWUID)
   struct passwd   *pw;
@@ -1328,9 +1304,7 @@ int len;
  */
 
 #ifdef HAVE_SYS_UTSNAME_H
-void mch_get_host_name(s, len)
-char_u  *s;
-int len;
+void mch_get_host_name(char_u *s, int len)
 {
   struct utsname vutsname;
 
@@ -1345,9 +1319,7 @@ int len;
 #  define gethostname(nam, len) sysinfo(SI_HOSTNAME, nam, len)
 # endif
 
-void mch_get_host_name(s, len)
-char_u  *s;
-int len;
+void mch_get_host_name(char_u *s, int len)
 {
   gethostname((char *)s, len);
   s[len - 1] = NUL;     /* make sure it's terminated */
@@ -1364,8 +1336,7 @@ long mch_get_pid()          {
 #if !defined(HAVE_STRERROR) && defined(USE_GETCWD)
 static char *strerror __ARGS((int));
 
-static char * strerror(err)
-int err;
+static char * strerror(int err)
 {
   extern int sys_nerr;
   extern char     *sys_errlist[];
@@ -1382,9 +1353,7 @@ int err;
  * Get name of current directory into buffer 'buf' of length 'len' bytes.
  * Return OK for success, FAIL for failure.
  */
-int mch_dirname(buf, len)
-char_u  *buf;
-int len;
+int mch_dirname(char_u *buf, int len)
 {
 #if defined(USE_GETCWD)
   if (getcwd((char *)buf, len) == NULL) {
@@ -1403,10 +1372,12 @@ int len;
  *
  * return FAIL for failure, OK for success
  */
-int mch_FullName(fname, buf, len, force)
-char_u      *fname, *buf;
-int len;
-int force;                      /* also expand when already absolute path */
+int mch_FullName(
+        char_u      *fname,
+        char_u      *buf,
+        int len,
+        int force                       /* also expand when already absolute path */
+        )
 {
   int l;
 #ifdef HAVE_FCHDIR
@@ -1512,8 +1483,7 @@ int force;                      /* also expand when already absolute path */
 /*
  * Return TRUE if "fname" does not depend on the current directory.
  */
-int mch_isFullName(fname)
-char_u      *fname;
+int mch_isFullName(char_u *fname)
 {
   return *fname == '/' || *fname == '~';
 }
@@ -1524,9 +1494,10 @@ char_u      *fname;
  * file name to remain exactly the same.
  * Only required for file systems where case is ignored and preserved.
  */
-void fname_case(name, len)
-char_u      *name;
-int len UNUSED;              /* buffer size, only used when name gets longer */
+void fname_case(
+char_u      *name,
+int len;              /* buffer size, only used when name gets longer */
+)
 {
   struct stat st;
   char_u      *slash, *tail;
@@ -1578,8 +1549,7 @@ int len UNUSED;              /* buffer size, only used when name gets longer */
  * Get file permissions for 'name'.
  * Returns -1 when it doesn't exist.
  */
-long mch_getperm(name)
-char_u *name;
+long mch_getperm(char_u *name)
 {
   struct stat statb;
 
@@ -1600,9 +1570,7 @@ char_u *name;
  *
  * return FAIL for failure, OK otherwise
  */
-int mch_setperm(name, perm)
-char_u  *name;
-long perm;
+int mch_setperm(char_u *name, long perm)
 {
   return chmod((char *)
       name,
@@ -1622,9 +1590,7 @@ long perm;
 /*
  * Copy security info from "from_file" to "to_file".
  */
-void mch_copy_sec(from_file, to_file)
-char_u      *from_file;
-char_u      *to_file;
+void mch_copy_sec(char_u *from_file, char_u *to_file)
 {
   if (from_file == NULL)
     return;
@@ -1672,8 +1638,7 @@ char_u      *to_file;
  * Return a pointer to the ACL of file "fname" in allocated memory.
  * Return NULL if the ACL is not available for whatever reason.
  */
-vim_acl_T mch_get_acl(fname)
-char_u      *fname UNUSED;
+vim_acl_T mch_get_acl(char_u *fname)
 {
   vim_acl_T ret = NULL;
   return ret;
@@ -1682,16 +1647,13 @@ char_u      *fname UNUSED;
 /*
  * Set the ACL of file "fname" to "acl" (unless it's NULL).
  */
-void mch_set_acl(fname, aclent)
-char_u      *fname UNUSED;
-vim_acl_T aclent;
+void mch_set_acl(char_u *fname, vim_acl_T aclent)
 {
   if (aclent == NULL)
     return;
 }
 
-void mch_free_acl(aclent)
-vim_acl_T aclent;
+void mch_free_acl(vim_acl_T aclent)
 {
   if (aclent == NULL)
     return;
@@ -1701,8 +1663,7 @@ vim_acl_T aclent;
 /*
  * Set hidden flag for "name".
  */
-void mch_hide(name)
-char_u      *name UNUSED;
+void mch_hide(char_u *name)
 {
   /* can't hide a file */
 }
@@ -1712,8 +1673,7 @@ char_u      *name UNUSED;
  * return FALSE if "name" is not a directory
  * return FALSE for error
  */
-int mch_isdir(name)
-char_u *name;
+int mch_isdir(char_u *name)
 {
   struct stat statb;
 
@@ -1733,8 +1693,7 @@ static int executable_file __ARGS((char_u *name));
 /*
  * Return 1 if "name" is an executable file, 0 if not or it doesn't exist.
  */
-static int executable_file(name)
-char_u      *name;
+static int executable_file(char_u *name)
 {
   struct stat st;
 
@@ -1747,8 +1706,7 @@ char_u      *name;
  * Return 1 if "name" can be found in $PATH and executed, 0 if not.
  * Return -1 if unknown.
  */
-int mch_can_exe(name)
-char_u      *name;
+int mch_can_exe(char_u *name)
 {
   char_u      *buf;
   char_u      *p, *e;
@@ -1801,8 +1759,7 @@ char_u      *name;
  * NODE_WRITABLE: writable device, socket, fifo, etc.
  * NODE_OTHER: non-writable things
  */
-int mch_nodetype(name)
-char_u      *name;
+int mch_nodetype(char_u *name)
 {
   struct stat st;
 
@@ -1876,8 +1833,7 @@ static void exit_scroll()                 {
   }
 }
 
-void mch_exit(r)
-int r;
+void mch_exit(int r)
 {
   exiting = TRUE;
 
@@ -1934,8 +1890,7 @@ static void may_core_dump()                 {
   }
 }
 
-void mch_settmode(tmode)
-int tmode;
+void mch_settmode(int tmode)
 {
   static int first = TRUE;
 
@@ -2196,7 +2151,7 @@ void check_mouse_termcode()          {
  * set screen mode, always fails.
  */
 int mch_screenmode(arg)
-char_u   *arg UNUSED;
+char_u   *arg;
 {
   EMSG(_(e_screenmode));
   return FAIL;
@@ -3153,7 +3108,7 @@ long msec;
 static int RealWaitForChar(fd, msec, check_for_gpm)
 int fd;
 long msec;
-int         *check_for_gpm UNUSED;
+int         *check_for_gpm;
 {
   int ret;
 

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -81,7 +81,7 @@
 #  define SIGDUMMYARG   0, 0, (struct sigcontext *)0
 # else
 #  define SIGPROTOARG   (int)
-#  define SIGDEFARG(s)  (s) int s UNUSED;
+#  define SIGDEFARG(s)  (s) int s;
 #  define SIGDUMMYARG   0
 # endif
 #else

--- a/src/po/sjiscorr.c
+++ b/src/po/sjiscorr.c
@@ -1,15 +1,4 @@
-/*
- * Simplistic program to correct SJIS inside strings.  When a trail byte is a
- * backslash it needs to be doubled.
- * Public domain.
- */
-#include <stdio.h>
-#include <string.h>
-
-	int
-main(argc, argv)
-	int	argc;
-	char	**argv;
+__END_DECLS int main(int argc, char **argv)
 {
 	char buffer[BUFSIZ];
 	char *p;

--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -40,11 +40,13 @@ static int pum_set_selected __ARGS((int n, int repeat));
  * When possible the leftmost character is aligned with screen column "col".
  * The menu appears above the screen line "row" or at "row" + "height" - 1.
  */
-void pum_display(array, size, selected)
-pumitem_T   *array;
-int size;
-int selected;                   /* index of initially selected item, none if
+void 
+pum_display (
+    pumitem_T *array,
+    int size,
+    int selected                   /* index of initially selected item, none if
                                    out of range */
+)
 {
   int w;
   int def_width;
@@ -231,7 +233,7 @@ redo:
 /*
  * Redraw the popup menu, using "pum_first" and "pum_selected".
  */
-void pum_redraw()          {
+void pum_redraw(void)          {
   int row = pum_row;
   int col;
   int attr_norm = highlight_attr[HLF_PNI];
@@ -415,9 +417,7 @@ void pum_redraw()          {
  * Returns TRUE when the window was resized and the location of the popup menu
  * must be recomputed.
  */
-static int pum_set_selected(n, repeat)
-int n;
-int repeat;
+static int pum_set_selected(int n, int repeat)
 {
   int resized = FALSE;
   int context = pum_height / 2;
@@ -584,7 +584,7 @@ int repeat;
 /*
  * Undisplay the popup menu (later).
  */
-void pum_undisplay()          {
+void pum_undisplay(void)          {
   pum_array = NULL;
   redraw_all_later(SOME_VALID);
   redraw_tabline = TRUE;
@@ -595,7 +595,7 @@ void pum_undisplay()          {
  * Clear the popup menu.  Currently only resets the offset to the first
  * displayed item.
  */
-void pum_clear()          {
+void pum_clear(void)          {
   pum_first = 0;
 }
 
@@ -603,7 +603,7 @@ void pum_clear()          {
  * Return TRUE if the popup menu is displayed.
  * Overruled when "pum_do_redraw" is set, used to redraw the status lines.
  */
-int pum_visible()         {
+int pum_visible(void)         {
   return !pum_do_redraw && pum_array != NULL;
 }
 
@@ -611,7 +611,7 @@ int pum_visible()         {
  * Return the height of the popup menu, the number of entries visible.
  * Only valid when pum_visible() returns TRUE!
  */
-int pum_get_height()         {
+int pum_get_height(void)         {
   return pum_height;
 }
 

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -152,12 +152,14 @@ static qf_info_T *ll_get_or_alloc_list __ARGS((win_T *));
  * list. Set the error list's title to qf_title.
  * Return -1 for error, number of errors for success.
  */
-int qf_init(wp, efile, errorformat, newlist, qf_title)
-win_T           *wp;
-char_u          *efile;
-char_u          *errorformat;
-int newlist;                            /* TRUE: start a new error list */
-char_u          *qf_title;
+int 
+qf_init (
+    win_T *wp,
+    char_u *efile,
+    char_u *errorformat,
+    int newlist,                            /* TRUE: start a new error list */
+    char_u *qf_title
+)
 {
   qf_info_T       *qi = &ql_info;
 
@@ -184,18 +186,18 @@ char_u          *qf_title;
  * Set the title of the list to "qf_title".
  * Return -1 for error, number of errors for success.
  */
-static int qf_init_ext(qi, efile, buf, tv, errorformat, newlist, lnumfirst,
-    lnumlast,
-    qf_title)
-qf_info_T       *qi;
-char_u          *efile;
-buf_T           *buf;
-typval_T        *tv;
-char_u          *errorformat;
-int newlist;                            /* TRUE: start a new error list */
-linenr_T lnumfirst;                     /* first line number to use */
-linenr_T lnumlast;                      /* last line number to use */
-char_u          *qf_title;
+static int 
+qf_init_ext (
+    qf_info_T *qi,
+    char_u *efile,
+    buf_T *buf,
+    typval_T *tv,
+    char_u *errorformat,
+    int newlist,                            /* TRUE: start a new error list */
+    linenr_T lnumfirst,                     /* first line number to use */
+    linenr_T lnumlast,                      /* last line number to use */
+    char_u *qf_title
+)
 {
   char_u          *namebuf;
   char_u          *errmsg;
@@ -803,9 +805,7 @@ qf_init_end:
 /*
  * Prepare for adding a new quickfix list.
  */
-static void qf_new_list(qi, qf_title)
-qf_info_T   *qi;
-char_u      *qf_title;
+static void qf_new_list(qf_info_T *qi, char_u *qf_title)
 {
   int i;
 
@@ -841,8 +841,7 @@ char_u      *qf_title;
 /*
  * Free a location list
  */
-static void ll_free_all(pqi)
-qf_info_T   **pqi;
+static void ll_free_all(qf_info_T **pqi)
 {
   int i;
   qf_info_T   *qi;
@@ -861,8 +860,7 @@ qf_info_T   **pqi;
   }
 }
 
-void qf_free_all(wp)
-win_T       *wp;
+void qf_free_all(win_T *wp)
 {
   int i;
   qf_info_T   *qi = &ql_info;
@@ -881,23 +879,22 @@ win_T       *wp;
  * Add an entry to the end of the list of errors.
  * Returns OK or FAIL.
  */
-static int qf_add_entry(qi, prevp, dir, fname, bufnum, mesg, lnum, col, vis_col,
-    pattern,
-    nr, type,
-    valid)
-qf_info_T   *qi;                /* quickfix list */
-qfline_T    **prevp;            /* pointer to previously added entry or NULL */
-char_u      *dir;               /* optional directory name */
-char_u      *fname;             /* file name or NULL */
-int bufnum;                     /* buffer number or zero */
-char_u      *mesg;              /* message */
-long lnum;                      /* line number */
-int col;                        /* column */
-int vis_col;                    /* using visual column */
-char_u      *pattern;           /* search pattern */
-int nr;                         /* error number */
-int type;                       /* type character */
-int valid;                      /* valid entry */
+static int 
+qf_add_entry (
+    qf_info_T *qi,                /* quickfix list */
+    qfline_T **prevp,            /* pointer to previously added entry or NULL */
+    char_u *dir,               /* optional directory name */
+    char_u *fname,             /* file name or NULL */
+    int bufnum,                     /* buffer number or zero */
+    char_u *mesg,              /* message */
+    long lnum,                      /* line number */
+    int col,                        /* column */
+    int vis_col,                    /* using visual column */
+    char_u *pattern,           /* search pattern */
+    int nr,                         /* error number */
+    int type,                       /* type character */
+    int valid                      /* valid entry */
+)
 {
   qfline_T    *qfp;
 
@@ -952,7 +949,7 @@ int valid;                      /* valid entry */
 /*
  * Allocate a new location list
  */
-static qf_info_T * ll_new_list()                        {
+static qf_info_T *ll_new_list(void)                        {
   qf_info_T *qi;
 
   qi = (qf_info_T *)alloc((unsigned)sizeof(qf_info_T));
@@ -968,8 +965,7 @@ static qf_info_T * ll_new_list()                        {
  * Return the location list for window 'wp'.
  * If not present, allocate a location list
  */
-static qf_info_T * ll_get_or_alloc_list(wp)
-win_T   *wp;
+static qf_info_T *ll_get_or_alloc_list(win_T *wp)
 {
   if (IS_LL_WINDOW(wp))
     /* For a location list window, use the referenced location list */
@@ -989,9 +985,7 @@ win_T   *wp;
 /*
  * Copy the location list from window "from" to window "to".
  */
-void copy_loclist(from, to)
-win_T       *from;
-win_T       *to;
+void copy_loclist(win_T *from, win_T *to)
 {
   qf_info_T   *qi;
   int idx;
@@ -1087,9 +1081,7 @@ win_T       *to;
 /*
  * get buffer number for file "dir.name"
  */
-static int qf_get_fnum(directory, fname)
-char_u   *directory;
-char_u   *fname;
+static int qf_get_fnum(char_u *directory, char_u *fname)
 {
   if (fname == NULL || *fname == NUL)           /* no file name */
     return 0;
@@ -1131,9 +1123,7 @@ char_u   *fname;
  * push dirbuf onto the directory stack and return pointer to actual dir or
  * NULL on error
  */
-static char_u * qf_push_dir(dirbuf, stackptr)
-char_u              *dirbuf;
-struct dir_stack_T  **stackptr;
+static char_u *qf_push_dir(char_u *dirbuf, struct dir_stack_T **stackptr)
 {
   struct dir_stack_T  *ds_new;
   struct dir_stack_T  *ds_ptr;
@@ -1198,8 +1188,7 @@ struct dir_stack_T  **stackptr;
  * pop dirbuf from the directory stack and return previous directory or NULL if
  * stack is empty
  */
-static char_u * qf_pop_dir(stackptr)
-struct dir_stack_T  **stackptr;
+static char_u *qf_pop_dir(struct dir_stack_T **stackptr)
 {
   struct dir_stack_T  *ds_ptr;
 
@@ -1221,8 +1210,7 @@ struct dir_stack_T  **stackptr;
 /*
  * clean up directory stack
  */
-static void qf_clean_dir_stack(stackptr)
-struct dir_stack_T  **stackptr;
+static void qf_clean_dir_stack(struct dir_stack_T **stackptr)
 {
   struct dir_stack_T  *ds_ptr;
 
@@ -1253,8 +1241,7 @@ struct dir_stack_T  **stackptr;
  * Then qf_push_dir thinks we are in ./aa/bb, but we are in ./bb.
  * qf_guess_filepath will return NULL.
  */
-static char_u * qf_guess_filepath(filename)
-char_u *filename;
+static char_u *qf_guess_filepath(char_u *filename)
 {
   struct dir_stack_T     *ds_ptr;
   struct dir_stack_T     *ds_tmp;
@@ -1302,11 +1289,7 @@ char_u *filename;
  * else if "errornr" is zero, redisplay the same line
  * else go to entry "errornr"
  */
-void qf_jump(qi, dir, errornr, forceit)
-qf_info_T   *qi;
-int dir;
-int errornr;
-int forceit;
+void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
 {
   qf_info_T           *ll_ref;
   qfline_T            *qf_ptr;
@@ -1734,8 +1717,7 @@ theend:
  * ":clist": list all errors
  * ":llist": list all locations
  */
-void qf_list(eap)
-exarg_T     *eap;
+void qf_list(exarg_T *eap)
 {
   buf_T       *buf;
   char_u      *fname;
@@ -1831,10 +1813,7 @@ exarg_T     *eap;
  * Remove newlines and leading whitespace from an error message.
  * Put the result in "buf[bufsize]".
  */
-static void qf_fmt_text(text, buf, bufsize)
-char_u      *text;
-char_u      *buf;
-int bufsize;
+static void qf_fmt_text(char_u *text, char_u *buf, int bufsize)
 {
   int i;
   char_u      *p = text;
@@ -1857,8 +1836,7 @@ int bufsize;
  * ":lolder [count]": Up in the location list stack.
  * ":lnewer [count]": Down in the location list stack.
  */
-void qf_age(eap)
-exarg_T     *eap;
+void qf_age(exarg_T *eap)
 {
   qf_info_T   *qi = &ql_info;
   int count;
@@ -1893,8 +1871,7 @@ exarg_T     *eap;
   qf_msg(qi);
 }
 
-static void qf_msg(qi)
-qf_info_T   *qi;
+static void qf_msg(qf_info_T *qi)
 {
   smsg((char_u *)_("error list %d of %d; %d errors"),
       qi->qf_curlist + 1, qi->qf_listcount,
@@ -1905,9 +1882,7 @@ qf_info_T   *qi;
 /*
  * Free error list "idx".
  */
-static void qf_free(qi, idx)
-qf_info_T   *qi;
-int idx;
+static void qf_free(qf_info_T *qi, int idx)
 {
   qfline_T    *qfp;
   int stop = FALSE;
@@ -1935,12 +1910,7 @@ int idx;
 /*
  * qf_mark_adjust: adjust marks
  */
-void qf_mark_adjust(wp, line1, line2, amount, amount_after)
-win_T       *wp;
-linenr_T line1;
-linenr_T line2;
-long amount;
-long amount_after;
+void qf_mark_adjust(win_T *wp, linenr_T line1, linenr_T line2, long amount, long amount_after)
 {
   int i;
   qfline_T    *qfp;
@@ -1983,8 +1953,7 @@ long amount_after;
  *  other     n		" c n"
  *  1	      x		""	:helpgrep
  */
-static char_u * qf_types(c, nr)
-int c, nr;
+static char_u *qf_types(int c, int nr)
 {
   static char_u buf[20];
   static char_u cc[3];
@@ -2018,8 +1987,7 @@ int c, nr;
  * ":lwindow": open the location list window if we have locations to display,
  *	       close it if not.
  */
-void ex_cwindow(eap)
-exarg_T     *eap;
+void ex_cwindow(exarg_T *eap)
 {
   qf_info_T   *qi = &ql_info;
   win_T       *win;
@@ -2051,8 +2019,7 @@ exarg_T     *eap;
  * ":cclose": close the window showing the list of errors.
  * ":lclose": close the window showing the location list
  */
-void ex_cclose(eap)
-exarg_T     *eap;
+void ex_cclose(exarg_T *eap)
 {
   win_T       *win = NULL;
   qf_info_T   *qi = &ql_info;
@@ -2073,8 +2040,7 @@ exarg_T     *eap;
  * ":copen": open a window that shows the list of errors.
  * ":lopen": open a window that shows the location list.
  */
-void ex_copen(eap)
-exarg_T     *eap;
+void ex_copen(exarg_T *eap)
 {
   qf_info_T   *qi = &ql_info;
   int height;
@@ -2178,8 +2144,7 @@ exarg_T     *eap;
  * Return the number of the current entry (line number in the quickfix
  * window).
  */
-linenr_T qf_current_entry(wp)
-win_T       *wp;
+linenr_T qf_current_entry(win_T *wp)
 {
   qf_info_T   *qi = &ql_info;
 
@@ -2194,9 +2159,11 @@ win_T       *wp;
  * Update the cursor position in the quickfix window to the current error.
  * Return TRUE if there is a quickfix window.
  */
-static int qf_win_pos_update(qi, old_qf_index)
-qf_info_T   *qi;
-int old_qf_index;               /* previous qf_index or zero */
+static int 
+qf_win_pos_update (
+    qf_info_T *qi,
+    int old_qf_index               /* previous qf_index or zero */
+)
 {
   win_T       *win;
   int qf_index = qi->qf_lists[qi->qf_curlist].qf_index;
@@ -2235,9 +2202,7 @@ int old_qf_index;               /* previous qf_index or zero */
  * Check whether the given window is displaying the specified quickfix/location
  * list buffer
  */
-static int is_qf_win(win, qi)
-win_T       *win;
-qf_info_T   *qi;
+static int is_qf_win(win_T *win, qf_info_T *qi)
 {
   /*
    * A window displaying the quickfix buffer will have the w_llist_ref field
@@ -2257,8 +2222,7 @@ qf_info_T   *qi;
  * Find a window displaying the quickfix/location list 'qi'
  * Searches in only the windows opened in the current tab.
  */
-static win_T * qf_find_win(qi)
-qf_info_T   *qi;
+static win_T *qf_find_win(qf_info_T *qi)
 {
   win_T       *win;
 
@@ -2273,8 +2237,7 @@ qf_info_T   *qi;
  * Find a quickfix buffer.
  * Searches in windows opened in all the tabs.
  */
-static buf_T * qf_find_buf(qi)
-qf_info_T   *qi;
+static buf_T *qf_find_buf(qf_info_T *qi)
 {
   tabpage_T   *tp;
   win_T       *win;
@@ -2289,8 +2252,7 @@ qf_info_T   *qi;
 /*
  * Find the quickfix buffer.  If it exists, update the contents.
  */
-static void qf_update_buffer(qi)
-qf_info_T   *qi;
+static void qf_update_buffer(qf_info_T *qi)
 {
   buf_T       *buf;
   win_T       *win;
@@ -2321,8 +2283,7 @@ qf_info_T   *qi;
   }
 }
 
-static void qf_set_title(qi)
-qf_info_T   *qi;
+static void qf_set_title(qf_info_T *qi)
 {
   set_internal_string_var((char_u *)"w:quickfix_title",
       qi->qf_lists[qi->qf_curlist].qf_title);
@@ -2332,8 +2293,7 @@ qf_info_T   *qi;
  * Fill current buffer with quickfix errors, replacing any previous contents.
  * curbuf must be the quickfix buffer!
  */
-static void qf_fill_buffer(qi)
-qf_info_T   *qi;
+static void qf_fill_buffer(qf_info_T *qi)
 {
   linenr_T lnum;
   qfline_T    *qfp;
@@ -2423,8 +2383,7 @@ qf_info_T   *qi;
 /*
  * Return TRUE if "buf" is the quickfix buffer.
  */
-int bt_quickfix(buf)
-buf_T       *buf;
+int bt_quickfix(buf_T *buf)
 {
   return buf != NULL && buf->b_p_bt[0] == 'q';
 }
@@ -2433,8 +2392,7 @@ buf_T       *buf;
  * Return TRUE if "buf" is a "nofile" or "acwrite" buffer.
  * This means the buffer name is not a file name.
  */
-int bt_nofile(buf)
-buf_T       *buf;
+int bt_nofile(buf_T *buf)
 {
   return buf != NULL && ((buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f')
                          || buf->b_p_bt[0] == 'a');
@@ -2443,14 +2401,12 @@ buf_T       *buf;
 /*
  * Return TRUE if "buf" is a "nowrite" or "nofile" buffer.
  */
-int bt_dontwrite(buf)
-buf_T       *buf;
+int bt_dontwrite(buf_T *buf)
 {
   return buf != NULL && buf->b_p_bt[0] == 'n';
 }
 
-int bt_dontwrite_msg(buf)
-buf_T       *buf;
+int bt_dontwrite_msg(buf_T *buf)
 {
   if (bt_dontwrite(buf)) {
     EMSG(_("E382: Cannot write, 'buftype' option is set"));
@@ -2463,8 +2419,7 @@ buf_T       *buf;
  * Return TRUE if the buffer should be hidden, according to 'hidden', ":hide"
  * and 'bufhidden'.
  */
-int buf_hide(buf)
-buf_T       *buf;
+int buf_hide(buf_T *buf)
 {
   /* 'bufhidden' overrules 'hidden' and ":hide", check it first */
   switch (buf->b_p_bh[0]) {
@@ -2479,8 +2434,7 @@ buf_T       *buf;
 /*
  * Return TRUE when using ":vimgrep" for ":grep".
  */
-int grep_internal(cmdidx)
-cmdidx_T cmdidx;
+int grep_internal(cmdidx_T cmdidx)
 {
   return (cmdidx == CMD_grep
           || cmdidx == CMD_lgrep
@@ -2493,8 +2447,7 @@ cmdidx_T cmdidx;
 /*
  * Used for ":make", ":lmake", ":grep", ":lgrep", ":grepadd", and ":lgrepadd"
  */
-void ex_make(eap)
-exarg_T     *eap;
+void ex_make(exarg_T *eap)
 {
   char_u      *fname;
   char_u      *cmd;
@@ -2591,7 +2544,7 @@ exarg_T     *eap;
  * Find a new unique name when 'makeef' contains "##".
  * Returns NULL for error.
  */
-static char_u * get_mef_name()                     {
+static char_u *get_mef_name(void)                     {
   char_u      *p;
   char_u      *name;
   static int start = -1;
@@ -2643,8 +2596,7 @@ static char_u * get_mef_name()                     {
  * ":cc", ":crewind", ":cfirst" and ":clast".
  * ":ll", ":lrewind", ":lfirst" and ":llast".
  */
-void ex_cc(eap)
-exarg_T     *eap;
+void ex_cc(exarg_T *eap)
 {
   qf_info_T   *qi = &ql_info;
 
@@ -2675,8 +2627,7 @@ exarg_T     *eap;
  * ":cnext", ":cnfile", ":cNext" and ":cprevious".
  * ":lnext", ":lNext", ":lprevious", ":lnfile", ":lNfile" and ":lpfile".
  */
-void ex_cnext(eap)
-exarg_T     *eap;
+void ex_cnext(exarg_T *eap)
 {
   qf_info_T   *qi = &ql_info;
 
@@ -2708,8 +2659,7 @@ exarg_T     *eap;
  * ":cfile"/":cgetfile"/":caddfile" commands.
  * ":lfile"/":lgetfile"/":laddfile" commands.
  */
-void ex_cfile(eap)
-exarg_T     *eap;
+void ex_cfile(exarg_T *eap)
 {
   win_T       *wp = NULL;
   qf_info_T   *qi = &ql_info;
@@ -2765,8 +2715,7 @@ exarg_T     *eap;
  * ":lvimgrep {pattern} file(s)"
  * ":lvimgrepadd {pattern} file(s)"
  */
-void ex_vimgrep(eap)
-exarg_T     *eap;
+void ex_vimgrep(exarg_T *eap)
 {
   regmmatch_T regmatch;
   int fcount;
@@ -3103,10 +3052,7 @@ theend:
  * If "s" is not NULL terminate the pattern with a NUL.
  * Return a pointer to the char just past the pattern plus flags.
  */
-char_u * skip_vimgrep_pat(p, s, flags)
-char_u  *p;
-char_u  **s;
-int     *flags;
+char_u *skip_vimgrep_pat(char_u *p, char_u **s, int *flags)
 {
   int c;
 
@@ -3149,8 +3095,7 @@ int     *flags;
  * Restore current working directory to "dirname_start" if they differ, taking
  * into account whether it is set locally or globally.
  */
-static void restore_start_dir(dirname_start)
-char_u      *dirname_start;
+static void restore_start_dir(char_u *dirname_start)
 {
   char_u *dirname_now = alloc(MAXPATHL);
 
@@ -3181,10 +3126,12 @@ char_u      *dirname_start;
  *
  * Returns NULL if it fails.
  */
-static buf_T * load_dummy_buffer(fname, dirname_start, resulting_dir)
-char_u      *fname;
-char_u      *dirname_start;      /* in: old directory */
-char_u      *resulting_dir;      /* out: new directory */
+static buf_T *
+load_dummy_buffer (
+    char_u *fname,
+    char_u *dirname_start,      /* in: old directory */
+    char_u *resulting_dir      /* out: new directory */
+)
 {
   buf_T       *newbuf;
   buf_T       *newbuf_to_wipe = NULL;
@@ -3258,9 +3205,7 @@ char_u      *resulting_dir;      /* out: new directory */
  * directory to "dirname_start" prior to returning, if autocmds or the
  * 'autochdir' option have changed it.
  */
-static void wipe_dummy_buffer(buf, dirname_start)
-buf_T       *buf;
-char_u      *dirname_start;
+static void wipe_dummy_buffer(buf_T *buf, char_u *dirname_start)
 {
   if (curbuf != buf) {          /* safety check */
     cleanup_T cs;
@@ -3285,9 +3230,7 @@ char_u      *dirname_start;
  * directory to "dirname_start" prior to returning, if autocmds or the
  * 'autochdir' option have changed it.
  */
-static void unload_dummy_buffer(buf, dirname_start)
-buf_T       *buf;
-char_u      *dirname_start;
+static void unload_dummy_buffer(buf_T *buf, char_u *dirname_start)
 {
   if (curbuf != buf) {          /* safety check */
     close_buffer(NULL, buf, DOBUF_UNLOAD, FALSE);
@@ -3300,9 +3243,7 @@ char_u      *dirname_start;
 /*
  * Add each quickfix error to list "list" as a dictionary.
  */
-int get_errorlist(wp, list)
-win_T       *wp;
-list_T      *list;
+int get_errorlist(win_T *wp, list_T *list)
 {
   qf_info_T   *qi = &ql_info;
   dict_T      *dict;
@@ -3357,11 +3298,7 @@ list_T      *list;
  * Populate the quickfix list with the items supplied in the list
  * of dictionaries. "title" will be copied to w:quickfix_title
  */
-int set_errorlist(wp, list, action, title)
-win_T       *wp;
-list_T      *list;
-int action;
-char_u      *title;
+int set_errorlist(win_T *wp, list_T *list, int action, char_u *title)
 {
   listitem_T  *li;
   dict_T      *d;
@@ -3473,8 +3410,7 @@ char_u      *title;
  * ":[range]laddbuffer [bufnr]" command.
  * ":[range]lgetbuffer [bufnr]" command.
  */
-void ex_cbuffer(eap)
-exarg_T   *eap;
+void ex_cbuffer(exarg_T *eap)
 {
   buf_T       *buf = NULL;
   qf_info_T   *qi = &ql_info;
@@ -3527,8 +3463,7 @@ exarg_T   *eap;
  * ":cexpr {expr}", ":cgetexpr {expr}", ":caddexpr {expr}" command.
  * ":lexpr {expr}", ":lgetexpr {expr}", ":laddexpr {expr}" command.
  */
-void ex_cexpr(eap)
-exarg_T     *eap;
+void ex_cexpr(exarg_T *eap)
 {
   typval_T    *tv;
   qf_info_T   *qi = &ql_info;
@@ -3562,8 +3497,7 @@ exarg_T     *eap;
 /*
  * ":helpgrep {pattern}"
  */
-void ex_helpgrep(eap)
-exarg_T     *eap;
+void ex_helpgrep(exarg_T *eap)
 {
   regmatch_T regmatch;
   char_u      *save_cpo;

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -255,16 +255,14 @@
 static int no_Magic __ARGS((int x));
 static int toggle_Magic __ARGS((int x));
 
-static int no_Magic(x)
-int x;
+static int no_Magic(int x)
 {
   if (is_Magic(x))
     return un_Magic(x);
   return x;
 }
 
-static int toggle_Magic(x)
-int x;
+static int toggle_Magic(int x)
 {
   if (is_Magic(x))
     return un_Magic(x);
@@ -376,8 +374,7 @@ static char_u e_empty_sb[]  = N_("E70: Empty %s%%[]");
  * Return MULTI_ONE if c is a single "multi" operator.
  * Return MULTI_MULT if c is a multi "multi" operator.
  */
-static int re_multi_type(c)
-int c;
+static int re_multi_type(int c)
 {
   if (c == Magic('@') || c == Magic('=') || c == Magic('?'))
     return MULTI_ONE;
@@ -434,8 +431,7 @@ static void init_class_tab __ARGS((void));
 /*
  * Translate '\x' to its control character, except "\n", which is Magic.
  */
-static int backslash_trans(c)
-int c;
+static int backslash_trans(int c)
 {
   switch (c) {
   case 'r':   return CAR;
@@ -451,8 +447,7 @@ int c;
  * Returns one of the CLASS_ items. CLASS_NONE means that no item was
  * recognized.  Otherwise "pp" is advanced to after the item.
  */
-static int get_char_class(pp)
-char_u      **pp;
+static int get_char_class(char_u **pp)
 {
   static const char *(class_names[]) =
   {
@@ -518,7 +513,7 @@ static short class_tab[256];
 #define     RI_UPPER    0x80
 #define     RI_WHITE    0x100
 
-static void init_class_tab()                 {
+static void init_class_tab(void)                 {
   int i;
   static int done = FALSE;
 
@@ -687,8 +682,7 @@ static regengine_T nfa_regengine;
 /*
  * Return TRUE if compiled regular expression "prog" can match a line break.
  */
-int re_multiline(prog)
-regprog_T *prog;
+int re_multiline(regprog_T *prog)
 {
   return prog->regflags & RF_HASNL;
 }
@@ -697,8 +691,7 @@ regprog_T *prog;
  * Return TRUE if compiled regular expression "prog" looks before the start
  * position (pattern contains "\@<=" or "\@<!").
  */
-int re_lookbehind(prog)
-regprog_T *prog;
+int re_lookbehind(regprog_T *prog)
 {
   return prog->regflags & RF_LOOKBH;
 }
@@ -708,8 +701,7 @@ regprog_T *prog;
  * Returns a character representing the class. Zero means that no item was
  * recognized.  Otherwise "pp" is advanced to after the item.
  */
-static int get_equi_class(pp)
-char_u      **pp;
+static int get_equi_class(char_u **pp)
 {
   int c;
   int l = 1;
@@ -736,8 +728,7 @@ char_u      **pp;
  * Currently only handles latin1, latin9 and utf-8.
  * NOTE: When changing this function, also change nfa_emit_equi_class()
  */
-static void reg_equi_class(c)
-int c;
+static void reg_equi_class(int c)
 {
   if (enc_utf8 || STRCMP(p_enc, "latin1") == 0
       || STRCMP(p_enc, "iso-8859-15") == 0) {
@@ -1044,8 +1035,7 @@ int c;
  * "pp" is advanced to after the item.
  * Currently only single characters are recognized!
  */
-static int get_coll_element(pp)
-char_u      **pp;
+static int get_coll_element(char_u **pp)
 {
   int c;
   int l = 1;
@@ -1070,7 +1060,7 @@ static void get_cpo_flags __ARGS((void));
 static int reg_cpo_lit; /* 'cpoptions' contains 'l' flag */
 static int reg_cpo_bsl; /* 'cpoptions' contains '\' flag */
 
-static void get_cpo_flags()                 {
+static void get_cpo_flags(void)                 {
   reg_cpo_lit = vim_strchr(p_cpo, CPO_LITERAL) != NULL;
   reg_cpo_bsl = vim_strchr(p_cpo, CPO_BACKSL) != NULL;
 }
@@ -1080,8 +1070,7 @@ static void get_cpo_flags()                 {
  * "p" must point to the character after the '['.
  * The returned pointer is on the matching ']', or the terminating NUL.
  */
-static char_u * skip_anyof(p)
-char_u      *p;
+static char_u *skip_anyof(char_u *p)
 {
   int l;
 
@@ -1122,11 +1111,7 @@ char_u      *p;
  * expression and change "\?" to "?".  If "*newp" is not NULL the expression
  * is changed in-place.
  */
-char_u * skip_regexp(startp, dirc, magic, newp)
-char_u      *startp;
-int dirc;
-int magic;
-char_u      **newp;
+char_u *skip_regexp(char_u *startp, int dirc, int magic, char_u **newp)
 {
   int mymagic;
   char_u      *p = startp;
@@ -1192,9 +1177,7 @@ static void bt_regfree __ARGS((regprog_T *prog));
  * of the structure of the compiled regexp.
  * "re_flags": RE_MAGIC and/or RE_STRING.
  */
-static regprog_T * bt_regcomp(expr, re_flags)
-char_u      *expr;
-int re_flags;
+static regprog_T *bt_regcomp(char_u *expr, int re_flags)
 {
   bt_regprog_T    *r;
   char_u      *scan;
@@ -1314,8 +1297,7 @@ int re_flags;
 /*
  * Free a compiled regexp program, returned by bt_regcomp().
  */
-static void bt_regfree(prog)
-regprog_T   *prog;
+static void bt_regfree(regprog_T *prog)
 {
   vim_free(prog);
 }
@@ -1323,9 +1305,11 @@ regprog_T   *prog;
 /*
  * Setup to parse the regexp.  Used once to get the length and once to do it.
  */
-static void regcomp_start(expr, re_flags)
-char_u      *expr;
-int re_flags;                       /* see vim_regcomp() */
+static void 
+regcomp_start (
+    char_u *expr,
+    int re_flags                       /* see vim_regcomp() */
+)
 {
   initchr(expr);
   if (re_flags & RE_MAGIC)
@@ -1351,7 +1335,7 @@ int re_flags;                       /* see vim_regcomp() */
  * Check if during the previous call to vim_regcomp the EOL item "$" has been
  * found.  This is messy, but it works fine.
  */
-int vim_regcomp_had_eol()         {
+int vim_regcomp_had_eol(void)         {
   return had_eol;
 }
 
@@ -1364,9 +1348,11 @@ int vim_regcomp_had_eol()         {
  * is a trifle forced, but the need to tie the tails of the branches to what
  * follows makes it hard to avoid.
  */
-static char_u * reg(paren, flagp)
-int paren;              /* REG_NOPAREN, REG_PAREN, REG_NPAREN or REG_ZPAREN */
-int         *flagp;
+static char_u *
+reg (
+    int paren,              /* REG_NOPAREN, REG_PAREN, REG_NPAREN or REG_ZPAREN */
+    int *flagp
+)
 {
   char_u      *ret;
   char_u      *br;
@@ -1460,8 +1446,7 @@ int         *flagp;
  * Parse one alternative of an | operator.
  * Implements the & operator.
  */
-static char_u * regbranch(flagp)
-int         *flagp;
+static char_u *regbranch(int *flagp)
 {
   char_u      *ret;
   char_u      *chain = NULL;
@@ -1501,8 +1486,7 @@ int         *flagp;
  * Parse one alternative of an | or & operator.
  * Implements the concatenation operator.
  */
-static char_u * regconcat(flagp)
-int         *flagp;
+static char_u *regconcat(int *flagp)
 {
   char_u      *first = NULL;
   char_u      *chain = NULL;
@@ -1581,8 +1565,7 @@ int         *flagp;
  * It might seem that this node could be dispensed with entirely, but the
  * endmarker role is not redundant.
  */
-static char_u * regpiece(flagp)
-int             *flagp;
+static char_u *regpiece(int *flagp)
 {
   char_u          *ret;
   int op;
@@ -1728,8 +1711,7 @@ static int classcodes[] = {
  * it can turn them into a single node, which is smaller to store and
  * faster to run.  Don't do this when one_exactly is set.
  */
-static char_u * regatom(flagp)
-int            *flagp;
+static char_u *regatom(int *flagp)
 {
   char_u          *ret;
   int flags;
@@ -2427,8 +2409,7 @@ do_multibyte:
  * Return TRUE if MULTIBYTECODE should be used instead of EXACTLY for
  * character "c".
  */
-static int use_multibytecode(c)
-int c;
+static int use_multibytecode(int c)
 {
   return has_mbyte && (*mb_char2len)(c) > 1
          && (re_multi_type(peekchr()) != NOT_MULTI
@@ -2439,8 +2420,7 @@ int c;
  * Emit a node.
  * Return pointer to generated code.
  */
-static char_u * regnode(op)
-int op;
+static char_u *regnode(int op)
 {
   char_u  *ret;
 
@@ -2458,8 +2438,7 @@ int op;
 /*
  * Emit (if appropriate) a byte of code
  */
-static void regc(b)
-int b;
+static void regc(int b)
 {
   if (regcode == JUST_CALC_SIZE)
     regsize++;
@@ -2470,8 +2449,7 @@ int b;
 /*
  * Emit (if appropriate) a multi-byte character of code
  */
-static void regmbc(c)
-int c;
+static void regmbc(int c)
 {
   if (!has_mbyte && c > 0xff)
     return;
@@ -2486,9 +2464,7 @@ int c;
  *
  * Means relocating the operand.
  */
-static void reginsert(op, opnd)
-int op;
-char_u     *opnd;
+static void reginsert(int op, char_u *opnd)
 {
   char_u      *src;
   char_u      *dst;
@@ -2514,10 +2490,7 @@ char_u     *opnd;
  * Insert an operator in front of already-emitted operand.
  * Add a number to the operator.
  */
-static void reginsert_nr(op, val, opnd)
-int op;
-long val;
-char_u      *opnd;
+static void reginsert_nr(int op, long val, char_u *opnd)
 {
   char_u      *src;
   char_u      *dst;
@@ -2546,11 +2519,7 @@ char_u      *opnd;
  *
  * Means relocating the operand.
  */
-static void reginsert_limits(op, minval, maxval, opnd)
-int op;
-long minval;
-long maxval;
-char_u      *opnd;
+static void reginsert_limits(int op, long minval, long maxval, char_u *opnd)
 {
   char_u      *src;
   char_u      *dst;
@@ -2578,9 +2547,7 @@ char_u      *opnd;
 /*
  * Write a long as four bytes at "p" and return pointer to the next char.
  */
-static char_u * re_put_long(p, val)
-char_u      *p;
-long_u val;
+static char_u *re_put_long(char_u *p, long_u val)
 {
   *p++ = (char_u) ((val >> 24) & 0377);
   *p++ = (char_u) ((val >> 16) & 0377);
@@ -2592,9 +2559,7 @@ long_u val;
 /*
  * Set the next-pointer at the end of a node chain.
  */
-static void regtail(p, val)
-char_u      *p;
-char_u      *val;
+static void regtail(char_u *p, char_u *val)
 {
   char_u      *scan;
   char_u      *temp;
@@ -2630,9 +2595,7 @@ char_u      *val;
 /*
  * Like regtail, on item after a BRANCH; nop if none.
  */
-static void regoptail(p, val)
-char_u      *p;
-char_u      *val;
+static void regoptail(char_u *p, char_u *val)
 {
   /* When op is neither BRANCH nor BRACE_COMPLEX0-9, it is "operandless" */
   if (p == NULL || p == JUST_CALC_SIZE
@@ -2652,8 +2615,7 @@ static int prev_at_start;       /* True when on the second character */
 /*
  * Start parsing at "str".
  */
-static void initchr(str)
-char_u *str;
+static void initchr(char_u *str)
 {
   regparse = str;
   prevchr_len = 0;
@@ -2666,8 +2628,7 @@ char_u *str;
  * Save the current parse state, so that it can be restored and parsing
  * starts in the same state again.
  */
-static void save_parse_state(ps)
-parse_state_T *ps;
+static void save_parse_state(parse_state_T *ps)
 {
   ps->regparse = regparse;
   ps->prevchr_len = prevchr_len;
@@ -2683,8 +2644,7 @@ parse_state_T *ps;
 /*
  * Restore a previously saved parse state.
  */
-static void restore_parse_state(ps)
-parse_state_T *ps;
+static void restore_parse_state(parse_state_T *ps)
 {
   regparse = ps->regparse;
   prevchr_len = ps->prevchr_len;
@@ -2701,7 +2661,7 @@ parse_state_T *ps;
 /*
  * Get the next character without advancing.
  */
-static int peekchr()                {
+static int peekchr(void)                {
   static int after_slash = FALSE;
 
   if (curchr == -1) {
@@ -2844,7 +2804,7 @@ static int peekchr()                {
 /*
  * Eat one lexed character.  Do this in a way that we can undo it.
  */
-static void skipchr()                 {
+static void skipchr(void)                 {
   /* peekchr() eats a backslash, do the same here */
   if (*regparse == '\\')
     prevchr_len = 1;
@@ -2872,7 +2832,7 @@ static void skipchr()                 {
  * Skip a character while keeping the value of prev_at_start for at_start.
  * prevchr and prevprevchr are also kept.
  */
-static void skipchr_keepstart()                 {
+static void skipchr_keepstart(void)                 {
   int as = prev_at_start;
   int pr = prevchr;
   int prpr = prevprevchr;
@@ -2887,7 +2847,7 @@ static void skipchr_keepstart()                 {
  * Get the next character from the pattern. We know about magic and such, so
  * therefore we need a lexical analyzer.
  */
-static int getchr()                {
+static int getchr(void)                {
   int chr = peekchr();
 
   skipchr();
@@ -2897,7 +2857,7 @@ static int getchr()                {
 /*
  * put character back.  Works only once!
  */
-static void ungetchr()                 {
+static void ungetchr(void)                 {
   nextchr = curchr;
   curchr = prevchr;
   prevchr = prevprevchr;
@@ -2918,8 +2878,7 @@ static void ungetchr()                 {
  * The parameter controls the maximum number of input characters. This will be
  * 2 when reading a \%x20 sequence and 4 when reading a \%u20AC sequence.
  */
-static int gethexchrs(maxinputlen)
-int maxinputlen;
+static int gethexchrs(int maxinputlen)
 {
   int nr = 0;
   int c;
@@ -2943,7 +2902,7 @@ int maxinputlen;
  * Get and return the value of the decimal string immediately after the
  * current position. Return -1 for invalid.  Consumes all digits.
  */
-static int getdecchrs()                {
+static int getdecchrs(void)                {
   int nr = 0;
   int c;
   int i;
@@ -2971,7 +2930,7 @@ static int getdecchrs()                {
  *     blahblah\%o210asdf
  *	   before-^  ^-after
  */
-static int getoctchrs()                {
+static int getoctchrs(void)                {
   int nr = 0;
   int c;
   int i;
@@ -2994,7 +2953,7 @@ static int getoctchrs()                {
  * Get a number after a backslash that is inside [].
  * When nothing is recognized return a backslash.
  */
-static int coll_get_char()                {
+static int coll_get_char(void)                {
   int nr = -1;
 
   switch (*regparse++) {
@@ -3019,9 +2978,7 @@ static int coll_get_char()                {
  * Should end with 'end'.  If minval is missing, zero is default, if maxval is
  * missing, a very big number is the default.
  */
-static int read_limits(minval, maxval)
-long        *minval;
-long        *maxval;
+static int read_limits(long *minval, long *maxval)
 {
   int reverse = FALSE;
   char_u      *first_char;
@@ -3282,7 +3239,7 @@ static garray_T backpos = {0, 0, 0, 0, NULL};
 #define BACKPOS_INITIAL         64
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_regexp_stuff()          {
+void free_regexp_stuff(void)          {
   ga_clear(&regstack);
   ga_clear(&backpos);
   vim_free(reg_tofree);
@@ -3294,8 +3251,7 @@ void free_regexp_stuff()          {
 /*
  * Get pointer to the line "lnum", which is relative to "reg_firstlnum".
  */
-static char_u * reg_getline(lnum)
-linenr_T lnum;
+static char_u *reg_getline(linenr_T lnum)
 {
   /* when looking behind for a match/no-match lnum is negative.  But we
    * can't go before line 1 */
@@ -3326,10 +3282,12 @@ static int bt_regexec __ARGS((regmatch_T *rmp, char_u *line, colnr_T col));
  *
  * Return TRUE if there is a match, FALSE if not.
  */
-static int bt_regexec(rmp, line, col)
-regmatch_T  *rmp;
-char_u      *line;      /* string to match against */
-colnr_T col;            /* column to start looking for match */
+static int 
+bt_regexec (
+    regmatch_T *rmp,
+    char_u *line,      /* string to match against */
+    colnr_T col            /* column to start looking for match */
+)
 {
   reg_match = rmp;
   reg_mmatch = NULL;
@@ -3351,10 +3309,12 @@ static int bt_regexec_nl __ARGS((regmatch_T *rmp, char_u *line, colnr_T col));
 /*
  * Like vim_regexec(), but consider a "\n" in "line" to be a line break.
  */
-static int bt_regexec_nl(rmp, line, col)
-regmatch_T  *rmp;
-char_u      *line;      /* string to match against */
-colnr_T col;            /* column to start looking for match */
+static int 
+bt_regexec_nl (
+    regmatch_T *rmp,
+    char_u *line,      /* string to match against */
+    colnr_T col            /* column to start looking for match */
+)
 {
   reg_match = rmp;
   reg_mmatch = NULL;
@@ -3414,7 +3374,7 @@ proftime_T  *tm;                /* timeout limit or NULL */
 static long bt_regexec_both(line, col, tm)
 char_u      *line;
 colnr_T col;                    /* column to start looking for match */
-proftime_T  *tm UNUSED;         /* timeout limit or NULL */
+proftime_T  *tm;         /* timeout limit or NULL */
 {
   bt_regprog_T        *prog;
   char_u      *s;
@@ -3602,7 +3562,7 @@ static reg_extmatch_T *make_extmatch __ARGS((void));
 /*
  * Create a new extmatch and mark it as referenced once.
  */
-static reg_extmatch_T * make_extmatch()                             {
+static reg_extmatch_T *make_extmatch(void)                             {
   reg_extmatch_T      *em;
 
   em = (reg_extmatch_T *)alloc_clear((unsigned)sizeof(reg_extmatch_T));
@@ -3614,8 +3574,7 @@ static reg_extmatch_T * make_extmatch()                             {
 /*
  * Add a reference to an extmatch.
  */
-reg_extmatch_T * ref_extmatch(em)
-reg_extmatch_T      *em;
+reg_extmatch_T *ref_extmatch(reg_extmatch_T *em)
 {
   if (em != NULL)
     em->refcnt++;
@@ -3626,8 +3585,7 @@ reg_extmatch_T      *em;
  * Remove a reference to an extmatch.  If there are no references left, free
  * the info.
  */
-void unref_extmatch(em)
-reg_extmatch_T      *em;
+void unref_extmatch(reg_extmatch_T *em)
 {
   int i;
 
@@ -3642,9 +3600,7 @@ reg_extmatch_T      *em;
  * regtry - try match of "prog" with at regline["col"].
  * Returns 0 for failure, number of lines contained in the match otherwise.
  */
-static long regtry(prog, col)
-bt_regprog_T    *prog;
-colnr_T col;
+static long regtry(bt_regprog_T *prog, colnr_T col)
 {
   reginput = regline + col;
   need_clear_subexpr = TRUE;
@@ -3707,7 +3663,7 @@ static int reg_prev_class __ARGS((void));
 /*
  * Get class of previous character.
  */
-static int reg_prev_class()                {
+static int reg_prev_class(void)                {
   if (reginput > regline)
     return mb_get_class_buf(reginput - 1
         - (*mb_head_off)(regline, reginput - 1), reg_buf);
@@ -3719,7 +3675,7 @@ static int reg_match_visual __ARGS((void));
 /*
  * Return TRUE if the current reginput position matches the Visual area.
  */
-static int reg_match_visual()                {
+static int reg_match_visual(void)                {
   pos_T top, bot;
   linenr_T lnum;
   colnr_T col;
@@ -3802,8 +3758,10 @@ static long bl_maxval;
  * Returns FALSE when there is no match.  Leaves reginput and reglnum in an
  * undefined state!
  */
-static int regmatch(scan)
-char_u      *scan;              /* Current node. */
+static int 
+regmatch (
+    char_u *scan              /* Current node. */
+)
 {
   char_u        *next;          /* Next node. */
   int op;
@@ -5103,9 +5061,7 @@ char_u      *scan;              /* Current node. */
  * Push an item onto the regstack.
  * Returns pointer to new item.  Returns NULL when out of memory.
  */
-static regitem_T * regstack_push(state, scan)
-regstate_T state;
-char_u      *scan;
+static regitem_T *regstack_push(regstate_T state, char_u *scan)
 {
   regitem_T   *rp;
 
@@ -5127,8 +5083,7 @@ char_u      *scan;
 /*
  * Pop an item from the regstack.
  */
-static void regstack_pop(scan)
-char_u      **scan;
+static void regstack_pop(char_u **scan)
 {
   regitem_T   *rp;
 
@@ -5142,9 +5097,11 @@ char_u      **scan;
  * regrepeat - repeatedly match something simple, return how many.
  * Advances reginput (and reglnum) to just after the matched chars.
  */
-static int regrepeat(p, maxcount)
-char_u      *p;
-long maxcount;              /* maximum number of matches allowed */
+static int 
+regrepeat (
+    char_u *p,
+    long maxcount              /* maximum number of matches allowed */
+)
 {
   long count = 0;
   char_u      *scan;
@@ -5486,8 +5443,7 @@ do_class:
  * Returns NULL when calculating size, when there is no next item and when
  * there is an error.
  */
-static char_u * regnext(p)
-char_u  *p;
+static char_u *regnext(char_u *p)
 {
   int offset;
 
@@ -5508,7 +5464,7 @@ char_u  *p;
  * Check the regexp program for its magic number.
  * Return TRUE if it's wrong.
  */
-static int prog_magic_wrong()                {
+static int prog_magic_wrong(void)                {
   regprog_T   *prog;
 
   prog = REG_MULTI ? reg_mmatch->regprog : reg_match->regprog;
@@ -5528,7 +5484,7 @@ static int prog_magic_wrong()                {
  * This construction is used to clear the subexpressions only when they are
  * used (to increase speed).
  */
-static void cleanup_subexpr()                 {
+static void cleanup_subexpr(void)                 {
   if (need_clear_subexpr) {
     if (REG_MULTI) {
       /* Use 0xff to set lnum to -1 */
@@ -5542,7 +5498,7 @@ static void cleanup_subexpr()                 {
   }
 }
 
-static void cleanup_zsubexpr()                 {
+static void cleanup_zsubexpr(void)                 {
   if (need_clear_zsubexpr) {
     if (REG_MULTI) {
       /* Use 0xff to set lnum to -1 */
@@ -5560,8 +5516,7 @@ static void cleanup_zsubexpr()                 {
  * Save the current subexpr to "bp", so that they can be restored
  * later by restore_subexpr().
  */
-static void save_subexpr(bp)
-regbehind_T *bp;
+static void save_subexpr(regbehind_T *bp)
 {
   int i;
 
@@ -5584,8 +5539,7 @@ regbehind_T *bp;
 /*
  * Restore the subexpr from "bp".
  */
-static void restore_subexpr(bp)
-regbehind_T *bp;
+static void restore_subexpr(regbehind_T *bp)
 {
   int i;
 
@@ -5607,7 +5561,7 @@ regbehind_T *bp;
 /*
  * Advance reglnum, regline and reginput to the next line.
  */
-static void reg_nextline()                 {
+static void reg_nextline(void)                 {
   regline = reg_getline(++reglnum);
   reginput = regline;
   fast_breakcheck();
@@ -5616,9 +5570,7 @@ static void reg_nextline()                 {
 /*
  * Save the input line and position in a regsave_T.
  */
-static void reg_save(save, gap)
-regsave_T   *save;
-garray_T    *gap;
+static void reg_save(regsave_T *save, garray_T *gap)
 {
   if (REG_MULTI) {
     save->rs_u.pos.col = (colnr_T)(reginput - regline);
@@ -5631,9 +5583,7 @@ garray_T    *gap;
 /*
  * Restore the input line and position from a regsave_T.
  */
-static void reg_restore(save, gap)
-regsave_T   *save;
-garray_T    *gap;
+static void reg_restore(regsave_T *save, garray_T *gap)
 {
   if (REG_MULTI) {
     if (reglnum != save->rs_u.pos.lnum) {
@@ -5651,8 +5601,7 @@ garray_T    *gap;
 /*
  * Return TRUE if current position is equal to saved position.
  */
-static int reg_save_equal(save)
-regsave_T   *save;
+static int reg_save_equal(regsave_T *save)
 {
   if (REG_MULTI)
     return reglnum == save->rs_u.pos.lnum
@@ -5667,18 +5616,14 @@ regsave_T   *save;
  * Use se_save() to use pointer (save_se_multi()) or position (save_se_one()),
  * depending on REG_MULTI.
  */
-static void save_se_multi(savep, posp)
-save_se_T   *savep;
-lpos_T      *posp;
+static void save_se_multi(save_se_T *savep, lpos_T *posp)
 {
   savep->se_u.pos = *posp;
   posp->lnum = reglnum;
   posp->col = (colnr_T)(reginput - regline);
 }
 
-static void save_se_one(savep, pp)
-save_se_T   *savep;
-char_u      **pp;
+static void save_se_one(save_se_T *savep, char_u **pp)
 {
   savep->se_u.ptr = *pp;
   *pp = reginput;
@@ -5687,9 +5632,7 @@ char_u      **pp;
 /*
  * Compare a number with the operand of RE_LNUM, RE_COL or RE_VCOL.
  */
-static int re_num_cmp(val, scan)
-long_u val;
-char_u      *scan;
+static int re_num_cmp(long_u val, char_u *scan)
 {
   long_u n = OPERAND_MIN(scan);
 
@@ -5706,12 +5649,7 @@ char_u      *scan;
  * If "bytelen" is not NULL, it is set to the byte length of the match in the
  * last line.
  */
-static int match_with_backref(start_lnum, start_col, end_lnum, end_col, bytelen)
-linenr_T start_lnum;
-colnr_T start_col;
-linenr_T end_lnum;
-colnr_T end_col;
-int      *bytelen;
+static int match_with_backref(linenr_T start_lnum, colnr_T start_col, linenr_T end_lnum, colnr_T end_col, int *bytelen)
 {
   linenr_T clnum = start_lnum;
   colnr_T ccol = start_col;
@@ -5774,9 +5712,7 @@ int      *bytelen;
 /*
  * regdump - dump a regexp onto stdout in vaguely comprehensible form
  */
-static void regdump(pattern, r)
-char_u      *pattern;
-bt_regprog_T        *r;
+static void regdump(char_u *pattern, bt_regprog_T *r)
 {
   char_u  *s;
   int op = EXACTLY;             /* Arbitrary non-END op. */
@@ -5857,8 +5793,7 @@ bt_regprog_T        *r;
 /*
  * regprop - printable representation of opcode
  */
-static char_u * regprop(op)
-char_u         *op;
+static char_u *regprop(char_u *op)
 {
   char            *p;
   static char buf[50];
@@ -6265,21 +6200,21 @@ static decomp_T decomp_table[0xfb4f-0xfb20+1] =
   {0x5d4, 0x5bc, 0},            /* 0xfb34	he+dagesh */
   {0x5d5, 0x5bc, 0},            /* 0xfb35	vav+dagesh */
   {0x5d6, 0x5bc, 0},            /* 0xfb36	zayin+dagesh */
-  {0xfb37, 0, 0},               /* 0xfb37 -- UNUSED */
+  {0xfb37, 0, 0},               /* 0xfb37 -- */
   {0x5d8, 0x5bc, 0},            /* 0xfb38	tet+dagesh */
   {0x5d9, 0x5bc, 0},            /* 0xfb39	yud+dagesh */
   {0x5da, 0x5bc, 0},            /* 0xfb3a	kaf sofit+dagesh */
   {0x5db, 0x5bc, 0},            /* 0xfb3b	kaf+dagesh */
   {0x5dc, 0x5bc, 0},            /* 0xfb3c	lamed+dagesh */
-  {0xfb3d, 0, 0},               /* 0xfb3d -- UNUSED */
+  {0xfb3d, 0, 0},               /* 0xfb3d -- */
   {0x5de, 0x5bc, 0},            /* 0xfb3e	mem+dagesh */
-  {0xfb3f, 0, 0},               /* 0xfb3f -- UNUSED */
+  {0xfb3f, 0, 0},               /* 0xfb3f -- */
   {0x5e0, 0x5bc, 0},            /* 0xfb40	nun+dagesh */
   {0x5e1, 0x5bc, 0},            /* 0xfb41	samech+dagesh */
-  {0xfb42, 0, 0},               /* 0xfb42 -- UNUSED */
+  {0xfb42, 0, 0},               /* 0xfb42 -- */
   {0x5e3, 0x5bc, 0},            /* 0xfb43	pe sofit+dagesh */
   {0x5e4, 0x5bc,0},             /* 0xfb44	pe+dagesh */
-  {0xfb45, 0, 0},               /* 0xfb45 -- UNUSED */
+  {0xfb45, 0, 0},               /* 0xfb45 -- */
   {0x5e6, 0x5bc, 0},            /* 0xfb46	tsadi+dagesh */
   {0x5e7, 0x5bc, 0},            /* 0xfb47	qof+dagesh */
   {0x5e8, 0x5bc, 0},            /* 0xfb48	resh+dagesh */
@@ -6292,8 +6227,7 @@ static decomp_T decomp_table[0xfb4f-0xfb20+1] =
   {0x5d0, 0x5dc, 0}             /* 0xfb4f	alef-lamed */
 };
 
-static void mb_decompose(c, c1, c2, c3)
-int c, *c1, *c2, *c3;
+static void mb_decompose(int c, int *c1, int *c2, int *c3)
 {
   decomp_T d;
 
@@ -6313,9 +6247,7 @@ int c, *c1, *c2, *c3;
  * Return 0 if strings match, non-zero otherwise.
  * Correct the length "*n" when composing characters are ignored.
  */
-static int cstrncmp(s1, s2, n)
-char_u      *s1, *s2;
-int         *n;
+static int cstrncmp(char_u *s1, char_u *s2, int *n)
 {
   int result;
 
@@ -6363,9 +6295,7 @@ int         *n;
 /*
  * cstrchr: This function is used a lot for simple searches, keep it fast!
  */
-static char_u * cstrchr(s, c)
-char_u      *s;
-int c;
+static char_u *cstrchr(char_u *s, int c)
 {
   char_u      *p;
   int cc;
@@ -6475,9 +6405,7 @@ int c;
  *
  * The tildes are parsed once before the first call to vim_regsub().
  */
-char_u * regtilde(source, magic)
-char_u      *source;
-int magic;
+char_u *regtilde(char_u *source, int magic)
 {
   char_u      *newsub = source;
   char_u      *tmpsub;
@@ -6557,13 +6485,7 @@ static int submatch_line_lbr;
  *
  * Returns the size of the replacement, including terminating NUL.
  */
-int vim_regsub(rmp, source, dest, copy, magic, backslash)
-regmatch_T  *rmp;
-char_u      *source;
-char_u      *dest;
-int copy;
-int magic;
-int backslash;
+int vim_regsub(regmatch_T *rmp, char_u *source, char_u *dest, int copy, int magic, int backslash)
 {
   reg_match = rmp;
   reg_mmatch = NULL;
@@ -6572,14 +6494,7 @@ int backslash;
   return vim_regsub_both(source, dest, copy, magic, backslash);
 }
 
-int vim_regsub_multi(rmp, lnum, source, dest, copy, magic, backslash)
-regmmatch_T *rmp;
-linenr_T lnum;
-char_u      *source;
-char_u      *dest;
-int copy;
-int magic;
-int backslash;
+int vim_regsub_multi(regmmatch_T *rmp, linenr_T lnum, char_u *source, char_u *dest, int copy, int magic, int backslash)
 {
   reg_match = NULL;
   reg_mmatch = rmp;
@@ -6589,12 +6504,7 @@ int backslash;
   return vim_regsub_both(source, dest, copy, magic, backslash);
 }
 
-static int vim_regsub_both(source, dest, copy, magic, backslash)
-char_u      *source;
-char_u      *dest;
-int copy;
-int magic;
-int backslash;
+static int vim_regsub_both(char_u *source, char_u *dest, int copy, int magic, int backslash)
 {
   char_u      *src;
   char_u      *dst;
@@ -6902,8 +6812,7 @@ static char_u *reg_getline_submatch __ARGS((linenr_T lnum));
  * substitute() was used the reg_maxline and other values have been
  * overwritten.
  */
-static char_u * reg_getline_submatch(lnum)
-linenr_T lnum;
+static char_u *reg_getline_submatch(linenr_T lnum)
 {
   char_u *s;
   linenr_T save_first = reg_firstlnum;
@@ -6924,8 +6833,7 @@ linenr_T lnum;
  * allocated memory.
  * Returns NULL when not in a ":s" command and for a non-existing submatch.
  */
-char_u * reg_submatch(no)
-int no;
+char_u *reg_submatch(int no)
 {
   char_u      *retval = NULL;
   char_u      *s;
@@ -7054,9 +6962,7 @@ static char_u regname[][30] = {
  * Use vim_regfree() to free the memory.
  * Returns NULL for an error.
  */
-regprog_T * vim_regcomp(expr_arg, re_flags)
-char_u      *expr_arg;
-int re_flags;
+regprog_T *vim_regcomp(char_u *expr_arg, int re_flags)
 {
   regprog_T   *prog = NULL;
   char_u      *expr = expr_arg;
@@ -7122,8 +7028,7 @@ int re_flags;
 /*
  * Free a compiled regexp program, returned by vim_regcomp().
  */
-void vim_regfree(prog)
-regprog_T   *prog;
+void vim_regfree(regprog_T *prog)
 {
   if (prog != NULL)
     prog->engine->regfree(prog);
@@ -7136,10 +7041,12 @@ regprog_T   *prog;
  *
  * Return TRUE if there is a match, FALSE if not.
  */
-int vim_regexec(rmp, line, col)
-regmatch_T *rmp;
-char_u      *line;      /* string to match against */
-colnr_T col;            /* column to start looking for match */
+int 
+vim_regexec (
+    regmatch_T *rmp,
+    char_u *line,      /* string to match against */
+    colnr_T col            /* column to start looking for match */
+)
 {
   return rmp->regprog->engine->regexec(rmp, line, col);
 }
@@ -7149,10 +7056,7 @@ colnr_T col;            /* column to start looking for match */
 /*
  * Like vim_regexec(), but consider a "\n" in "line" to be a line break.
  */
-int vim_regexec_nl(rmp, line, col)
-regmatch_T *rmp;
-char_u *line;
-colnr_T col;
+int vim_regexec_nl(regmatch_T *rmp, char_u *line, colnr_T col)
 {
   return rmp->regprog->engine->regexec_nl(rmp, line, col);
 }

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -327,9 +327,11 @@ static int failure_chance __ARGS((nfa_state_T *state, int depth));
  * Initialize internal variables before NFA compilation.
  * Return OK on success, FAIL otherwise.
  */
-static int nfa_regcomp_start(expr, re_flags)
-char_u      *expr;
-int re_flags;                       /* see vim_regcomp() */
+static int 
+nfa_regcomp_start (
+    char_u *expr,
+    int re_flags                       /* see vim_regcomp() */
+)
 {
   size_t postfix_size;
   int nstate_max;
@@ -364,9 +366,7 @@ int re_flags;                       /* see vim_regcomp() */
  * Figure out if the NFA state list starts with an anchor, must match at start
  * of the line.
  */
-static int nfa_get_reganch(start, depth)
-nfa_state_T *start;
-int depth;
+static int nfa_get_reganch(nfa_state_T *start, int depth)
 {
   nfa_state_T *p = start;
 
@@ -423,9 +423,7 @@ int depth;
  * Figure out if the NFA state list starts with a character which must match
  * at start of the match.
  */
-static int nfa_get_regstart(start, depth)
-nfa_state_T *start;
-int depth;
+static int nfa_get_regstart(nfa_state_T *start, int depth)
 {
   nfa_state_T *p = start;
 
@@ -504,8 +502,7 @@ int depth;
  * else.  If so return a string in allocated memory with what must match after
  * regstart.  Otherwise return NULL.
  */
-static char_u * nfa_get_match_text(start)
-nfa_state_T *start;
+static char_u *nfa_get_match_text(nfa_state_T *start)
 {
   nfa_state_T *p = start;
   int len = 0;
@@ -543,7 +540,7 @@ nfa_state_T *start;
  * Allocate more space for post_start.  Called when
  * running above the estimated number of states.
  */
-static int realloc_post_list()                {
+static int realloc_post_list(void)                {
   int nstate_max = (int)(post_end - post_start);
   int new_max = nstate_max + 1000;
   int   *new_start;
@@ -571,10 +568,7 @@ static int realloc_post_list()                {
  * Keep in mind that 'ignorecase' applies at execution time, thus [a-z] may
  * need to be interpreted as [a-zA-Z].
  */
-static int nfa_recognize_char_class(start, end, extra_newl)
-char_u  *start;
-char_u  *end;
-int extra_newl;
+static int nfa_recognize_char_class(char_u *start, char_u *end, int extra_newl)
 {
 #   define CLASS_not            0x80
 #   define CLASS_af             0x40
@@ -696,8 +690,7 @@ int extra_newl;
  *
  * NOTE! When changing this function, also update reg_equi_class()
  */
-static int nfa_emit_equi_class(c)
-int c;
+static int nfa_emit_equi_class(int c)
 {
 #define EMIT2(c)    EMIT(c); EMIT(NFA_CONCAT);
 # define EMITMBC(c) EMIT(c); EMIT(NFA_CONCAT);
@@ -1061,7 +1054,7 @@ int c;
  *     or  \%( pattern \)
  *     or  \z( pattern \)
  */
-static int nfa_regatom()                {
+static int nfa_regatom(void)                {
   int c;
   int charclass;
   int equiclass;
@@ -1740,7 +1733,7 @@ nfa_do_multibyte:
  * piece   ::=	    atom
  *	or  atom  multi
  */
-static int nfa_regpiece()                {
+static int nfa_regpiece(void)                {
   int i;
   int op;
   int ret;
@@ -1931,7 +1924,7 @@ static int nfa_regpiece()                {
  *	or  piece piece piece
  *	etc.
  */
-static int nfa_regconcat()                {
+static int nfa_regconcat(void)                {
   int cont = TRUE;
   int first = TRUE;
 
@@ -2003,7 +1996,7 @@ static int nfa_regconcat()                {
  *		or  concat \& concat \& concat
  *		etc.
  */
-static int nfa_regbranch()                {
+static int nfa_regbranch(void)                {
   int ch;
   int old_post_pos;
 
@@ -2047,8 +2040,10 @@ static int nfa_regbranch()                {
  *	or  branch \| branch \| branch
  *	etc.
  */
-static int nfa_reg(paren)
-int paren;              /* REG_NOPAREN, REG_PAREN, REG_NPAREN or REG_ZPAREN */
+static int 
+nfa_reg (
+    int paren              /* REG_NOPAREN, REG_PAREN, REG_NPAREN or REG_ZPAREN */
+)
 {
   int parno = 0;
 
@@ -2101,8 +2096,7 @@ int paren;              /* REG_NOPAREN, REG_PAREN, REG_NPAREN or REG_ZPAREN */
 #ifdef REGEXP_DEBUG
 static char_u code[50];
 
-static void nfa_set_code(c)
-int c;
+static void nfa_set_code(int c)
 {
   int addnl = FALSE;
 
@@ -2330,9 +2324,7 @@ static FILE *log_fd;
 /*
  * Print the postfix notation of the current regexp.
  */
-static void nfa_postfix_dump(expr, retval)
-char_u  *expr;
-int retval;
+static void nfa_postfix_dump(char_u *expr, int retval)
 {
   int *p;
   FILE *f;
@@ -2360,9 +2352,7 @@ int retval;
 /*
  * Print the NFA starting with a root node "state".
  */
-static void nfa_print_state(debugf, state)
-FILE *debugf;
-nfa_state_T *state;
+static void nfa_print_state(FILE *debugf, nfa_state_T *state)
 {
   garray_T indent;
 
@@ -2372,10 +2362,7 @@ nfa_state_T *state;
   ga_clear(&indent);
 }
 
-static void nfa_print_state2(debugf, state, indent)
-FILE *debugf;
-nfa_state_T *state;
-garray_T *indent;
+static void nfa_print_state2(FILE *debugf, nfa_state_T *state, garray_T *indent)
 {
   char_u  *p;
 
@@ -2433,8 +2420,7 @@ garray_T *indent;
 /*
  * Print the NFA state machine.
  */
-static void nfa_dump(prog)
-nfa_regprog_T *prog;
+static void nfa_dump(nfa_regprog_T *prog)
 {
   FILE *debugf = fopen(NFA_REGEXP_DUMP_LOG, "a");
 
@@ -2459,7 +2445,7 @@ nfa_regprog_T *prog;
  * Parse r.e. @expr and convert it into postfix form.
  * Return the postfix string on success, NULL otherwise.
  */
-static int * re2post()                  {
+static int *re2post(void)                  {
   if (nfa_reg(REG_NOPAREN) == FAIL)
     return NULL;
   EMIT(NFA_MOPEN);
@@ -2480,10 +2466,7 @@ static nfa_state_T      *state_ptr; /* points to nfa_prog->state */
 /*
  * Allocate and initialize nfa_state_T.
  */
-static nfa_state_T * alloc_state(c, out, out1)
-int c;
-nfa_state_T *out;
-nfa_state_T *out1;
+static nfa_state_T *alloc_state(int c, nfa_state_T *out, nfa_state_T *out1)
 {
   nfa_state_T *s;
 
@@ -2536,9 +2519,7 @@ static Frag_T st_pop __ARGS((Frag_T **p, Frag_T *stack));
 /*
  * Initialize a Frag_T struct and return it.
  */
-static Frag_T frag(start, out)
-nfa_state_T *start;
-Ptrlist     *out;
+static Frag_T frag(nfa_state_T *start, Ptrlist *out)
 {
   Frag_T n;
 
@@ -2550,8 +2531,7 @@ Ptrlist     *out;
 /*
  * Create singleton list containing just outp.
  */
-static Ptrlist * list1(outp)
-nfa_state_T **outp;
+static Ptrlist *list1(nfa_state_T **outp)
 {
   Ptrlist *l;
 
@@ -2563,9 +2543,7 @@ nfa_state_T **outp;
 /*
  * Patch the list of states at out to point to start.
  */
-static void patch(l, s)
-Ptrlist     *l;
-nfa_state_T *s;
+static void patch(Ptrlist *l, nfa_state_T *s)
 {
   Ptrlist *next;
 
@@ -2579,9 +2557,7 @@ nfa_state_T *s;
 /*
  * Join the two lists l1 and l2, returning the combination.
  */
-static Ptrlist * append(l1, l2)
-Ptrlist *l1;
-Ptrlist *l2;
+static Ptrlist *append(Ptrlist *l1, Ptrlist *l2)
 {
   Ptrlist *oldl1;
 
@@ -2597,10 +2573,7 @@ Ptrlist *l2;
  */
 static Frag_T empty;
 
-static void st_error(postfix, end, p)
-int *postfix UNUSED;
-int *end UNUSED;
-int *p UNUSED;
+static void st_error(int *postfix, int *end, int *p)
 {
 #ifdef NFA_REGEXP_ERROR_LOG
   FILE *df;
@@ -2643,10 +2616,7 @@ int *p UNUSED;
 /*
  * Push an item onto the stack.
  */
-static void st_push(s, p, stack_end)
-Frag_T s;
-Frag_T **p;
-Frag_T *stack_end;
+static void st_push(Frag_T s, Frag_T **p, Frag_T *stack_end)
 {
   Frag_T *stackp = *p;
 
@@ -2659,9 +2629,7 @@ Frag_T *stack_end;
 /*
  * Pop an item from the stack.
  */
-static Frag_T st_pop(p, stack)
-Frag_T **p;
-Frag_T *stack;
+static Frag_T st_pop(Frag_T **p, Frag_T *stack)
 {
   Frag_T *stackp;
 
@@ -2676,9 +2644,7 @@ Frag_T *stack;
  * Estimate the maximum byte length of anything matching "state".
  * When unknown or unlimited return -1.
  */
-static int nfa_max_width(startstate, depth)
-nfa_state_T *startstate;
-int depth;
+static int nfa_max_width(nfa_state_T *startstate, int depth)
 {
   int l, r;
   nfa_state_T     *state = startstate;
@@ -2888,10 +2854,7 @@ int depth;
  * Convert a postfix form into its equivalent NFA.
  * Return the NFA start state on success, NULL otherwise.
  */
-static nfa_state_T * post2nfa(postfix, end, nfa_calc_size)
-int         *postfix;
-int         *end;
-int nfa_calc_size;
+static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
 {
   int         *p;
   int mopen;
@@ -3375,8 +3338,7 @@ theend:
 /*
  * After building the NFA program, inspect it to add optimization hints.
  */
-static void nfa_postprocess(prog)
-nfa_regprog_T   *prog;
+static void nfa_postprocess(nfa_regprog_T *prog)
 {
   int i;
   int c;
@@ -3489,16 +3451,14 @@ static void log_subsexpr __ARGS((regsubs_T *subs));
 static void log_subexpr __ARGS((regsub_T *sub));
 static char *pim_info __ARGS((nfa_pim_T *pim));
 
-static void log_subsexpr(subs)
-regsubs_T *subs;
+static void log_subsexpr(regsubs_T *subs)
 {
   log_subexpr(&subs->norm);
   if (nfa_has_zsubexpr)
     log_subexpr(&subs->synt);
 }
 
-static void log_subexpr(sub)
-regsub_T *sub;
+static void log_subexpr(regsub_T *sub)
 {
   int j;
 
@@ -3521,8 +3481,7 @@ regsub_T *sub;
     }
 }
 
-static char * pim_info(pim)
-nfa_pim_T *pim;
+static char *pim_info(nfa_pim_T *pim)
 {
   static char buf[30];
 
@@ -3563,9 +3522,7 @@ static void addstate_here __ARGS((nfa_list_T *l, nfa_state_T *state,
 /*
  * Copy postponed invisible match info from "from" to "to".
  */
-static void copy_pim(to, from)
-nfa_pim_T *to;
-nfa_pim_T *from;
+static void copy_pim(nfa_pim_T *to, nfa_pim_T *from)
 {
   to->result = from->result;
   to->state = from->state;
@@ -3575,8 +3532,7 @@ nfa_pim_T *from;
   to->end = from->end;
 }
 
-static void clear_sub(sub)
-regsub_T *sub;
+static void clear_sub(regsub_T *sub)
 {
   if (REG_MULTI)
     /* Use 0xff to set lnum to -1 */
@@ -3590,9 +3546,7 @@ regsub_T *sub;
 /*
  * Copy the submatches from "from" to "to".
  */
-static void copy_sub(to, from)
-regsub_T    *to;
-regsub_T    *from;
+static void copy_sub(regsub_T *to, regsub_T *from)
 {
   to->in_use = from->in_use;
   if (from->in_use > 0) {
@@ -3611,9 +3565,7 @@ regsub_T    *from;
 /*
  * Like copy_sub() but exclude the main match.
  */
-static void copy_sub_off(to, from)
-regsub_T    *to;
-regsub_T    *from;
+static void copy_sub_off(regsub_T *to, regsub_T *from)
 {
   if (to->in_use < from->in_use)
     to->in_use = from->in_use;
@@ -3633,9 +3585,7 @@ regsub_T    *from;
 /*
  * Like copy_sub() but only do the end of the main match if \ze is present.
  */
-static void copy_ze_off(to, from)
-regsub_T    *to;
-regsub_T    *from;
+static void copy_ze_off(regsub_T *to, regsub_T *from)
 {
   if (nfa_has_zend) {
     if (REG_MULTI) {
@@ -3651,9 +3601,7 @@ regsub_T    *from;
 /*
  * Return TRUE if "sub1" and "sub2" have the same start positions.
  */
-static int sub_equal(sub1, sub2)
-regsub_T    *sub1;
-regsub_T    *sub2;
+static int sub_equal(regsub_T *sub1, regsub_T *sub2)
 {
   int i;
   int todo;
@@ -3723,11 +3671,13 @@ static void report_state(char *action,
  * Return TRUE if the same state is already in list "l" with the same
  * positions as "subs".
  */
-static int has_state_with_pos(l, state, subs, pim)
-nfa_list_T          *l;         /* runtime state list */
-nfa_state_T         *state;     /* state to update */
-regsubs_T           *subs;      /* pointers to subexpressions */
-nfa_pim_T           *pim;       /* postponed match or NULL */
+static int 
+has_state_with_pos (
+    nfa_list_T *l,         /* runtime state list */
+    nfa_state_T *state,     /* state to update */
+    regsubs_T *subs,      /* pointers to subexpressions */
+    nfa_pim_T *pim       /* postponed match or NULL */
+)
 {
   nfa_thread_T        *thread;
   int i;
@@ -3748,9 +3698,7 @@ nfa_pim_T           *pim;       /* postponed match or NULL */
  * Return TRUE if "one" and "two" are equal.  That includes when both are not
  * set.
  */
-static int pim_equal(one, two)
-nfa_pim_T *one;
-nfa_pim_T *two;
+static int pim_equal(nfa_pim_T *one, nfa_pim_T *two)
 {
   int one_unused = (one == NULL || one->result == NFA_PIM_UNUSED);
   int two_unused = (two == NULL || two->result == NFA_PIM_UNUSED);
@@ -3774,9 +3722,7 @@ nfa_pim_T *two;
 /*
  * Return TRUE if "state" leads to a NFA_MATCH without advancing the input.
  */
-static int match_follows(startstate, depth)
-nfa_state_T *startstate;
-int depth;
+static int match_follows(nfa_state_T *startstate, int depth)
 {
   nfa_state_T     *state = startstate;
 
@@ -3865,10 +3811,12 @@ int depth;
 /*
  * Return TRUE if "state" is already in list "l".
  */
-static int state_in_list(l, state, subs)
-nfa_list_T          *l;         /* runtime state list */
-nfa_state_T         *state;     /* state to update */
-regsubs_T           *subs;      /* pointers to subexpressions */
+static int 
+state_in_list (
+    nfa_list_T *l,         /* runtime state list */
+    nfa_state_T *state,     /* state to update */
+    regsubs_T *subs      /* pointers to subexpressions */
+)
 {
   if (state->lastlist[nfa_ll_index] == l->id) {
     if (!nfa_has_backref || has_state_with_pos(l, state, subs, NULL))
@@ -3882,12 +3830,14 @@ regsubs_T           *subs;      /* pointers to subexpressions */
  * Returns "subs_arg", possibly copied into temp_subs.
  */
 
-static regsubs_T * addstate(l, state, subs_arg, pim, off)
-nfa_list_T          *l;             /* runtime state list */
-nfa_state_T         *state;         /* state to update */
-regsubs_T           *subs_arg;      /* pointers to subexpressions */
-nfa_pim_T           *pim;           /* postponed look-behind match */
-int off;                            /* byte offset, when -1 go to next line */
+static regsubs_T *
+addstate (
+    nfa_list_T *l,             /* runtime state list */
+    nfa_state_T *state,         /* state to update */
+    regsubs_T *subs_arg,      /* pointers to subexpressions */
+    nfa_pim_T *pim,           /* postponed look-behind match */
+    int off                            /* byte offset, when -1 go to next line */
+)
 {
   int subidx;
   nfa_thread_T        *thread;
@@ -4226,12 +4176,14 @@ skip_add:
  * This makes sure the order of states to be tried does not change, which
  * matters for alternatives.
  */
-static void addstate_here(l, state, subs, pim, ip)
-nfa_list_T          *l;         /* runtime state list */
-nfa_state_T         *state;     /* state to update */
-regsubs_T           *subs;      /* pointers to subexpressions */
-nfa_pim_T           *pim;       /* postponed look-behind match */
-int                 *ip;
+static void 
+addstate_here (
+    nfa_list_T *l,         /* runtime state list */
+    nfa_state_T *state,     /* state to update */
+    regsubs_T *subs,      /* pointers to subexpressions */
+    nfa_pim_T *pim,       /* postponed look-behind match */
+    int *ip
+)
 {
   int tlen = l->n;
   int count;
@@ -4290,9 +4242,7 @@ int                 *ip;
 /*
  * Check character class "class" against current character c.
  */
-static int check_char_class(class, c)
-int class;
-int c;
+static int check_char_class(int class, int c)
 {
   switch (class) {
   case NFA_CLASS_ALNUM:
@@ -4372,10 +4322,12 @@ int c;
  * Check for a match with subexpression "subidx".
  * Return TRUE if it matches.
  */
-static int match_backref(sub, subidx, bytelen)
-regsub_T    *sub;           /* pointers to subexpressions */
-int subidx;
-int         *bytelen;       /* out: length of match in bytes */
+static int 
+match_backref (
+    regsub_T *sub,           /* pointers to subexpressions */
+    int subidx,
+    int *bytelen       /* out: length of match in bytes */
+)
 {
   int len;
 
@@ -4428,9 +4380,11 @@ static int match_zref __ARGS((int subidx, int *bytelen));
  * Check for a match with \z subexpression "subidx".
  * Return TRUE if it matches.
  */
-static int match_zref(subidx, bytelen)
-int subidx;
-int         *bytelen;       /* out: length of match in bytes */
+static int 
+match_zref (
+    int subidx,
+    int *bytelen       /* out: length of match in bytes */
+)
 {
   int len;
 
@@ -4454,9 +4408,7 @@ int         *bytelen;       /* out: length of match in bytes */
  * Also reset the IDs to zero.
  * Only used for the recursive value lastlist[1].
  */
-static void nfa_save_listids(prog, list)
-nfa_regprog_T   *prog;
-int             *list;
+static void nfa_save_listids(nfa_regprog_T *prog, int *list)
 {
   int i;
   nfa_state_T     *p;
@@ -4473,9 +4425,7 @@ int             *list;
 /*
  * Restore list IDs from "list" to all NFA states.
  */
-static void nfa_restore_listids(prog, list)
-nfa_regprog_T   *prog;
-int             *list;
+static void nfa_restore_listids(nfa_regprog_T *prog, int *list)
 {
   int i;
   nfa_state_T     *p;
@@ -4487,10 +4437,7 @@ int             *list;
   }
 }
 
-static int nfa_re_num_cmp(val, op, pos)
-long_u val;
-int op;
-long_u pos;
+static int nfa_re_num_cmp(long_u val, int op, long_u pos)
 {
   if (op == 1) return pos > val;
   if (op == 2) return pos < val;
@@ -4510,13 +4457,7 @@ static int nfa_regmatch __ARGS((nfa_regprog_T *prog, nfa_state_T *start,
  * "pim" is NULL or contains info about a Postponed Invisible Match (start
  * position).
  */
-static int recursive_regmatch(state, pim, prog, submatch, m, listids)
-nfa_state_T     *state;
-nfa_pim_T       *pim;
-nfa_regprog_T   *prog;
-regsubs_T       *submatch;
-regsubs_T       *m;
-int             **listids;
+static int recursive_regmatch(nfa_state_T *state, nfa_pim_T *pim, nfa_regprog_T *prog, regsubs_T *submatch, regsubs_T *m, int **listids)
 {
   int save_reginput_col = (int)(reginput - regline);
   int save_reglnum = reglnum;
@@ -4666,9 +4607,7 @@ static long find_match_text __ARGS((colnr_T startcol, int regstart,
  * NFA_ANY: 1
  * specific character: 99
  */
-static int failure_chance(state, depth)
-nfa_state_T *state;
-int depth;
+static int failure_chance(nfa_state_T *state, int depth)
 {
   int c = state->c;
   int l, r;
@@ -4821,9 +4760,7 @@ int depth;
 /*
  * Skip until the char "c" we know a match must start with.
  */
-static int skip_to_start(c, colp)
-int c;
-colnr_T     *colp;
+static int skip_to_start(int c, colnr_T *colp)
 {
   char_u *s;
 
@@ -4845,10 +4782,7 @@ colnr_T     *colp;
  * Called after skip_to_start() has found regstart.
  * Returns zero for no match, 1 for a match.
  */
-static long find_match_text(startcol, regstart, match_text)
-colnr_T startcol;
-int regstart;
-char_u  *match_text;
+static long find_match_text(colnr_T startcol, int regstart, char_u *match_text)
 {
   colnr_T col = startcol;
   int c1, c2;
@@ -4904,11 +4838,7 @@ char_u  *match_text;
  * When there is a match "submatch" contains the positions.
  * Note: Caller must ensure that: start != NULL.
  */
-static int nfa_regmatch(prog, start, submatch, m)
-nfa_regprog_T       *prog;
-nfa_state_T         *start;
-regsubs_T           *submatch;
-regsubs_T           *m;
+static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *submatch, regsubs_T *m)
 {
   int result;
   int size = 0;
@@ -6116,9 +6046,7 @@ theend:
  * Try match of "prog" with at regline["col"].
  * Returns 0 for failure, number of lines contained in the match otherwise.
  */
-static long nfa_regtry(prog, col)
-nfa_regprog_T   *prog;
-colnr_T col;
+static long nfa_regtry(nfa_regprog_T *prog, colnr_T col)
 {
   int i;
   regsubs_T subs, m;
@@ -6221,9 +6149,11 @@ colnr_T col;
  *
  * Returns 0 for failure, number of lines contained in the match otherwise.
  */
-static long nfa_regexec_both(line, startcol)
-char_u      *line;
-colnr_T startcol;               /* column to start looking for match */
+static long 
+nfa_regexec_both (
+    char_u *line,
+    colnr_T startcol               /* column to start looking for match */
+)
 {
   nfa_regprog_T   *prog;
   long retval = 0L;
@@ -6319,9 +6249,7 @@ theend:
  * Compile a regular expression into internal code for the NFA matcher.
  * Returns the program in allocated space.  Returns NULL for an error.
  */
-static regprog_T * nfa_regcomp(expr, re_flags)
-char_u      *expr;
-int re_flags;
+static regprog_T *nfa_regcomp(char_u *expr, int re_flags)
 {
   nfa_regprog_T       *prog = NULL;
   size_t prog_size;
@@ -6435,8 +6363,7 @@ fail:
 /*
  * Free a compiled regexp program, returned by nfa_regcomp().
  */
-static void nfa_regfree(prog)
-regprog_T   *prog;
+static void nfa_regfree(regprog_T *prog)
 {
   if (prog != NULL) {
     vim_free(((nfa_regprog_T *)prog)->match_text);
@@ -6454,10 +6381,12 @@ regprog_T   *prog;
  *
  * Return TRUE if there is a match, FALSE if not.
  */
-static int nfa_regexec(rmp, line, col)
-regmatch_T  *rmp;
-char_u      *line;      /* string to match against */
-colnr_T col;            /* column to start looking for match */
+static int 
+nfa_regexec (
+    regmatch_T *rmp,
+    char_u *line,      /* string to match against */
+    colnr_T col            /* column to start looking for match */
+)
 {
   reg_match = rmp;
   reg_mmatch = NULL;
@@ -6479,10 +6408,12 @@ static int nfa_regexec_nl __ARGS((regmatch_T *rmp, char_u *line, colnr_T col));
 /*
  * Like nfa_regexec(), but consider a "\n" in "line" to be a line break.
  */
-static int nfa_regexec_nl(rmp, line, col)
-regmatch_T  *rmp;
-char_u      *line;      /* string to match against */
-colnr_T col;            /* column to start looking for match */
+static int 
+nfa_regexec_nl (
+    regmatch_T *rmp,
+    char_u *line,      /* string to match against */
+    colnr_T col            /* column to start looking for match */
+)
 {
   reg_match = rmp;
   reg_mmatch = NULL;
@@ -6529,7 +6460,7 @@ win_T       *win;               /* window in which to search or NULL */
 buf_T       *buf;               /* buffer in which to search */
 linenr_T lnum;                  /* nr of line to start looking for match */
 colnr_T col;                    /* column to start looking for match */
-proftime_T  *tm UNUSED;         /* timeout limit or NULL */
+proftime_T  *tm;         /* timeout limit or NULL */
 {
   reg_match = NULL;
   reg_mmatch = rmp;

--- a/src/screen.c
+++ b/src/screen.c
@@ -163,15 +163,12 @@ static int screen_char_attr = 0;
  * Set must_redraw only if not already set to a higher value.
  * e.g. if must_redraw is CLEAR, type NOT_VALID will do nothing.
  */
-void redraw_later(type)
-int type;
+void redraw_later(int type)
 {
   redraw_win_later(curwin, type);
 }
 
-void redraw_win_later(wp, type)
-win_T       *wp;
-int type;
+void redraw_win_later(win_T *wp, int type)
 {
   if (wp->w_redr_type < type) {
     wp->w_redr_type = type;
@@ -186,7 +183,7 @@ int type;
  * Force a complete redraw later.  Also resets the highlighting.  To be used
  * after executing a shell command that messes up the screen.
  */
-void redraw_later_clear()          {
+void redraw_later_clear(void)          {
   redraw_all_later(CLEAR);
   /* Use attributes that is very unlikely to appear in text. */
   screen_attr = HL_BOLD | HL_UNDERLINE | HL_INVERSE;
@@ -195,8 +192,7 @@ void redraw_later_clear()          {
 /*
  * Mark all windows to be redrawn later.
  */
-void redraw_all_later(type)
-int type;
+void redraw_all_later(int type)
 {
   win_T       *wp;
 
@@ -209,15 +205,12 @@ int type;
 /*
  * Mark all windows that are editing the current buffer to be updated later.
  */
-void redraw_curbuf_later(type)
-int type;
+void redraw_curbuf_later(int type)
 {
   redraw_buf_later(curbuf, type);
 }
 
-void redraw_buf_later(buf, type)
-buf_T       *buf;
-int type;
+void redraw_buf_later(buf_T *buf, int type)
 {
   win_T       *wp;
 
@@ -233,8 +226,7 @@ int type;
  * right away and restore what was on the command line.
  * Return a code indicating what happened.
  */
-int redraw_asap(type)
-int type;
+int redraw_asap(int type)
 {
   int rows;
   int r;
@@ -360,9 +352,11 @@ int type;
  * Note that when also inserting/deleting lines w_redraw_top and w_redraw_bot
  * may become invalid and the whole window will have to be redrawn.
  */
-void redrawWinline(lnum, invalid)
-linenr_T lnum;
-int invalid UNUSED;             /* window line height is invalid now */
+void 
+redrawWinline (
+    linenr_T lnum,
+    int invalid             /* window line height is invalid now */
+)
 {
   int i;
 
@@ -385,8 +379,7 @@ int invalid UNUSED;             /* window line height is invalid now */
 /*
  * update all windows that are editing the current buffer
  */
-void update_curbuf(type)
-int type;
+void update_curbuf(int type)
 {
   redraw_curbuf_later(type);
   update_screen(type);
@@ -399,8 +392,7 @@ int type;
  * Based on the current value of curwin->w_topline, transfer a screenfull
  * of stuff from Filemem to ScreenLines[], and update curwin->w_botline.
  */
-void update_screen(type)
-int type;
+void update_screen(int type)
 {
   win_T       *wp;
   static int did_intro = FALSE;
@@ -591,8 +583,7 @@ int type;
  * Return TRUE if the cursor line in window "wp" may be concealed, according
  * to the 'concealcursor' option.
  */
-int conceal_cursor_line(wp)
-win_T       *wp;
+int conceal_cursor_line(win_T *wp)
 {
   int c;
 
@@ -614,7 +605,7 @@ win_T       *wp;
 /*
  * Check if the cursor line needs to be redrawn because of 'concealcursor'.
  */
-void conceal_check_cursur_line()          {
+void conceal_check_cursur_line(void)          {
   if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)) {
     need_cursor_line_redraw = TRUE;
     /* Need to recompute cursor column, e.g., when starting Visual mode
@@ -623,9 +614,7 @@ void conceal_check_cursur_line()          {
   }
 }
 
-void update_single_line(wp, lnum)
-win_T       *wp;
-linenr_T lnum;
+void update_single_line(win_T *wp, linenr_T lnum)
 {
   int row;
   int j;
@@ -680,8 +669,7 @@ linenr_T lnum;
  * mid: from mid_start to mid_end (update inversion or changed text)
  * bot: from bot_start to last row (when scrolled up)
  */
-static void win_update(wp)
-win_T       *wp;
+static void win_update(win_T *wp)
 {
   buf_T       *buf = wp->w_buffer;
   int type;
@@ -1633,13 +1621,7 @@ win_T       *wp;
  * Clear the rest of the window and mark the unused lines with "c1".  use "c2"
  * as the filler character.
  */
-static void win_draw_end(wp, c1, c2, row, endrow, hl)
-win_T       *wp;
-int c1;
-int c2;
-int row;
-int endrow;
-hlf_T hl;
+static void win_draw_end(win_T *wp, int c1, int c2, int row, int endrow, hlf_T hl)
 {
   int n = 0;
 # define FDC_OFF n
@@ -1695,9 +1677,7 @@ static int advance_color_col __ARGS((int vcol, int **color_cols));
 /*
  * Advance **color_cols and return TRUE when there are columns to draw.
  */
-static int advance_color_col(vcol, color_cols)
-int vcol;
-int     **color_cols;
+static int advance_color_col(int vcol, int **color_cols)
 {
   while (**color_cols >= 0 && vcol > **color_cols)
     ++*color_cols;
@@ -1707,12 +1687,7 @@ int     **color_cols;
 /*
  * Display one folded line.
  */
-static void fold_line(wp, fold_count, foldinfo, lnum, row)
-win_T       *wp;
-long fold_count;
-foldinfo_T  *foldinfo;
-linenr_T lnum;
-int row;
+static void fold_line(win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T lnum, int row)
 {
   char_u buf[51];
   pos_T       *top, *bot;
@@ -2018,11 +1993,7 @@ int row;
 /*
  * Copy "buf[len]" to ScreenLines["off"] and set attributes to "attr".
  */
-static void copy_text_attr(off, buf, len, attr)
-int off;
-char_u      *buf;
-int len;
-int attr;
+static void copy_text_attr(int off, char_u *buf, int len, int attr)
 {
   int i;
 
@@ -2037,11 +2008,13 @@ int attr;
  * Fill the foldcolumn at "p" for window "wp".
  * Only to be called when 'foldcolumn' > 0.
  */
-static void fill_foldcolumn(p, wp, closed, lnum)
-char_u      *p;
-win_T       *wp;
-int closed;                     /* TRUE of FALSE */
-linenr_T lnum;                  /* current line number */
+static void 
+fill_foldcolumn (
+    char_u *p,
+    win_T *wp,
+    int closed,                     /* TRUE of FALSE */
+    linenr_T lnum                  /* current line number */
+)
 {
   int i = 0;
   int level;
@@ -2087,12 +2060,14 @@ linenr_T lnum;                  /* current line number */
  *
  * Return the number of last row the line occupies.
  */
-static int win_line(wp, lnum, startrow, endrow, nochange)
-win_T       *wp;
-linenr_T lnum;
-int startrow;
-int endrow;
-int nochange UNUSED;                    /* not updating for changed text */
+static int 
+win_line (
+    win_T *wp,
+    linenr_T lnum,
+    int startrow,
+    int endrow,
+    int nochange                    /* not updating for changed text */
+)
 {
   int col;                              /* visual column on screen */
   unsigned off;                         /* offset in ScreenLines/ScreenAttrs */
@@ -4056,9 +4031,7 @@ static int comp_char_differs __ARGS((int, int));
  * Return if the composing characters at "off_from" and "off_to" differ.
  * Only to be used when ScreenLinesUC[off_from] != 0.
  */
-static int comp_char_differs(off_from, off_to)
-int off_from;
-int off_to;
+static int comp_char_differs(int off_from, int off_to)
 {
   int i;
 
@@ -4078,10 +4051,7 @@ int off_to;
  * - the character is multi-byte and the next byte is different
  * - the character is two cells wide and the second cell differs.
  */
-static int char_needs_redraw(off_from, off_to, cols)
-int off_from;
-int off_to;
-int cols;
+static int char_needs_redraw(int off_from, int off_to, int cols)
 {
   if (cols > 0
       && ((ScreenLines[off_from] != ScreenLines[off_to]
@@ -4116,13 +4086,7 @@ int cols;
  *    When TRUE and "clear_width" > 0, clear columns 0 to "endcol"
  *    When FALSE and "clear_width" > 0, clear columns "endcol" to "clear_width"
  */
-static void screen_line(row, coloff, endcol, clear_width
-    , rlflag    )
-int row;
-int coloff;
-int endcol;
-int clear_width;
-int rlflag;
+static void screen_line(int row, int coloff, int endcol, int clear_width, int rlflag)
 {
   unsigned off_from;
   unsigned off_to;
@@ -4376,8 +4340,7 @@ int rlflag;
  * Mirror text "str" for right-left displaying.
  * Only works for single-byte characters (e.g., numbers).
  */
-void rl_mirror(str)
-char_u      *str;
+void rl_mirror(char_u *str)
 {
   char_u      *p1, *p2;
   int t;
@@ -4392,7 +4355,7 @@ char_u      *str;
 /*
  * mark all status lines for redraw; used after first :cd
  */
-void status_redraw_all()          {
+void status_redraw_all(void)          {
   win_T       *wp;
 
   for (wp = firstwin; wp; wp = wp->w_next)
@@ -4405,7 +4368,7 @@ void status_redraw_all()          {
 /*
  * mark all status lines of the current buffer for redraw
  */
-void status_redraw_curbuf()          {
+void status_redraw_curbuf(void)          {
   win_T       *wp;
 
   for (wp = firstwin; wp; wp = wp->w_next)
@@ -4418,7 +4381,7 @@ void status_redraw_curbuf()          {
 /*
  * Redraw all status lines that need to be redrawn.
  */
-void redraw_statuslines()          {
+void redraw_statuslines(void)          {
   win_T       *wp;
 
   for (wp = firstwin; wp; wp = wp->w_next)
@@ -4431,8 +4394,7 @@ void redraw_statuslines()          {
 /*
  * Redraw all status lines at the bottom of frame "frp".
  */
-void win_redraw_last_status(frp)
-frame_T     *frp;
+void win_redraw_last_status(frame_T *frp)
 {
   if (frp->fr_layout == FR_LEAF)
     frp->fr_win->w_redr_status = TRUE;
@@ -4450,9 +4412,7 @@ frame_T     *frp;
 /*
  * Draw the verticap separator right of window "wp" starting with line "row".
  */
-static void draw_vsep_win(wp, row)
-win_T       *wp;
-int row;
+static void draw_vsep_win(win_T *wp, int row)
 {
   int hl;
   int c;
@@ -4472,9 +4432,7 @@ static int skip_status_match_char __ARGS((expand_T *xp, char_u *s));
 /*
  * Get the length of an item as it will be shown in the status line.
  */
-static int status_match_len(xp, s)
-expand_T    *xp;
-char_u      *s;
+static int status_match_len(expand_T *xp, char_u *s)
 {
   int len = 0;
 
@@ -4498,9 +4456,7 @@ char_u      *s;
  * Return the number of characters that should be skipped in a status match.
  * These are backslashes used for escaping.  Do show backslashes in help tags.
  */
-static int skip_status_match_char(xp, s)
-expand_T    *xp;
-char_u      *s;
+static int skip_status_match_char(expand_T *xp, char_u *s)
 {
   if ((rem_backslash(s) && xp->xp_context != EXPAND_HELP)
       || ((xp->xp_context == EXPAND_MENUS
@@ -4523,12 +4479,14 @@ char_u      *s;
  *
  * If inversion is possible we use it. Else '=' characters are used.
  */
-void win_redr_status_matches(xp, num_matches, matches, match, showtail)
-expand_T    *xp;
-int num_matches;
-char_u      **matches;          /* list of matches */
-int match;
-int showtail;
+void 
+win_redr_status_matches (
+    expand_T *xp,
+    int num_matches,
+    char_u **matches,          /* list of matches */
+    int match,
+    int showtail
+)
 {
 #define L_MATCH(m) (showtail ? sm_gettail(matches[m]) : matches[m])
   int row;
@@ -4702,8 +4660,7 @@ int showtail;
  *
  * If inversion is possible we use it. Else '=' characters are used.
  */
-void win_redr_status(wp)
-win_T       *wp;
+void win_redr_status(win_T *wp)
 {
   int row;
   char_u      *p;
@@ -4823,8 +4780,7 @@ win_T       *wp;
  * Redraw the status line according to 'statusline' and take care of any
  * errors encountered.
  */
-static void redraw_custom_statusline(wp)
-win_T           *wp;
+static void redraw_custom_statusline(win_T *wp)
 {
   static int entered = FALSE;
   int save_called_emsg = called_emsg;
@@ -4854,8 +4810,7 @@ win_T           *wp;
  * line of the window right of it.  If not, then it's a vertical separator.
  * Only call if (wp->w_vsep_width != 0).
  */
-int stl_connected(wp)
-win_T       *wp;
+int stl_connected(win_T *wp)
 {
   frame_T     *fr;
 
@@ -4877,10 +4832,12 @@ win_T       *wp;
 /*
  * Get the value to show for the language mappings, active 'keymap'.
  */
-int get_keymap_str(wp, buf, len)
-win_T       *wp;
-char_u      *buf;           /* buffer for the result */
-int len;                    /* length of buffer */
+int 
+get_keymap_str (
+    win_T *wp,
+    char_u *buf,           /* buffer for the result */
+    int len                    /* length of buffer */
+)
 {
   char_u      *p;
 
@@ -4919,9 +4876,11 @@ int len;                    /* length of buffer */
  * Redraw the status line or ruler of window "wp".
  * When "wp" is NULL redraw the tab pages line from 'tabline'.
  */
-static void win_redr_custom(wp, draw_ruler)
-win_T       *wp;
-int draw_ruler;                 /* TRUE or FALSE */
+static void 
+win_redr_custom (
+    win_T *wp,
+    int draw_ruler                 /* TRUE or FALSE */
+)
 {
   static int entered = FALSE;
   int attr;
@@ -5079,10 +5038,7 @@ theend:
 /*
  * Output a single character directly to the screen and update ScreenLines.
  */
-void screen_putchar(c, row, col, attr)
-int c;
-int row, col;
-int attr;
+void screen_putchar(int c, int row, int col, int attr)
 {
   char_u buf[MB_MAXBYTES + 1];
 
@@ -5099,10 +5055,7 @@ int attr;
  * Get a single character directly from ScreenLines into "bytes[]".
  * Also return its attribute in *attrp;
  */
-void screen_getbytes(row, col, bytes, attrp)
-int row, col;
-char_u  *bytes;
-int     *attrp;
+void screen_getbytes(int row, int col, char_u *bytes, int *attrp)
 {
   unsigned off;
 
@@ -5133,9 +5086,7 @@ static int screen_comp_differs __ARGS((int, int*));
  * composing characters in "u8cc".
  * Only to be used when ScreenLinesUC[off] != 0.
  */
-static int screen_comp_differs(off, u8cc)
-int off;
-int     *u8cc;
+static int screen_comp_differs(int off, int *u8cc)
 {
   int i;
 
@@ -5154,11 +5105,7 @@ int     *u8cc;
  * Note: only outputs within one row, message is truncated at screen boundary!
  * Note: if ScreenLines[], row and/or col is invalid, nothing is done.
  */
-void screen_puts(text, row, col, attr)
-char_u      *text;
-int row;
-int col;
-int attr;
+void screen_puts(char_u *text, int row, int col, int attr)
 {
   screen_puts_len(text, -1, row, col, attr);
 }
@@ -5167,12 +5114,7 @@ int attr;
  * Like screen_puts(), but output "text[len]".  When "len" is -1 output up to
  * a NUL.
  */
-void screen_puts_len(text, len, row, col, attr)
-char_u      *text;
-int len;
-int row;
-int col;
-int attr;
+void screen_puts_len(char_u *text, int len, int row, int col, int attr)
 {
   unsigned off;
   char_u      *ptr = text;
@@ -5383,7 +5325,7 @@ int attr;
 /*
  * Prepare for 'hlsearch' highlighting.
  */
-static void start_search_hl()                 {
+static void start_search_hl(void)                 {
   if (p_hls && !no_hlsearch) {
     last_pat_prog(&search_hl.rm);
     search_hl.attr = hl_attr(HLF_L);
@@ -5395,7 +5337,7 @@ static void start_search_hl()                 {
 /*
  * Clean up for 'hlsearch' highlighting.
  */
-static void end_search_hl()                 {
+static void end_search_hl(void)                 {
   if (search_hl.rm.regprog != NULL) {
     vim_regfree(search_hl.rm.regprog);
     search_hl.rm.regprog = NULL;
@@ -5405,8 +5347,7 @@ static void end_search_hl()                 {
 /*
  * Init for calling prepare_search_hl().
  */
-static void init_search_hl(wp)
-win_T       *wp;
+static void init_search_hl(win_T *wp)
 {
   matchitem_T *cur;
 
@@ -5435,9 +5376,7 @@ win_T       *wp;
 /*
  * Advance to the match in window "wp" line "lnum" or past it.
  */
-static void prepare_search_hl(wp, lnum)
-win_T       *wp;
-linenr_T lnum;
+static void prepare_search_hl(win_T *wp, linenr_T lnum)
 {
   matchitem_T *cur;             /* points to the match list */
   match_T     *shl;             /* points to search_hl or a match */
@@ -5495,11 +5434,13 @@ linenr_T lnum;
  * shl->lnum is zero.
  * Careful: Any pointers for buffer lines will become invalid.
  */
-static void next_search_hl(win, shl, lnum, mincol)
-win_T       *win;
-match_T     *shl;               /* points to search_hl or a match */
-linenr_T lnum;
-colnr_T mincol;                 /* minimal column for a match */
+static void 
+next_search_hl (
+    win_T *win,
+    match_T *shl,               /* points to search_hl or a match */
+    linenr_T lnum,
+    colnr_T mincol                 /* minimal column for a match */
+)
 {
   linenr_T l;
   colnr_T matchcol;
@@ -5586,8 +5527,7 @@ colnr_T mincol;                 /* minimal column for a match */
   }
 }
 
-static void screen_start_highlight(attr)
-int attr;
+static void screen_start_highlight(int attr)
 {
   attrentry_T *aep = NULL;
 
@@ -5641,7 +5581,7 @@ int attr;
   }
 }
 
-void screen_stop_highlight()            {
+void screen_stop_highlight(void)            {
   int do_ME = FALSE;                /* output T_ME code */
 
   if (screen_attr != 0
@@ -5716,7 +5656,7 @@ void screen_stop_highlight()            {
  * Reset the colors for a cterm.  Used when leaving Vim.
  * The machine specific code may override this again.
  */
-void reset_cterm_colors()          {
+void reset_cterm_colors(void)          {
   if (t_colors > 1) {
     /* set Normal cterm colors */
     if (cterm_normal_fg_color > 0 || cterm_normal_bg_color > 0) {
@@ -5734,10 +5674,7 @@ void reset_cterm_colors()          {
  * Put character ScreenLines["off"] on the screen at position "row" and "col",
  * using the attributes from ScreenAttrs["off"].
  */
-static void screen_char(off, row, col)
-unsigned off;
-int row;
-int col;
+static void screen_char(unsigned off, int row, int col)
 {
   int attr;
 
@@ -5799,10 +5736,7 @@ int col;
  * The attributes of the first byte is used for all.  This is required to
  * output the two bytes of a double-byte character with nothing in between.
  */
-static void screen_char_2(off, row, col)
-unsigned off;
-int row;
-int col;
+static void screen_char_2(unsigned off, int row, int col)
 {
   /* Check for illegal values (could be wrong when screen was resized). */
   if (off + 1 >= (unsigned)(screen_Rows * screen_Columns))
@@ -5826,12 +5760,7 @@ int col;
  * Draw a rectangle of the screen, inverted when "invert" is TRUE.
  * This uses the contents of ScreenLines[] and doesn't change it.
  */
-void screen_draw_rectangle(row, col, height, width, invert)
-int row;
-int col;
-int height;
-int width;
-int invert;
+void screen_draw_rectangle(int row, int col, int height, int width, int invert)
 {
   int r, c;
   int off;
@@ -5863,10 +5792,7 @@ int invert;
 /*
  * Redraw the characters for a vertically split window.
  */
-static void redraw_block(row, end, wp)
-int row;
-int end;
-win_T       *wp;
+static void redraw_block(int row, int end, win_T *wp)
 {
   int col;
   int width;
@@ -5887,11 +5813,7 @@ win_T       *wp;
  * with character 'c1' in first column followed by 'c2' in the other columns.
  * Use attributes 'attr'.
  */
-void screen_fill(start_row, end_row, start_col, end_col, c1, c2, attr)
-int start_row, end_row;
-int start_col, end_col;
-int c1, c2;
-int attr;
+void screen_fill(int start_row, int end_row, int start_col, int end_col, int c1, int c2, int attr)
 {
   int row;
   int col;
@@ -6042,8 +5964,7 @@ int attr;
  * Check if there should be a delay.  Used before clearing or redrawing the
  * screen or the command line.
  */
-void check_for_delay(check_msg_scroll)
-int check_msg_scroll;
+void check_for_delay(int check_msg_scroll)
 {
   if ((emsg_on_display || (check_msg_scroll && msg_scroll))
       && !did_wait_return
@@ -6062,8 +5983,7 @@ int check_msg_scroll;
  *	Returns TRUE if there is a valid screen to write to.
  *	Returns FALSE when starting up and screen not initialized yet.
  */
-int screen_valid(doclear)
-int doclear;
+int screen_valid(int doclear)
 {
   screenalloc(doclear);            /* allocate screen buffers if size changed */
   return ScreenLines != NULL;
@@ -6079,8 +5999,7 @@ int doclear;
  * in ScreenLines[].  Use Rows and Columns for positioning text etc. where the
  * final size of the shell is needed.
  */
-void screenalloc(doclear)
-int doclear;
+void screenalloc(int doclear)
 {
   int new_row, old_row;
   win_T           *wp;
@@ -6327,7 +6246,7 @@ give_up:
   }
 }
 
-void free_screenlines()          {
+void free_screenlines(void)          {
   int i;
 
   vim_free(ScreenLinesUC);
@@ -6341,13 +6260,13 @@ void free_screenlines()          {
   vim_free(TabPageIdxs);
 }
 
-void screenclear()          {
+void screenclear(void)          {
   check_for_delay(FALSE);
   screenalloc(FALSE);       /* allocate screen buffers if size changed */
   screenclear2();           /* clear the screen */
 }
 
-static void screenclear2()                 {
+static void screenclear2(void)                 {
   int i;
 
   if (starting == NO_SCREEN || ScreenLines == NULL
@@ -6394,9 +6313,7 @@ static void screenclear2()                 {
 /*
  * Clear one line in ScreenLines.
  */
-static void lineclear(off, width)
-unsigned off;
-int width;
+static void lineclear(unsigned off, int width)
 {
   (void)vim_memset(ScreenLines + off, ' ', (size_t)width * sizeof(schar_T));
   if (enc_utf8)
@@ -6409,9 +6326,7 @@ int width;
  * Mark one line in ScreenLines invalid by setting the attributes to an
  * invalid value.
  */
-static void lineinvalid(off, width)
-unsigned off;
-int width;
+static void lineinvalid(unsigned off, int width)
 {
   (void)vim_memset(ScreenAttrs + off, -1, (size_t)width * sizeof(sattr_T));
 }
@@ -6419,10 +6334,7 @@ int width;
 /*
  * Copy part of a Screenline for vertically split window "wp".
  */
-static void linecopy(to, from, wp)
-int to;
-int from;
-win_T       *wp;
+static void linecopy(int to, int from, win_T *wp)
 {
   unsigned off_to = LineOffset[to] + wp->w_wincol;
   unsigned off_from = LineOffset[from] + wp->w_wincol;
@@ -6449,8 +6361,7 @@ win_T       *wp;
  * Return TRUE if clearing with term string "p" would work.
  * It can't work when the string is empty or it won't set the right background.
  */
-int can_clear(p)
-char_u      *p;
+int can_clear(char_u *p)
 {
   return *p != NUL && (t_colors <= 1
                        || cterm_normal_bg_color == 0 || *T_UT != NUL);
@@ -6461,7 +6372,7 @@ char_u      *p;
  * something directly to the screen (shell commands) or a terminal control
  * code.
  */
-void screen_start()          {
+void screen_start(void)          {
   screen_cur_row = screen_cur_col = 9999;
 }
 
@@ -6470,9 +6381,7 @@ void screen_start()          {
  * This tries to find the most efficient way to move, minimizing the number of
  * characters sent to the terminal.
  */
-void windgoto(row, col)
-int row;
-int col;
+void windgoto(int row, int col)
 {
   sattr_T         *p;
   int i;
@@ -6685,7 +6594,7 @@ int col;
 /*
  * Set cursor to its position in the current window.
  */
-void setcursor()          {
+void setcursor(void)          {
   if (redrawing()) {
     validate_cursor();
     windgoto(W_WINROW(curwin) + curwin->w_wrow,
@@ -6708,12 +6617,7 @@ void setcursor()          {
  * scrolling.
  * Returns FAIL if the lines are not inserted, OK for success.
  */
-int win_ins_lines(wp, row, line_count, invalid, mayclear)
-win_T       *wp;
-int row;
-int line_count;
-int invalid;
-int mayclear;
+int win_ins_lines(win_T *wp, int row, int line_count, int invalid, int mayclear)
 {
   int did_delete;
   int nextrow;
@@ -6782,12 +6686,7 @@ int mayclear;
  * scrolling
  * Return OK for success, FAIL if the lines are not deleted.
  */
-int win_del_lines(wp, row, line_count, invalid, mayclear)
-win_T       *wp;
-int row;
-int line_count;
-int invalid;
-int mayclear;
+int win_del_lines(win_T *wp, int row, int line_count, int invalid, int mayclear)
 {
   int retval;
 
@@ -6830,12 +6729,7 @@ int mayclear;
  * Returns OK or FAIL when the work has been done.
  * Returns MAYBE when not finished yet.
  */
-static int win_do_lines(wp, row, line_count, mayclear, del)
-win_T       *wp;
-int row;
-int line_count;
-int mayclear;
-int del;
+static int win_do_lines(win_T *wp, int row, int line_count, int mayclear, int del)
 {
   int retval;
 
@@ -6900,8 +6794,7 @@ int del;
 /*
  * window 'wp' and everything after it is messed up, mark it for redraw
  */
-static void win_rest_invalid(wp)
-win_T       *wp;
+static void win_rest_invalid(win_T *wp)
 {
   while (wp != NULL) {
     redraw_win_later(wp, NOT_VALID);
@@ -6942,12 +6835,14 @@ win_T       *wp;
  *
  * return FAIL for failure, OK for success.
  */
-int screen_ins_lines(off, row, line_count, end, wp)
-int off;
-int row;
-int line_count;
-int end;
-win_T       *wp;            /* NULL or window to use width from */
+int 
+screen_ins_lines (
+    int off,
+    int row,
+    int line_count,
+    int end,
+    win_T *wp            /* NULL or window to use width from */
+)
 {
   int i;
   int j;
@@ -7113,13 +7008,15 @@ win_T       *wp;            /* NULL or window to use width from */
  *
  * Return OK for success, FAIL if the lines are not deleted.
  */
-int screen_del_lines(off, row, line_count, end, force, wp)
-int off;
-int row;
-int line_count;
-int end;
-int force;                      /* even when line_count > p_ttyscroll */
-win_T       *wp UNUSED;         /* NULL or window to use width from */
+int 
+screen_del_lines (
+    int off,
+    int row,
+    int line_count,
+    int end,
+    int force,                      /* even when line_count > p_ttyscroll */
+    win_T *wp         /* NULL or window to use width from */
+)
 {
   int j;
   int i;
@@ -7292,7 +7189,7 @@ win_T       *wp UNUSED;         /* NULL or window to use width from */
  * cleared only if a mode is shown.
  * Return the length of the message (0 if no message).
  */
-int showmode()         {
+int showmode(void)         {
   int need_clear;
   int length = 0;
   int do_mode;
@@ -7443,7 +7340,7 @@ int showmode()         {
 /*
  * Position for a mode message.
  */
-static void msg_pos_mode()                 {
+static void msg_pos_mode(void)                 {
   msg_col = 0;
   msg_row = Rows - 1;
 }
@@ -7453,8 +7350,7 @@ static void msg_pos_mode()                 {
  * Insert mode (but Insert mode didn't end yet!).
  * Caller should check "mode_displayed".
  */
-void unshowmode(force)
-int force;
+void unshowmode(int force)
 {
   /*
    * Don't delete it right now, when not redrawing or inside a mapping.
@@ -7472,7 +7368,7 @@ int force;
 /*
  * Draw the tab pages line at the top of the Vim window.
  */
-static void draw_tabline()                 {
+static void draw_tabline(void)                 {
   int tabcount = 0;
   tabpage_T   *tp;
   int tabwidth;
@@ -7622,8 +7518,7 @@ static void draw_tabline()                 {
  * Get buffer name for "buf" into NameBuff[].
  * Takes care of special buffer names and translates special characters.
  */
-void get_trans_bufname(buf)
-buf_T       *buf;
+void get_trans_bufname(buf_T *buf)
 {
   if (buf_spname(buf) != NULL)
     vim_strncpy(NameBuff, buf_spname(buf), MAXPATHL - 1);
@@ -7635,9 +7530,7 @@ buf_T       *buf;
 /*
  * Get the character to use in a status line.  Get its attributes in "*attr".
  */
-static int fillchar_status(attr, is_curwin)
-int         *attr;
-int is_curwin;
+static int fillchar_status(int *attr, int is_curwin)
 {
   int fill;
   if (is_curwin) {
@@ -7663,8 +7556,7 @@ int is_curwin;
  * Get the character to use in a separator between vertically split windows.
  * Get its attributes in "*attr".
  */
-static int fillchar_vsep(attr)
-int     *attr;
+static int fillchar_vsep(int *attr)
 {
   *attr = hl_attr(HLF_C);
   if (*attr == 0 && fill_vert == ' ')
@@ -7676,7 +7568,7 @@ int     *attr;
 /*
  * Return TRUE if redrawing should currently be done.
  */
-int redrawing()         {
+int redrawing(void)         {
   return !RedrawingDisabled
          && !(p_lz && char_avail() && !KeyTyped && !do_redraw);
 }
@@ -7684,7 +7576,7 @@ int redrawing()         {
 /*
  * Return TRUE if printing messages should currently be done.
  */
-int messaging()         {
+int messaging(void)         {
   return !(p_lz && char_avail() && !KeyTyped);
 }
 
@@ -7692,8 +7584,7 @@ int messaging()         {
  * Show current status info in ruler and various other places
  * If always is FALSE, only show ruler if position has changed.
  */
-void showruler(always)
-int always;
+void showruler(int always)
 {
   if (!always && !redrawing())
     return;
@@ -7717,9 +7608,7 @@ int always;
     draw_tabline();
 }
 
-static void win_redr_ruler(wp, always)
-win_T       *wp;
-int always;
+static void win_redr_ruler(win_T *wp, int always)
 {
 #define RULER_BUF_LEN 70
   char_u buffer[RULER_BUF_LEN];
@@ -7887,8 +7776,7 @@ int always;
  * Caller may need to check if 'number' or 'relativenumber' is set.
  * Otherwise it depends on 'numberwidth' and the line count.
  */
-int number_width(wp)
-win_T       *wp;
+int number_width(win_T *wp)
 {
   int n;
   linenr_T lnum;
@@ -7922,7 +7810,7 @@ win_T       *wp;
  * Return the current cursor column. This is the actual position on the
  * screen. First column is 0.
  */
-int screen_screencol()         {
+int screen_screencol(void)         {
   return screen_cur_col;
 }
 
@@ -7930,7 +7818,7 @@ int screen_screencol()         {
  * Return the current cursor row. This is the actual position on the screen.
  * First row is 0.
  */
-int screen_screenrow()         {
+int screen_screenrow(void)         {
   return screen_cur_row;
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -113,12 +113,14 @@ typedef struct SearchedFile {
  *
  * returns FAIL if failed, OK otherwise.
  */
-int search_regcomp(pat, pat_save, pat_use, options, regmatch)
-char_u      *pat;
-int pat_save;
-int pat_use;
-int options;
-regmmatch_T *regmatch;          /* return: pattern and ignore-case flag */
+int 
+search_regcomp (
+    char_u *pat,
+    int pat_save,
+    int pat_use,
+    int options,
+    regmmatch_T *regmatch          /* return: pattern and ignore-case flag */
+)
 {
   int magic;
   int i;
@@ -190,7 +192,7 @@ regmmatch_T *regmatch;          /* return: pattern and ignore-case flag */
 /*
  * Get search pattern used by search_regcomp().
  */
-char_u * get_search_pat()              {
+char_u *get_search_pat(void)              {
   return mr_pattern;
 }
 
@@ -198,8 +200,7 @@ char_u * get_search_pat()              {
  * Reverse text into allocated memory.
  * Returns the allocated string, NULL when out of memory.
  */
-char_u * reverse_text(s)
-char_u *s;
+char_u *reverse_text(char_u *s)
 {
   unsigned len;
   unsigned s_i, rev_i;
@@ -229,10 +230,7 @@ char_u *s;
   return rev;
 }
 
-static void save_re_pat(idx, pat, magic)
-int idx;
-char_u      *pat;
-int magic;
+static void save_re_pat(int idx, char_u *pat, int magic)
 {
   if (spats[idx].pat != pat) {
     vim_free(spats[idx].pat);
@@ -253,7 +251,7 @@ int magic;
  */
 static int save_level = 0;
 
-void save_search_patterns()          {
+void save_search_patterns(void)          {
   if (save_level++ == 0) {
     saved_spats[0] = spats[0];
     if (spats[0].pat != NULL)
@@ -266,7 +264,7 @@ void save_search_patterns()          {
   }
 }
 
-void restore_search_patterns()          {
+void restore_search_patterns(void)          {
   if (--save_level == 0) {
     vim_free(spats[0].pat);
     spats[0] = saved_spats[0];
@@ -279,7 +277,7 @@ void restore_search_patterns()          {
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_search_patterns()          {
+void free_search_patterns(void)          {
   vim_free(spats[0].pat);
   vim_free(spats[1].pat);
 
@@ -296,8 +294,7 @@ void free_search_patterns()          {
  * Return TRUE when case should be ignored for search pattern "pat".
  * Uses the 'ignorecase' and 'smartcase' options.
  */
-int ignorecase(pat)
-char_u      *pat;
+int ignorecase(char_u *pat)
 {
   int ic = p_ic;
 
@@ -313,8 +310,7 @@ char_u      *pat;
 /*
  * Return TRUE if patter "pat" has an uppercase character.
  */
-int pat_has_uppercase(pat)
-char_u      *pat;
+int pat_has_uppercase(char_u *pat)
 {
   char_u *p = pat;
 
@@ -342,14 +338,14 @@ char_u      *pat;
   return FALSE;
 }
 
-char_u * last_search_pat()              {
+char_u *last_search_pat(void)              {
   return spats[last_idx].pat;
 }
 
 /*
  * Reset search direction to forward.  For "gd" and "gD" commands.
  */
-void reset_search_dir()          {
+void reset_search_dir(void)          {
   spats[0].off.dir = '/';
   set_vv_searchforward();
 }
@@ -358,11 +354,7 @@ void reset_search_dir()          {
  * Set the last search pattern.  For ":let @/ =" and viminfo.
  * Also set the saved search pattern, so that this works in an autocommand.
  */
-void set_last_search_pat(s, idx, magic, setlast)
-char_u      *s;
-int idx;
-int magic;
-int setlast;
+void set_last_search_pat(char_u *s, int idx, int magic, int setlast)
 {
   vim_free(spats[idx].pat);
   /* An empty string means that nothing should be matched. */
@@ -398,8 +390,7 @@ int setlast;
  * This is used for highlighting all matches in a window.
  * Values returned in regmatch->regprog and regmatch->rmm_ic.
  */
-void last_pat_prog(regmatch)
-regmmatch_T *regmatch;
+void last_pat_prog(regmmatch_T *regmatch)
 {
   if (spats[last_idx].pat == NULL) {
     regmatch->regprog = NULL;
@@ -440,7 +431,7 @@ long count;
 int options;
 int pat_use;                    /* which pattern to use when "pat" is empty */
 linenr_T stop_lnum;             /* stop after this line number when != 0 */
-proftime_T  *tm UNUSED;         /* timeout limit or NULL */
+proftime_T  *tm;         /* timeout limit or NULL */
 {
   int found;
   linenr_T lnum;                /* no init to shut up Apollo cc */
@@ -827,21 +818,19 @@ proftime_T  *tm UNUSED;         /* timeout limit or NULL */
   return submatch + 1;
 }
 
-void set_search_direction(cdir)
-int cdir;
+void set_search_direction(int cdir)
 {
   spats[0].off.dir = cdir;
 }
 
-static void set_vv_searchforward()                 {
+static void set_vv_searchforward(void)                 {
   set_vim_var_nr(VV_SEARCHFORWARD, (long)(spats[0].off.dir == '/'));
 }
 
 /*
  * Return the number of the first subpat that matched.
  */
-static int first_submatch(rp)
-regmmatch_T *rp;
+static int first_submatch(regmmatch_T *rp)
 {
   int submatch;
 
@@ -1208,11 +1197,7 @@ end_do_search:
  * ADDING is set.  if p_ic is set then the pattern must be in lowercase.
  * Return OK for success, or FAIL if no line found.
  */
-int search_for_exact_line(buf, pos, dir, pat)
-buf_T       *buf;
-pos_T       *pos;
-int dir;
-char_u      *pat;
+int search_for_exact_line(buf_T *buf, pos_T *pos, int dir, char_u *pat)
 {
   linenr_T start = 0;
   char_u      *ptr;
@@ -1275,9 +1260,7 @@ char_u      *pat;
  * Do this "cap->count1" times.
  * Return FAIL or OK.
  */
-int searchc(cap, t_cmd)
-cmdarg_T    *cap;
-int t_cmd;
+int searchc(cmdarg_T *cap, int t_cmd)
 {
   int c = cap->nchar;                   /* char to search for */
   int dir = cap->arg;                   /* TRUE for searching forward */
@@ -1389,9 +1372,7 @@ int t_cmd;
  *
  * Improvement over vi: Braces inside quotes are ignored.
  */
-pos_T * findmatch(oap, initc)
-oparg_T   *oap;
-int initc;
+pos_T *findmatch(oparg_T *oap, int initc)
 {
   return findmatchlimit(oap, initc, 0, 0);
 }
@@ -1403,11 +1384,7 @@ int initc;
  * is NULL.
  * Handles multibyte string correctly.
  */
-static int check_prevcol(linep, col, ch, prevcol)
-char_u      *linep;
-int col;
-int ch;
-int         *prevcol;
+static int check_prevcol(char_u *linep, int col, int ch, int *prevcol)
 {
   --col;
   if (col > 0 && has_mbyte)
@@ -1434,11 +1411,7 @@ int         *prevcol;
  * NULL
  */
 
-pos_T * findmatchlimit(oap, initc, flags, maxtravel)
-oparg_T     *oap;
-int initc;
-int flags;
-int maxtravel;
+pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int maxtravel)
 {
   static pos_T pos;                     /* current search position */
   int findc = 0;                        /* matching brace */
@@ -1945,8 +1918,7 @@ int maxtravel;
  * Return MAXCOL if not, otherwise return the column.
  * TODO: skip strings.
  */
-static int check_linecomment(line)
-char_u      *line;
+static int check_linecomment(char_u *line)
 {
   char_u  *p;
 
@@ -1993,8 +1965,10 @@ char_u      *line;
  * Show the match only if it is visible on the screen.
  * If there isn't a match, then beep.
  */
-void showmatch(c)
-int c;                      /* char to show match for */
+void 
+showmatch (
+    int c                      /* char to show match for */
+)
 {
   pos_T       *lpos, save_cursor;
   pos_T mpos;
@@ -2085,9 +2059,7 @@ int c;                      /* char to show match for */
  * space or a line break. Also stop at an empty line.
  * Return OK if the next sentence was found.
  */
-int findsent(dir, count)
-int dir;
-long count;
+int findsent(int dir, long count)
 {
   pos_T pos, tpos;
   int c;
@@ -2201,12 +2173,14 @@ found:
  * If 'both' is TRUE also stop at '}'.
  * Return TRUE if the next paragraph or section was found.
  */
-int findpar(pincl, dir, count, what, both)
-int         *pincl;         /* Return: TRUE if last char is to be included */
-int dir;
-long count;
-int what;
-int both;
+int 
+findpar (
+    int *pincl,         /* Return: TRUE if last char is to be included */
+    int dir,
+    long count,
+    int what,
+    int both
+)
 {
   linenr_T curr;
   int did_skip;             /* TRUE after separating lines have been skipped */
@@ -2267,9 +2241,7 @@ int both;
 /*
  * check if the string 's' is a nroff macro that is in option 'opt'
  */
-static int inmacro(opt, s)
-char_u      *opt;
-char_u      *s;
+static int inmacro(char_u *opt, char_u *s)
 {
   char_u      *macro;
 
@@ -2296,10 +2268,7 @@ char_u      *s;
  * If 'para' is '{' or '}' only check for sections.
  * If 'both' is TRUE also stop at '}'
  */
-int startPS(lnum, para, both)
-linenr_T lnum;
-int para;
-int both;
+int startPS(linenr_T lnum, int para, int both)
 {
   char_u      *s;
 
@@ -2337,7 +2306,7 @@ static int cls_bigword;         /* TRUE for "W", "B" or "E" */
  * from class 2 and higher are reported as class 1 since only white space
  * boundaries are of interest.
  */
-static int cls()                {
+static int cls(void)                {
   int c;
 
   c = gchar_cursor();
@@ -2375,10 +2344,12 @@ static int cls()                {
  * Returns FAIL if the cursor was already at the end of the file.
  * If eol is TRUE, last word stops at end of line (for operators).
  */
-int fwd_word(count, bigword, eol)
-long count;
-int bigword;                /* "W", "E" or "B" */
-int eol;
+int 
+fwd_word (
+    long count,
+    int bigword,                /* "W", "E" or "B" */
+    int eol
+)
 {
   int sclass;               /* starting class */
   int i;
@@ -2439,10 +2410,7 @@ int eol;
  *
  * Returns FAIL if top of the file was reached.
  */
-int bck_word(count, bigword, stop)
-long count;
-int bigword;
-int stop;
+int bck_word(long count, int bigword, int stop)
 {
   int sclass;               /* starting class */
 
@@ -2499,11 +2467,7 @@ finished:
  * If stop is TRUE and we are already on the end of a word, move one less.
  * If empty is TRUE stop on an empty line.
  */
-int end_word(count, bigword, stop, empty)
-long count;
-int bigword;
-int stop;
-int empty;
+int end_word(long count, int bigword, int stop, int empty)
 {
   int sclass;               /* starting class */
 
@@ -2559,10 +2523,12 @@ finished:
  *
  * Returns FAIL if start of the file was reached.
  */
-int bckend_word(count, bigword, eol)
-long count;
-int bigword;                /* TRUE for "B" */
-int eol;                    /* TRUE: stop at end of line. */
+int 
+bckend_word (
+    long count,
+    int bigword,                /* TRUE for "B" */
+    int eol                    /* TRUE: stop at end of line. */
+)
 {
   int sclass;               /* starting class */
   int i;
@@ -2602,9 +2568,7 @@ int eol;                    /* TRUE: stop at end of line. */
  * Skip a row of characters of the same class.
  * Return TRUE when end-of-file reached, FALSE otherwise.
  */
-static int skip_chars(cclass, dir)
-int cclass;
-int dir;
+static int skip_chars(int cclass, int dir)
 {
   while (cls() == cclass)
     if ((dir == FORWARD ? inc_cursor() : dec_cursor()) == -1)
@@ -2615,7 +2579,7 @@ int dir;
 /*
  * Go back to the start of the word or the start of white space
  */
-static void back_in_line()                 {
+static void back_in_line(void)                 {
   int sclass;                       /* starting class */
 
   sclass = cls();
@@ -2630,8 +2594,7 @@ static void back_in_line()                 {
   }
 }
 
-static void find_first_blank(posp)
-pos_T    *posp;
+static void find_first_blank(pos_T *posp)
 {
   int c;
 
@@ -2647,9 +2610,11 @@ pos_T    *posp;
 /*
  * Skip count/2 sentences and count/2 separating white spaces.
  */
-static void findsent_forward(count, at_start_sent)
-long count;
-int at_start_sent;              /* cursor is at start of sentence */
+static void 
+findsent_forward (
+    long count,
+    int at_start_sent              /* cursor is at start of sentence */
+)
 {
   while (count--) {
     findsent(FORWARD, 1L);
@@ -2665,11 +2630,13 @@ int at_start_sent;              /* cursor is at start of sentence */
  * Find word under cursor, cursor at end.
  * Used while an operator is pending, and in Visual mode.
  */
-int current_word(oap, count, include, bigword)
-oparg_T     *oap;
-long count;
-int include;                    /* TRUE: include word and white space */
-int bigword;                    /* FALSE == word, TRUE == WORD */
+int 
+current_word (
+    oparg_T *oap,
+    long count,
+    int include,                    /* TRUE: include word and white space */
+    int bigword                    /* FALSE == word, TRUE == WORD */
+)
 {
   pos_T start_pos;
   pos_T pos;
@@ -2815,10 +2782,7 @@ int bigword;                    /* FALSE == word, TRUE == WORD */
  * Find sentence(s) under the cursor, cursor at end.
  * When Visual active, extend it by one or more sentences.
  */
-int current_sent(oap, count, include)
-oparg_T     *oap;
-long count;
-int include;
+int current_sent(oparg_T *oap, long count, int include)
 {
   pos_T start_pos;
   pos_T pos;
@@ -2973,12 +2937,14 @@ extend:
  * Find block under the cursor, cursor at end.
  * "what" and "other" are two matching parenthesis/brace/etc.
  */
-int current_block(oap, count, include, what, other)
-oparg_T     *oap;
-long count;
-int include;                    /* TRUE == include white space */
-int what;                       /* '(', '{', etc. */
-int other;                      /* ')', '}', etc. */
+int 
+current_block (
+    oparg_T *oap,
+    long count,
+    int include,                    /* TRUE == include white space */
+    int what,                       /* '(', '{', etc. */
+    int other                      /* ')', '}', etc. */
+)
 {
   pos_T old_pos;
   pos_T       *pos = NULL;
@@ -3106,8 +3072,7 @@ static int in_html_tag __ARGS((int));
  * Return TRUE if the cursor is on a "<aaa>" tag.  Ignore "<aaa/>".
  * When "end_tag" is TRUE return TRUE if the cursor is on "</aaa>".
  */
-static int in_html_tag(end_tag)
-int end_tag;
+static int in_html_tag(int end_tag)
 {
   char_u      *line = ml_get_curline();
   char_u      *p;
@@ -3169,10 +3134,12 @@ int end_tag;
 /*
  * Find tag block under the cursor, cursor at end.
  */
-int current_tagblock(oap, count_arg, include)
-oparg_T     *oap;
-long count_arg;
-int include;                    /* TRUE == include white space */
+int 
+current_tagblock (
+    oparg_T *oap,
+    long count_arg,
+    int include                    /* TRUE == include white space */
+)
 {
   long count = count_arg;
   long n;
@@ -3344,11 +3311,13 @@ theend:
   return retval;
 }
 
-int current_par(oap, count, include, type)
-oparg_T     *oap;
-long count;
-int include;                    /* TRUE == include white space */
-int type;                       /* 'p' for paragraph, 'S' for section */
+int 
+current_par (
+    oparg_T *oap,
+    long count,
+    int include,                    /* TRUE == include white space */
+    int type                       /* 'p' for paragraph, 'S' for section */
+)
 {
   linenr_T start_lnum;
   linenr_T end_lnum;
@@ -3509,11 +3478,13 @@ static int find_prev_quote __ARGS((char_u *line, int col_start, int quotechar,
  * as a quote.
  * Returns column number of "quotechar" or -1 when not found.
  */
-static int find_next_quote(line, col, quotechar, escape)
-char_u      *line;
-int col;
-int quotechar;
-char_u      *escape;            /* escape characters, can be NULL */
+static int 
+find_next_quote (
+    char_u *line,
+    int col,
+    int quotechar,
+    char_u *escape            /* escape characters, can be NULL */
+)
 {
   int c;
 
@@ -3539,11 +3510,13 @@ char_u      *escape;            /* escape characters, can be NULL */
  * as a quote.
  * Return the found column or zero.
  */
-static int find_prev_quote(line, col_start, quotechar, escape)
-char_u      *line;
-int col_start;
-int quotechar;
-char_u      *escape;            /* escape characters, can be NULL */
+static int 
+find_prev_quote (
+    char_u *line,
+    int col_start,
+    int quotechar,
+    char_u *escape            /* escape characters, can be NULL */
+)
 {
   int n;
 
@@ -3567,11 +3540,13 @@ char_u      *escape;            /* escape characters, can be NULL */
  * Find quote under the cursor, cursor at end.
  * Returns TRUE if found, else FALSE.
  */
-int current_quote(oap, count, include, quotechar)
-oparg_T     *oap;
-long count;
-int include;                    /* TRUE == include quote char */
-int quotechar;                  /* Quote character */
+int 
+current_quote (
+    oparg_T *oap,
+    long count,
+    int include,                    /* TRUE == include quote char */
+    int quotechar                  /* Quote character */
+)
 {
   char_u      *line = ml_get_curline();
   int col_end;
@@ -3779,9 +3754,11 @@ static int is_one_char __ARGS((char_u *pattern));
  * Used while an operator is pending, and in Visual mode.
  * TODO: redo only works when used in operator pending mode
  */
-int current_search(count, forward)
-long count;
-int forward;                    /* move forward or backwards */
+int 
+current_search (
+    long count,
+    int forward                    /* move forward or backwards */
+)
 {
   pos_T start_pos;              /* position before the pattern */
   pos_T orig_pos;               /* position of the cursor at beginning */
@@ -3909,8 +3886,7 @@ int forward;                    /* move forward or backwards */
  * Check if the pattern is one character or zero-width.
  * Returns TRUE, FALSE or -1 for failure.
  */
-static int is_one_char(pattern)
-char_u      *pattern;
+static int is_one_char(char_u *pattern)
 {
   regmmatch_T regmatch;
   int nmatched = 0;
@@ -3951,8 +3927,7 @@ char_u      *pattern;
 /*
  * return TRUE if line 'lnum' is empty or has white chars only.
  */
-int linewhite(lnum)
-linenr_T lnum;
+int linewhite(linenr_T lnum)
 {
   char_u  *p;
 
@@ -3965,19 +3940,20 @@ linenr_T lnum;
  * Find identifiers or defines in included files.
  * If p_ic && (compl_cont_status & CONT_SOL) then ptr must be in lowercase.
  */
-void find_pattern_in_path(ptr, dir, len, whole, skip_comments,
-    type, count, action, start_lnum, end_lnum)
-char_u      *ptr;               /* pointer to search pattern */
-int dir UNUSED;                 /* direction of expansion */
-int len;                        /* length of search pattern */
-int whole;                      /* match whole words only */
-int skip_comments;              /* don't match inside comments */
-int type;                       /* Type of search; are we looking for a type?
+void 
+find_pattern_in_path (
+    char_u *ptr,               /* pointer to search pattern */
+    int dir,                 /* direction of expansion */
+    int len,                        /* length of search pattern */
+    int whole,                      /* match whole words only */
+    int skip_comments,              /* don't match inside comments */
+    int type,                       /* Type of search; are we looking for a type?
                                    a macro? */
-long count;
-int action;                     /* What to do when we find it */
-linenr_T start_lnum;            /* first line to start searching */
-linenr_T end_lnum;              /* last line for searching */
+    long count,
+    int action,                     /* What to do when we find it */
+    linenr_T start_lnum,            /* first line to start searching */
+    linenr_T end_lnum              /* last line for searching */
+)
 {
   SearchedFile *files;                  /* Stack of included files */
   SearchedFile *bigger;                 /* When we need more space */
@@ -4554,14 +4530,7 @@ fpip_end:
   vim_regfree(def_regmatch.regprog);
 }
 
-static void show_pat_in_path(line, type, did_show, action, fp, lnum, count)
-char_u  *line;
-int type;
-int did_show;
-int action;
-FILE    *fp;
-linenr_T *lnum;
-long count;
+static void show_pat_in_path(char_u *line, int type, int did_show, int action, FILE *fp, linenr_T *lnum, long count)
 {
   char_u  *p;
 
@@ -4609,9 +4578,7 @@ long count;
   }
 }
 
-int read_viminfo_search_pattern(virp, force)
-vir_T       *virp;
-int force;
+int read_viminfo_search_pattern(vir_T *virp, int force)
 {
   char_u      *lp;
   int idx = -1;
@@ -4684,8 +4651,7 @@ int force;
   return viminfo_readline(virp);
 }
 
-void write_viminfo_search_pattern(fp)
-FILE        *fp;
+void write_viminfo_search_pattern(FILE *fp)
 {
   if (get_viminfo_parameter('/') != 0) {
     fprintf(fp, "\n# hlsearch on (H) or off (h):\n~%c",
@@ -4695,11 +4661,13 @@ FILE        *fp;
   }
 }
 
-static void wvsp_one(fp, idx, s, sc)
-FILE        *fp;        /* file to write to */
-int idx;                /* spats[] index */
-char        *s;         /* search pat */
-int sc;                 /* dir char */
+static void 
+wvsp_one (
+    FILE *fp,        /* file to write to */
+    int idx,                /* spats[] index */
+    char *s,         /* search pat */
+    int sc                 /* dir char */
+)
 {
   if (spats[idx].pat != NULL) {
     fprintf(fp, _("\n# Last %sSearch Pattern:\n~"), s);

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -41,8 +41,7 @@ static void sha256_process __ARGS((context_sha256_T *ctx, char_u data[64]));
     (b)[(i) + 3] = (char_u)((n)      );   \
   }
 
-void sha256_start(ctx)
-context_sha256_T *ctx;
+void sha256_start(context_sha256_T *ctx)
 {
   ctx->total[0] = 0;
   ctx->total[1] = 0;
@@ -57,9 +56,7 @@ context_sha256_T *ctx;
   ctx->state[7] = 0x5BE0CD19;
 }
 
-static void sha256_process(ctx, data)
-context_sha256_T *ctx;
-char_u data[64];
+static void sha256_process(context_sha256_T *ctx, char_u data[64])
 {
   UINT32_T temp1, temp2, W[64];
   UINT32_T A, B, C, D, E, F, G, H;
@@ -190,10 +187,7 @@ char_u data[64];
   ctx->state[7] += H;
 }
 
-void sha256_update(ctx, input, length)
-context_sha256_T *ctx;
-char_u           *input;
-UINT32_T length;
+void sha256_update(context_sha256_T *ctx, char_u *input, UINT32_T length)
 {
   UINT32_T left, fill;
 
@@ -234,9 +228,7 @@ static char_u sha256_padding[64] = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
-void sha256_finish(ctx, digest)
-context_sha256_T *ctx;
-char_u digest[32];
+void sha256_finish(context_sha256_T *ctx, char_u digest[32])
 {
   UINT32_T last, padn;
   UINT32_T high, low;
@@ -270,11 +262,7 @@ static unsigned int get_some_time __ARGS((void));
  * Returns hex digest of "buf[buf_len]" in a static array.
  * if "salt" is not NULL also do "salt[salt_len]".
  */
-char_u * sha256_bytes(buf, buf_len, salt, salt_len)
-char_u *buf;
-int buf_len;
-char_u *salt;
-int salt_len;
+char_u *sha256_bytes(char_u *buf, int buf_len, char_u *salt, int salt_len)
 {
   char_u sha256sum[32];
   static char_u hexit[65];
@@ -297,10 +285,7 @@ int salt_len;
 /*
  * Returns sha256(buf) as 64 hex chars in static array.
  */
-char_u * sha256_key(buf, salt, salt_len)
-char_u *buf;
-char_u *salt;
-int salt_len;
+char_u *sha256_key(char_u *buf, char_u *salt, int salt_len)
 {
   /* No passwd means don't encrypt */
   if (buf == NULL || *buf == NUL)
@@ -332,7 +317,7 @@ static char *sha_self_test_vector[] = {
  * Perform a test on the SHA256 algorithm.
  * Return FAIL or OK.
  */
-int sha256_self_test()         {
+int sha256_self_test(void)         {
   int i, j;
   char output[65];
   context_sha256_T ctx;
@@ -370,7 +355,7 @@ int sha256_self_test()         {
   return failures > 0 ? FAIL : OK;
 }
 
-static unsigned int get_some_time()                         {
+static unsigned int get_some_time(void)                         {
 # ifdef HAVE_GETTIMEOFDAY
   struct timeval tv;
 
@@ -386,11 +371,7 @@ static unsigned int get_some_time()                         {
  * Fill "header[header_len]" with random_data.
  * Also "salt[salt_len]" when "salt" is not NULL.
  */
-void sha2_seed(header, header_len, salt, salt_len)
-char_u *header;
-int header_len;
-char_u *salt;
-int salt_len;
+void sha2_seed(char_u *header, int header_len, char_u *salt, int salt_len)
 {
   int i;
   static char_u random_data[1000];

--- a/src/spell.c
+++ b/src/spell.c
@@ -996,12 +996,14 @@ static char_u   *repl_to = NULL;
  * Returns the length of the word in bytes, also when it's OK, so that the
  * caller can skip over the word.
  */
-int spell_check(wp, ptr, attrp, capcol, docount)
-win_T       *wp;                /* current window */
-char_u      *ptr;
-hlf_T       *attrp;
-int         *capcol;            /* column to check for Capital */
-int docount;                    /* count good words */
+int 
+spell_check (
+    win_T *wp,                /* current window */
+    char_u *ptr,
+    hlf_T *attrp,
+    int *capcol,            /* column to check for Capital */
+    int docount                    /* count good words */
+)
 {
   matchinf_T mi;                /* Most things are put in "mi" so that it can
                                    be passed to functions quickly. */
@@ -1191,9 +1193,7 @@ int docount;                    /* count good words */
  *
  * For a match mip->mi_result is updated.
  */
-static void find_word(mip, mode)
-matchinf_T  *mip;
-int mode;
+static void find_word(matchinf_T *mip, int mode)
 {
   idx_T arridx = 0;
   int endlen[MAXWLEN];              /* length at possible word endings */
@@ -1643,10 +1643,12 @@ int mode;
  * A match means that the first part of CHECKCOMPOUNDPATTERN matches at the
  * end of ptr[wlen] and the second part matches after it.
  */
-static int match_checkcompoundpattern(ptr, wlen, gap)
-char_u      *ptr;
-int wlen;
-garray_T    *gap;      /* &sl_comppat */
+static int 
+match_checkcompoundpattern (
+    char_u *ptr,
+    int wlen,
+    garray_T *gap      /* &sl_comppat */
+)
 {
   int i;
   char_u      *p;
@@ -1670,10 +1672,7 @@ garray_T    *gap;      /* &sl_comppat */
  * Return TRUE if "flags" is a valid sequence of compound flags and "word"
  * does not have too many syllables.
  */
-static int can_compound(slang, word, flags)
-slang_T     *slang;
-char_u      *word;
-char_u      *flags;
+static int can_compound(slang_T *slang, char_u *word, char_u *flags)
 {
   regmatch_T regmatch;
   char_u uflags[MAXWLEN * 2];
@@ -1710,11 +1709,7 @@ char_u      *flags;
  * possibly form a valid compounded word.  This also checks the COMPOUNDRULE
  * lines if they don't contain wildcards.
  */
-static int can_be_compound(sp, slang, compflags, flag)
-trystate_T  *sp;
-slang_T     *slang;
-char_u      *compflags;
-int flag;
+static int can_be_compound(trystate_T *sp, slang_T *slang, char_u *compflags, int flag)
 {
   /* If the flag doesn't appear in sl_compstartflags or sl_compallflags
    * then it can't possibly compound. */
@@ -1745,9 +1740,7 @@ int flag;
  * collected so far can't possibly match any compound rule.
  * Caller must check that slang->sl_comprules is not NULL.
  */
-static int match_compoundrule(slang, compflags)
-slang_T     *slang;
-char_u      *compflags;
+static int match_compoundrule(slang_T *slang, char_u *compflags)
 {
   char_u      *p;
   int i;
@@ -1795,13 +1788,15 @@ char_u      *compflags;
  * ID in "flags" for the word "word".
  * The WF_RAREPFX flag is included in the return value for a rare prefix.
  */
-static int valid_word_prefix(totprefcnt, arridx, flags, word, slang, cond_req)
-int totprefcnt;                 /* nr of prefix IDs */
-int arridx;                     /* idx in sl_pidxs[] */
-int flags;
-char_u      *word;
-slang_T     *slang;
-int cond_req;                   /* only use prefixes with a condition */
+static int 
+valid_word_prefix (
+    int totprefcnt,                 /* nr of prefix IDs */
+    int arridx,                     /* idx in sl_pidxs[] */
+    int flags,
+    char_u *word,
+    slang_T *slang,
+    int cond_req                   /* only use prefixes with a condition */
+)
 {
   int prefcnt;
   int pidx;
@@ -1848,9 +1843,7 @@ int cond_req;                   /* only use prefixes with a condition */
  *
  * For a match mip->mi_result is updated.
  */
-static void find_prefix(mip, mode)
-matchinf_T  *mip;
-int mode;
+static void find_prefix(matchinf_T *mip, int mode)
 {
   idx_T arridx = 0;
   int len;
@@ -1960,8 +1953,7 @@ int mode;
  * for efficiency.  Include the non-word character too.
  * Return the length of the folded chars in bytes.
  */
-static int fold_more(mip)
-matchinf_T  *mip;
+static int fold_more(matchinf_T *mip)
 {
   int flen;
   char_u      *p;
@@ -1987,9 +1979,11 @@ matchinf_T  *mip;
  * Check case flags for a word.  Return TRUE if the word has the requested
  * case.
  */
-static int spell_valid_case(wordflags, treeflags)
-int wordflags;              /* flags for the checked word. */
-int treeflags;              /* flags for the word in the spell tree */
+static int 
+spell_valid_case (
+    int wordflags,              /* flags for the checked word. */
+    int treeflags              /* flags for the word in the spell tree */
+)
 {
   return (wordflags == WF_ALLCAP && (treeflags & WF_FIXCAP) == 0)
          || ((treeflags & (WF_ALLCAP | WF_KEEPCAP)) == 0
@@ -2000,8 +1994,7 @@ int treeflags;              /* flags for the word in the spell tree */
 /*
  * Return TRUE if spell checking is not enabled.
  */
-static int no_spell_checking(wp)
-win_T       *wp;
+static int no_spell_checking(win_T *wp)
 {
   if (!wp->w_p_spell || *wp->w_s->b_p_spl == NUL
       || wp->w_s->b_langp.ga_len == 0) {
@@ -2019,13 +2012,15 @@ win_T       *wp;
  * to after badly spelled word before the cursor.
  * Return 0 if not found, length of the badly spelled word otherwise.
  */
-int spell_move_to(wp, dir, allwords, curline, attrp)
-win_T       *wp;
-int dir;                        /* FORWARD or BACKWARD */
-int allwords;                   /* TRUE for "[s"/"]s", FALSE for "[S"/"]S" */
-int curline;
-hlf_T       *attrp;             /* return: attributes of bad word or NULL
+int 
+spell_move_to (
+    win_T *wp,
+    int dir,                        /* FORWARD or BACKWARD */
+    int allwords,                   /* TRUE for "[s"/"]s", FALSE for "[S"/"]S" */
+    int curline,
+    hlf_T *attrp             /* return: attributes of bad word or NULL
                                    (only when "dir" is FORWARD) */
+)
 {
   linenr_T lnum;
   pos_T found_pos;
@@ -2240,10 +2235,7 @@ hlf_T       *attrp;             /* return: attributes of bad word or NULL
  * Keep the blanks at the start of the next line, this is used in win_line()
  * to skip those bytes if the word was OK.
  */
-void spell_cat_line(buf, line, maxlen)
-char_u      *buf;
-char_u      *line;
-int maxlen;
+void spell_cat_line(char_u *buf, char_u *line, int maxlen)
 {
   char_u      *p;
   int n;
@@ -2276,8 +2268,7 @@ typedef struct spelload_S {
  * Load word list(s) for "lang" from Vim spell file(s).
  * "lang" must be the language without the region: e.g., "en".
  */
-static void spell_load_lang(lang)
-char_u      *lang;
+static void spell_load_lang(char_u *lang)
 {
   char_u fname_enc[85];
   int r;
@@ -2332,7 +2323,7 @@ char_u      *lang;
  * Return the encoding used for spell checking: Use 'encoding', except that we
  * use "latin1" for "latin9".  And limit to 60 characters (just in case).
  */
-static char_u * spell_enc()                     {
+static char_u *spell_enc(void)                     {
 
   if (STRLEN(p_enc) < 60 && STRCMP(p_enc, "iso-8859-15") != 0)
     return p_enc;
@@ -2343,8 +2334,7 @@ static char_u * spell_enc()                     {
  * Get the name of the .spl file for the internal wordlist into
  * "fname[MAXPATHL]".
  */
-static void int_wordlist_spl(fname)
-char_u          *fname;
+static void int_wordlist_spl(char_u *fname)
 {
   vim_snprintf((char *)fname, MAXPATHL, SPL_FNAME_TMPL,
       int_wordlist, spell_enc());
@@ -2354,8 +2344,7 @@ char_u          *fname;
  * Allocate a new slang_T for language "lang".  "lang" can be NULL.
  * Caller must fill "sl_next".
  */
-static slang_T * slang_alloc(lang)
-char_u      *lang;
+static slang_T *slang_alloc(char_u *lang)
 {
   slang_T *lp;
 
@@ -2376,8 +2365,7 @@ char_u      *lang;
 /*
  * Free the contents of an slang_T and the structure itself.
  */
-static void slang_free(lp)
-slang_T     *lp;
+static void slang_free(slang_T *lp)
 {
   vim_free(lp->sl_name);
   vim_free(lp->sl_fname);
@@ -2388,8 +2376,7 @@ slang_T     *lp;
 /*
  * Clear an slang_T so that the file can be reloaded.
  */
-static void slang_clear(lp)
-slang_T     *lp;
+static void slang_clear(slang_T *lp)
 {
   garray_T    *gap;
   fromto_T    *ftp;
@@ -2485,8 +2472,7 @@ slang_T     *lp;
 /*
  * Clear the info from the .sug file in "lp".
  */
-static void slang_clear_sug(lp)
-slang_T     *lp;
+static void slang_clear_sug(slang_T *lp)
 {
   vim_free(lp->sl_sbyts);
   lp->sl_sbyts = NULL;
@@ -2502,9 +2488,7 @@ slang_T     *lp;
  * Load one spell file and store the info into a slang_T.
  * Invoked through do_in_runtimepath().
  */
-static void spell_load_cb(fname, cookie)
-char_u      *fname;
-void        *cookie;
+static void spell_load_cb(char_u *fname, void *cookie)
 {
   spelload_T  *slp = (spelload_T *)cookie;
   slang_T     *slang;
@@ -2535,11 +2519,13 @@ void        *cookie;
  *
  * Returns the slang_T the spell file was loaded into.  NULL for error.
  */
-static slang_T * spell_load_file(fname, lang, old_lp, silent)
-char_u      *fname;
-char_u      *lang;
-slang_T     *old_lp;
-int silent;                     /* no error if file doesn't exist */
+static slang_T *
+spell_load_file (
+    char_u *fname,
+    char_u *lang,
+    slang_T *old_lp,
+    int silent                     /* no error if file doesn't exist */
+)
 {
   FILE        *fd;
   char_u buf[VIMSPELLMAGICL];
@@ -2773,10 +2759,7 @@ endOK:
  * Sets "*cntp" to SP_*ERROR when there is an error, length of the result
  * otherwise.
  */
-static char_u * read_cnt_string(fd, cnt_bytes, cntp)
-FILE        *fd;
-int cnt_bytes;
-int         *cntp;
+static char_u *read_cnt_string(FILE *fd, int cnt_bytes, int *cntp)
 {
   int cnt = 0;
   int i;
@@ -2803,10 +2786,7 @@ int         *cntp;
  * Read SN_REGION: <regionname> ...
  * Return SP_*ERROR flags.
  */
-static int read_region_section(fd, lp, len)
-FILE        *fd;
-slang_T     *lp;
-int len;
+static int read_region_section(FILE *fd, slang_T *lp, int len)
 {
   int i;
 
@@ -2823,8 +2803,7 @@ int len;
  *				<folcharslen> <folchars>
  * Return SP_*ERROR flags.
  */
-static int read_charflags_section(fd)
-FILE        *fd;
+static int read_charflags_section(FILE *fd)
 {
   char_u      *flags;
   char_u      *fol;
@@ -2859,9 +2838,7 @@ FILE        *fd;
  * Read SN_PREFCOND section.
  * Return SP_*ERROR flags.
  */
-static int read_prefcond_section(fd, lp)
-FILE        *fd;
-slang_T     *lp;
+static int read_prefcond_section(FILE *fd, slang_T *lp)
 {
   int cnt;
   int i;
@@ -2904,10 +2881,7 @@ slang_T     *lp;
  * Read REP or REPSAL items section from "fd": <repcount> <rep> ...
  * Return SP_*ERROR flags.
  */
-static int read_rep_section(fd, gap, first)
-FILE        *fd;
-garray_T    *gap;
-short       *first;
+static int read_rep_section(FILE *fd, garray_T *gap, short *first)
 {
   int cnt;
   fromto_T    *ftp;
@@ -2952,9 +2926,7 @@ short       *first;
  * Read SN_SAL section: <salflags> <salcount> <sal> ...
  * Return SP_*ERROR flags.
  */
-static int read_sal_section(fd, slang)
-FILE        *fd;
-slang_T     *slang;
+static int read_sal_section(FILE *fd, slang_T *slang)
 {
   int i;
   int cnt;
@@ -3090,10 +3062,7 @@ slang_T     *slang;
  * Read SN_WORDS: <word> ...
  * Return SP_*ERROR flags.
  */
-static int read_words_section(fd, lp, len)
-FILE        *fd;
-slang_T     *lp;
-int len;
+static int read_words_section(FILE *fd, slang_T *lp, int len)
 {
   int done = 0;
   int i;
@@ -3124,11 +3093,13 @@ int len;
  * Add a word to the hashtable of common words.
  * If it's already there then the counter is increased.
  */
-static void count_common_word(lp, word, len, count)
-slang_T     *lp;
-char_u      *word;
-int len;                    /* word length, -1 for upto NUL */
-int count;                  /* 1 to count once, 10 to init */
+static void 
+count_common_word (
+    slang_T *lp,
+    char_u *word,
+    int len,                    /* word length, -1 for upto NUL */
+    int count                  /* 1 to count once, 10 to init */
+)
 {
   hash_T hash;
   hashitem_T  *hi;
@@ -3162,11 +3133,13 @@ int count;                  /* 1 to count once, 10 to init */
 /*
  * Adjust the score of common words.
  */
-static int score_wordcount_adj(slang, score, word, split)
-slang_T     *slang;
-int score;
-char_u      *word;
-int split;                  /* word was split, less bonus */
+static int 
+score_wordcount_adj (
+    slang_T *slang,
+    int score,
+    char_u *word,
+    int split                  /* word was split, less bonus */
+)
 {
   hashitem_T  *hi;
   wordcount_T *wc;
@@ -3197,9 +3170,7 @@ int split;                  /* word was split, less bonus */
  * SN_SOFO: <sofofromlen> <sofofrom> <sofotolen> <sofoto>
  * Return SP_*ERROR flags.
  */
-static int read_sofo_section(fd, slang)
-FILE        *fd;
-slang_T     *slang;
+static int read_sofo_section(FILE *fd, slang_T *slang)
 {
   int cnt;
   char_u      *from, *to;
@@ -3237,10 +3208,7 @@ slang_T     *slang;
  *	<compmax> <compminlen> <compsylmax> <compoptions> <compflags>
  * Returns SP_*ERROR flags.
  */
-static int read_compound(fd, slang, len)
-FILE        *fd;
-slang_T     *slang;
-int len;
+static int read_compound(FILE *fd, slang_T *slang, int len)
 {
   int todo = len;
   int c;
@@ -3416,9 +3384,7 @@ int len;
  * Return TRUE if byte "n" appears in "str".
  * Like strchr() but independent of locale.
  */
-static int byte_in_str(str, n)
-char_u      *str;
-int n;
+static int byte_in_str(char_u *str, int n)
 {
   char_u      *p;
 
@@ -3438,8 +3404,7 @@ typedef struct syl_item_S {
  * Truncate "slang->sl_syllable" at the first slash and put the following items
  * in "slang->sl_syl_items".
  */
-static int init_syl_tab(slang)
-slang_T     *slang;
+static int init_syl_tab(slang_T *slang)
 {
   char_u      *p;
   char_u      *s;
@@ -3475,9 +3440,7 @@ slang_T     *slang;
  * When "word" contains spaces the syllables after the last space are counted.
  * Returns zero if syllables are not defines.
  */
-static int count_syllables(slang, word)
-slang_T     *slang;
-char_u      *word;
+static int count_syllables(slang_T *slang, char_u *word)
 {
   int cnt = 0;
   int skip = FALSE;
@@ -3528,10 +3491,7 @@ char_u      *word;
  * Set the SOFOFROM and SOFOTO items in language "lp".
  * Returns SP_*ERROR flags when there is something wrong.
  */
-static int set_sofo(lp, from, to)
-slang_T     *lp;
-char_u      *from;
-char_u      *to;
+static int set_sofo(slang_T *lp, char_u *from, char_u *to)
 {
   int i;
 
@@ -3609,8 +3569,7 @@ char_u      *to;
 /*
  * Fill the first-index table for "lp".
  */
-static void set_sal_first(lp)
-slang_T     *lp;
+static void set_sal_first(slang_T *lp)
 {
   salfirst_T  *sfirst;
   int i;
@@ -3665,8 +3624,7 @@ slang_T     *lp;
  * Turn a multi-byte string into a wide character string.
  * Return it in allocated memory (NULL for out-of-memory)
  */
-static int * mb_str2wide(s)
-char_u      *s;
+static int *mb_str2wide(char_u *s)
 {
   int         *res;
   char_u      *p;
@@ -3687,12 +3645,14 @@ char_u      *s;
  * This is skipped when the tree has zero length.
  * Returns zero when OK, SP_ value for an error.
  */
-static int spell_read_tree(fd, bytsp, idxsp, prefixtree, prefixcnt)
-FILE        *fd;
-char_u      **bytsp;
-idx_T       **idxsp;
-int prefixtree;                 /* TRUE for the prefix tree */
-int prefixcnt;                  /* when "prefixtree" is TRUE: prefix count */
+static int 
+spell_read_tree (
+    FILE *fd,
+    char_u **bytsp,
+    idx_T **idxsp,
+    int prefixtree,                 /* TRUE for the prefix tree */
+    int prefixcnt                  /* when "prefixtree" is TRUE: prefix count */
+)
 {
   int len;
   int idx;
@@ -3735,15 +3695,16 @@ int prefixcnt;                  /* when "prefixtree" is TRUE: prefix count */
  * Returns SP_TRUNCERROR if the file is shorter than expected.
  * Returns SP_FORMERROR if there is a format error.
  */
-static idx_T read_tree_node(fd, byts, idxs, maxidx, startidx, prefixtree,
-    maxprefcondnr)
-FILE        *fd;
-char_u      *byts;
-idx_T       *idxs;
-int maxidx;                         /* size of arrays */
-idx_T startidx;                     /* current index in "byts" and "idxs" */
-int prefixtree;                     /* TRUE for reading PREFIXTREE */
-int maxprefcondnr;                  /* maximum for <prefcondnr> */
+static idx_T 
+read_tree_node (
+    FILE *fd,
+    char_u *byts,
+    idx_T *idxs,
+    int maxidx,                         /* size of arrays */
+    idx_T startidx,                     /* current index in "byts" and "idxs" */
+    int prefixtree,                     /* TRUE for reading PREFIXTREE */
+    int maxprefcondnr                  /* maximum for <prefcondnr> */
+)
 {
   int len;
   int i;
@@ -3839,8 +3800,7 @@ int maxprefcondnr;                  /* maximum for <prefcondnr> */
  * Parse 'spelllang' and set w_s->b_langp accordingly.
  * Returns NULL if it's OK, an error message otherwise.
  */
-char_u * did_set_spelllang(wp)
-win_T       *wp;
+char_u *did_set_spelllang(win_T *wp)
 {
   garray_T ga;
   char_u      *splp;
@@ -4120,8 +4080,7 @@ theend:
 /*
  * Clear the midword characters for buffer "buf".
  */
-static void clear_midword(wp)
-win_T       *wp;
+static void clear_midword(win_T *wp)
 {
   vim_memset(wp->w_s->b_spell_ismw, 0, 256);
   vim_free(wp->w_s->b_spell_ismw_mb);
@@ -4132,9 +4091,7 @@ win_T       *wp;
  * Use the "sl_midword" field of language "lp" for buffer "buf".
  * They add up to any currently used midword characters.
  */
-static void use_midword(lp, wp)
-slang_T     *lp;
-win_T       *wp;
+static void use_midword(slang_T *lp, win_T *wp)
 {
   char_u      *p;
 
@@ -4173,9 +4130,7 @@ win_T       *wp;
  * Each region is simply stored as the two characters of it's name.
  * Returns the index if found (first is 0), REGION_ALL if not found.
  */
-static int find_region(rp, region)
-char_u      *rp;
-char_u      *region;
+static int find_region(char_u *rp, char_u *region)
 {
   int i;
 
@@ -4195,9 +4150,11 @@ char_u      *region;
  * W WORD	WF_ALLCAP
  * WoRd	wOrd	WF_KEEPCAP
  */
-static int captype(word, end)
-char_u      *word;
-char_u      *end;           /* When NULL use up to NUL byte. */
+static int 
+captype (
+    char_u *word,
+    char_u *end           /* When NULL use up to NUL byte. */
+)
 {
   char_u      *p;
   int c;
@@ -4245,9 +4202,7 @@ char_u      *end;           /* When NULL use up to NUL byte. */
  * capital.  So that make_case_word() can turn WOrd into Word.
  * Add ALLCAP for "WOrD".
  */
-static int badword_captype(word, end)
-char_u      *word;
-char_u      *end;
+static int badword_captype(char_u *word, char_u *end)
 {
   int flags = captype(word, end);
   int c;
@@ -4287,7 +4242,7 @@ char_u      *end;
 /*
  * Delete the internal wordlist and its .spl file.
  */
-void spell_delete_wordlist()          {
+void spell_delete_wordlist(void)          {
   char_u fname[MAXPATHL];
 
   if (int_wordlist != NULL) {
@@ -4302,7 +4257,7 @@ void spell_delete_wordlist()          {
 /*
  * Free all languages.
  */
-void spell_free_all()          {
+void spell_free_all(void)          {
   slang_T     *slang;
   buf_T       *buf;
 
@@ -4328,7 +4283,7 @@ void spell_free_all()          {
  * Clear all spelling tables and reload them.
  * Used after 'encoding' is set and when ":mkspell" was used.
  */
-void spell_reload()          {
+void spell_reload(void)          {
   win_T       *wp;
 
   /* Initialize the table for spell_iswordp(). */
@@ -4353,9 +4308,11 @@ void spell_reload()          {
 /*
  * Reload the spell file "fname" if it's loaded.
  */
-static void spell_reload_one(fname, added_word)
-char_u      *fname;
-int added_word;                 /* invoked through "zg" */
+static void 
+spell_reload_one (
+    char_u *fname,
+    int added_word                 /* invoked through "zg" */
+)
 {
   slang_T     *slang;
   int didit = FALSE;
@@ -4756,9 +4713,7 @@ static void spell_print_tree(wordnode_T *root)                 {
  * Read the affix file "fname".
  * Returns an afffile_T, NULL for complete failure.
  */
-static afffile_T * spell_read_aff(spin, fname)
-spellinfo_T *spin;
-char_u      *fname;
+static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
 {
   FILE        *fd;
   afffile_T   *aff;
@@ -5536,11 +5491,7 @@ char_u      *fname;
  * Return TRUE when items[0] equals "rulename", there are "mincount" items or
  * a comment is following after item "mincount".
  */
-static int is_aff_rule(items, itemcnt, rulename, mincount)
-char_u      **items;
-int itemcnt;
-char        *rulename;
-int mincount;
+static int is_aff_rule(char_u **items, int itemcnt, char *rulename, int mincount)
 {
   return STRCMP(items[0], rulename) == 0
          && (itemcnt == mincount
@@ -5551,9 +5502,7 @@ int mincount;
  * For affix "entry" move COMPOUNDFORBIDFLAG and COMPOUNDPERMITFLAG from
  * ae_flags to ae_comppermit and ae_compforbid.
  */
-static void aff_process_flags(affile, entry)
-afffile_T   *affile;
-affentry_T  *entry;
+static void aff_process_flags(afffile_T *affile, affentry_T *entry)
 {
   char_u      *p;
   char_u      *prevp;
@@ -5583,8 +5532,7 @@ affentry_T  *entry;
 /*
  * Return TRUE if "s" is the name of an info item in the affix file.
  */
-static int spell_info_item(s)
-char_u      *s;
+static int spell_info_item(char_u *s)
 {
   return STRCMP(s, "NAME") == 0
          || STRCMP(s, "HOME") == 0
@@ -5598,11 +5546,7 @@ char_u      *s;
  * Turn an affix flag name into a number, according to the FLAG type.
  * returns zero for failure.
  */
-static unsigned affitem2flag(flagtype, item, fname, lnum)
-int flagtype;
-char_u      *item;
-char_u      *fname;
-int lnum;
+static unsigned affitem2flag(int flagtype, char_u *item, char_u *fname, int lnum)
 {
   unsigned res;
   char_u      *p = item;
@@ -5628,9 +5572,7 @@ int lnum;
  * Get one affix name from "*pp" and advance the pointer.
  * Returns zero for an error, still advances the pointer then.
  */
-static unsigned get_affitem(flagtype, pp)
-int flagtype;
-char_u      **pp;
+static unsigned get_affitem(int flagtype, char_u **pp)
 {
   int res;
 
@@ -5658,10 +5600,7 @@ char_u      **pp;
  * The processing involves changing the affix names to ID numbers, so that
  * they fit in one byte.
  */
-static void process_compflags(spin, aff, compflags)
-spellinfo_T *spin;
-afffile_T   *aff;
-char_u      *compflags;
+static void process_compflags(spellinfo_T *spin, afffile_T *aff, char_u *compflags)
 {
   char_u      *p;
   char_u      *prevp;
@@ -5735,8 +5674,7 @@ char_u      *compflags;
  * using two bytes for utf-8.  When the 0-127 range is used up go to 128-255.
  * When that is used up an error message is given.
  */
-static void check_renumber(spin)
-spellinfo_T *spin;
+static void check_renumber(spellinfo_T *spin)
 {
   if (spin->si_newprefID == spin->si_newcompID && spin->si_newcompID < 128) {
     spin->si_newprefID = 127;
@@ -5747,10 +5685,7 @@ spellinfo_T *spin;
 /*
  * Return TRUE if flag "flag" appears in affix list "afflist".
  */
-static int flag_in_afflist(flagtype, afflist, flag)
-int flagtype;
-char_u      *afflist;
-unsigned flag;
+static int flag_in_afflist(int flagtype, char_u *afflist, unsigned flag)
 {
   char_u      *p;
   unsigned n;
@@ -5787,10 +5722,7 @@ unsigned flag;
 /*
  * Give a warning when "spinval" and "affval" numbers are set and not the same.
  */
-static void aff_check_number(spinval, affval, name)
-int spinval;
-int affval;
-char    *name;
+static void aff_check_number(int spinval, int affval, char *name)
 {
   if (spinval != 0 && spinval != affval)
     smsg((char_u *)_(
@@ -5800,10 +5732,7 @@ char    *name;
 /*
  * Give a warning when "spinval" and "affval" strings are set and not the same.
  */
-static void aff_check_string(spinval, affval, name)
-char_u      *spinval;
-char_u      *affval;
-char        *name;
+static void aff_check_string(char_u *spinval, char_u *affval, char *name)
 {
   if (spinval != NULL && STRCMP(spinval, affval) != 0)
     smsg((char_u *)_(
@@ -5814,9 +5743,7 @@ char        *name;
  * Return TRUE if strings "s1" and "s2" are equal.  Also consider both being
  * NULL as equal.
  */
-static int str_equal(s1, s2)
-char_u      *s1;
-char_u      *s2;
+static int str_equal(char_u *s1, char_u *s2)
 {
   if (s1 == NULL || s2 == NULL)
     return s1 == s2;
@@ -5827,11 +5754,7 @@ char_u      *s2;
  * Add a from-to item to "gap".  Used for REP and SAL items.
  * They are stored case-folded.
  */
-static void add_fromto(spin, gap, from, to)
-spellinfo_T *spin;
-garray_T    *gap;
-char_u      *from;
-char_u      *to;
+static void add_fromto(spellinfo_T *spin, garray_T *gap, char_u *from, char_u *to)
 {
   fromto_T    *ftp;
   char_u word[MAXWLEN];
@@ -5849,8 +5772,7 @@ char_u      *to;
 /*
  * Convert a boolean argument in a SAL line to TRUE or FALSE;
  */
-static int sal_to_bool(s)
-char_u      *s;
+static int sal_to_bool(char_u *s)
 {
   return STRCMP(s, "1") == 0 || STRCMP(s, "true") == 0;
 }
@@ -5858,8 +5780,7 @@ char_u      *s;
 /*
  * Free the structure filled by spell_read_aff().
  */
-static void spell_free_aff(aff)
-afffile_T   *aff;
+static void spell_free_aff(afffile_T *aff)
 {
   hashtab_T   *ht;
   hashitem_T  *hi;
@@ -5893,10 +5814,7 @@ afffile_T   *aff;
  * Read dictionary file "fname".
  * Returns OK or FAIL;
  */
-static int spell_read_dic(spin, fname, affile)
-spellinfo_T *spin;
-char_u      *fname;
-afffile_T   *affile;
+static int spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
 {
   hashtab_T ht;
   char_u line[MAXLINELEN];
@@ -6092,9 +6010,7 @@ afffile_T   *affile;
  * Check for affix flags in "afflist" that are turned into word flags.
  * Return WF_ flags.
  */
-static int get_affix_flags(affile, afflist)
-afffile_T   *affile;
-char_u      *afflist;
+static int get_affix_flags(afffile_T *affile, char_u *afflist)
 {
   int flags = 0;
 
@@ -6125,10 +6041,7 @@ char_u      *afflist;
  * Put the resulting flags in "store_afflist[MAXWLEN]" with a terminating NUL
  * and return the number of affixes.
  */
-static int get_pfxlist(affile, afflist, store_afflist)
-afffile_T   *affile;
-char_u      *afflist;
-char_u      *store_afflist;
+static int get_pfxlist(afffile_T *affile, char_u *afflist, char_u *store_afflist)
 {
   char_u      *p;
   char_u      *prevp;
@@ -6163,10 +6076,7 @@ char_u      *store_afflist;
  * for compound words.
  * Puts the flags in "store_afflist[]".
  */
-static void get_compflags(affile, afflist, store_afflist)
-afffile_T   *affile;
-char_u      *afflist;
-char_u      *store_afflist;
+static void get_compflags(afffile_T *affile, char_u *afflist, char_u *store_afflist)
 {
   char_u      *p;
   char_u      *prevp;
@@ -6199,19 +6109,20 @@ char_u      *store_afflist;
  *
  * Returns FAIL when out of memory.
  */
-static int store_aff_word(spin, word, afflist, affile, ht, xht, condit, flags,
-    pfxlist, pfxlen)
-spellinfo_T *spin;              /* spell info */
-char_u      *word;              /* basic word start */
-char_u      *afflist;           /* list of names of supported affixes */
-afffile_T   *affile;
-hashtab_T   *ht;
-hashtab_T   *xht;
-int condit;                     /* CONDIT_SUF et al. */
-int flags;                      /* flags for the word */
-char_u      *pfxlist;           /* list of prefix IDs */
-int pfxlen;                     /* nr of flags in "pfxlist" for prefixes, rest
+static int 
+store_aff_word (
+    spellinfo_T *spin,              /* spell info */
+    char_u *word,              /* basic word start */
+    char_u *afflist,           /* list of names of supported affixes */
+    afffile_T *affile,
+    hashtab_T *ht,
+    hashtab_T *xht,
+    int condit,                     /* CONDIT_SUF et al. */
+    int flags,                      /* flags for the word */
+    char_u *pfxlist,           /* list of prefix IDs */
+    int pfxlen                     /* nr of flags in "pfxlist" for prefixes, rest
                                  * is compound flags */
+)
 {
   int todo;
   hashitem_T  *hi;
@@ -6442,9 +6353,7 @@ int pfxlen;                     /* nr of flags in "pfxlist" for prefixes, rest
 /*
  * Read a file with a list of words.
  */
-static int spell_read_wordfile(spin, fname)
-spellinfo_T *spin;
-char_u      *fname;
+static int spell_read_wordfile(spellinfo_T *spin, char_u *fname)
 {
   FILE        *fd;
   long lnum = 0;
@@ -6626,10 +6535,12 @@ char_u      *fname;
  * The memory is cleared to all zeros.
  * Returns NULL when out of memory.
  */
-static void * getroom(spin, len, align)
-spellinfo_T *spin;
-size_t len;                     /* length needed */
-int align;                      /* align for pointer */
+static void *
+getroom (
+    spellinfo_T *spin,
+    size_t len,                     /* length needed */
+    int align                      /* align for pointer */
+)
 {
   char_u      *p;
   sblock_T    *bl = spin->si_blocks;
@@ -6670,9 +6581,7 @@ int align;                      /* align for pointer */
  * Make a copy of a string into memory allocated with getroom().
  * Returns NULL when out of memory.
  */
-static char_u * getroom_save(spin, s)
-spellinfo_T *spin;
-char_u      *s;
+static char_u *getroom_save(spellinfo_T *spin, char_u *s)
 {
   char_u      *sc;
 
@@ -6686,8 +6595,7 @@ char_u      *s;
 /*
  * Free the list of allocated sblock_T.
  */
-static void free_blocks(bl)
-sblock_T    *bl;
+static void free_blocks(sblock_T *bl)
 {
   sblock_T    *next;
 
@@ -6702,8 +6610,7 @@ sblock_T    *bl;
  * Allocate the root of a word tree.
  * Returns NULL when out of memory.
  */
-static wordnode_T * wordtree_alloc(spin)
-spellinfo_T *spin;
+static wordnode_T *wordtree_alloc(spellinfo_T *spin)
 {
   return (wordnode_T *)getroom(spin, sizeof(wordnode_T), TRUE);
 }
@@ -6717,13 +6624,15 @@ spellinfo_T *spin;
  * When "pfxlist" is not NULL store the word for each postponed prefix ID and
  * compound flag.
  */
-static int store_word(spin, word, flags, region, pfxlist, need_affix)
-spellinfo_T *spin;
-char_u      *word;
-int flags;                      /* extra flags, WF_BANNED */
-int region;                     /* supported region(s) */
-char_u      *pfxlist;           /* list of prefix IDs or NULL */
-int need_affix;                 /* only store word with affix ID */
+static int 
+store_word (
+    spellinfo_T *spin,
+    char_u *word,
+    int flags,                      /* extra flags, WF_BANNED */
+    int region,                     /* supported region(s) */
+    char_u *pfxlist,           /* list of prefix IDs or NULL */
+    int need_affix                 /* only store word with affix ID */
+)
 {
   int len = (int)STRLEN(word);
   int ct = captype(word, word + len);
@@ -6760,13 +6669,7 @@ int need_affix;                 /* only store word with affix ID */
  * "rare" and "region" is the condition nr.
  * Returns FAIL when out of memory.
  */
-static int tree_add_word(spin, word, root, flags, region, affixID)
-spellinfo_T *spin;
-char_u      *word;
-wordnode_T  *root;
-int flags;
-int region;
-int affixID;
+static int tree_add_word(spellinfo_T *spin, char_u *word, wordnode_T *root, int flags, int region, int affixID)
 {
   wordnode_T  *node = root;
   wordnode_T  *np;
@@ -6929,7 +6832,7 @@ int affixID;
  * Check the 'mkspellmem' option.  Return FAIL if it's wrong.
  * Sets "sps_flags".
  */
-int spell_check_msm()         {
+int spell_check_msm(void)         {
   char_u      *p = p_msm;
   long start = 0;
   long incr = 0;
@@ -6968,8 +6871,7 @@ int spell_check_msm()         {
  * allocate a new one.
  * Returns NULL when out of memory.
  */
-static wordnode_T * get_wordnode(spin)
-spellinfo_T     *spin;
+static wordnode_T *get_wordnode(spellinfo_T *spin)
 {
   wordnode_T *n;
 
@@ -6994,9 +6896,7 @@ spellinfo_T     *spin;
  * siblings.
  * Returns the number of nodes actually freed.
  */
-static int deref_wordnode(spin, node)
-spellinfo_T *spin;
-wordnode_T  *node;
+static int deref_wordnode(spellinfo_T *spin, wordnode_T *node)
 {
   wordnode_T  *np;
   int cnt = 0;
@@ -7017,9 +6917,7 @@ wordnode_T  *node;
  * Free a wordnode_T for re-use later.
  * Only the "wn_child" field becomes invalid.
  */
-static void free_wordnode(spin, n)
-spellinfo_T *spin;
-wordnode_T  *n;
+static void free_wordnode(spellinfo_T *spin, wordnode_T *n)
 {
   n->wn_child = spin->si_first_free;
   spin->si_first_free = n;
@@ -7029,9 +6927,7 @@ wordnode_T  *n;
 /*
  * Compress a tree: find tails that are identical and can be shared.
  */
-static void wordtree_compress(spin, root)
-spellinfo_T     *spin;
-wordnode_T      *root;
+static void wordtree_compress(spellinfo_T *spin, wordnode_T *root)
 {
   hashtab_T ht;
   int n;
@@ -7070,12 +6966,14 @@ wordnode_T      *root;
  * Compress a node, its siblings and its children, depth first.
  * Returns the number of compressed nodes.
  */
-static int node_compress(spin, node, ht, tot)
-spellinfo_T *spin;
-wordnode_T  *node;
-hashtab_T   *ht;
-int         *tot;           /* total count of nodes before compressing,
+static int 
+node_compress (
+    spellinfo_T *spin,
+    wordnode_T *node,
+    hashtab_T *ht,
+    int *tot           /* total count of nodes before compressing,
                                incremented while going through the tree */
+)
 {
   wordnode_T  *np;
   wordnode_T  *tp;
@@ -7168,9 +7066,7 @@ int         *tot;           /* total count of nodes before compressing,
 /*
  * Return TRUE when two nodes have identical siblings and children.
  */
-static int node_equal(n1, n2)
-wordnode_T  *n1;
-wordnode_T  *n2;
+static int node_equal(wordnode_T *n1, wordnode_T *n2)
 {
   wordnode_T  *p1;
   wordnode_T  *p2;
@@ -7194,9 +7090,7 @@ rep_compare __ARGS((const void *s1, const void *s2));
 /*
  * Function given to qsort() to sort the REP items on "from" string.
  */
-static int rep_compare(s1, s2)
-const void  *s1;
-const void  *s2;
+static int rep_compare(const void *s1, const void *s2)
 {
   fromto_T    *p1 = (fromto_T *)s1;
   fromto_T    *p2 = (fromto_T *)s2;
@@ -7208,9 +7102,7 @@ const void  *s2;
  * Write the Vim .spl file "fname".
  * Return FAIL or OK;
  */
-static int write_vim_spell(spin, fname)
-spellinfo_T *spin;
-char_u      *fname;
+static int write_vim_spell(spellinfo_T *spin, char_u *fname)
 {
   FILE        *fd;
   int regionmask;
@@ -7589,8 +7481,7 @@ theend:
  * children.  This is needed because they are a union with other items to save
  * space.
  */
-static void clear_node(node)
-wordnode_T  *node;
+static void clear_node(wordnode_T *node)
 {
   wordnode_T  *np;
 
@@ -7617,12 +7508,14 @@ wordnode_T  *node;
  *
  * Returns the number of nodes used.
  */
-static int put_node(fd, node, idx, regionmask, prefixtree)
-FILE        *fd;                /* NULL when only counting */
-wordnode_T  *node;
-int idx;
-int regionmask;
-int prefixtree;                 /* TRUE for PREFIXTREE */
+static int 
+put_node (
+    FILE *fd,                /* NULL when only counting */
+    wordnode_T *node,
+    int idx,
+    int regionmask,
+    int prefixtree                 /* TRUE for PREFIXTREE */
+)
 {
   int newindex = idx;
   int siblingcount = 0;
@@ -7727,8 +7620,7 @@ int prefixtree;                 /* TRUE for PREFIXTREE */
  * ":mkspell [-ascii] outfile  infile ..."
  * ":mkspell [-ascii] addfile"
  */
-void ex_mkspell(eap)
-exarg_T *eap;
+void ex_mkspell(exarg_T *eap)
 {
   int fcount;
   char_u      **fnames;
@@ -7752,9 +7644,7 @@ exarg_T *eap;
  * Uses the soundfold info in "spin".
  * Writes the file with the name "wfname", with ".spl" changed to ".sug".
  */
-static void spell_make_sugfile(spin, wfname)
-spellinfo_T *spin;
-char_u      *wfname;
+static void spell_make_sugfile(spellinfo_T *spin, char_u *wfname)
 {
   char_u      *fname = NULL;
   int len;
@@ -7839,9 +7729,7 @@ theend:
 /*
  * Build the soundfold trie for language "slang".
  */
-static int sug_filltree(spin, slang)
-spellinfo_T *spin;
-slang_T     *slang;
+static int sug_filltree(spellinfo_T *spin, slang_T *slang)
 {
   char_u      *byts;
   idx_T       *idxs;
@@ -7938,8 +7826,7 @@ slang_T     *slang;
  * the table efficiently.
  * Returns FAIL when out of memory.
  */
-static int sug_maketable(spin)
-spellinfo_T *spin;
+static int sug_maketable(spellinfo_T *spin)
 {
   garray_T ga;
   int res = OK;
@@ -7967,11 +7854,13 @@ spellinfo_T *spin;
  * Returns the wordnr at the start of the node.
  * Returns -1 when out of memory.
  */
-static int sug_filltable(spin, node, startwordnr, gap)
-spellinfo_T *spin;
-wordnode_T  *node;
-int startwordnr;
-garray_T    *gap;           /* place to store line of numbers */
+static int 
+sug_filltable (
+    spellinfo_T *spin,
+    wordnode_T *node,
+    int startwordnr,
+    garray_T *gap           /* place to store line of numbers */
+)
 {
   wordnode_T  *p, *np;
   int wordnr = startwordnr;
@@ -8028,9 +7917,7 @@ garray_T    *gap;           /* place to store line of numbers */
  * Similar to utf_char2byters, but use 8 bits in followup bytes and avoid NUL
  * bytes.
  */
-static int offset2bytes(nr, buf)
-int nr;
-char_u  *buf;
+static int offset2bytes(int nr, char_u *buf)
 {
   int rem;
   int b1, b2, b3, b4;
@@ -8071,8 +7958,7 @@ char_u  *buf;
  * "pp" points to the bytes and is advanced over it.
  * Returns the offset.
  */
-static int bytes2offset(pp)
-char_u      **pp;
+static int bytes2offset(char_u **pp)
 {
   char_u      *p = *pp;
   int nr;
@@ -8102,9 +7988,7 @@ char_u      **pp;
 /*
  * Write the .sug file in "fname".
  */
-static void sug_write(spin, fname)
-spellinfo_T *spin;
-char_u      *fname;
+static void sug_write(spellinfo_T *spin, char_u *fname)
 {
   FILE        *fd;
   wordnode_T  *tree;
@@ -8196,7 +8080,7 @@ theend:
  * NULL and there is no undo info.
  * Returns NULL when out of memory.
  */
-static buf_T * open_spellbuf()                    {
+static buf_T *open_spellbuf(void)                    {
   buf_T       *buf;
 
   buf = (buf_T *)alloc_clear(sizeof(buf_T));
@@ -8213,8 +8097,7 @@ static buf_T * open_spellbuf()                    {
 /*
  * Close the buffer used for spell info.
  */
-static void close_spellbuf(buf)
-buf_T       *buf;
+static void close_spellbuf(buf_T *buf)
 {
   if (buf != NULL) {
     ml_close(buf, TRUE);
@@ -8230,12 +8113,14 @@ buf_T       *buf;
  * Exception: when "fnames[0]" ends in ".add" it's used as the input file name
  * and ".spl" is appended to make the output file name.
  */
-static void mkspell(fcount, fnames, ascii, over_write, added_word)
-int fcount;
-char_u      **fnames;
-int ascii;                          /* -ascii argument given */
-int over_write;                     /* overwrite existing output file */
-int added_word;                     /* invoked through "zg" */
+static void 
+mkspell (
+    int fcount,
+    char_u **fnames,
+    int ascii,                          /* -ascii argument given */
+    int over_write,                     /* overwrite existing output file */
+    int added_word                     /* invoked through "zg" */
+)
 {
   char_u      *fname = NULL;
   char_u      *wfname;
@@ -8466,9 +8351,7 @@ theend:
  * Display a message for spell file processing when 'verbose' is set or using
  * ":mkspell".  "str" can be IObuff.
  */
-static void spell_message(spin, str)
-spellinfo_T *spin;
-char_u      *str;
+static void spell_message(spellinfo_T *spin, char_u *str)
 {
   if (spin->si_verbose || p_verbose > 2) {
     if (!spin->si_verbose)
@@ -8485,8 +8368,7 @@ char_u      *str;
  * ":[count]spellwrong  {word}"
  * ":[count]spellundo  {word}"
  */
-void ex_spell(eap)
-exarg_T *eap;
+void ex_spell(exarg_T *eap)
 {
   spell_add_word(eap->arg, (int)STRLEN(eap->arg), eap->cmdidx == CMD_spellwrong,
       eap->forceit ? 0 : (int)eap->line2,
@@ -8496,13 +8378,15 @@ exarg_T *eap;
 /*
  * Add "word[len]" to 'spellfile' as a good or bad word.
  */
-void spell_add_word(word, len, bad, idx, undo)
-char_u      *word;
-int len;
-int bad;
-int idx;                    /* "zG" and "zW": zero, otherwise index in
+void 
+spell_add_word (
+    char_u *word,
+    int len,
+    int bad,
+    int idx,                    /* "zG" and "zW": zero, otherwise index in
                                'spellfile' */
-int undo;                   /* TRUE for "zug", "zuG", "zuw" and "zuW" */
+    int undo                   /* TRUE for "zug", "zuG", "zuw" and "zuW" */
+)
 {
   FILE        *fd = NULL;
   buf_T       *buf = NULL;
@@ -8644,7 +8528,7 @@ int undo;                   /* TRUE for "zug", "zuG", "zuw" and "zuW" */
 /*
  * Initialize 'spellfile' for the current buffer.
  */
-static void init_spellfile()                 {
+static void init_spellfile(void)                 {
   char_u      *buf;
   int l;
   char_u      *fname;
@@ -8717,8 +8601,7 @@ static void init_spellfile()                 {
  * Init the chartab used for spelling for ASCII.
  * EBCDIC is not supported!
  */
-static void clear_spell_chartab(sp)
-spelltab_T  *sp;
+static void clear_spell_chartab(spelltab_T *sp)
 {
   int i;
 
@@ -8752,7 +8635,7 @@ spelltab_T  *sp;
  * characters to make it possible that 'encoding' differs from the current
  * locale.  For utf-8 we don't use isalpha() but our own functions.
  */
-void init_spell_chartab()          {
+void init_spell_chartab(void)          {
   int i;
 
   did_set_spelltab = FALSE;
@@ -8793,10 +8676,7 @@ void init_spell_chartab()          {
 /*
  * Set the spell character tables from strings in the affix file.
  */
-static int set_spell_chartab(fol, low, upp)
-char_u      *fol;
-char_u      *low;
-char_u      *upp;
+static int set_spell_chartab(char_u *fol, char_u *low, char_u *upp)
 {
   /* We build the new tables here first, so that we can compare with the
    * previous one. */
@@ -8857,10 +8737,12 @@ char_u      *upp;
 /*
  * Set the spell character tables from strings in the .spl file.
  */
-static void set_spell_charflags(flags, cnt, fol)
-char_u      *flags;
-int cnt;                    /* length of "flags" */
-char_u      *fol;
+static void 
+set_spell_charflags (
+    char_u *flags,
+    int cnt,                    /* length of "flags" */
+    char_u *fol
+)
 {
   /* We build the new tables here first, so that we can compare with the
    * previous one. */
@@ -8888,8 +8770,7 @@ char_u      *fol;
   (void)set_spell_finish(&new_st);
 }
 
-static int set_spell_finish(new_st)
-spelltab_T  *new_st;
+static int set_spell_finish(spelltab_T *new_st)
 {
   int i;
 
@@ -8919,9 +8800,11 @@ spelltab_T  *new_st;
  * followed by a word character.  This finds they'there but not 'they there'.
  * Thus this only works properly when past the first character of the word.
  */
-static int spell_iswordp(p, wp)
-char_u      *p;
-win_T       *wp;            /* buffer used */
+static int 
+spell_iswordp (
+    char_u *p,
+    win_T *wp            /* buffer used */
+)
 {
   char_u      *s;
   int l;
@@ -8955,9 +8838,7 @@ win_T       *wp;            /* buffer used */
  * Return TRUE if "p" points to a word character.
  * Unlike spell_iswordp() this doesn't check for "midword" characters.
  */
-static int spell_iswordp_nmw(p, wp)
-char_u      *p;
-win_T       *wp;
+static int spell_iswordp_nmw(char_u *p, win_T *wp)
 {
   int c;
 
@@ -8976,9 +8857,7 @@ win_T       *wp;
  * Unicode subscript and superscript are not considered word characters.
  * See also dbcs_class() and utf_class() in mbyte.c.
  */
-static int spell_mb_isword_class(cl, wp)
-int cl;
-win_T       *wp;
+static int spell_mb_isword_class(int cl, win_T *wp)
 {
   if (wp->w_s->b_cjk)
     /* East Asian characters are not considered word characters. */
@@ -8990,9 +8869,7 @@ win_T       *wp;
  * Return TRUE if "p" points to a word character.
  * Wide version of spell_iswordp().
  */
-static int spell_iswordp_w(p, wp)
-int         *p;
-win_T       *wp;
+static int spell_iswordp_w(int *p, win_T *wp)
 {
   int         *s;
 
@@ -9018,9 +8895,7 @@ win_T       *wp;
  * Write the table with prefix conditions to the .spl file.
  * When "fd" is NULL only count the length of what is written.
  */
-static int write_spell_prefcond(fd, gap)
-FILE        *fd;
-garray_T    *gap;
+static int write_spell_prefcond(FILE *fd, garray_T *gap)
 {
   int i;
   char_u      *p;
@@ -9056,11 +8931,7 @@ garray_T    *gap;
  * When using a multi-byte 'encoding' the length may change!
  * Returns FAIL when something wrong.
  */
-static int spell_casefold(str, len, buf, buflen)
-char_u      *str;
-int len;
-char_u      *buf;
-int buflen;
+static int spell_casefold(char_u *str, int len, char_u *buf, int buflen)
 {
   int i;
 
@@ -9106,7 +8977,7 @@ static int sps_limit = 9999;            /* max nr of suggestions given */
  * Check the 'spellsuggest' option.  Return FAIL if it's wrong.
  * Sets "sps_flags" and "sps_limit".
  */
-int spell_check_sps()         {
+int spell_check_sps(void)         {
   char_u      *p;
   char_u      *s;
   char_u buf[MAXPATHL];
@@ -9155,8 +9026,7 @@ int spell_check_sps()         {
  * In Visual mode use the highlighted word as the bad word.
  * When "count" is non-zero use that suggestion.
  */
-void spell_suggest(count)
-int count;
+void spell_suggest(int count)
 {
   char_u      *line;
   pos_T prev_cursor = curwin->w_cursor;
@@ -9370,9 +9240,7 @@ skip:
  * Check if the word at line "lnum" column "col" is required to start with a
  * capital.  This uses 'spellcapcheck' of the current buffer.
  */
-static int check_need_cap(lnum, col)
-linenr_T lnum;
-colnr_T col;
+static int check_need_cap(linenr_T lnum, colnr_T col)
 {
   int need_cap = FALSE;
   char_u      *line;
@@ -9431,8 +9299,7 @@ colnr_T col;
 /*
  * ":spellrepall"
  */
-void ex_spellrepall(eap)
-exarg_T *eap UNUSED;
+void ex_spellrepall(exarg_T *eap)
 {
   pos_T pos = curwin->w_cursor;
   char_u      *frompat;
@@ -9499,12 +9366,14 @@ exarg_T *eap UNUSED;
  * Find spell suggestions for "word".  Return them in the growarray "*gap" as
  * a list of allocated strings.
  */
-void spell_suggest_list(gap, word, maxcount, need_cap, interactive)
-garray_T    *gap;
-char_u      *word;
-int maxcount;                   /* maximum nr of suggestions */
-int need_cap;                   /* 'spellcapcheck' matched */
-int interactive;
+void 
+spell_suggest_list (
+    garray_T *gap,
+    char_u *word,
+    int maxcount,                   /* maximum nr of suggestions */
+    int need_cap,                   /* 'spellcapcheck' matched */
+    int interactive
+)
 {
   suginfo_T sug;
   int i;
@@ -9541,16 +9410,16 @@ int interactive;
  * Note: does use info for the current window.
  * This is based on the mechanisms of Aspell, but completely reimplemented.
  */
-static void spell_find_suggest(badptr, badlen, su, maxcount, banbadword,
-    need_cap,
-    interactive)
-char_u      *badptr;
-int badlen;                     /* length of bad word or 0 if unknown */
-suginfo_T   *su;
-int maxcount;
-int banbadword;                 /* don't include badword in suggestions */
-int need_cap;                   /* word should start with capital */
-int interactive;
+static void 
+spell_find_suggest (
+    char_u *badptr,
+    int badlen,                     /* length of bad word or 0 if unknown */
+    suginfo_T *su,
+    int maxcount,
+    int banbadword,                 /* don't include badword in suggestions */
+    int need_cap,                   /* word should start with capital */
+    int interactive
+)
 {
   hlf_T attr = HLF_COUNT;
   char_u buf[MAXPATHL];
@@ -9662,9 +9531,7 @@ int interactive;
 /*
  * Find suggestions by evaluating expression "expr".
  */
-static void spell_suggest_expr(su, expr)
-suginfo_T   *su;
-char_u      *expr;
+static void spell_suggest_expr(suginfo_T *su, char_u *expr)
 {
   list_T      *list;
   listitem_T  *li;
@@ -9696,9 +9563,7 @@ char_u      *expr;
 /*
  * Find suggestions in file "fname".  Used for "file:" in 'spellsuggest'.
  */
-static void spell_suggest_file(su, fname)
-suginfo_T   *su;
-char_u      *fname;
+static void spell_suggest_file(suginfo_T *su, char_u *fname)
 {
   FILE        *fd;
   char_u line[MAXWLEN * 2];
@@ -9749,9 +9614,7 @@ char_u      *fname;
 /*
  * Find suggestions for the internal method indicated by "sps_flags".
  */
-static void spell_suggest_intern(su, interactive)
-suginfo_T   *su;
-int interactive;
+static void spell_suggest_intern(suginfo_T *su, int interactive)
 {
   /*
    * Load the .sug file(s) that are available and not done yet.
@@ -9837,7 +9700,7 @@ int interactive;
 /*
  * Load the .sug files for languages that have one and weren't loaded yet.
  */
-static void suggest_load_files()                 {
+static void suggest_load_files(void)                 {
   langp_T     *lp;
   int lpi;
   slang_T     *slang;
@@ -9965,9 +9828,7 @@ nextone:
  * Fill in the wordcount fields for a trie.
  * Returns the total number of words.
  */
-static void tree_count_words(byts, idxs)
-char_u      *byts;
-idx_T       *idxs;
+static void tree_count_words(char_u *byts, idx_T *idxs)
 {
   int depth;
   idx_T arridx[MAXWLEN];
@@ -10019,8 +9880,7 @@ idx_T       *idxs;
 /*
  * Free the info put in "*su" by spell_find_suggest().
  */
-static void spell_find_cleanup(su)
-suginfo_T   *su;
+static void spell_find_cleanup(suginfo_T *su)
 {
   int i;
 
@@ -10041,10 +9901,12 @@ suginfo_T   *su;
  * "wcopy[MAXWLEN]".  "word" must not be empty.
  * The result is NUL terminated.
  */
-static void onecap_copy(word, wcopy, upper)
-char_u      *word;
-char_u      *wcopy;
-int upper;                  /* TRUE: first letter made upper case */
+static void 
+onecap_copy (
+    char_u *word,
+    char_u *wcopy,
+    int upper                  /* TRUE: first letter made upper case */
+)
 {
   char_u      *p;
   int c;
@@ -10072,9 +9934,7 @@ int upper;                  /* TRUE: first letter made upper case */
  * Make a copy of "word" with all the letters upper cased into
  * "wcopy[MAXWLEN]".  The result is NUL terminated.
  */
-static void allcap_copy(word, wcopy)
-char_u      *word;
-char_u      *wcopy;
+static void allcap_copy(char_u *word, char_u *wcopy)
 {
   char_u      *s;
   char_u      *d;
@@ -10113,8 +9973,7 @@ char_u      *wcopy;
 /*
  * Try finding suggestions by recognizing specific situations.
  */
-static void suggest_try_special(su)
-suginfo_T   *su;
+static void suggest_try_special(suginfo_T *su)
 {
   char_u      *p;
   size_t len;
@@ -10145,8 +10004,7 @@ suginfo_T   *su;
 /*
  * Try finding suggestions by adding/removing/swapping letters.
  */
-static void suggest_try_change(su)
-suginfo_T   *su;
+static void suggest_try_change(suginfo_T *su)
 {
   char_u fword[MAXWLEN];            /* copy of the bad word, case-folded */
   int n;
@@ -10210,11 +10068,7 @@ suginfo_T   *su;
  *	"similar_chars()"
  *	use "slang->sl_repsal" instead of "lp->lp_replang->sl_rep"
  */
-static void suggest_trie_walk(su, lp, fword, soundfold)
-suginfo_T   *su;
-langp_T     *lp;
-char_u      *fword;
-int soundfold;
+static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, int soundfold)
 {
   char_u tword[MAXWLEN];            /* good word collected so far */
   trystate_T stack[MAXWLEN];
@@ -11484,10 +11338,7 @@ int soundfold;
 /*
  * Go one level deeper in the tree.
  */
-static void go_deeper(stack, depth, score_add)
-trystate_T  *stack;
-int depth;
-int score_add;
+static void go_deeper(trystate_T *stack, int depth, int score_add)
 {
   stack[depth + 1] = stack[depth];
   stack[depth + 1].ts_state = STATE_START;
@@ -11500,10 +11351,7 @@ int score_add;
  * Case-folding may change the number of bytes: Count nr of chars in
  * fword[flen] and return the byte length of that many chars in "word".
  */
-static int nofold_len(fword, flen, word)
-char_u      *fword;
-int flen;
-char_u      *word;
+static int nofold_len(char_u *fword, int flen, char_u *word)
 {
   char_u      *p;
   int i = 0;
@@ -11521,10 +11369,7 @@ char_u      *word;
  * Theoretically there could be several keep-case words that result in the
  * same case-folded word, but we only find one...
  */
-static void find_keepcap_word(slang, fword, kword)
-slang_T     *slang;
-char_u      *fword;
-char_u      *kword;
+static void find_keepcap_word(slang_T *slang, char_u *fword, char_u *kword)
 {
   char_u uword[MAXWLEN];                /* "fword" in upper-case */
   int depth;
@@ -11657,8 +11502,7 @@ char_u      *kword;
  * Compute the sound-a-like score for suggestions in su->su_ga and add them to
  * su->su_sga.
  */
-static void score_comp_sal(su)
-suginfo_T   *su;
+static void score_comp_sal(suginfo_T *su)
 {
   langp_T     *lp;
   char_u badsound[MAXWLEN];
@@ -11706,8 +11550,7 @@ suginfo_T   *su;
  * Combine the list of suggestions in su->su_ga and su->su_sga.
  * They are entwined.
  */
-static void score_combine(su)
-suginfo_T   *su;
+static void score_combine(suginfo_T *su)
 {
   int i;
   int j;
@@ -11809,11 +11652,13 @@ suginfo_T   *su;
  * For the goodword in "stp" compute the soundalike score compared to the
  * badword.
  */
-static int stp_sal_score(stp, su, slang, badsound)
-suggest_T   *stp;
-suginfo_T   *su;
-slang_T     *slang;
-char_u      *badsound;          /* sound-folded badword */
+static int 
+stp_sal_score (
+    suggest_T *stp,
+    suginfo_T *su,
+    slang_T *slang,
+    char_u *badsound          /* sound-folded badword */
+)
 {
   char_u      *p;
   char_u      *pbad;
@@ -11874,7 +11719,7 @@ static sftword_T dumsft;
 /*
  * Prepare for calling suggest_try_soundalike().
  */
-static void suggest_try_soundalike_prep()                 {
+static void suggest_try_soundalike_prep(void)                 {
   langp_T     *lp;
   int lpi;
   slang_T     *slang;
@@ -11894,8 +11739,7 @@ static void suggest_try_soundalike_prep()                 {
  * Find suggestions by comparing the word in a sound-a-like form.
  * Note: This doesn't support postponed prefixes.
  */
-static void suggest_try_soundalike(su)
-suginfo_T   *su;
+static void suggest_try_soundalike(suginfo_T *su)
 {
   char_u salword[MAXWLEN];
   langp_T     *lp;
@@ -11922,7 +11766,7 @@ suginfo_T   *su;
 /*
  * Finish up after calling suggest_try_soundalike().
  */
-static void suggest_try_soundalike_finish()                 {
+static void suggest_try_soundalike_finish(void)                 {
   langp_T     *lp;
   int lpi;
   slang_T     *slang;
@@ -11954,11 +11798,13 @@ static void suggest_try_soundalike_finish()                 {
  * A match with a soundfolded word is found.  Add the good word(s) that
  * produce this soundfolded word.
  */
-static void add_sound_suggest(su, goodword, score, lp)
-suginfo_T   *su;
-char_u      *goodword;
-int score;                      /* soundfold score  */
-langp_T     *lp;
+static void 
+add_sound_suggest (
+    suginfo_T *su,
+    char_u *goodword,
+    int score,                      /* soundfold score  */
+    langp_T *lp
+)
 {
   slang_T     *slang = lp->lp_slang;    /* language for sound folding */
   int sfwordnr;
@@ -12141,9 +11987,7 @@ badword:
 /*
  * Find word "word" in fold-case tree for "slang" and return the word number.
  */
-static int soundfold_find(slang, word)
-slang_T     *slang;
-char_u      *word;
+static int soundfold_find(slang_T *slang, char_u *word)
 {
   idx_T arridx = 0;
   int len;
@@ -12212,10 +12056,7 @@ char_u      *word;
 /*
  * Copy "fword" to "cword", fixing case according to "flags".
  */
-static void make_case_word(fword, cword, flags)
-char_u      *fword;
-char_u      *cword;
-int flags;
+static void make_case_word(char_u *fword, char_u *cword, int flags)
 {
   if (flags & WF_ALLCAP)
     /* Make it all upper-case */
@@ -12231,9 +12072,7 @@ int flags;
 /*
  * Use map string "map" for languages "lp".
  */
-static void set_map_str(lp, map)
-slang_T     *lp;
-char_u      *map;
+static void set_map_str(slang_T *lp, char_u *map)
 {
   char_u      *p;
   int headc = 0;
@@ -12301,10 +12140,7 @@ char_u      *map;
  * Return TRUE if "c1" and "c2" are similar characters according to the MAP
  * lines in the .aff file.
  */
-static int similar_chars(slang, c1, c2)
-slang_T     *slang;
-int c1;
-int c2;
+static int similar_chars(slang_T *slang, int c1, int c2)
 {
   int m1, m2;
   char_u buf[MB_MAXBYTES + 1];
@@ -12340,20 +12176,19 @@ int c2;
  * Add a suggestion to the list of suggestions.
  * For a suggestion that is already in the list the lowest score is remembered.
  */
-static void add_suggestion(su, gap, goodword, badlenarg, score, altscore,
-    had_bonus,
-    slang,
-    maxsf)
-suginfo_T   *su;
-garray_T    *gap;               /* either su_ga or su_sga */
-char_u      *goodword;
-int badlenarg;                  /* len of bad word replaced with "goodword" */
-int score;
-int altscore;
-int had_bonus;                  /* value for st_had_bonus */
-slang_T     *slang;             /* language for sound folding */
-int maxsf;                      /* su_maxscore applies to soundfold score,
+static void 
+add_suggestion (
+    suginfo_T *su,
+    garray_T *gap,               /* either su_ga or su_sga */
+    char_u *goodword,
+    int badlenarg,                  /* len of bad word replaced with "goodword" */
+    int score,
+    int altscore,
+    int had_bonus,                  /* value for st_had_bonus */
+    slang_T *slang,             /* language for sound folding */
+    int maxsf                      /* su_maxscore applies to soundfold score,
                                    su_sfmaxscore to the total score. */
+)
 {
   int goodlen;                  /* len of goodword changed */
   int badlen;                   /* len of bad word changed */
@@ -12464,9 +12299,11 @@ int maxsf;                      /* su_maxscore applies to soundfold score,
  * Suggestions may in fact be flagged as errors.  Esp. for banned words and
  * for split words, such as "the the".  Remove these from the list here.
  */
-static void check_suggestions(su, gap)
-suginfo_T   *su;
-garray_T    *gap;                   /* either su_ga or su_sga */
+static void 
+check_suggestions (
+    suginfo_T *su,
+    garray_T *gap                   /* either su_ga or su_sga */
+)
 {
   suggest_T   *stp;
   int i;
@@ -12498,9 +12335,7 @@ garray_T    *gap;                   /* either su_ga or su_sga */
 /*
  * Add a word to be banned.
  */
-static void add_banned(su, word)
-suginfo_T   *su;
-char_u      *word;
+static void add_banned(suginfo_T *su, char_u *word)
 {
   char_u      *s;
   hash_T hash;
@@ -12519,8 +12354,7 @@ char_u      *word;
  * Recompute the score for all suggestions if sound-folding is possible.  This
  * is slow, thus only done for the final results.
  */
-static void rescore_suggestions(su)
-suginfo_T   *su;
+static void rescore_suggestions(suginfo_T *su)
 {
   int i;
 
@@ -12532,9 +12366,7 @@ suginfo_T   *su;
 /*
  * Recompute the score for one suggestion if sound-folding is possible.
  */
-static void rescore_one(su, stp)
-suginfo_T   *su;
-suggest_T   *stp;
+static void rescore_one(suginfo_T *su, suggest_T *stp)
 {
   slang_T     *slang = stp->st_slang;
   char_u sal_badword[MAXWLEN];
@@ -12565,9 +12397,7 @@ sug_compare __ARGS((const void *s1, const void *s2));
  * Function given to qsort() to sort the suggestions on st_score.
  * First on "st_score", then "st_altscore" then alphabetically.
  */
-static int sug_compare(s1, s2)
-const void  *s1;
-const void  *s2;
+static int sug_compare(const void *s1, const void *s2)
 {
   suggest_T   *p1 = (suggest_T *)s1;
   suggest_T   *p2 = (suggest_T *)s2;
@@ -12587,10 +12417,12 @@ const void  *s2;
  * - Remove words that won't be displayed.
  * Returns the maximum score in the list or "maxscore" unmodified.
  */
-static int cleanup_suggestions(gap, maxscore, keep)
-garray_T    *gap;
-int maxscore;
-int keep;                       /* nr of suggestions to keep */
+static int 
+cleanup_suggestions (
+    garray_T *gap,
+    int maxscore,
+    int keep                       /* nr of suggestions to keep */
+)
 {
   suggest_T   *stp = &SUG(*gap, 0);
   int i;
@@ -12612,8 +12444,7 @@ int keep;                       /* nr of suggestions to keep */
  * Soundfold a string, for soundfold().
  * Result is in allocated memory, NULL for an error.
  */
-char_u * eval_soundfold(word)
-char_u      *word;
+char_u *eval_soundfold(char_u *word)
 {
   langp_T     *lp;
   char_u sound[MAXWLEN];
@@ -12646,11 +12477,13 @@ char_u      *word;
  * 1. SOFOFROM/SOFOTO do a simple character mapping.
  * 2. SAL items define a more advanced sound-folding (and much slower).
  */
-static void spell_soundfold(slang, inword, folded, res)
-slang_T     *slang;
-char_u      *inword;
-int folded;                 /* "inword" is already case-folded */
-char_u      *res;
+static void 
+spell_soundfold (
+    slang_T *slang,
+    char_u *inword,
+    int folded,                 /* "inword" is already case-folded */
+    char_u *res
+)
 {
   char_u fword[MAXWLEN];
   char_u      *word;
@@ -12678,10 +12511,7 @@ char_u      *res;
  * Perform sound folding of "inword" into "res" according to SOFOFROM and
  * SOFOTO lines.
  */
-static void spell_soundfold_sofo(slang, inword, res)
-slang_T     *slang;
-char_u      *inword;
-char_u      *res;
+static void spell_soundfold_sofo(slang_T *slang, char_u *inword, char_u *res)
 {
   char_u      *s;
   int ri = 0;
@@ -12739,10 +12569,7 @@ char_u      *res;
   res[ri] = NUL;
 }
 
-static void spell_soundfold_sal(slang, inword, res)
-slang_T     *slang;
-char_u      *inword;
-char_u      *res;
+static void spell_soundfold_sal(slang_T *slang, char_u *inword, char_u *res)
 {
   salitem_T   *smp;
   char_u word[MAXWLEN];
@@ -12986,10 +12813,7 @@ char_u      *res;
  * Turn "inword" into its sound-a-like equivalent in "res[MAXWLEN]".
  * Multi-byte version of spell_soundfold().
  */
-static void spell_soundfold_wsal(slang, inword, res)
-slang_T     *slang;
-char_u      *inword;
-char_u      *res;
+static void spell_soundfold_wsal(slang_T *slang, char_u *inword, char_u *res)
 {
   salitem_T   *smp = (salitem_T *)slang->sl_sal.ga_data;
   int word[MAXWLEN];
@@ -13271,9 +13095,11 @@ char_u      *res;
  * Instead of a generic loop we write out the code.  That keeps it fast by
  * avoiding checks that will not be possible.
  */
-static int soundalike_score(goodstart, badstart)
-char_u      *goodstart;         /* sound-folded good word */
-char_u      *badstart;          /* sound-folded bad word */
+static int 
+soundalike_score (
+    char_u *goodstart,         /* sound-folded good word */
+    char_u *badstart          /* sound-folded bad word */
+)
 {
   char_u      *goodsound = goodstart;
   char_u      *badsound = badstart;
@@ -13486,10 +13312,7 @@ char_u      *badstart;          /* sound-folded bad word */
  * edit_distance().  It has been converted from C++ to C and modified to
  * support multi-byte characters.
  */
-static int spell_edit_score(slang, badword, goodword)
-slang_T     *slang;
-char_u      *badword;
-char_u      *goodword;
+static int spell_edit_score(slang_T *slang, char_u *badword, char_u *goodword)
 {
   int         *cnt;
   int badlen, goodlen;                  /* lengths including NUL */
@@ -13595,11 +13418,7 @@ typedef struct {
  * The idea comes from Aspell leditdist.cpp.  Rewritten in C and added support
  * for multi-byte characters.
  */
-static int spell_edit_score_limit(slang, badword, goodword, limit)
-slang_T     *slang;
-char_u      *badword;
-char_u      *goodword;
-int limit;
+static int spell_edit_score_limit(slang_T *slang, char_u *badword, char_u *goodword, int limit)
 {
   limitscore_T stack[10];               /* allow for over 3 * 2 edits */
   int stackidx;
@@ -13752,11 +13571,7 @@ pop:
  * Multi-byte version of spell_edit_score_limit().
  * Keep it in sync with the above!
  */
-static int spell_edit_score_limit_w(slang, badword, goodword, limit)
-slang_T     *slang;
-char_u      *badword;
-char_u      *goodword;
-int limit;
+static int spell_edit_score_limit_w(slang_T *slang, char_u *badword, char_u *goodword, int limit)
 {
   limitscore_T stack[10];               /* allow for over 3 * 2 edits */
   int stackidx;
@@ -13918,8 +13733,7 @@ pop:
 /*
  * ":spellinfo"
  */
-void ex_spellinfo(eap)
-exarg_T *eap UNUSED;
+void ex_spellinfo(exarg_T *eap)
 {
   int lpi;
   langp_T     *lp;
@@ -13952,8 +13766,7 @@ exarg_T *eap UNUSED;
 /*
  * ":spelldump"
  */
-void ex_spelldump(eap)
-exarg_T *eap;
+void ex_spelldump(exarg_T *eap)
 {
   char_u  *spl;
   long dummy;
@@ -13988,11 +13801,13 @@ exarg_T *eap;
  *	"ic" and "dir" are not used.
  * 2. When "pat" is not NULL: add matching words to insert mode completion.
  */
-void spell_dump_compl(pat, ic, dir, dumpflags_arg)
-char_u      *pat;           /* leading part of the word */
-int ic;                     /* ignore case */
-int         *dir;           /* direction for adding matches */
-int dumpflags_arg;              /* DUMPFLAG_* */
+void 
+spell_dump_compl (
+    char_u *pat,           /* leading part of the word */
+    int ic,                     /* ignore case */
+    int *dir,           /* direction for adding matches */
+    int dumpflags_arg              /* DUMPFLAG_* */
+)
 {
   langp_T     *lp;
   slang_T     *slang;
@@ -14161,14 +13976,7 @@ int dumpflags_arg;              /* DUMPFLAG_* */
  * Dump one word: apply case modifications and append a line to the buffer.
  * When "lnum" is zero add insert mode completion.
  */
-static void dump_word(slang, word, pat, dir, dumpflags, wordflags, lnum)
-slang_T     *slang;
-char_u      *word;
-char_u      *pat;
-int         *dir;
-int dumpflags;
-int wordflags;
-linenr_T lnum;
+static void dump_word(slang_T *slang, char_u *word, char_u *pat, int *dir, int dumpflags, int wordflags, linenr_T lnum)
 {
   int keepcap = FALSE;
   char_u      *p;
@@ -14242,15 +14050,16 @@ linenr_T lnum;
  * When "lnum" is zero add insert mode completion.
  * Return the updated line number.
  */
-static linenr_T dump_prefixes(slang, word, pat, dir, dumpflags, flags,
-    startlnum)
-slang_T     *slang;
-char_u      *word;          /* case-folded word */
-char_u      *pat;
-int         *dir;
-int dumpflags;
-int flags;                  /* flags with prefix ID */
-linenr_T startlnum;
+static linenr_T 
+dump_prefixes (
+    slang_T *slang,
+    char_u *word,          /* case-folded word */
+    char_u *pat,
+    int *dir,
+    int dumpflags,
+    int flags,                  /* flags with prefix ID */
+    linenr_T startlnum
+)
 {
   idx_T arridx[MAXWLEN];
   int curi[MAXWLEN];
@@ -14346,9 +14155,7 @@ linenr_T startlnum;
  * Move "p" to the end of word "start".
  * Uses the spell-checking word characters.
  */
-char_u * spell_to_word_end(start, win)
-char_u  *start;
-win_T   *win;
+char_u *spell_to_word_end(char_u *start, win_T *win)
 {
   char_u  *p = start;
 
@@ -14364,8 +14171,7 @@ win_T   *win;
  * the word in front of the cursor.
  * Returns the column number of the word.
  */
-int spell_word_start(startcol)
-int startcol;
+int spell_word_start(int startcol)
 {
   char_u      *line;
   char_u      *p;
@@ -14400,8 +14206,7 @@ int startcol;
  */
 static int spell_expand_need_cap;
 
-void spell_expand_check_cap(col)
-colnr_T col;
+void spell_expand_check_cap(colnr_T col)
 {
   spell_expand_need_cap = check_need_cap(curwin->w_cursor.lnum, col);
 }
@@ -14412,10 +14217,7 @@ colnr_T col;
  * Returns the number of matches.  The matches are in "matchp[]", array of
  * allocated strings.
  */
-int expand_spelling(lnum, pat, matchp)
-linenr_T lnum UNUSED;
-char_u      *pat;
-char_u      ***matchp;
+int expand_spelling(linenr_T lnum, char_u *pat, char_u ***matchp)
 {
   garray_T ga;
 

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -448,9 +448,7 @@ static void syn_incl_toplevel __ARGS((int id, int *flagsp));
  * it.	Careful: curbuf and curwin are likely to point to another buffer and
  * window.
  */
-void syntax_start(wp, lnum)
-win_T       *wp;
-linenr_T lnum;
+void syntax_start(win_T *wp, linenr_T lnum)
 {
   synstate_T  *p;
   synstate_T  *last_valid = NULL;
@@ -610,8 +608,7 @@ linenr_T lnum;
  * We cannot simply discard growarrays full of state_items or buf_states; we
  * have to manually release their extmatch pointers first.
  */
-static void clear_syn_state(p)
-synstate_T *p;
+static void clear_syn_state(synstate_T *p)
 {
   int i;
   garray_T    *gap;
@@ -630,7 +627,7 @@ synstate_T *p;
 /*
  * Cleanup the current_state stack.
  */
-static void clear_current_state()                 {
+static void clear_current_state(void)                 {
   int i;
   stateitem_T *sip;
 
@@ -649,10 +646,7 @@ static void clear_current_state()                 {
  * 2. Search backwards for given sync patterns.
  * 3. Simply start on a given number of lines above "lnum".
  */
-static void syn_sync(wp, start_lnum, last_valid)
-win_T       *wp;
-linenr_T start_lnum;
-synstate_T  *last_valid;
+static void syn_sync(win_T *wp, linenr_T start_lnum, synstate_T *last_valid)
 {
   buf_T       *curbuf_save;
   win_T       *curwin_save;
@@ -901,8 +895,7 @@ synstate_T  *last_valid;
 /*
  * Return TRUE if the line-continuation pattern matches in line "lnum".
  */
-static int syn_match_linecont(lnum)
-linenr_T lnum;
+static int syn_match_linecont(linenr_T lnum)
 {
   regmmatch_T regmatch;
 
@@ -918,7 +911,7 @@ linenr_T lnum;
 /*
  * Prepare the current state for the start of a line.
  */
-static void syn_start_line()                 {
+static void syn_start_line(void)                 {
   current_finished = FALSE;
   current_col = 0;
 
@@ -940,8 +933,7 @@ static void syn_start_line()                 {
  * When "startofline" is TRUE the last item is always updated.
  * When "startofline" is FALSE the item with "keepend" is forcefully updated.
  */
-static void syn_update_ends(startofline)
-int startofline;
+static void syn_update_ends(int startofline)
 {
   stateitem_T *cur_si;
   int i;
@@ -1035,8 +1027,7 @@ int startofline;
  * number of entries SST_MAX_ENTRIES, and the distance is computed.
  */
 
-static void syn_stack_free_block(block)
-synblock_T  *block;
+static void syn_stack_free_block(synblock_T *block)
 {
   synstate_T  *p;
 
@@ -1052,8 +1043,7 @@ synblock_T  *block;
  * Free b_sst_array[] for buffer "buf".
  * Used when syntax items changed to force resyncing everywhere.
  */
-void syn_stack_free_all(block)
-synblock_T  *block;
+void syn_stack_free_all(synblock_T *block)
 {
   win_T       *wp;
 
@@ -1074,7 +1064,7 @@ synblock_T  *block;
  * small, reallocate it.
  * Also used to allocate b_sst_array[] for the first time.
  */
-static void syn_stack_alloc()                 {
+static void syn_stack_alloc(void)                 {
   long len;
   synstate_T  *to, *from;
   synstate_T  *sstp;
@@ -1144,8 +1134,7 @@ static void syn_stack_alloc()                 {
  * Called from update_screen(), before screen is being updated, once for each
  * displayed buffer.
  */
-void syn_stack_apply_changes(buf)
-buf_T       *buf;
+void syn_stack_apply_changes(buf_T *buf)
 {
   win_T       *wp;
 
@@ -1158,9 +1147,7 @@ buf_T       *buf;
   }
 }
 
-static void syn_stack_apply_changes_block(block, buf)
-synblock_T  *block;
-buf_T       *buf;
+static void syn_stack_apply_changes_block(synblock_T *block, buf_T *buf)
 {
   synstate_T  *p, *prev, *np;
   linenr_T n;
@@ -1207,7 +1194,7 @@ buf_T       *buf;
  * Reduce the number of entries in the state stack for syn_buf.
  * Returns TRUE if at least one entry was freed.
  */
-static int syn_stack_cleanup()                {
+static int syn_stack_cleanup(void)                {
   synstate_T  *p, *prev;
   disptick_T tick;
   int above;
@@ -1263,9 +1250,7 @@ static int syn_stack_cleanup()                {
  * Free the allocated memory for a syn_state item.
  * Move the entry into the free list.
  */
-static void syn_stack_free_entry(block, p)
-synblock_T  *block;
-synstate_T  *p;
+static void syn_stack_free_entry(synblock_T *block, synstate_T *p)
 {
   clear_syn_state(p);
   p->sst_next = block->b_sst_firstfree;
@@ -1277,8 +1262,7 @@ synstate_T  *p;
  * Find an entry in the list of state stacks at or before "lnum".
  * Returns NULL when there is no entry or the first entry is after "lnum".
  */
-static synstate_T * syn_stack_find_entry(lnum)
-linenr_T lnum;
+static synstate_T *syn_stack_find_entry(linenr_T lnum)
 {
   synstate_T  *p, *prev;
 
@@ -1296,7 +1280,7 @@ linenr_T lnum;
  * Try saving the current state in b_sst_array[].
  * The current state must be valid for the start of the current_lnum line!
  */
-static synstate_T * store_current_state()                         {
+static synstate_T *store_current_state(void)                         {
   int i;
   synstate_T  *p;
   bufstate_T  *bp;
@@ -1400,8 +1384,7 @@ static synstate_T * store_current_state()                         {
 /*
  * Copy a state stack from "from" in b_sst_array[] to current_state;
  */
-static void load_current_state(from)
-synstate_T  *from;
+static void load_current_state(synstate_T *from)
 {
   int i;
   bufstate_T  *bp;
@@ -1443,8 +1426,7 @@ synstate_T  *from;
  * Compare saved state stack "*sp" with the current state.
  * Return TRUE when they are equal.
  */
-static int syn_stack_equal(sp)
-synstate_T *sp;
+static int syn_stack_equal(synstate_T *sp)
 {
   int i, j;
   bufstate_T  *bp;
@@ -1510,8 +1492,7 @@ synstate_T *sp;
  *	    displayed line
  * lnum ->  line below window
  */
-void syntax_end_parsing(lnum)
-linenr_T lnum;
+void syntax_end_parsing(linenr_T lnum)
 {
   synstate_T  *sp;
 
@@ -1527,14 +1508,14 @@ linenr_T lnum;
  * End of handling of the state stack.
  ****************************************/
 
-static void invalidate_current_state()                 {
+static void invalidate_current_state(void)                 {
   clear_current_state();
   current_state.ga_itemsize = 0;        /* mark current_state invalid */
   current_next_list = NULL;
   keepend_level = -1;
 }
 
-static void validate_current_state()                 {
+static void validate_current_state(void)                 {
   current_state.ga_itemsize = sizeof(stateitem_T);
   current_state.ga_growsize = 3;
 }
@@ -1544,8 +1525,7 @@ static void validate_current_state()                 {
  * This will only be called just after get_syntax_attr() for the previous
  * line, to check if the next line needs to be redrawn too.
  */
-int syntax_check_changed(lnum)
-linenr_T lnum;
+int syntax_check_changed(linenr_T lnum)
 {
   int retval = TRUE;
   synstate_T  *sp;
@@ -1590,8 +1570,10 @@ linenr_T lnum;
  * the line.  It can start anywhere in the line, as long as the current state
  * is valid.
  */
-static int syn_finish_line(syncing)
-int syncing;                    /* called for syncing */
+static int 
+syn_finish_line (
+    int syncing                    /* called for syncing */
+)
 {
   stateitem_T *cur_si;
   colnr_T prev_current_col;
@@ -1636,10 +1618,12 @@ int syncing;                    /* called for syncing */
  * When "can_spell" is not NULL set it to TRUE when spell-checking should be
  * done.
  */
-int get_syntax_attr(col, can_spell, keep_state)
-colnr_T col;
-int         *can_spell;
-int keep_state;                 /* keep state of char at "col" */
+int 
+get_syntax_attr (
+    colnr_T col,
+    int *can_spell,
+    int keep_state                 /* keep state of char at "col" */
+)
 {
   int attr = 0;
 
@@ -1682,11 +1666,13 @@ int keep_state;                 /* keep state of char at "col" */
 /*
  * Get syntax attributes for current_lnum, current_col.
  */
-static int syn_current_attr(syncing, displaying, can_spell, keep_state)
-int syncing;                            /* When 1: called for syncing */
-int displaying;                         /* result will be displayed */
-int         *can_spell;                 /* return: do spell checking */
-int keep_state;                         /* keep syntax stack afterwards */
+static int 
+syn_current_attr (
+    int syncing,                            /* When 1: called for syncing */
+    int displaying,                         /* result will be displayed */
+    int *can_spell,                 /* return: do spell checking */
+    int keep_state                         /* keep syntax stack afterwards */
+)
 {
   int syn_id;
   lpos_T endpos;                /* was: char_u *endp; */
@@ -2203,9 +2189,7 @@ int keep_state;                         /* keep syntax stack afterwards */
 /*
  * Check if we already matched pattern "idx" at the current column.
  */
-static int did_match_already(idx, gap)
-int idx;
-garray_T    *gap;
+static int did_match_already(int idx, garray_T *gap)
 {
   int i;
 
@@ -2227,8 +2211,7 @@ garray_T    *gap;
 /*
  * Push the next match onto the stack.
  */
-static stateitem_T * push_next_match(cur_si)
-stateitem_T *cur_si;
+static stateitem_T *push_next_match(stateitem_T *cur_si)
 {
   synpat_T    *spp;
   int save_flags;
@@ -2307,7 +2290,7 @@ stateitem_T *cur_si;
 /*
  * Check for end of current state (and the states before it).
  */
-static void check_state_ends()                 {
+static void check_state_ends(void)                 {
   stateitem_T *cur_si;
   int had_extend;
 
@@ -2400,8 +2383,7 @@ static void check_state_ends()                 {
  * Update an entry in the current_state stack for a match or region.  This
  * fills in si_attr, si_next_list and si_cont_list.
  */
-static void update_si_attr(idx)
-int idx;
+static void update_si_attr(int idx)
 {
   stateitem_T *sip = &CUR_STATE(idx);
   synpat_T    *spp;
@@ -2450,7 +2432,7 @@ int idx;
  * Check the current stack for patterns with "keepend" flag.
  * Propagate the match-end to contained items, until a "skipend" item is found.
  */
-static void check_keepend()                 {
+static void check_keepend(void)                 {
   int i;
   lpos_T maxpos;
   lpos_T maxpos_h;
@@ -2505,10 +2487,12 @@ static void check_keepend()                 {
  *
  * Return the flags for the matched END.
  */
-static void update_si_end(sip, startcol, force)
-stateitem_T *sip;
-int startcol;               /* where to start searching for the end */
-int force;                  /* when TRUE overrule a previous end */
+static void 
+update_si_end (
+    stateitem_T *sip,
+    int startcol,               /* where to start searching for the end */
+    int force                  /* when TRUE overrule a previous end */
+)
 {
   lpos_T startpos;
   lpos_T endpos;
@@ -2564,8 +2548,7 @@ int force;                  /* when TRUE overrule a previous end */
  * It is cleared and the index set to "idx".
  * Return FAIL if it's not possible (out of memory).
  */
-static int push_current_state(idx)
-int idx;
+static int push_current_state(int idx)
 {
   if (ga_grow(&current_state, 1) == FAIL)
     return FAIL;
@@ -2578,7 +2561,7 @@ int idx;
 /*
  * Remove a state from the current_state stack.
  */
-static void pop_current_state()                 {
+static void pop_current_state(void)                 {
   if (current_state.ga_len) {
     unref_extmatch(CUR_STATE(current_state.ga_len - 1).si_extmatch);
     --current_state.ga_len;
@@ -2600,16 +2583,17 @@ static void pop_current_state()                 {
  * If found, the end of the region and the end of the highlighting is
  * computed.
  */
-static void find_endpos(idx, startpos, m_endpos, hl_endpos, flagsp, end_endpos,
-    end_idx, start_ext)
-int idx;                        /* index of the pattern */
-lpos_T      *startpos;          /* where to start looking for an END match */
-lpos_T      *m_endpos;          /* return: end of match */
-lpos_T      *hl_endpos;         /* return: end of highlighting */
-long        *flagsp;            /* return: flags of matching END */
-lpos_T      *end_endpos;        /* return: end of end pattern match */
-int         *end_idx;           /* return: group ID for end pat. match, or 0 */
-reg_extmatch_T *start_ext;      /* submatches from the start pattern */
+static void 
+find_endpos (
+    int idx,                        /* index of the pattern */
+    lpos_T *startpos,          /* where to start looking for an END match */
+    lpos_T *m_endpos,          /* return: end of match */
+    lpos_T *hl_endpos,         /* return: end of highlighting */
+    long *flagsp,            /* return: flags of matching END */
+    lpos_T *end_endpos,        /* return: end of end pattern match */
+    int *end_idx,           /* return: group ID for end pat. match, or 0 */
+    reg_extmatch_T *start_ext      /* submatches from the start pattern */
+)
 {
   colnr_T matchcol;
   synpat_T    *spp, *spp_skip;
@@ -2806,9 +2790,7 @@ reg_extmatch_T *start_ext;      /* submatches from the start pattern */
 /*
  * Limit "pos" not to be after "limit".
  */
-static void limit_pos(pos, limit)
-lpos_T      *pos;
-lpos_T      *limit;
+static void limit_pos(lpos_T *pos, lpos_T *limit)
 {
   if (pos->lnum > limit->lnum)
     *pos = *limit;
@@ -2819,9 +2801,7 @@ lpos_T      *limit;
 /*
  * Limit "pos" not to be after "limit", unless pos->lnum is zero.
  */
-static void limit_pos_zero(pos, limit)
-lpos_T      *pos;
-lpos_T      *limit;
+static void limit_pos_zero(lpos_T *pos, lpos_T *limit)
 {
   if (pos->lnum == 0)
     *pos = *limit;
@@ -2832,12 +2812,14 @@ lpos_T      *limit;
 /*
  * Add offset to matched text for end of match or highlight.
  */
-static void syn_add_end_off(result, regmatch, spp, idx, extra)
-lpos_T      *result;            /* returned position */
-regmmatch_T *regmatch;          /* start/end of match */
-synpat_T    *spp;               /* matched pattern */
-int idx;                        /* index of offset */
-int extra;                      /* extra chars for offset to start */
+static void 
+syn_add_end_off (
+    lpos_T *result,            /* returned position */
+    regmmatch_T *regmatch,          /* start/end of match */
+    synpat_T *spp,               /* matched pattern */
+    int idx,                        /* index of offset */
+    int extra                      /* extra chars for offset to start */
+)
 {
   int col;
   int off;
@@ -2876,12 +2858,14 @@ int extra;                      /* extra chars for offset to start */
  * Add offset to matched text for start of match or highlight.
  * Avoid resulting column to become negative.
  */
-static void syn_add_start_off(result, regmatch, spp, idx, extra)
-lpos_T      *result;            /* returned position */
-regmmatch_T *regmatch;          /* start/end of match */
-synpat_T    *spp;
-int idx;
-int extra;                  /* extra chars for offset to end */
+static void 
+syn_add_start_off (
+    lpos_T *result,            /* returned position */
+    regmmatch_T *regmatch,          /* start/end of match */
+    synpat_T *spp,
+    int idx,
+    int extra                  /* extra chars for offset to end */
+)
 {
   int col;
   int off;
@@ -2920,7 +2904,7 @@ int extra;                  /* extra chars for offset to end */
 /*
  * Get current line in syntax buffer.
  */
-static char_u * syn_getcurline()                     {
+static char_u *syn_getcurline(void)                     {
   return ml_get_buf(syn_buf, current_lnum, FALSE);
 }
 
@@ -2928,11 +2912,7 @@ static char_u * syn_getcurline()                     {
  * Call vim_regexec() to find a match with "rmp" in "syn_buf".
  * Returns TRUE when there is a match.
  */
-static int syn_regexec(rmp, lnum, col, st)
-regmmatch_T *rmp;
-linenr_T lnum;
-colnr_T col;
-syn_time_T  *st UNUSED;
+static int syn_regexec(regmmatch_T *rmp, linenr_T lnum, colnr_T col, syn_time_T *st)
 {
   int r;
   proftime_T pt;
@@ -2966,15 +2946,16 @@ syn_time_T  *st UNUSED;
  * The caller must check if a keyword can start at startcol.
  * Return it's ID if found, 0 otherwise.
  */
-static int check_keyword_id(line, startcol, endcolp, flagsp, next_listp, cur_si,
-    ccharp)
-char_u      *line;
-int startcol;                   /* position in line to check for keyword */
-int         *endcolp;           /* return: character after found keyword */
-long        *flagsp;            /* return: flags of matching keyword */
-short       **next_listp;       /* return: next_list of matching keyword */
-stateitem_T *cur_si;            /* item at the top of the stack */
-int         *ccharp UNUSED;     /* conceal substitution char */
+static int 
+check_keyword_id (
+    char_u *line,
+    int startcol,                   /* position in line to check for keyword */
+    int *endcolp,           /* return: character after found keyword */
+    long *flagsp,            /* return: flags of matching keyword */
+    short **next_listp,       /* return: next_list of matching keyword */
+    stateitem_T *cur_si,            /* item at the top of the stack */
+    int *ccharp     /* conceal substitution char */
+)
 {
   keyentry_T  *kp;
   char_u      *kwp;
@@ -3046,9 +3027,7 @@ int         *ccharp UNUSED;     /* conceal substitution char */
 /*
  * Handle ":syntax conceal" command.
  */
-static void syn_cmd_conceal(eap, syncing)
-exarg_T     *eap UNUSED;
-int syncing UNUSED;
+static void syn_cmd_conceal(exarg_T *eap, int syncing)
 {
   char_u      *arg = eap->arg;
   char_u      *next;
@@ -3069,9 +3048,7 @@ int syncing UNUSED;
 /*
  * Handle ":syntax case" command.
  */
-static void syn_cmd_case(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_case(exarg_T *eap, int syncing)
 {
   char_u      *arg = eap->arg;
   char_u      *next;
@@ -3092,9 +3069,7 @@ int syncing UNUSED;
 /*
  * Handle ":syntax spell" command.
  */
-static void syn_cmd_spell(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_spell(exarg_T *eap, int syncing)
 {
   char_u      *arg = eap->arg;
   char_u      *next;
@@ -3117,8 +3092,7 @@ int syncing UNUSED;
 /*
  * Clear all syntax info for one buffer.
  */
-void syntax_clear(block)
-synblock_T  *block;
+void syntax_clear(synblock_T *block)
 {
   int i;
 
@@ -3165,8 +3139,7 @@ synblock_T  *block;
 /*
  * Get rid of ownsyntax for window "wp".
  */
-void reset_synblock(wp)
-win_T *wp;
+void reset_synblock(win_T *wp)
 {
   if (wp->w_s != &wp->w_buffer->b_s) {
     syntax_clear(wp->w_s);
@@ -3178,7 +3151,7 @@ win_T *wp;
 /*
  * Clear syncing info for one buffer.
  */
-static void syntax_sync_clear()                 {
+static void syntax_sync_clear(void)                 {
   int i;
 
   /* free the syntax patterns */
@@ -3202,9 +3175,7 @@ static void syntax_sync_clear()                 {
 /*
  * Remove one pattern from the buffer's pattern list.
  */
-static void syn_remove_pattern(block, idx)
-synblock_T  *block;
-int idx;
+static void syn_remove_pattern(synblock_T *block, int idx)
 {
   synpat_T    *spp;
 
@@ -3221,9 +3192,7 @@ int idx;
  * Clear and free one syntax pattern.  When clearing all, must be called from
  * last to first!
  */
-static void syn_clear_pattern(block, i)
-synblock_T  *block;
-int i;
+static void syn_clear_pattern(synblock_T *block, int i)
 {
   vim_free(SYN_ITEMS(block)[i].sp_pattern);
   vim_regfree(SYN_ITEMS(block)[i].sp_prog);
@@ -3238,9 +3207,7 @@ int i;
 /*
  * Clear and free one syntax cluster.
  */
-static void syn_clear_cluster(block, i)
-synblock_T  *block;
-int i;
+static void syn_clear_cluster(synblock_T *block, int i)
 {
   vim_free(SYN_CLSTR(block)[i].scl_name);
   vim_free(SYN_CLSTR(block)[i].scl_name_u);
@@ -3250,9 +3217,7 @@ int i;
 /*
  * Handle ":syntax clear" command.
  */
-static void syn_cmd_clear(eap, syncing)
-exarg_T     *eap;
-int syncing;
+static void syn_cmd_clear(exarg_T *eap, int syncing)
 {
   char_u      *arg = eap->arg;
   char_u      *arg_end;
@@ -3323,9 +3288,7 @@ int syncing;
 /*
  * Clear one syntax group for the current buffer.
  */
-static void syn_clear_one(id, syncing)
-int id;
-int syncing;
+static void syn_clear_one(int id, int syncing)
 {
   synpat_T    *spp;
   int idx;
@@ -3348,9 +3311,7 @@ int syncing;
 /*
  * Handle ":syntax on" command.
  */
-static void syn_cmd_on(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_on(exarg_T *eap, int syncing)
 {
   syn_cmd_onoff(eap, "syntax");
 }
@@ -3358,9 +3319,7 @@ int syncing UNUSED;
 /*
  * Handle ":syntax enable" command.
  */
-static void syn_cmd_enable(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_enable(exarg_T *eap, int syncing)
 {
   set_internal_string_var((char_u *)"syntax_cmd", (char_u *)"enable");
   syn_cmd_onoff(eap, "syntax");
@@ -3370,9 +3329,7 @@ int syncing UNUSED;
 /*
  * Handle ":syntax reset" command.
  */
-static void syn_cmd_reset(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_reset(exarg_T *eap, int syncing)
 {
   eap->nextcmd = check_nextcmd(eap->arg);
   if (!eap->skip) {
@@ -3385,9 +3342,7 @@ int syncing UNUSED;
 /*
  * Handle ":syntax manual" command.
  */
-static void syn_cmd_manual(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_manual(exarg_T *eap, int syncing)
 {
   syn_cmd_onoff(eap, "manual");
 }
@@ -3395,16 +3350,12 @@ int syncing UNUSED;
 /*
  * Handle ":syntax off" command.
  */
-static void syn_cmd_off(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_off(exarg_T *eap, int syncing)
 {
   syn_cmd_onoff(eap, "nosyntax");
 }
 
-static void syn_cmd_onoff(eap, name)
-exarg_T     *eap;
-char        *name;
+static void syn_cmd_onoff(exarg_T *eap, char *name)
 {
   char_u buf[100];
 
@@ -3419,9 +3370,11 @@ char        *name;
 /*
  * Handle ":syntax [list]" command: list current syntax words.
  */
-static void syn_cmd_list(eap, syncing)
-exarg_T     *eap;
-int syncing;                        /* when TRUE: list syncing items */
+static void 
+syn_cmd_list (
+    exarg_T *eap,
+    int syncing                        /* when TRUE: list syncing items */
+)
 {
   char_u      *arg = eap->arg;
   int id;
@@ -3496,7 +3449,7 @@ int syncing;                        /* when TRUE: list syncing items */
   eap->nextcmd = check_nextcmd(arg);
 }
 
-static void syn_lines_msg()                 {
+static void syn_lines_msg(void)                 {
   if (curwin->w_s->b_syn_sync_maxlines > 0
       || curwin->w_s->b_syn_sync_minlines > 0) {
     MSG_PUTS("; ");
@@ -3514,7 +3467,7 @@ static void syn_lines_msg()                 {
   }
 }
 
-static void syn_match_msg()                 {
+static void syn_match_msg(void)                 {
   if (curwin->w_s->b_syn_sync_linebreaks > 0) {
     MSG_PUTS(_("; match "));
     msg_outnum(curwin->w_s->b_syn_sync_linebreaks);
@@ -3534,10 +3487,12 @@ static void syn_list_flags __ARGS((struct name_list *nl, int flags, int attr));
 /*
  * List one syntax item, for ":syntax" or "syntax list syntax_name".
  */
-static void syn_list_one(id, syncing, link_only)
-int id;
-int syncing;                        /* when TRUE: list syncing items */
-int link_only;                      /* when TRUE; list link-only too */
+static void 
+syn_list_one (
+    int id,
+    int syncing,                        /* when TRUE: list syncing items */
+    int link_only                      /* when TRUE; list link-only too */
+)
 {
   int attr;
   int idx;
@@ -3634,10 +3589,7 @@ int link_only;                      /* when TRUE; list link-only too */
   }
 }
 
-static void syn_list_flags(nlist, flags, attr)
-struct name_list    *nlist;
-int flags;
-int attr;
+static void syn_list_flags(struct name_list *nlist, int flags, int attr)
 {
   int i;
 
@@ -3651,8 +3603,7 @@ int attr;
 /*
  * List one syntax cluster, for ":syntax" or "syntax list syntax_name".
  */
-static void syn_list_cluster(id)
-int id;
+static void syn_list_cluster(int id)
 {
   int endcol = 15;
 
@@ -3675,10 +3626,7 @@ int id;
   }
 }
 
-static void put_id_list(name, list, attr)
-char_u      *name;
-short       *list;
-int attr;
+static void put_id_list(char_u *name, short *list, int attr)
 {
   short               *p;
 
@@ -3707,11 +3655,7 @@ int attr;
   msg_putchar(' ');
 }
 
-static void put_pattern(s, c, spp, attr)
-char        *s;
-int c;
-synpat_T    *spp;
-int attr;
+static void put_pattern(char *s, int c, synpat_T *spp, int attr)
 {
   long n;
   int mask;
@@ -3774,11 +3718,13 @@ int attr;
  * List or clear the keywords for one syntax group.
  * Return TRUE if the header has been printed.
  */
-static int syn_list_keywords(id, ht, did_header, attr)
-int id;
-hashtab_T   *ht;
-int did_header;                         /* header has already been printed */
-int attr;
+static int 
+syn_list_keywords (
+    int id,
+    hashtab_T *ht,
+    int did_header,                         /* header has already been printed */
+    int attr
+)
 {
   int outlen;
   hashitem_T  *hi;
@@ -3860,9 +3806,7 @@ int attr;
   return did_header;
 }
 
-static void syn_clear_keyword(id, ht)
-int id;
-hashtab_T   *ht;
+static void syn_clear_keyword(int id, hashtab_T *ht)
 {
   hashitem_T  *hi;
   keyentry_T  *kp;
@@ -3903,8 +3847,7 @@ hashtab_T   *ht;
 /*
  * Clear a whole keyword table.
  */
-static void clear_keywtab(ht)
-hashtab_T   *ht;
+static void clear_keywtab(hashtab_T *ht)
 {
   hashitem_T  *hi;
   int todo;
@@ -3930,13 +3873,15 @@ hashtab_T   *ht;
 /*
  * Add a keyword to the list of keywords.
  */
-static void add_keyword(name, id, flags, cont_in_list, next_list, conceal_char)
-char_u      *name;          /* name of keyword */
-int id;                     /* group ID for this keyword */
-int flags;                  /* flags for this keyword */
-short       *cont_in_list;     /* containedin for this keyword */
-short       *next_list;     /* nextgroup for this keyword */
-int conceal_char;
+static void 
+add_keyword (
+    char_u *name,          /* name of keyword */
+    int id,                     /* group ID for this keyword */
+    int flags,                  /* flags for this keyword */
+    short *cont_in_list,     /* containedin for this keyword */
+    short *next_list,     /* nextgroup for this keyword */
+    int conceal_char
+)
 {
   keyentry_T  *kp;
   hashtab_T   *ht;
@@ -3986,9 +3931,11 @@ int conceal_char;
  * Return a pointer to the first argument.
  * Return NULL if the end of the command was found instead of further args.
  */
-static char_u * get_group_name(arg, name_end)
-char_u      *arg;               /* start of the argument */
-char_u      **name_end;         /* pointer to end of the name */
+static char_u *
+get_group_name (
+    char_u *arg,               /* start of the argument */
+    char_u **name_end         /* pointer to end of the name */
+)
 {
   char_u      *rest;
 
@@ -4012,10 +3959,12 @@ char_u      **name_end;         /* pointer to end of the name */
  * Return a pointer to the next argument (which isn't an option).
  * Return NULL for any error;
  */
-static char_u * get_syn_options(arg, opt, conceal_char)
-char_u          *arg;                   /* next argument to be checked */
-syn_opt_arg_T   *opt;                   /* various things */
-int             *conceal_char UNUSED;
+static char_u *
+get_syn_options (
+    char_u *arg,                   /* next argument to be checked */
+    syn_opt_arg_T *opt,                   /* various things */
+    int *conceal_char
+)
 {
   char_u      *gname_start, *gname;
   int syn_id;
@@ -4161,9 +4110,7 @@ int             *conceal_char UNUSED;
  * Set the contained flag, and if the item is not already contained, add it
  * to the specified top-level group, if any.
  */
-static void syn_incl_toplevel(id, flagsp)
-int id;
-int         *flagsp;
+static void syn_incl_toplevel(int id, int *flagsp)
 {
   if ((*flagsp & HL_CONTAINED) || curwin->w_s->b_syn_topgrp == 0)
     return;
@@ -4185,9 +4132,7 @@ int         *flagsp;
 /*
  * Handle ":syntax include [@{group-name}] filename" command.
  */
-static void syn_cmd_include(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_include(exarg_T *eap, int syncing)
 {
   char_u      *arg = eap->arg;
   int sgl_id = 1;
@@ -4256,9 +4201,7 @@ int syncing UNUSED;
 /*
  * Handle ":syntax keyword {group-name} [{option}] keyword .." command.
  */
-static void syn_cmd_keyword(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_keyword(exarg_T *eap, int syncing)
 {
   char_u      *arg = eap->arg;
   char_u      *group_name_end;
@@ -4365,9 +4308,11 @@ int syncing UNUSED;
  *
  * Also ":syntax sync match {name} [[grouphere | groupthere] {group-name}] .."
  */
-static void syn_cmd_match(eap, syncing)
-exarg_T     *eap;
-int syncing;                        /* TRUE for ":syntax sync match .. " */
+static void 
+syn_cmd_match (
+    exarg_T *eap,
+    int syncing                        /* TRUE for ":syntax sync match .. " */
+)
 {
   char_u      *arg = eap->arg;
   char_u      *group_name_end;
@@ -4462,9 +4407,11 @@ int syncing;                        /* TRUE for ":syntax sync match .. " */
  * Handle ":syntax region {group-name} [matchgroup={group-name}]
  *		start {start} .. [skip {skip}] end {end} .. [{options}]".
  */
-static void syn_cmd_region(eap, syncing)
-exarg_T     *eap;
-int syncing;                        /* TRUE for ":syntax sync region .." */
+static void 
+syn_cmd_region (
+    exarg_T *eap,
+    int syncing                        /* TRUE for ":syntax sync region .." */
+)
 {
   char_u              *arg = eap->arg;
   char_u              *group_name_end;
@@ -4699,9 +4646,7 @@ int syncing;                        /* TRUE for ":syntax sync region .." */
 /*
  * A simple syntax group ID comparison function suitable for use in qsort()
  */
-static int syn_compare_stub(v1, v2)
-const void  *v1;
-const void  *v2;
+static int syn_compare_stub(const void *v1, const void *v2)
 {
   const short *s1 = v1;
   const short *s2 = v2;
@@ -4713,10 +4658,7 @@ const void  *v2;
  * Combines lists of syntax clusters.
  * *clstr1 and *clstr2 must both be allocated memory; they will be consumed.
  */
-static void syn_combine_list(clstr1, clstr2, list_op)
-short       **clstr1;
-short       **clstr2;
-int list_op;
+static void syn_combine_list(short **clstr1, short **clstr2, int list_op)
 {
   int count1 = 0;
   int count2 = 0;
@@ -4832,8 +4774,7 @@ int list_op;
  * Lookup a syntax cluster name and return it's ID.
  * If it is not found, 0 is returned.
  */
-static int syn_scl_name2id(name)
-char_u      *name;
+static int syn_scl_name2id(char_u *name)
 {
   int i;
   char_u      *name_u;
@@ -4853,9 +4794,7 @@ char_u      *name;
 /*
  * Like syn_scl_name2id(), but take a pointer + length argument.
  */
-static int syn_scl_namen2id(linep, len)
-char_u  *linep;
-int len;
+static int syn_scl_namen2id(char_u *linep, int len)
 {
   char_u  *name;
   int id = 0;
@@ -4874,9 +4813,7 @@ int len;
  * If it doesn't exist yet, a new entry is created.
  * Return 0 for failure.
  */
-static int syn_check_cluster(pp, len)
-char_u      *pp;
-int len;
+static int syn_check_cluster(char_u *pp, int len)
 {
   int id;
   char_u      *name;
@@ -4898,8 +4835,7 @@ int len;
  * "name" must be an allocated string, it will be consumed.
  * Return 0 for failure.
  */
-static int syn_add_cluster(name)
-char_u      *name;
+static int syn_add_cluster(char_u *name)
 {
   int len;
 
@@ -4944,9 +4880,7 @@ char_u      *name;
  * Handle ":syntax cluster {cluster-name} [contains={groupname},..]
  *		[add={groupname},..] [remove={groupname},..]".
  */
-static void syn_cmd_cluster(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_cluster(exarg_T *eap, int syncing)
 {
   char_u      *arg = eap->arg;
   char_u      *group_name_end;
@@ -5010,7 +4944,7 @@ int syncing UNUSED;
 /*
  * On first call for current buffer: Init growing array.
  */
-static void init_syn_patterns()                 {
+static void init_syn_patterns(void)                 {
   curwin->w_s->b_syn_patterns.ga_itemsize = sizeof(synpat_T);
   curwin->w_s->b_syn_patterns.ga_growsize = 10;
 }
@@ -5020,9 +4954,7 @@ static void init_syn_patterns()                 {
  * Stores the pattern and program in a synpat_T.
  * Returns a pointer to the next argument, or NULL in case of an error.
  */
-static char_u * get_syn_pattern(arg, ci)
-char_u      *arg;
-synpat_T    *ci;
+static char_u *get_syn_pattern(char_u *arg, synpat_T *ci)
 {
   char_u      *end;
   int         *p;
@@ -5108,9 +5040,7 @@ synpat_T    *ci;
 /*
  * Handle ":syntax sync .." command.
  */
-static void syn_cmd_sync(eap, syncing)
-exarg_T     *eap;
-int syncing UNUSED;
+static void syn_cmd_sync(exarg_T *eap, int syncing)
 {
   char_u      *arg_start = eap->arg;
   char_u      *arg_end;
@@ -5239,11 +5169,13 @@ int syncing UNUSED;
  * Careful: the argument is modified (NULs added).
  * returns FAIL for some error, OK for success.
  */
-static int get_id_list(arg, keylen, list)
-char_u      **arg;
-int keylen;                     /* length of keyword */
-short       **list;             /* where to store the resulting list, if not
+static int 
+get_id_list (
+    char_u **arg,
+    int keylen,                     /* length of keyword */
+    short **list             /* where to store the resulting list, if not
                                    NULL, the list is silently skipped! */
+)
 {
   char_u      *p = NULL;
   char_u      *end;
@@ -5409,8 +5341,7 @@ short       **list;             /* where to store the resulting list, if not
 /*
  * Make a copy of an ID list.
  */
-static short * copy_id_list(list)
-short   *list;
+static short *copy_id_list(short *list)
 {
   int len;
   int count;
@@ -5436,11 +5367,13 @@ short   *list;
  * the current item.
  * This function is called very often, keep it fast!!
  */
-static int in_id_list(cur_si, list, ssp, contained)
-stateitem_T *cur_si;            /* current item or NULL */
-short       *list;              /* id list */
-struct sp_syn *ssp;             /* group id and ":syn include" tag of group */
-int contained;                  /* group id is contained */
+static int 
+in_id_list (
+    stateitem_T *cur_si,            /* current item or NULL */
+    short *list,              /* id list */
+    struct sp_syn *ssp,             /* group id and ":syn include" tag of group */
+    int contained                  /* group id is contained */
+)
 {
   int retval;
   short       *scl_list;
@@ -5554,8 +5487,7 @@ static struct subcommand subcommands[] =
  * This searches the subcommands[] table for the subcommand name, and calls a
  * syntax_subcommand() function to do the rest.
  */
-void ex_syntax(eap)
-exarg_T     *eap;
+void ex_syntax(exarg_T *eap)
 {
   char_u      *arg = eap->arg;
   char_u      *subcmd_end;
@@ -5588,8 +5520,7 @@ exarg_T     *eap;
   }
 }
 
-void ex_ownsyntax(eap)
-exarg_T     *eap;
+void ex_ownsyntax(exarg_T *eap)
 {
   char_u      *old_value;
   char_u      *new_value;
@@ -5628,8 +5559,7 @@ exarg_T     *eap;
   }
 }
 
-int syntax_present(win)
-win_T       *win;
+int syntax_present(win_T *win)
 {
   return win->w_s->b_syn_patterns.ga_len != 0
          || win->w_s->b_syn_clusters.ga_len != 0
@@ -5647,7 +5577,7 @@ static enum {
  * Reset include_link, include_default, include_none to 0.
  * Called when we are done expanding.
  */
-void reset_expand_highlight()          {
+void reset_expand_highlight(void)          {
   include_link = include_default = include_none = 0;
 }
 
@@ -5655,9 +5585,7 @@ void reset_expand_highlight()          {
  * Handle command line completion for :match and :echohl command: Add "None"
  * as highlight group.
  */
-void set_context_in_echohl_cmd(xp, arg)
-expand_T    *xp;
-char_u      *arg;
+void set_context_in_echohl_cmd(expand_T *xp, char_u *arg)
 {
   xp->xp_context = EXPAND_HIGHLIGHT;
   xp->xp_pattern = arg;
@@ -5667,9 +5595,7 @@ char_u      *arg;
 /*
  * Handle command line completion for :syntax command.
  */
-void set_context_in_syntax_cmd(xp, arg)
-expand_T    *xp;
-char_u      *arg;
+void set_context_in_syntax_cmd(expand_T *xp, char_u *arg)
 {
   char_u      *p;
 
@@ -5706,9 +5632,7 @@ static char *(case_args[]) = {"match", "ignore", NULL};
  * Function given to ExpandGeneric() to obtain the list syntax names for
  * expansion.
  */
-char_u * get_syntax_name(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_syntax_name(expand_T *xp, int idx)
 {
   if (expand_what == EXP_SUBCMD)
     return (char_u *)subcommands[idx].name;
@@ -5719,13 +5643,15 @@ int idx;
 /*
  * Function called for expression evaluation: get syntax ID at file position.
  */
-int syn_get_id(wp, lnum, col, trans, spellp, keep_state)
-win_T       *wp;
-long lnum;
-colnr_T col;
-int trans;                   /* remove transparency */
-int         *spellp;         /* return: can do spell checking */
-int keep_state;              /* keep state of char at "col" */
+int 
+syn_get_id (
+    win_T *wp,
+    long lnum,
+    colnr_T col,
+    int trans,                   /* remove transparency */
+    int *spellp,         /* return: can do spell checking */
+    int keep_state              /* keep state of char at "col" */
+)
 {
   /* When the position is not after the current position and in the same
    * line of the same buffer, need to restart parsing. */
@@ -5745,8 +5671,7 @@ int keep_state;              /* keep state of char at "col" */
  * Stores the current item sequence nr in "*seqnrp".
  * Returns the current flags.
  */
-int get_syntax_info(seqnrp)
-int         *seqnrp;
+int get_syntax_info(int *seqnrp)
 {
   *seqnrp = current_seqnr;
   return current_flags;
@@ -5755,7 +5680,7 @@ int         *seqnrp;
 /*
  * Return conceal substitution character
  */
-int syn_get_sub_char()         {
+int syn_get_sub_char(void)         {
   return current_sub_char;
 }
 
@@ -5764,8 +5689,7 @@ int syn_get_sub_char()         {
  * The caller must have called syn_get_id() before to fill the stack.
  * Returns -1 when "i" is out of range.
  */
-int syn_get_stack_item(i)
-int i;
+int syn_get_stack_item(int i)
 {
   if (i >= current_state.ga_len) {
     /* Need to invalidate the state, because we didn't properly finish it
@@ -5780,9 +5704,7 @@ int i;
 /*
  * Function called to get folding level for line "lnum" in window "wp".
  */
-int syn_get_foldlevel(wp, lnum)
-win_T       *wp;
-long lnum;
+int syn_get_foldlevel(win_T *wp, long lnum)
 {
   int level = 0;
   int i;
@@ -5806,8 +5728,7 @@ long lnum;
 /*
  * ":syntime".
  */
-void ex_syntime(eap)
-exarg_T     *eap;
+void ex_syntime(exarg_T *eap)
 {
   if (STRCMP(eap->arg, "on") == 0)
     syn_time_on = TRUE;
@@ -5821,8 +5742,7 @@ exarg_T     *eap;
     EMSG2(_(e_invarg2), eap->arg);
 }
 
-static void syn_clear_time(st)
-syn_time_T *st;
+static void syn_clear_time(syn_time_T *st)
 {
   profile_zero(&st->total);
   profile_zero(&st->slowest);
@@ -5833,7 +5753,7 @@ syn_time_T *st;
 /*
  * Clear the syntax timing for the current buffer.
  */
-static void syntime_clear()                 {
+static void syntime_clear(void)                 {
   int idx;
   synpat_T    *spp;
 
@@ -5851,9 +5771,7 @@ static void syntime_clear()                 {
  * Function given to ExpandGeneric() to obtain the possible arguments of the
  * ":syntime {on,off,clear,report}" command.
  */
-char_u * get_syntime_arg(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_syntime_arg(expand_T *xp, int idx)
 {
   switch (idx) {
   case 0: return (char_u *)"on";
@@ -5874,9 +5792,7 @@ typedef struct {
   char_u      *pattern;
 } time_entry_T;
 
-static int syn_compare_syntime(v1, v2)
-const void  *v1;
-const void  *v2;
+static int syn_compare_syntime(const void *v1, const void *v2)
 {
   const time_entry_T  *s1 = v1;
   const time_entry_T  *s2 = v2;
@@ -5887,7 +5803,7 @@ const void  *v2;
 /*
  * Clear the syntax timing for the current buffer.
  */
-static void syntime_report()                 {
+static void syntime_report(void)                 {
   int idx;
   synpat_T    *spp;
   proftime_T tm;
@@ -6151,9 +6067,11 @@ static char *(highlight_init_dark[]) =
   NULL
 };
 
-void init_highlight(both, reset)
-int both;                   /* include groups where 'bg' doesn't matter */
-int reset;                  /* clear group first */
+void 
+init_highlight (
+    int both,                   /* include groups where 'bg' doesn't matter */
+    int reset                  /* clear group first */
+)
 {
   int i;
   char        **pp;
@@ -6227,8 +6145,7 @@ int reset;                  /* clear group first */
  * Load color file "name".
  * Return OK for success, FAIL for failure.
  */
-int load_colors(name)
-char_u      *name;
+int load_colors(char_u *name)
 {
   char_u      *buf;
   int retval = FAIL;
@@ -6258,10 +6175,12 @@ char_u      *name;
  * When using ":hi clear" this is called recursively for each group with
  * "forceit" and "init" both TRUE.
  */
-void do_highlight(line, forceit, init)
-char_u      *line;
-int forceit;
-int init;                   /* TRUE when called for initializing */
+void 
+do_highlight (
+    char_u *line,
+    int forceit,
+    int init                   /* TRUE when called for initializing */
+)
 {
   char_u      *name_end;
   char_u      *p;
@@ -6871,7 +6790,7 @@ int init;                   /* TRUE when called for initializing */
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_highlight()          {
+void free_highlight(void)          {
   int i;
 
   for (i = 0; i < highlight_ga.ga_len; ++i) {
@@ -6888,7 +6807,7 @@ void free_highlight()          {
  * Reset the cterm colors to what they were before Vim was started, if
  * possible.  Otherwise reset them to zero.
  */
-void restore_cterm_colors()          {
+void restore_cterm_colors(void)          {
   cterm_normal_fg_color = 0;
   cterm_normal_fg_bold = 0;
   cterm_normal_bg_color = 0;
@@ -6898,9 +6817,7 @@ void restore_cterm_colors()          {
  * Return TRUE if highlight group "idx" has any settings.
  * When "check_link" is TRUE also check for an existing link.
  */
-static int hl_has_settings(idx, check_link)
-int idx;
-int check_link;
+static int hl_has_settings(int idx, int check_link)
 {
   return HL_TABLE()[idx].sg_term_attr != 0
          || HL_TABLE()[idx].sg_cterm_attr != 0
@@ -6910,8 +6827,7 @@ int check_link;
 /*
  * Clear highlighting for one group.
  */
-static void highlight_clear(idx)
-int idx;
+static void highlight_clear(int idx)
 {
   HL_TABLE()[idx].sg_term = 0;
   vim_free(HL_TABLE()[idx].sg_start);
@@ -6958,9 +6874,7 @@ static garray_T cterm_attr_table = {0, 0, 0, 0, NULL};
  * if the combination is new.
  * Return 0 for error (no more room).
  */
-static int get_attr_entry(table, aep)
-garray_T    *table;
-attrentry_T *aep;
+static int get_attr_entry(garray_T *table, attrentry_T *aep)
 {
   int i;
   attrentry_T *taep;
@@ -7051,7 +6965,7 @@ attrentry_T *aep;
 /*
  * Clear all highlight tables.
  */
-void clear_hl_tables()          {
+void clear_hl_tables(void)          {
   int i;
   attrentry_T *taep;
 
@@ -7073,9 +6987,7 @@ void clear_hl_tables()          {
  * result.
  * Return the resulting attributes.
  */
-int hl_combine_attr(char_attr, prim_attr)
-int char_attr;
-int prim_attr;
+int hl_combine_attr(int char_attr, int prim_attr)
 {
   attrentry_T *char_aep = NULL;
   attrentry_T *spell_aep;
@@ -7142,8 +7054,7 @@ int prim_attr;
  * Get the highlight attributes (HL_BOLD etc.) from an attribute nr.
  * Only to be used when "attr" > HL_ALL.
  */
-int syn_attr2attr(attr)
-int attr;
+int syn_attr2attr(int attr)
 {
   attrentry_T *aep;
 
@@ -7158,8 +7069,7 @@ int attr;
 }
 
 
-attrentry_T * syn_term_attr2entry(attr)
-int attr;
+attrentry_T *syn_term_attr2entry(int attr)
 {
   attr -= ATTR_OFF;
   if (attr >= term_attr_table.ga_len)       /* did ":syntax clear" */
@@ -7167,8 +7077,7 @@ int attr;
   return &(TERM_ATTR_ENTRY(attr));
 }
 
-attrentry_T * syn_cterm_attr2entry(attr)
-int attr;
+attrentry_T *syn_cterm_attr2entry(int attr)
 {
   attr -= ATTR_OFF;
   if (attr >= cterm_attr_table.ga_len)          /* did ":syntax clear" */
@@ -7180,8 +7089,7 @@ int attr;
 #define LIST_STRING 2
 #define LIST_INT    3
 
-static void highlight_list_one(id)
-int id;
+static void highlight_list_one(int id)
 {
   struct hl_group     *sgp;
   int didh = FALSE;
@@ -7225,13 +7133,7 @@ int id;
     last_set_msg(sgp->sg_scriptID);
 }
 
-static int highlight_list_arg(id, didh, type, iarg, sarg, name)
-int id;
-int didh;
-int type;
-int iarg;
-char_u      *sarg;
-char        *name;
+static int highlight_list_arg(int id, int didh, int type, int iarg, char_u *sarg, char *name)
 {
   char_u buf[100];
   char_u      *ts;
@@ -7275,10 +7177,12 @@ char        *name;
  * Return "1" if highlight group "id" has attribute "flag".
  * Return NULL otherwise.
  */
-char_u * highlight_has_attr(id, flag, modec)
-int id;
-int flag;
-int modec;              /* 'g' for GUI, 'c' for cterm, 't' for term */
+char_u *
+highlight_has_attr (
+    int id,
+    int flag,
+    int modec              /* 'g' for GUI, 'c' for cterm, 't' for term */
+)
 {
   int attr;
 
@@ -7300,10 +7204,12 @@ int modec;              /* 'g' for GUI, 'c' for cterm, 't' for term */
 /*
  * Return color name of highlight group "id".
  */
-char_u * highlight_color(id, what, modec)
-int id;
-char_u      *what;      /* "font", "fg", "bg", "sp", "fg#", "bg#" or "sp#" */
-int modec;              /* 'g' for GUI, 'c' for cterm, 't' for term */
+char_u *
+highlight_color (
+    int id,
+    char_u *what,      /* "font", "fg", "bg", "sp", "fg#", "bg#" or "sp#" */
+    int modec              /* 'g' for GUI, 'c' for cterm, 't' for term */
+)
 {
   static char_u name[20];
   int n;
@@ -7349,9 +7255,11 @@ int modec;              /* 'g' for GUI, 'c' for cterm, 't' for term */
 /*
  * Return color name of highlight group "id" as RGB value.
  */
-long_u highlight_gui_color_rgb(id, fg)
-int id;
-int fg;                 /* TRUE = fg, FALSE = bg */
+long_u 
+highlight_gui_color_rgb (
+    int id,
+    int fg                 /* TRUE = fg, FALSE = bg */
+)
 {
   guicolor_T color;
 
@@ -7374,10 +7282,12 @@ int fg;                 /* TRUE = fg, FALSE = bg */
  * Output the syntax list header.
  * Return TRUE when started a new line.
  */
-static int syn_list_header(did_header, outlen, id)
-int did_header;                 /* did header already */
-int outlen;                     /* length of string that comes */
-int id;                         /* highlight group id */
+static int 
+syn_list_header (
+    int did_header,                 /* did header already */
+    int outlen,                     /* length of string that comes */
+    int id                         /* highlight group id */
+)
 {
   int endcol = 19;
   int newline = TRUE;
@@ -7417,8 +7327,10 @@ int id;                         /* highlight group id */
  * Set the attribute numbers for a highlight group.
  * Called after one of the attributes has changed.
  */
-static void set_hl_attr(idx)
-int idx;                    /* index in array */
+static void 
+set_hl_attr (
+    int idx                    /* index in array */
+)
 {
   attrentry_T at_en;
   struct hl_group     *sgp = HL_TABLE() + idx;
@@ -7458,8 +7370,7 @@ int idx;                    /* index in array */
  * Lookup a highlight group name and return it's ID.
  * If it is not found, 0 is returned.
  */
-int syn_name2id(name)
-char_u      *name;
+int syn_name2id(char_u *name)
 {
   int i;
   char_u name_u[200];
@@ -7479,8 +7390,7 @@ char_u      *name;
 /*
  * Return TRUE if highlight group "name" exists.
  */
-int highlight_exists(name)
-char_u      *name;
+int highlight_exists(char_u *name)
 {
   return syn_name2id(name) > 0;
 }
@@ -7489,8 +7399,7 @@ char_u      *name;
  * Return the name of highlight group "id".
  * When not a valid ID return an empty string.
  */
-char_u * syn_id2name(id)
-int id;
+char_u *syn_id2name(int id)
 {
   if (id <= 0 || id > highlight_ga.ga_len)
     return (char_u *)"";
@@ -7500,9 +7409,7 @@ int id;
 /*
  * Like syn_name2id(), but take a pointer + length argument.
  */
-int syn_namen2id(linep, len)
-char_u  *linep;
-int len;
+int syn_namen2id(char_u *linep, int len)
 {
   char_u  *name;
   int id = 0;
@@ -7521,9 +7428,7 @@ int len;
  * If it doesn't exist yet, a new entry is created.
  * Return 0 for failure.
  */
-int syn_check_group(pp, len)
-char_u              *pp;
-int len;
+int syn_check_group(char_u *pp, int len)
 {
   int id;
   char_u  *name;
@@ -7545,8 +7450,7 @@ int len;
  * "name" must be an allocated string, it will be consumed.
  * Return 0 for failure.
  */
-static int syn_add_group(name)
-char_u      *name;
+static int syn_add_group(char_u *name)
 {
   char_u      *p;
 
@@ -7599,7 +7503,7 @@ char_u      *name;
  * When, just after calling syn_add_group(), an error is discovered, this
  * function deletes the new name.
  */
-static void syn_unadd_group()                 {
+static void syn_unadd_group(void)                 {
   --highlight_ga.ga_len;
   vim_free(HL_TABLE()[highlight_ga.ga_len].sg_name);
   vim_free(HL_TABLE()[highlight_ga.ga_len].sg_name_u);
@@ -7608,8 +7512,7 @@ static void syn_unadd_group()                 {
 /*
  * Translate a group ID to highlight attributes.
  */
-int syn_id2attr(hl_id)
-int hl_id;
+int syn_id2attr(int hl_id)
 {
   int attr;
   struct hl_group     *sgp;
@@ -7629,8 +7532,7 @@ int hl_id;
 /*
  * Translate a group ID to the final group ID (following links).
  */
-int syn_get_final_id(hl_id)
-int hl_id;
+int syn_get_final_id(int hl_id)
 {
   int count;
   struct hl_group     *sgp;
@@ -7661,7 +7563,7 @@ int hl_id;
  * screen redraw after any :highlight command.
  * Return FAIL when an invalid flag is found in 'highlight'.  OK otherwise.
  */
-int highlight_changed()         {
+int highlight_changed(void)         {
   int hlf;
   int i;
   char_u      *p;
@@ -7827,9 +7729,7 @@ static void highlight_list_two __ARGS((int cnt, int attr));
 /*
  * Handle command line completion for :highlight command.
  */
-void set_context_in_highlight_cmd(xp, arg)
-expand_T    *xp;
-char_u      *arg;
+void set_context_in_highlight_cmd(expand_T *xp, char_u *arg)
 {
   char_u      *p;
 
@@ -7872,7 +7772,7 @@ char_u      *arg;
 /*
  * List highlighting matches in a nice way.
  */
-static void highlight_list()                 {
+static void highlight_list(void)                 {
   int i;
 
   for (i = 10; --i >= 0; )
@@ -7881,9 +7781,7 @@ static void highlight_list()                 {
     highlight_list_two(99, 0);
 }
 
-static void highlight_list_two(cnt, attr)
-int cnt;
-int attr;
+static void highlight_list_two(int cnt, int attr)
 {
   msg_puts_attr((char_u *)&("N \bI \b!  \b"[cnt / 11]), attr);
   msg_clr_eos();
@@ -7898,9 +7796,7 @@ int attr;
  * Function given to ExpandGeneric() to obtain the list of group names.
  * Also used for synIDattr() function.
  */
-char_u * get_highlight_name(xp, idx)
-expand_T    *xp UNUSED;
-int idx;
+char_u *get_highlight_name(expand_T *xp, int idx)
 {
   if (idx == highlight_ga.ga_len && include_none != 0)
     return (char_u *)"none";

--- a/src/tag.c
+++ b/src/tag.c
@@ -107,12 +107,14 @@ static taggy_T ptag_entry = {NULL, {INIT_POS_T(0, 0, 0), 0}, 0, 0};
  *
  * for cscope, returns TRUE if we jumped to tag or aborted, FALSE otherwise
  */
-int do_tag(tag, type, count, forceit, verbose)
-char_u      *tag;               /* tag (pattern) to jump to */
-int type;
-int count;
-int forceit;                    /* :ta with ! */
-int verbose;                    /* print "tag not found" message */
+int 
+do_tag (
+    char_u *tag,               /* tag (pattern) to jump to */
+    int type,
+    int count,
+    int forceit,                    /* :ta with ! */
+    int verbose                    /* print "tag not found" message */
+)
 {
   taggy_T     *tagstack = curwin->w_tagstack;
   int tagstackidx = curwin->w_tagstackidx;
@@ -910,13 +912,12 @@ end_do_tag:
 /*
  * Free cached tags.
  */
-void tag_freematch()          {
+void tag_freematch(void)          {
   vim_free(tagmatchname);
   tagmatchname = NULL;
 }
 
-static void taglen_advance(l)
-int l;
+static void taglen_advance(int l)
 {
   if (l == MAXCOL) {
     msg_putchar('\n');
@@ -928,8 +929,7 @@ int l;
 /*
  * Print the tag stack
  */
-void do_tags(eap)
-exarg_T     *eap UNUSED;
+void do_tags(exarg_T *eap)
 {
   int i;
   char_u      *name;
@@ -978,10 +978,7 @@ static int tag_strnicmp __ARGS((char_u *s1, char_u *s2, size_t len));
  * return 0 for match, < 0 for smaller, > 0 for bigger
  * Make sure case is folded to uppercase in comparison (like for 'sort -f')
  */
-static int tag_strnicmp(s1, s2, len)
-char_u      *s1;
-char_u      *s2;
-size_t len;
+static int tag_strnicmp(char_u *s1, char_u *s2, size_t len)
 {
   int i;
 
@@ -1014,9 +1011,7 @@ static void prepare_pats __ARGS((pat_T *pats, int has_re));
 /*
  * Extract info from the tag search pattern "pats->pat".
  */
-static void prepare_pats(pats, has_re)
-pat_T       *pats;
-int has_re;
+static void prepare_pats(pat_T *pats, int has_re)
 {
   pats->head = pats->pat;
   pats->headlen = pats->len;
@@ -1070,14 +1065,16 @@ int has_re;
  * TAG_NOIC	  don't always ignore case
  * TAG_KEEP_LANG  keep language
  */
-int find_tags(pat, num_matches, matchesp, flags, mincount, buf_ffname)
-char_u      *pat;                       /* pattern to search for */
-int         *num_matches;               /* return: number of matches found */
-char_u      ***matchesp;                /* return: array of matches found */
-int flags;
-int mincount;                           /*  MAXCOL: find all matches
+int 
+find_tags (
+    char_u *pat,                       /* pattern to search for */
+    int *num_matches,               /* return: number of matches found */
+    char_u ***matchesp,                /* return: array of matches found */
+    int flags,
+    int mincount,                           /*  MAXCOL: find all matches
                                              other: minimal number of matches */
-char_u      *buf_ffname;                /* name of buffer for priority */
+    char_u *buf_ffname                /* name of buffer for priority */
+)
 {
   FILE       *fp;
   char_u     *lbuf;                     /* line buffer */
@@ -2020,9 +2017,7 @@ static void found_tagfile_cb __ARGS((char_u *fname, void *cookie));
  * Callback function for finding all "tags" and "tags-??" files in
  * 'runtimepath' doc directories.
  */
-static void found_tagfile_cb(fname, cookie)
-char_u      *fname;
-void        *cookie UNUSED;
+static void found_tagfile_cb(char_u *fname, void *cookie)
 {
   if (ga_grow(&tag_fnames, 1) == OK)
     ((char_u **)(tag_fnames.ga_data))[tag_fnames.ga_len++] =
@@ -2030,7 +2025,7 @@ void        *cookie UNUSED;
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void free_tag_stuff()          {
+void free_tag_stuff(void)          {
   ga_clear_strings(&tag_fnames);
   do_tag(NULL, DT_FREE, 0, 0, 0);
   tag_freematch();
@@ -2049,10 +2044,12 @@ void free_tag_stuff()          {
  *
  * Return FAIL if no more tag file names, OK otherwise.
  */
-int get_tagfname(tnp, first, buf)
-tagname_T   *tnp;       /* holds status info */
-int first;              /* TRUE when first file name is wanted */
-char_u      *buf;       /* pointer to buffer of MAXPATHL chars */
+int 
+get_tagfname (
+    tagname_T *tnp,       /* holds status info */
+    int first,              /* TRUE when first file name is wanted */
+    char_u *buf       /* pointer to buffer of MAXPATHL chars */
+)
 {
   char_u              *fname = NULL;
   char_u              *r_ptr;
@@ -2152,8 +2149,7 @@ char_u      *buf;       /* pointer to buffer of MAXPATHL chars */
 /*
  * Free the contents of a tagname_T that was filled by get_tagfname().
  */
-void tagname_free(tnp)
-tagname_T   *tnp;
+void tagname_free(tagname_T *tnp)
 {
   vim_free(tnp->tn_tags);
   vim_findfile_cleanup(tnp->tn_search_ctx);
@@ -2169,10 +2165,11 @@ tagname_T   *tnp;
  *
  * Return FAIL if there is a format error in this line, OK otherwise.
  */
-static int parse_tag_line(lbuf,
-    tagp)
-char_u      *lbuf;              /* line to be parsed */
-tagptrs_T   *tagp;
+static int 
+parse_tag_line (
+    char_u *lbuf,              /* line to be parsed */
+    tagptrs_T *tagp
+)
 {
   char_u      *p;
 
@@ -2232,8 +2229,7 @@ tagptrs_T   *tagp;
  * Return TRUE if it is a static tag and adjust *tagname to the real tag.
  * Return FALSE if it is not a static tag.
  */
-static int test_for_static(tagp)
-tagptrs_T   *tagp;
+static int test_for_static(tagptrs_T *tagp)
 {
   char_u      *p;
 
@@ -2274,9 +2270,11 @@ tagptrs_T   *tagp;
  *
  * Return OK or FAIL.
  */
-static int parse_match(lbuf, tagp)
-char_u      *lbuf;          /* input: matching line */
-tagptrs_T   *tagp;          /* output: pointers into the line */
+static int 
+parse_match (
+    char_u *lbuf,          /* input: matching line */
+    tagptrs_T *tagp          /* output: pointers into the line */
+)
 {
   int retval;
   char_u      *p;
@@ -2330,8 +2328,7 @@ tagptrs_T   *tagp;          /* output: pointers into the line */
  * with the matching tag file name.
  * Returns an allocated string or NULL (out of memory).
  */
-static char_u * tag_full_fname(tagp)
-tagptrs_T   *tagp;
+static char_u *tag_full_fname(tagptrs_T *tagp)
 {
   char_u      *fullname;
   int c;
@@ -2352,10 +2349,12 @@ tagptrs_T   *tagp;
  *
  * returns OK for success, NOTAGFILE when file not found, FAIL otherwise.
  */
-static int jumpto_tag(lbuf, forceit, keep_help)
-char_u      *lbuf;              /* line from the tags file for this tag */
-int forceit;                    /* :ta with ! */
-int keep_help;                  /* keep help flag (FALSE for cscope) */
+static int 
+jumpto_tag (
+    char_u *lbuf,              /* line from the tags file for this tag */
+    int forceit,                    /* :ta with ! */
+    int keep_help                  /* keep help flag (FALSE for cscope) */
+)
 {
   int save_secure;
   int save_magic;
@@ -2647,10 +2646,7 @@ erret:
  * according to tag_fname (name of tag file containing fname).
  * Returns a pointer to allocated memory (or NULL when out of memory).
  */
-static char_u * expand_tag_fname(fname, tag_fname, expand)
-char_u      *fname;
-char_u      *tag_fname;
-int expand;
+static char_u *expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
 {
   char_u      *p;
   char_u      *retval;
@@ -2696,8 +2692,7 @@ int expand;
  * resulting file name is simplified in place and will either be the same
  * length as that supplied, or shorter.
  */
-void simplify_filename(filename)
-char_u      *filename;
+void simplify_filename(char_u *filename)
 {
   int components = 0;
   char_u      *p, *tail, *start;
@@ -2866,11 +2861,7 @@ char_u      *filename;
  * Return TRUE if tag for file "fname" if tag file "tag_fname" is for current
  * file.
  */
-static int test_for_current(fname, fname_end, tag_fname, buf_ffname)
-char_u  *fname;
-char_u  *fname_end;
-char_u  *tag_fname;
-char_u  *buf_ffname;
+static int test_for_current(char_u *fname, char_u *fname_end, char_u *tag_fname, char_u *buf_ffname)
 {
   int c;
   int retval = FALSE;
@@ -2896,8 +2887,7 @@ char_u  *buf_ffname;
  * Find the end of the tagaddress.
  * Return OK if ";\"" is following, FAIL otherwise.
  */
-static int find_extra(pp)
-char_u      **pp;
+static int find_extra(char_u **pp)
 {
   char_u      *str = *pp;
 
@@ -2926,11 +2916,13 @@ char_u      **pp;
   return FAIL;
 }
 
-int expand_tags(tagnames, pat, num_file, file)
-int tagnames;                   /* expand tag names */
-char_u      *pat;
-int         *num_file;
-char_u      ***file;
+int 
+expand_tags (
+    int tagnames,                   /* expand tag names */
+    char_u *pat,
+    int *num_file,
+    char_u ***file
+)
 {
   int i;
   int c;
@@ -2978,11 +2970,13 @@ static int add_tag_field __ARGS((dict_T *dict, char *field_name, char_u *start,
  * Add a tag field to the dictionary "dict".
  * Return OK or FAIL.
  */
-static int add_tag_field(dict, field_name, start, end)
-dict_T  *dict;
-char    *field_name;
-char_u  *start;                 /* start of the value */
-char_u  *end;                   /* after the value; can be NULL */
+static int 
+add_tag_field (
+    dict_T *dict,
+    char *field_name,
+    char_u *start,                 /* start of the value */
+    char_u *end                   /* after the value; can be NULL */
+)
 {
   char_u      *buf;
   int len = 0;
@@ -3021,9 +3015,7 @@ char_u  *end;                   /* after the value; can be NULL */
  * Add the tags matching the specified pattern to the list "list"
  * as a dictionary
  */
-int get_tags(list, pat)
-list_T *list;
-char_u *pat;
+int get_tags(list_T *list, char_u *pat)
 {
   int num_matches, i, ret;
   char_u      **matches, *p;

--- a/src/term.c
+++ b/src/term.c
@@ -1143,8 +1143,7 @@ static int need_gather = FALSE;             /* need to fill termleader[] */
 static char_u termleader[256 + 1];          /* for check_termcode() */
 static int check_for_codes = FALSE;         /* check for key code response */
 
-static struct builtin_term * find_builtin_term(term)
-char_u      *term;
+static struct builtin_term *find_builtin_term(char_u *term)
 {
   struct builtin_term *p;
 
@@ -1171,8 +1170,7 @@ char_u      *term;
  * Caller should check if 'name' is a valid builtin term.
  * The terminal's name is not set, as this is already done in termcapinit().
  */
-static void parse_builtin_tcap(term)
-char_u  *term;
+static void parse_builtin_tcap(char_u *term)
 {
   struct builtin_term     *p;
   char_u name[2];
@@ -1222,8 +1220,7 @@ static void set_color_count __ARGS((int nr));
  * Store it as a number in t_colors.
  * Store it as a string in T_CCO (using nr_colors[]).
  */
-static void set_color_count(nr)
-int nr;
+static void set_color_count(int nr)
 {
   char_u nr_colors[20];                 /* string for number of colors */
 
@@ -1259,8 +1256,7 @@ static char *(key_names[]) =
  *
  * While doing this, until ttest(), some options may be NULL, be careful.
  */
-int set_termname(term)
-char_u *term;
+int set_termname(char_u *term)
 {
   struct builtin_term *termp;
 #ifdef HAVE_TGETENT
@@ -1655,9 +1651,11 @@ char_u *term;
 #  define HMT_SGR       64
 static int has_mouse_termcode = 0;
 
-void set_mouse_termcode(n, s)
-int n;                  /* KS_MOUSE, KS_NETTERM_MOUSE or KS_DEC_MOUSE */
-char_u      *s;
+void 
+set_mouse_termcode (
+    int n,                  /* KS_MOUSE, KS_NETTERM_MOUSE or KS_DEC_MOUSE */
+    char_u *s
+)
 {
   char_u name[2];
 
@@ -1683,8 +1681,10 @@ char_u      *s;
 
 # if ((defined(UNIX) || defined(VMS) || defined(OS2)) \
   && defined(FEAT_MOUSE_TTY)) || defined(PROTO)
-void del_mouse_termcode(n)
-int n;                  /* KS_MOUSE, KS_NETTERM_MOUSE or KS_DEC_MOUSE */
+void 
+del_mouse_termcode (
+    int n                  /* KS_MOUSE, KS_NETTERM_MOUSE or KS_DEC_MOUSE */
+)
 {
   char_u name[2];
 
@@ -1714,9 +1714,7 @@ int n;                  /* KS_MOUSE, KS_NETTERM_MOUSE or KS_DEC_MOUSE */
  * Call tgetent()
  * Return error message if it fails, NULL if it's OK.
  */
-static char_u * tgetent_error(tbuf, term)
-char_u  *tbuf;
-char_u  *term;
+static char_u *tgetent_error(char_u *tbuf, char_u *term)
 {
   int i;
 
@@ -1749,9 +1747,7 @@ char_u  *term;
  * Some versions of tgetstr() have been reported to return -1 instead of NULL.
  * Fix that here.
  */
-static char_u * vim_tgetstr(s, pp)
-char        *s;
-char_u      **pp;
+static char_u *vim_tgetstr(char *s, char_u **pp)
 {
   char        *p;
 
@@ -1770,9 +1766,11 @@ char_u      **pp;
  * and "li" entries never change. But on some systems this works.
  * Errors while getting the entries are ignored.
  */
-void getlinecol(cp, rp)
-long        *cp;        /* pointer to columns */
-long        *rp;        /* pointer to rows */
+void 
+getlinecol (
+    long *cp,        /* pointer to columns */
+    long *rp        /* pointer to rows */
+)
 {
   char_u tbuf[TBUFSZ];
 
@@ -1793,9 +1791,7 @@ long        *rp;        /* pointer to rows */
  * If force given, replace an existing entry.
  * Return FAIL if the entry was not found, OK if the entry was added.
  */
-int add_termcap_entry(name, force)
-char_u  *name;
-int force;
+int add_termcap_entry(char_u *name, int force)
 {
   char_u  *term;
   int key;
@@ -1888,8 +1884,7 @@ int force;
   return FAIL;
 }
 
-static int term_is_builtin(name)
-char_u  *name;
+static int term_is_builtin(char_u *name)
 {
   return STRNCMP(name, "builtin_", (size_t)8) == 0;
 }
@@ -1899,8 +1894,7 @@ char_u  *name;
  * Assume that the terminal is using 8-bit controls when the name contains
  * "8bit", like in "xterm-8bit".
  */
-int term_is_8bit(name)
-char_u  *name;
+int term_is_8bit(char_u *name)
 {
   return detected_8bit || strstr((char *)name, "8bit") != NULL;
 }
@@ -1911,8 +1905,7 @@ char_u  *name;
  * <Esc>] -> <M-C-]>
  * <Esc>O -> <M-C-O>
  */
-static int term_7to8bit(p)
-char_u  *p;
+static int term_7to8bit(char_u *p)
 {
   if (*p == ESC) {
     if (p[1] == '[')
@@ -1928,8 +1921,7 @@ char_u  *p;
 
 #if !defined(HAVE_TGETENT) || defined(AMIGA) || defined(PROTO)
 
-char_u * tltoa(i)
-unsigned long i;
+char_u *tltoa(unsigned long i)
 {
   static char_u buf[16];
   char_u      *p;
@@ -1953,9 +1945,7 @@ unsigned long i;
  */
 static char *tgoto __ARGS((char *, int, int));
 
-static char * tgoto(cm, x, y)
-char *cm;
-int x, y;
+static char *tgoto(char *cm, int x, int y)
 {
   static char buf[30];
   char *p, *s, *e;
@@ -2001,8 +1991,7 @@ int x, y;
  * If "name" is NULL or empty, get the terminal name from the environment.
  * If that fails, use the default terminal name.
  */
-void termcapinit(name)
-char_u *name;
+void termcapinit(char_u *name)
 {
   char_u      *term;
 
@@ -2037,7 +2026,7 @@ static int out_pos = 0;                 /* number of chars in out_buf */
 /*
  * out_flush(): flush the output buffer
  */
-void out_flush()          {
+void out_flush(void)          {
   int len;
 
   if (out_pos != 0) {
@@ -2052,7 +2041,7 @@ void out_flush()          {
  * Sometimes a byte out of a multi-byte character is written with out_char().
  * To avoid flushing half of the character, call this function first.
  */
-void out_flush_check()          {
+void out_flush_check(void)          {
   if (enc_dbcs != 0 && out_pos >= OUT_SIZE - MB_MAXBYTES)
     out_flush();
 }
@@ -2063,8 +2052,7 @@ void out_flush_check()          {
  * This should not be used for outputting text on the screen (use functions
  * like msg_puts() and screen_putchar() for that).
  */
-void out_char(c)
-unsigned c;
+void out_char(unsigned c)
 {
 #if defined(UNIX) || defined(VMS) || defined(AMIGA) || defined(MACOS_X_UNIX)
   if (c == '\n')        /* turn LF into CR-LF (CRMOD doesn't seem to do this) */
@@ -2083,8 +2071,7 @@ static void out_char_nf __ARGS((unsigned));
 /*
  * out_char_nf(c): like out_char(), but don't flush when p_wd is set
  */
-static void out_char_nf(c)
-unsigned c;
+static void out_char_nf(unsigned c)
 {
 #if defined(UNIX) || defined(VMS) || defined(AMIGA) || defined(MACOS_X_UNIX)
   if (c == '\n')        /* turn LF into CR-LF (CRMOD doesn't seem to do this) */
@@ -2108,8 +2095,7 @@ unsigned c;
  * This should only be used for writing terminal codes, not for outputting
  * normal text (use functions like msg_puts() and screen_putchar() for that).
  */
-void out_str_nf(s)
-char_u *s;
+void out_str_nf(char_u *s)
 {
   if (out_pos > OUT_SIZE - 20)    /* avoid terminal strings being split up */
     out_flush();
@@ -2128,8 +2114,7 @@ char_u *s;
  * This should only be used for writing terminal codes, not for outputting
  * normal text (use functions like msg_puts() and screen_putchar() for that).
  */
-void out_str(s)
-char_u       *s;
+void out_str(char_u *s)
 {
   if (s != NULL && *s) {
     /* avoid terminal strings being split up */
@@ -2151,35 +2136,28 @@ char_u       *s;
 /*
  * cursor positioning using termcap parser. (jw)
  */
-void term_windgoto(row, col)
-int row;
-int col;
+void term_windgoto(int row, int col)
 {
   OUT_STR(tgoto((char *)T_CM, col, row));
 }
 
-void term_cursor_right(i)
-int i;
+void term_cursor_right(int i)
 {
   OUT_STR(tgoto((char *)T_CRI, 0, i));
 }
 
-void term_append_lines(line_count)
-int line_count;
+void term_append_lines(int line_count)
 {
   OUT_STR(tgoto((char *)T_CAL, 0, line_count));
 }
 
-void term_delete_lines(line_count)
-int line_count;
+void term_delete_lines(int line_count)
 {
   OUT_STR(tgoto((char *)T_CDL, 0, line_count));
 }
 
 #if defined(HAVE_TGETENT) || defined(PROTO)
-void term_set_winpos(x, y)
-int x;
-int y;
+void term_set_winpos(int x, int y)
 {
   /* Can't handle a negative value here */
   if (x < 0)
@@ -2189,16 +2167,13 @@ int y;
   OUT_STR(tgoto((char *)T_CWP, y, x));
 }
 
-void term_set_winsize(width, height)
-int width;
-int height;
+void term_set_winsize(int width, int height)
 {
   OUT_STR(tgoto((char *)T_CWS, height, width));
 }
 #endif
 
-void term_fg_color(n)
-int n;
+void term_fg_color(int n)
 {
   /* Use "AF" termcap entry if present, "Sf" entry otherwise */
   if (*T_CAF)
@@ -2207,8 +2182,7 @@ int n;
     term_color(T_CSF, n);
 }
 
-void term_bg_color(n)
-int n;
+void term_bg_color(int n)
 {
   /* Use "AB" termcap entry if present, "Sb" entry otherwise */
   if (*T_CAB)
@@ -2217,9 +2191,7 @@ int n;
     term_color(T_CSB, n);
 }
 
-static void term_color(s, n)
-char_u      *s;
-int n;
+static void term_color(char_u *s, int n)
 {
   char buf[20];
   int i = 2;    /* index in s[] just after <Esc>[ or CSI */
@@ -2252,8 +2224,7 @@ int n;
 /*
  * Generic function to set window title, using t_ts and t_fs.
  */
-void term_settitle(title)
-char_u      *title;
+void term_settitle(char_u *title)
 {
   /* t_ts takes one argument: column in status line */
   OUT_STR(tgoto((char *)T_TS, 0, 0));   /* set title start */
@@ -2267,8 +2238,7 @@ char_u      *title;
  * Make sure we have a valid set or terminal options.
  * Replace all entries that are NULL by empty_option
  */
-void ttest(pairs)
-int pairs;
+void ttest(int pairs)
 {
   check_options();                  /* make sure no options are NULL */
 
@@ -2360,9 +2330,7 @@ int pairs;
  * Represent the given long_u as individual bytes, with the most significant
  * byte first, and store them in dst.
  */
-void add_long_to_buf(val, dst)
-long_u val;
-char_u  *dst;
+void add_long_to_buf(long_u val, char_u *dst)
 {
   int i;
   int shift;
@@ -2383,9 +2351,7 @@ static int get_long_from_buf __ARGS((char_u *buf, long_u *val));
  * (between sizeof(long_u) and 2 * sizeof(long_u)), or -1 if not enough bytes
  * were present.
  */
-static int get_long_from_buf(buf, val)
-char_u  *buf;
-long_u  *val;
+static int get_long_from_buf(char_u *buf, long_u *val)
 {
   int len;
   char_u bytes[sizeof(long_u)];
@@ -2413,10 +2379,7 @@ long_u  *val;
  * from buf (between num_bytes and num_bytes*2), or -1 if not enough bytes were
  * available.
  */
-static int get_bytes_from_buf(buf, bytes, num_bytes)
-char_u  *buf;
-char_u  *bytes;
-int num_bytes;
+static int get_bytes_from_buf(char_u *buf, char_u *bytes, int num_bytes)
 {
   int len = 0;
   int i;
@@ -2449,7 +2412,7 @@ int num_bytes;
  * Check if the new shell size is valid, correct it if it's too small or way
  * too big.
  */
-void check_shellsize()          {
+void check_shellsize(void)          {
   if (Rows < min_rows())        /* need room for one window and command line */
     Rows = min_rows();
   limit_screen_size();
@@ -2458,7 +2421,7 @@ void check_shellsize()          {
 /*
  * Limit Rows and Columns to avoid an overflow in Rows * Columns.
  */
-void limit_screen_size()          {
+void limit_screen_size(void)          {
   if (Columns < MIN_COLUMNS)
     Columns = MIN_COLUMNS;
   else if (Columns > 10000)
@@ -2470,7 +2433,7 @@ void limit_screen_size()          {
 /*
  * Invoked just before the screen structures are going to be (re)allocated.
  */
-void win_new_shellsize()          {
+void win_new_shellsize(void)          {
   static int old_Rows = 0;
   static int old_Columns = 0;
 
@@ -2493,7 +2456,7 @@ void win_new_shellsize()          {
  * Call this function when the Vim shell has been resized in any way.
  * Will obtain the current size and redraw (also when size didn't change).
  */
-void shell_resized()          {
+void shell_resized(void)          {
   set_shellsize(0, 0, FALSE);
 }
 
@@ -2501,7 +2464,7 @@ void shell_resized()          {
  * Check if the shell size changed.  Handle a resize.
  * When the size didn't change, nothing happens.
  */
-void shell_resized_check()          {
+void shell_resized_check(void)          {
   int old_Rows = Rows;
   int old_Columns = Columns;
 
@@ -2521,9 +2484,7 @@ void shell_resized_check()          {
  * If 'mustset' is FALSE, we may try to get the real window size and if
  * it fails use 'width' and 'height'.
  */
-void set_shellsize(width, height, mustset)
-int width, height;
-int mustset;
+void set_shellsize(int width, int height, int mustset)
 {
   static int busy = FALSE;
 
@@ -2616,8 +2577,7 @@ int mustset;
  * Set the terminal to TMODE_RAW (for Normal mode) or TMODE_COOK (for external
  * commands and Ex mode).
  */
-void settmode(tmode)
-int tmode;
+void settmode(int tmode)
 {
 
   if (full_screen) {
@@ -2652,7 +2612,7 @@ int tmode;
   }
 }
 
-void starttermcap()          {
+void starttermcap(void)          {
   if (full_screen && !termcap_active) {
     out_str(T_TI);                      /* start termcap mode */
     out_str(T_KS);                      /* start "keypad transmit" mode */
@@ -2669,7 +2629,7 @@ void starttermcap()          {
   }
 }
 
-void stoptermcap()          {
+void stoptermcap(void)          {
   screen_stop_highlight();
   reset_cterm_colors();
   if (termcap_active) {
@@ -2714,7 +2674,7 @@ void stoptermcap()          {
  * request to terminal while reading from a file).
  * The result is caught in check_termcode().
  */
-void may_req_termresponse()          {
+void may_req_termresponse(void)          {
   if (crv_status == CRV_GET
       && cur_tmode == TMODE_RAW
       && starting == 0
@@ -2744,7 +2704,7 @@ void may_req_termresponse()          {
  * This function has the side effect that changes cursor position, so
  * it must be called immediately after entering termcap mode.
  */
-void may_req_ambiguous_char_width()          {
+void may_req_ambiguous_char_width(void)          {
   if (u7_status == U7_GET
       && cur_tmode == TMODE_RAW
       && termcap_active
@@ -2799,14 +2759,14 @@ static void log_tr(char *msg)                 {
 /*
  * Return TRUE when saving and restoring the screen.
  */
-int swapping_screen()         {
+int swapping_screen(void)         {
   return full_screen && *T_TI != NUL;
 }
 
 /*
  * setmouse() - switch mouse on/off depending on current mode and 'mouse'
  */
-void setmouse()          {
+void setmouse(void)          {
   int checkfor;
 
 
@@ -2846,8 +2806,7 @@ void setmouse()          {
  * - the current buffer is a help file and 'h' is in 'mouse' and we are in a
  *   normal editing mode (not at hit-return message).
  */
-int mouse_has(c)
-int c;
+int mouse_has(int c)
 {
   char_u      *p;
 
@@ -2867,7 +2826,7 @@ int c;
 /*
  * Return TRUE when 'mousemodel' is set to "popup" or "popup_setpos".
  */
-int mouse_model_popup()         {
+int mouse_model_popup(void)         {
   return p_mousem[0] == 'p';
 }
 
@@ -2876,7 +2835,7 @@ int mouse_model_popup()         {
  * terminals this makes the screen scrolled to the correct position.
  * Used when starting Vim or returning from a shell.
  */
-void scroll_start()          {
+void scroll_start(void)          {
   if (*T_VS != NUL) {
     out_str(T_VS);
     out_str(T_VE);
@@ -2889,7 +2848,7 @@ static int cursor_is_off = FALSE;
 /*
  * Enable the cursor.
  */
-void cursor_on()          {
+void cursor_on(void)          {
   if (cursor_is_off) {
     out_str(T_VE);
     cursor_is_off = FALSE;
@@ -2899,7 +2858,7 @@ void cursor_on()          {
 /*
  * Disable the cursor.
  */
-void cursor_off()          {
+void cursor_off(void)          {
   if (full_screen) {
     if (!cursor_is_off)
       out_str(T_VI);                /* disable cursor */
@@ -2911,7 +2870,7 @@ void cursor_off()          {
 /*
  * Set cursor shape to match Insert mode.
  */
-void term_cursor_shape()          {
+void term_cursor_shape(void)          {
   static int showing_insert_mode = MAYBE;
 
   if (!full_screen || *T_CSI == NUL || *T_CEI == NUL)
@@ -2936,9 +2895,7 @@ void term_cursor_shape()          {
  * Also set the vertical scroll region for a vertically split window.  Always
  * the full width of the window, excluding the vertical separator.
  */
-void scroll_region_set(wp, off)
-win_T       *wp;
-int off;
+void scroll_region_set(win_T *wp, int off)
 {
   OUT_STR(tgoto((char *)T_CS, W_WINROW(wp) + wp->w_height - 1,
           W_WINROW(wp) + off));
@@ -2951,7 +2908,7 @@ int off;
 /*
  * Reset scrolling region to the whole screen.
  */
-void scroll_region_reset()          {
+void scroll_region_reset(void)          {
   OUT_STR(tgoto((char *)T_CS, (int)Rows - 1, 0));
   if (*T_CSV != NUL)
     OUT_STR(tgoto((char *)T_CSV, (int)Columns - 1, 0));
@@ -2974,7 +2931,7 @@ static int tc_len = 0;      /* current number of entries in termcodes[] */
 
 static int termcode_star __ARGS((char_u *code, int len));
 
-void clear_termcodes()          {
+void clear_termcodes(void)          {
   while (tc_len > 0)
     vim_free(termcodes[--tc_len].code);
   vim_free(termcodes);
@@ -2999,10 +2956,7 @@ void clear_termcodes()          {
  * "flags" is TRUE when replacing 7-bit by 8-bit controls is desired.
  * "flags" can also be ATC_FROM_TERM for got_code_from_term().
  */
-void add_termcode(name, string, flags)
-char_u      *name;
-char_u      *string;
-int flags;
+void add_termcode(char_u *name, char_u *string, int flags)
 {
   struct termcode *new_tc;
   int i, j;
@@ -3107,9 +3061,7 @@ int flags;
  * The "X" can be any character.
  * Return 0 if not found, 2 for ;*X and 1 for O*X and <M-O>*X.
  */
-static int termcode_star(code, len)
-char_u      *code;
-int len;
+static int termcode_star(char_u *code, int len)
 {
   /* Shortest is <M-O>*X.  With ; shortest is <CSI>1;*X */
   if (len >= 3 && code[len - 2] == '*') {
@@ -3121,8 +3073,7 @@ int len;
   return 0;
 }
 
-char_u  * find_termcode(name)
-char_u  *name;
+char_u *find_termcode(char_u *name)
 {
   int i;
 
@@ -3132,16 +3083,14 @@ char_u  *name;
   return NULL;
 }
 
-char_u * get_termcode(i)
-int i;
+char_u *get_termcode(int i)
 {
   if (i >= tc_len)
     return NULL;
   return &termcodes[i].name[0];
 }
 
-void del_termcode(name)
-char_u  *name;
+void del_termcode(char_u *name)
 {
   int i;
 
@@ -3158,8 +3107,7 @@ char_u  *name;
   /* not found. Give error message? */
 }
 
-static void del_termcode_idx(idx)
-int idx;
+static void del_termcode_idx(int idx)
 {
   int i;
 
@@ -3173,7 +3121,7 @@ int idx;
  * Called when detected that the terminal sends 8-bit codes.
  * Convert all 7-bit codes to their 8-bit equivalent.
  */
-static void switch_to_8bit()                 {
+static void switch_to_8bit(void)                 {
   int i;
   int c;
 
@@ -3206,8 +3154,7 @@ static int orig_topfill = 0;
  * Set orig_topline.  Used when jumping to another window, so that a double
  * click still works.
  */
-void set_mouse_topline(wp)
-win_T       *wp;
+void set_mouse_topline(win_T *wp)
 {
   orig_topline = wp->w_topline;
   orig_topfill = wp->w_topfill;
@@ -3227,11 +3174,7 @@ win_T       *wp;
  * "buflen" is then the length of the string in buf[] and is updated for
  * inserts and deletes.
  */
-int check_termcode(max_offset, buf, bufsize, buflen)
-int max_offset;
-char_u      *buf;
-int bufsize;
-int         *buflen;
+int check_termcode(int max_offset, char_u *buf, int bufsize, int *buflen)
 {
   char_u      *tp;
   char_u      *p;
@@ -4196,12 +4139,14 @@ int         *buflen;
  * nothing).  When 'cpoptions' does not contain 'B', a backslash can be used
  * instead of a CTRL-V.
  */
-char_u * replace_termcodes(from, bufp, from_part, do_lt, special)
-char_u      *from;
-char_u      **bufp;
-int from_part;
-int do_lt;                      /* also translate <lt> */
-int special;                    /* always accept <key> notation */
+char_u *
+replace_termcodes (
+    char_u *from,
+    char_u **bufp,
+    int from_part,
+    int do_lt,                      /* also translate <lt> */
+    int special                    /* always accept <key> notation */
+)
 {
   int i;
   int slen;
@@ -4374,8 +4319,7 @@ int special;                    /* always accept <key> notation */
  * Find a termcode with keys 'src' (must be NUL terminated).
  * Return the index in termcodes[], or -1 if not found.
  */
-int find_term_bykeys(src)
-char_u      *src;
+int find_term_bykeys(char_u *src)
 {
   int i;
   int slen = (int)STRLEN(src);
@@ -4392,7 +4336,7 @@ char_u      *src;
  * Gather the first characters in the terminal key codes into a string.
  * Used to speed up check_termcode().
  */
-static void gather_termleader()                 {
+static void gather_termleader(void)                 {
   int i;
   int len = 0;
 
@@ -4414,7 +4358,7 @@ static void gather_termleader()                 {
  * Show all termcodes (for ":set termcap")
  * This code looks a lot like showoptions(), but is different.
  */
-void show_termcodes()          {
+void show_termcodes(void)          {
   int col;
   int         *items;
   int item_count;
@@ -4492,10 +4436,7 @@ void show_termcodes()          {
  * Show one termcode entry.
  * Output goes into IObuff[]
  */
-int show_one_termcode(name, code, printit)
-char_u  *name;
-char_u  *code;
-int printit;
+int show_one_termcode(char_u *name, char_u *code, int printit)
 {
   char_u      *p;
   int len;
@@ -4546,13 +4487,13 @@ int printit;
 static int xt_index_in = 0;
 static int xt_index_out = 0;
 
-static void req_codes_from_term()                 {
+static void req_codes_from_term(void)                 {
   xt_index_out = 0;
   xt_index_in = 0;
   req_more_codes_from_term();
 }
 
-static void req_more_codes_from_term()                 {
+static void req_more_codes_from_term(void)                 {
   char buf[11];
   int old_idx = xt_index_out;
 
@@ -4587,9 +4528,7 @@ static void req_more_codes_from_term()                 {
  * Both <name> and <string> are encoded in hex.
  * "code" points to the "0" or "1".
  */
-static void got_code_from_term(code, len)
-char_u      *code;
-int len;
+static void got_code_from_term(char_u *code, int len)
 {
 #define XT_LEN 100
   char_u name[3];
@@ -4668,7 +4607,7 @@ int len;
  * keyboard input.  We don't want responses to be send to that program or
  * handled as typed text.
  */
-static void check_for_codes_from_term()                 {
+static void check_for_codes_from_term(void)                 {
   int c;
 
   /* If no codes requested or all are answered, no need to wait. */
@@ -4714,9 +4653,11 @@ static void check_for_codes_from_term()                 {
  *
  * Returns NULL when there is a problem.
  */
-char_u * translate_mapping(str, expmap)
-char_u      *str;
-int expmap;              /* TRUE when expanding mappings on command-line */
+char_u *
+translate_mapping (
+    char_u *str,
+    int expmap              /* TRUE when expanding mappings on command-line */
+)
 {
   garray_T ga;
   int c;

--- a/src/ui.c
+++ b/src/ui.c
@@ -19,9 +19,7 @@
 #include "vim.h"
 
 
-void ui_write(s, len)
-char_u  *s;
-int len;
+void ui_write(char_u *s, int len)
 {
 #ifndef NO_CONSOLE
   /* Don't output anything in silent mode ("ex -s") unless 'verbose' set */
@@ -53,9 +51,7 @@ static char_u *ta_str = NULL;
 static int ta_off;      /* offset for next char to use when ta_str != NULL */
 static int ta_len;      /* length of ta_str when it's not NULL*/
 
-void ui_inchar_undo(s, len)
-char_u      *s;
-int len;
+void ui_inchar_undo(char_u *s, int len)
 {
   char_u  *new;
   int newlen;
@@ -91,11 +87,13 @@ int len;
  * from a remote client) "buf" can no longer be used.  "tb_change_cnt" is NULL
  * otherwise.
  */
-int ui_inchar(buf, maxlen, wtime, tb_change_cnt)
-char_u      *buf;
-int maxlen;
-long wtime;                 /* don't use "time", MIPS cannot handle it */
-int tb_change_cnt;
+int 
+ui_inchar (
+    char_u *buf,
+    int maxlen,
+    long wtime,                 /* don't use "time", MIPS cannot handle it */
+    int tb_change_cnt
+)
 {
   int retval = 0;
 
@@ -159,7 +157,7 @@ theend:
 /*
  * return non-zero if a character is available
  */
-int ui_char_avail()         {
+int ui_char_avail(void)         {
 #ifndef NO_CONSOLE
 # ifdef NO_CONSOLE_INPUT
   if (no_console_input())
@@ -175,9 +173,7 @@ int ui_char_avail()         {
  * Delay for the given number of milliseconds.	If ignoreinput is FALSE then we
  * cancel the delay if a key is hit.
  */
-void ui_delay(msec, ignoreinput)
-long msec;
-int ignoreinput;
+void ui_delay(long msec, int ignoreinput)
 {
   mch_delay(msec, ignoreinput);
 }
@@ -187,7 +183,7 @@ int ignoreinput;
  * otherwise fake it by starting a new shell.
  * When running the GUI iconify the window.
  */
-void ui_suspend()          {
+void ui_suspend(void)          {
   mch_suspend();
 }
 
@@ -196,7 +192,7 @@ void ui_suspend()          {
  * When the OS can't really suspend, call this function to start a shell.
  * This is never called in the GUI.
  */
-void suspend_shell()          {
+void suspend_shell(void)          {
   if (*p_sh == NUL)
     EMSG(_(e_shellempty));
   else {
@@ -212,7 +208,7 @@ void suspend_shell()          {
  * Use the new sizes as defaults for 'columns' and 'lines'.
  * Return OK when size could be determined, FAIL otherwise.
  */
-int ui_get_shellsize()         {
+int ui_get_shellsize(void)         {
   int retval;
 
   retval = mch_get_shellsize();
@@ -232,8 +228,10 @@ int ui_get_shellsize()         {
  * The gui_set_shellsize() or mch_set_shellsize() function will try to set the
  * new size.  If this is not possible, it will adjust Rows and Columns.
  */
-void ui_set_shellsize(mustset)
-int mustset UNUSED;             /* set by the user */
+void 
+ui_set_shellsize (
+    int mustset             /* set by the user */
+)
 {
   mch_set_shellsize();
 }
@@ -242,13 +240,13 @@ int mustset UNUSED;             /* set by the user */
  * Called when Rows and/or Columns changed.  Adjust scroll region and mouse
  * region.
  */
-void ui_new_shellsize()          {
+void ui_new_shellsize(void)          {
   if (full_screen && !exiting) {
     mch_new_shellsize();
   }
 }
 
-void ui_breakcheck()          {
+void ui_breakcheck(void)          {
   mch_breakcheck();
 }
 
@@ -305,16 +303,16 @@ static int inbufcount = 0;          /* number of chars in inbuf[] */
  * are used by the gui_* calls when a GUI is used to handle keyboard input.
  */
 
-int vim_is_input_buf_full()         {
+int vim_is_input_buf_full(void)         {
   return inbufcount >= INBUFLEN;
 }
 
-int vim_is_input_buf_empty()         {
+int vim_is_input_buf_empty(void)         {
   return inbufcount == 0;
 }
 
 #if defined(FEAT_OLE) || defined(PROTO)
-int vim_free_in_input_buf()         {
+int vim_free_in_input_buf(void)         {
   return INBUFLEN - inbufcount;
 }
 
@@ -325,7 +323,7 @@ int vim_free_in_input_buf()         {
  * Return the current contents of the input buffer and make it empty.
  * The returned pointer must be passed to set_input_buf() later.
  */
-char_u * get_input_buf()              {
+char_u *get_input_buf(void)              {
   garray_T    *gap;
 
   /* We use a growarray to store the data pointer and the length. */
@@ -345,8 +343,7 @@ char_u * get_input_buf()              {
  * Restore the input buffer with a pointer returned from get_input_buf().
  * The allocated memory is freed, this only works once!
  */
-void set_input_buf(p)
-char_u      *p;
+void set_input_buf(char_u *p)
 {
   garray_T    *gap = (garray_T *)p;
 
@@ -370,9 +367,7 @@ char_u      *p;
  * Special keys start with CSI.  A real CSI must have been translated to
  * CSI KS_EXTRA KE_CSI.  K_SPECIAL doesn't require translation.
  */
-void add_to_input_buf(s, len)
-char_u  *s;
-int len;
+void add_to_input_buf(char_u *s, int len)
 {
   if (inbufcount + len > INBUFLEN + MAX_KEY_CODE_LEN)
     return;         /* Shouldn't ever happen! */
@@ -413,9 +408,7 @@ void add_to_input_buf_csi(char_u *str, int len)          {
 
 #endif
 
-void push_raw_key(s, len)
-char_u  *s;
-int len;
+void push_raw_key(char_u *s, int len)
 {
   while (len--)
     inbuf[inbufcount++] = *s++;
@@ -424,7 +417,7 @@ int len;
 #if defined(FEAT_GUI) || defined(FEAT_EVAL) || defined(FEAT_EX_EXTRA) \
   || defined(PROTO)
 /* Remove everything from the input buffer.  Called when ^C is found */
-void trash_input_buf()          {
+void trash_input_buf(void)          {
   inbufcount = 0;
 }
 
@@ -435,9 +428,7 @@ void trash_input_buf()          {
  * it in buf.
  * Note: this function used to be Read() in unix.c
  */
-int read_from_input_buf(buf, maxlen)
-char_u  *buf;
-long maxlen;
+int read_from_input_buf(char_u *buf, long maxlen)
 {
   if (inbufcount == 0)          /* if the buffer is empty, fill it */
     fill_input_buf(TRUE);
@@ -450,8 +441,7 @@ long maxlen;
   return (int)maxlen;
 }
 
-void fill_input_buf(exit_on_error)
-int exit_on_error UNUSED;
+void fill_input_buf(int exit_on_error)
 {
 #if defined(UNIX) || defined(OS2) || defined(VMS) || defined(MACOS_X_UNIX)
   int len;
@@ -567,7 +557,7 @@ int exit_on_error UNUSED;
 /*
  * Exit because of an input read error.
  */
-void read_error_exit()          {
+void read_error_exit(void)          {
   if (silent_mode)      /* Normal way to exit for "ex -s" */
     getout(0);
   STRCPY(IObuff, _("Vim: Error reading input, exiting...\n"));
@@ -578,7 +568,7 @@ void read_error_exit()          {
 /*
  * May update the shape of the cursor.
  */
-void ui_cursor_shape()          {
+void ui_cursor_shape(void)          {
   term_cursor_shape();
 
 
@@ -592,8 +582,7 @@ void ui_cursor_shape()          {
 /*
  * Check bounds for column number
  */
-int check_col(col)
-int col;
+int check_col(int col)
 {
   if (col < 0)
     return 0;
@@ -605,8 +594,7 @@ int col;
 /*
  * Check bounds for row number
  */
-int check_row(row)
-int row;
+int check_row(int row)
 {
   if (row < 0)
     return 0;
@@ -626,9 +614,7 @@ int row;
 /*
  * Get the contents of the X CUT_BUFFER0 and put it in "cbd".
  */
-void yank_cut_buffer0(dpy, cbd)
-Display             *dpy;
-VimClipboard        *cbd;
+void yank_cut_buffer0(Display *dpy, VimClipboard *cbd)
 {
   int nbytes = 0;
   char_u      *buffer = (char_u *)XFetchBuffer(dpy, &nbytes, 0);
@@ -694,10 +680,12 @@ VimClipboard        *cbd;
  * If flags has MOUSE_SETPOS, nothing is done, only the current position is
  * remembered.
  */
-int jump_to_mouse(flags, inclusive, which_button)
-int flags;
-int         *inclusive;         /* used for inclusive operator, can be NULL */
-int which_button;               /* MOUSE_LEFT, MOUSE_RIGHT, MOUSE_MIDDLE */
+int 
+jump_to_mouse (
+    int flags,
+    int *inclusive,         /* used for inclusive operator, can be NULL */
+    int which_button               /* MOUSE_LEFT, MOUSE_RIGHT, MOUSE_MIDDLE */
+)
 {
   static int on_status_line = 0;        /* #lines below bottom of window */
   static int on_sep_line = 0;           /* on separator right of window */
@@ -986,11 +974,7 @@ retnomove:
  * window "win".
  * Returns TRUE if the position is below the last line.
  */
-int mouse_comp_pos(win, rowp, colp, lnump)
-win_T       *win;
-int         *rowp;
-int         *colp;
-linenr_T    *lnump;
+int mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
 {
   int col = *colp;
   int row = *rowp;
@@ -1056,9 +1040,7 @@ linenr_T    *lnump;
  * Find the window at screen position "*rowp" and "*colp".  The positions are
  * updated to become relative to the top-left of the window.
  */
-win_T * mouse_find_win(rowp, colp)
-int         *rowp;
-int         *colp UNUSED;
+win_T *mouse_find_win(int *rowp, int *colp)
 {
   frame_T     *fp;
 
@@ -1090,8 +1072,7 @@ int         *colp UNUSED;
 /*
  * Translate window coordinates to buffer position without any side effects
  */
-int get_fpos_of_mouse(mpos)
-pos_T       *mpos;
+int get_fpos_of_mouse(pos_T *mpos)
 {
   win_T       *wp;
   int row = mouse_row;
@@ -1129,10 +1110,7 @@ pos_T       *mpos;
  * Convert a virtual (screen) column to a character column.
  * The first column is one.
  */
-int vcol2col(wp, lnum, vcol)
-win_T       *wp;
-linenr_T lnum;
-int vcol;
+int vcol2col(win_T *wp, linenr_T lnum, int vcol)
 {
   /* try to advance to the specified column */
   int count = 0;
@@ -1154,8 +1132,7 @@ int vcol;
 /*
  * Save current Input Method status to specified place.
  */
-void im_save_status(psave)
-long *psave;
+void im_save_status(long *psave)
 {
   /* Don't save when 'imdisable' is set or "xic" is NULL, IM is always
    * disabled then (but might start later).

--- a/src/undo.c
+++ b/src/undo.c
@@ -98,9 +98,9 @@ static void u_freeentries __ARGS((buf_T *buf, u_header_T *uhp,
 static void u_freeentry __ARGS((u_entry_T *, long));
 static void corruption_error __ARGS((char *mesg, char_u *file_name));
 static void u_free_uhp __ARGS((u_header_T *uhp));
-static size_t fwrite_crypt __ARGS((buf_T *buf UNUSED, char_u *ptr, size_t len,
+static size_t fwrite_crypt __ARGS((buf_T *buf, char_u *ptr, size_t len,
                                    FILE *fp));
-static char_u *read_string_decrypt __ARGS((buf_T *buf UNUSED, FILE *fd, int len));
+static char_u *read_string_decrypt __ARGS((buf_T *buf, FILE *fd, int len));
 static int serialize_header __ARGS((FILE *fp, buf_T *buf, char_u *hash));
 static int serialize_uhp __ARGS((FILE *fp, buf_T *buf, u_header_T *uhp));
 static u_header_T *unserialize_uhp __ARGS((FILE *fp, char_u *file_name));
@@ -210,7 +210,7 @@ static void u_check(int newhead_may_be_NULL)                 {
  * Careful: may trigger autocommands that reload the buffer.
  * Returns OK or FAIL.
  */
-int u_save_cursor()         {
+int u_save_cursor(void)         {
   return u_save((linenr_T)(curwin->w_cursor.lnum - 1),
       (linenr_T)(curwin->w_cursor.lnum + 1));
 }
@@ -221,8 +221,7 @@ int u_save_cursor()         {
  * Careful: may trigger autocommands that reload the buffer.
  * Returns FAIL when lines could not be saved, OK otherwise.
  */
-int u_save(top, bot)
-linenr_T top, bot;
+int u_save(linenr_T top, linenr_T bot)
 {
   if (undo_off)
     return OK;
@@ -244,8 +243,7 @@ linenr_T top, bot;
  * Careful: may trigger autocommands that reload the buffer.
  * Returns FAIL when lines could not be saved, OK otherwise.
  */
-int u_savesub(lnum)
-linenr_T lnum;
+int u_savesub(linenr_T lnum)
 {
   if (undo_off)
     return OK;
@@ -259,8 +257,7 @@ linenr_T lnum;
  * Careful: may trigger autocommands that reload the buffer.
  * Returns FAIL when lines could not be saved, OK otherwise.
  */
-int u_inssub(lnum)
-linenr_T lnum;
+int u_inssub(linenr_T lnum)
 {
   if (undo_off)
     return OK;
@@ -275,9 +272,7 @@ linenr_T lnum;
  * Careful: may trigger autocommands that reload the buffer.
  * Returns FAIL when lines could not be saved, OK otherwise.
  */
-int u_savedel(lnum, nlines)
-linenr_T lnum;
-long nlines;
+int u_savedel(linenr_T lnum, long nlines)
 {
   if (undo_off)
     return OK;
@@ -290,7 +285,7 @@ long nlines;
  * Return TRUE when undo is allowed.  Otherwise give an error message and
  * return FALSE.
  */
-int undo_allowed()         {
+int undo_allowed(void)         {
   /* Don't allow changes when 'modifiable' is off.  */
   if (!curbuf->b_p_ma) {
     EMSG(_(e_modifiable));
@@ -318,7 +313,7 @@ int undo_allowed()         {
 /*
  * Get the undolevle value for the current buffer.
  */
-static long get_undolevel()                 {
+static long get_undolevel(void)                 {
   if (curbuf->b_p_ul == NO_LOCAL_UNDOLEVEL)
     return p_ul;
   return curbuf->b_p_ul;
@@ -333,10 +328,7 @@ static long get_undolevel()                 {
  * Careful: may trigger autocommands that reload the buffer.
  * Returns FAIL when lines could not be saved, OK otherwise.
  */
-int u_savecommon(top, bot, newbot, reload)
-linenr_T top, bot;
-linenr_T newbot;
-int reload;
+int u_savecommon(linenr_T top, linenr_T bot, linenr_T newbot, int reload)
 {
   linenr_T lnum;
   long i;
@@ -647,8 +639,7 @@ static char_u e_not_open[] = N_("E828: Cannot open undo file for writing: %s");
 /*
  * Compute the hash for the current buffer text into hash[UNDO_HASH_SIZE].
  */
-void u_compute_hash(hash)
-char_u *hash;
+void u_compute_hash(char_u *hash)
 {
   context_sha256_T ctx;
   linenr_T lnum;
@@ -669,9 +660,7 @@ char_u *hash;
  * When "reading" is FALSE use the first name where the directory exists.
  * Returns NULL when there is no place to write or no file to read.
  */
-char_u * u_get_undo_file_name(buf_ffname, reading)
-char_u      *buf_ffname;
-int reading;
+char_u *u_get_undo_file_name(char_u *buf_ffname, int reading)
 {
   char_u      *dirp;
   char_u dir_name[IOSIZE + 1];
@@ -738,15 +727,12 @@ int reading;
   return undo_file_name;
 }
 
-static void corruption_error(mesg, file_name)
-char *mesg;
-char_u *file_name;
+static void corruption_error(char *mesg, char_u *file_name)
 {
   EMSG3(_("E825: Corrupted undo file (%s): %s"), mesg, file_name);
 }
 
-static void u_free_uhp(uhp)
-u_header_T  *uhp;
+static void u_free_uhp(u_header_T *uhp)
 {
   u_entry_T   *nuep;
   u_entry_T   *uep;
@@ -764,11 +750,7 @@ u_header_T  *uhp;
  * Like fwrite() but crypt the bytes when 'key' is set.
  * Returns 1 if successful.
  */
-static size_t fwrite_crypt(buf, ptr, len, fp)
-buf_T       *buf UNUSED;
-char_u      *ptr;
-size_t len;
-FILE        *fp;
+static size_t fwrite_crypt(buf_T *buf, char_u *ptr, size_t len, FILE *fp)
 {
   char_u  *copy;
   char_u small_buf[100];
@@ -794,10 +776,7 @@ FILE        *fp;
  * Read a string of length "len" from "fd".
  * When 'key' is set decrypt the bytes.
  */
-static char_u * read_string_decrypt(buf, fd, len)
-buf_T   *buf UNUSED;
-FILE    *fd;
-int len;
+static char_u *read_string_decrypt(buf_T *buf, FILE *fd, int len)
 {
   char_u  *ptr;
 
@@ -807,10 +786,7 @@ int len;
   return ptr;
 }
 
-static int serialize_header(fp, buf, hash)
-FILE        *fp;
-buf_T       *buf;
-char_u      *hash;
+static int serialize_header(FILE *fp, buf_T *buf, char_u *hash)
 {
   int len;
 
@@ -872,10 +848,7 @@ char_u      *hash;
   return OK;
 }
 
-static int serialize_uhp(fp, buf, uhp)
-FILE        *fp;
-buf_T       *buf;
-u_header_T  *uhp;
+static int serialize_uhp(FILE *fp, buf_T *buf, u_header_T *uhp)
 {
   int i;
   u_entry_T   *uep;
@@ -914,9 +887,7 @@ u_header_T  *uhp;
   return OK;
 }
 
-static u_header_T * unserialize_uhp(fp, file_name)
-FILE        *fp;
-char_u      *file_name;
+static u_header_T *unserialize_uhp(FILE *fp, char_u *file_name)
 {
   u_header_T  *uhp;
   int i;
@@ -995,10 +966,7 @@ char_u      *file_name;
 /*
  * Serialize "uep" to "fp".
  */
-static int serialize_uep(fp, buf, uep)
-FILE        *fp;
-buf_T       *buf;
-u_entry_T   *uep;
+static int serialize_uep(FILE *fp, buf_T *buf, u_entry_T *uep)
 {
   int i;
   size_t len;
@@ -1017,10 +985,7 @@ u_entry_T   *uep;
   return OK;
 }
 
-static u_entry_T * unserialize_uep(fp, error, file_name)
-FILE        *fp;
-int         *error;
-char_u      *file_name;
+static u_entry_T *unserialize_uep(FILE *fp, int *error, char_u *file_name)
 {
   int i;
   u_entry_T   *uep;
@@ -1070,9 +1035,7 @@ char_u      *file_name;
 /*
  * Serialize "pos" to "fp".
  */
-static void serialize_pos(pos, fp)
-pos_T pos;
-FILE  *fp;
+static void serialize_pos(pos_T pos, FILE *fp)
 {
   put_bytes(fp, (long_u)pos.lnum, 4);
   put_bytes(fp, (long_u)pos.col, 4);
@@ -1082,9 +1045,7 @@ FILE  *fp;
 /*
  * Unserialize the pos_T at the current position in fp.
  */
-static void unserialize_pos(pos, fp)
-pos_T *pos;
-FILE  *fp;
+static void unserialize_pos(pos_T *pos, FILE *fp)
 {
   pos->lnum = get4c(fp);
   if (pos->lnum < 0)
@@ -1100,9 +1061,7 @@ FILE  *fp;
 /*
  * Serialize "info" to "fp".
  */
-static void serialize_visualinfo(info, fp)
-visualinfo_T    *info;
-FILE            *fp;
+static void serialize_visualinfo(visualinfo_T *info, FILE *fp)
 {
   serialize_pos(info->vi_start, fp);
   serialize_pos(info->vi_end, fp);
@@ -1113,9 +1072,7 @@ FILE            *fp;
 /*
  * Unserialize the visualinfo_T at the current position in fp.
  */
-static void unserialize_visualinfo(info, fp)
-visualinfo_T    *info;
-FILE            *fp;
+static void unserialize_visualinfo(visualinfo_T *info, FILE *fp)
 {
   unserialize_pos(&info->vi_start, fp);
   unserialize_pos(&info->vi_end, fp);
@@ -1127,9 +1084,7 @@ FILE            *fp;
  * Write the pointer to an undo header.  Instead of writing the pointer itself
  * we use the sequence number of the header.  This is converted back to
  * pointers when reading. */
-static void put_header_ptr(fp, uhp)
-FILE        *fp;
-u_header_T  *uhp;
+static void put_header_ptr(FILE *fp, u_header_T *uhp)
 {
   put_bytes(fp, (long_u)(uhp != NULL ? uhp->uh_seq : 0), 4);
 }
@@ -1143,11 +1098,7 @@ u_header_T  *uhp;
  * "forceit" is TRUE for ":wundo!", FALSE otherwise.
  * "hash[UNDO_HASH_SIZE]" must be the hash value of the buffer text.
  */
-void u_write_undo(name, forceit, buf, hash)
-char_u      *name;
-int forceit;
-buf_T       *buf;
-char_u      *hash;
+void u_write_undo(char_u *name, int forceit, buf_T *buf, char_u *hash)
 {
   u_header_T  *uhp;
   char_u      *file_name;
@@ -1378,10 +1329,7 @@ theend:
  * Otherwise use curbuf->b_ffname to generate the undo file name.
  * "hash[UNDO_HASH_SIZE]" must be the hash value of the buffer text.
  */
-void u_read_undo(name, hash, orig_name)
-char_u *name;
-char_u *hash;
-char_u *orig_name;
+void u_read_undo(char_u *name, char_u *hash, char_u *orig_name)
 {
   char_u      *file_name;
   FILE        *fp;
@@ -1684,8 +1632,7 @@ theend:
  * If 'cpoptions' contains 'u': Undo the previous undo or redo (vi compatible).
  * If 'cpoptions' does not contain 'u': Always undo.
  */
-void u_undo(count)
-int count;
+void u_undo(int count)
 {
   /*
    * If we get an undo command while executing a macro, we behave like the
@@ -1708,8 +1655,7 @@ int count;
  * If 'cpoptions' contains 'u': Repeat the previous undo or redo.
  * If 'cpoptions' does not contain 'u': Always redo.
  */
-void u_redo(count)
-int count;
+void u_redo(int count)
 {
   if (vim_strchr(p_cpo, CPO_UNDO) == NULL)
     undo_undoes = FALSE;
@@ -1719,8 +1665,7 @@ int count;
 /*
  * Undo or redo, depending on 'undo_undoes', 'count' times.
  */
-static void u_doit(startcount)
-int startcount;
+static void u_doit(int startcount)
 {
   int count = startcount;
 
@@ -1788,11 +1733,7 @@ int startcount;
  * When "absolute" is TRUE use "step" as the sequence number to jump to.
  * "sec" must be FALSE then.
  */
-void undo_time(step, sec, file, absolute)
-long step;
-int sec;
-int file;
-int absolute;
+void undo_time(long step, int sec, int file, int absolute)
 {
   long target;
   long closest;
@@ -2099,8 +2040,7 @@ int absolute;
  *
  * When "undo" is TRUE we go up in the tree, when FALSE we go down.
  */
-static void u_undoredo(undo)
-int undo;
+static void u_undoredo(int undo)
 {
   char_u      **newarray = NULL;
   linenr_T oldsize;
@@ -2344,9 +2284,11 @@ int undo;
  * Otherwise, report the number of changes (this may be incorrect
  * in some cases, but it's better than nothing).
  */
-static void u_undo_end(did_undo, absolute)
-int did_undo;                   /* just did an undo */
-int absolute;                   /* used ":undo N" */
+static void 
+u_undo_end (
+    int did_undo,                   /* just did an undo */
+    int absolute                   /* used ":undo N" */
+)
 {
   char        *msgstr;
   u_header_T  *uhp;
@@ -2417,8 +2359,10 @@ int absolute;                   /* used ":undo N" */
 /*
  * u_sync: stop adding to the current entry list
  */
-void u_sync(force)
-int force;              /* Also sync when no_u_sync is set. */
+void 
+u_sync (
+    int force              /* Also sync when no_u_sync is set. */
+)
 {
   /* Skip it when already synced or syncing is disabled. */
   if (curbuf->b_u_synced || (!force && no_u_sync > 0))
@@ -2434,8 +2378,7 @@ int force;              /* Also sync when no_u_sync is set. */
 /*
  * ":undolist": List the leafs of the undo tree
  */
-void ex_undolist(eap)
-exarg_T *eap UNUSED;
+void ex_undolist(exarg_T *eap)
 {
   garray_T ga;
   u_header_T  *uhp;
@@ -2528,10 +2471,7 @@ exarg_T *eap UNUSED;
 /*
  * Put the timestamp of an undo header in "buf[buflen]" in a nice format.
  */
-static void u_add_time(buf, buflen, tt)
-char_u      *buf;
-size_t buflen;
-time_t tt;
+static void u_add_time(char_u *buf, size_t buflen, time_t tt)
 {
 #ifdef HAVE_STRFTIME
   struct tm   *curtime;
@@ -2553,8 +2493,7 @@ time_t tt;
 /*
  * ":undojoin": continue adding to the last entry list
  */
-void ex_undojoin(eap)
-exarg_T *eap UNUSED;
+void ex_undojoin(exarg_T *eap)
 {
   if (curbuf->b_u_newhead == NULL)
     return;                 /* nothing changed before */
@@ -2577,8 +2516,7 @@ exarg_T *eap UNUSED;
  * Called after writing or reloading the file and setting b_changed to FALSE.
  * Now an undo means that the buffer is modified.
  */
-void u_unchanged(buf)
-buf_T       *buf;
+void u_unchanged(buf_T *buf)
 {
   u_unch_branch(buf->b_u_oldhead);
   buf->b_did_warn = FALSE;
@@ -2588,7 +2526,7 @@ buf_T       *buf;
  * After reloading a buffer which was saved for 'undoreload': Find the first
  * line that was changed and set the cursor there.
  */
-void u_find_first_changed()          {
+void u_find_first_changed(void)          {
   u_header_T  *uhp = curbuf->b_u_newhead;
   u_entry_T   *uep;
   linenr_T lnum;
@@ -2620,8 +2558,7 @@ void u_find_first_changed()          {
  * Increase the write count, store it in the last undo header, what would be
  * used for "u".
  */
-void u_update_save_nr(buf)
-buf_T *buf;
+void u_update_save_nr(buf_T *buf)
 {
   u_header_T  *uhp;
 
@@ -2636,8 +2573,7 @@ buf_T *buf;
     uhp->uh_save_nr = buf->b_u_save_nr_last;
 }
 
-static void u_unch_branch(uhp)
-u_header_T  *uhp;
+static void u_unch_branch(u_header_T *uhp)
 {
   u_header_T  *uh;
 
@@ -2652,7 +2588,7 @@ u_header_T  *uhp;
  * Get pointer to last added entry.
  * If it's not valid, give an error message and return NULL.
  */
-static u_entry_T * u_get_headentry()                        {
+static u_entry_T *u_get_headentry(void)                        {
   if (curbuf->b_u_newhead == NULL || curbuf->b_u_newhead->uh_entry == NULL) {
     EMSG(_("E439: undo list corrupt"));
     return NULL;
@@ -2664,7 +2600,7 @@ static u_entry_T * u_get_headentry()                        {
  * u_getbot(): compute the line number of the previous u_save
  *		It is called only when b_u_synced is FALSE.
  */
-static void u_getbot()                 {
+static void u_getbot(void)                 {
   u_entry_T   *uep;
   linenr_T extra;
 
@@ -2698,10 +2634,12 @@ static void u_getbot()                 {
 /*
  * Free one header "uhp" and its entry list and adjust the pointers.
  */
-static void u_freeheader(buf, uhp, uhpp)
-buf_T           *buf;
-u_header_T      *uhp;
-u_header_T      **uhpp;         /* if not NULL reset when freeing this header */
+static void 
+u_freeheader (
+    buf_T *buf,
+    u_header_T *uhp,
+    u_header_T **uhpp         /* if not NULL reset when freeing this header */
+)
 {
   u_header_T      *uhap;
 
@@ -2732,10 +2670,12 @@ u_header_T      **uhpp;         /* if not NULL reset when freeing this header */
 /*
  * Free an alternate branch and any following alternate branches.
  */
-static void u_freebranch(buf, uhp, uhpp)
-buf_T           *buf;
-u_header_T      *uhp;
-u_header_T      **uhpp;         /* if not NULL reset when freeing this header */
+static void 
+u_freebranch (
+    buf_T *buf,
+    u_header_T *uhp,
+    u_header_T **uhpp         /* if not NULL reset when freeing this header */
+)
 {
   u_header_T      *tofree, *next;
 
@@ -2764,10 +2704,12 @@ u_header_T      **uhpp;         /* if not NULL reset when freeing this header */
  * Free all the undo entries for one header and the header itself.
  * This means that "uhp" is invalid when returning.
  */
-static void u_freeentries(buf, uhp, uhpp)
-buf_T           *buf;
-u_header_T      *uhp;
-u_header_T      **uhpp;         /* if not NULL reset when freeing this header */
+static void 
+u_freeentries (
+    buf_T *buf,
+    u_header_T *uhp,
+    u_header_T **uhpp         /* if not NULL reset when freeing this header */
+)
 {
   u_entry_T       *uep, *nuep;
 
@@ -2794,9 +2736,7 @@ u_header_T      **uhpp;         /* if not NULL reset when freeing this header */
 /*
  * free entry 'uep' and 'n' lines in uep->ue_array[]
  */
-static void u_freeentry(uep, n)
-u_entry_T   *uep;
-long n;
+static void u_freeentry(u_entry_T *uep, long n)
 {
   while (n > 0)
     vim_free(uep->ue_array[--n]);
@@ -2810,8 +2750,7 @@ long n;
 /*
  * invalidate the undo buffer; called when storage has already been released
  */
-void u_clearall(buf)
-buf_T       *buf;
+void u_clearall(buf_T *buf)
 {
   buf->b_u_newhead = buf->b_u_oldhead = buf->b_u_curhead = NULL;
   buf->b_u_synced = TRUE;
@@ -2823,8 +2762,7 @@ buf_T       *buf;
 /*
  * save the line "lnum" for the "U" command
  */
-void u_saveline(lnum)
-linenr_T lnum;
+void u_saveline(linenr_T lnum)
 {
   if (lnum == curbuf->b_u_line_lnum)        /* line is already saved */
     return;
@@ -2844,7 +2782,7 @@ linenr_T lnum;
  * clear the line saved for the "U" command
  * (this is used externally for crossing a line while in insert mode)
  */
-void u_clearline()          {
+void u_clearline(void)          {
   if (curbuf->b_u_line_ptr != NULL) {
     vim_free(curbuf->b_u_line_ptr);
     curbuf->b_u_line_ptr = NULL;
@@ -2858,7 +2796,7 @@ void u_clearline()          {
  * We also allow the cursor to be in another line.
  * Careful: may trigger autocommands that reload the buffer.
  */
-void u_undoline()          {
+void u_undoline(void)          {
   colnr_T t;
   char_u  *oldp;
 
@@ -2896,8 +2834,7 @@ void u_undoline()          {
 /*
  * Free all allocated memory blocks for the buffer 'buf'.
  */
-void u_blockfree(buf)
-buf_T       *buf;
+void u_blockfree(buf_T *buf)
 {
   while (buf->b_u_oldhead != NULL)
     u_freeheader(buf, buf->b_u_oldhead, NULL);
@@ -2908,8 +2845,7 @@ buf_T       *buf;
  * u_save_line(): allocate memory and copy line 'lnum' into it.
  * Returns NULL when out of memory.
  */
-static char_u * u_save_line(lnum)
-linenr_T lnum;
+static char_u *u_save_line(linenr_T lnum)
 {
   return vim_strsave(ml_get(lnum));
 }
@@ -2919,15 +2855,14 @@ linenr_T lnum;
  * check the first character, because it can only be "dos", "unix" or "mac").
  * "nofile" and "scratch" type buffers are considered to always be unchanged.
  */
-int bufIsChanged(buf)
-buf_T       *buf;
+int bufIsChanged(buf_T *buf)
 {
   return
     !bt_dontwrite(buf) &&
     (buf->b_changed || file_ff_differs(buf, TRUE));
 }
 
-int curbufIsChanged()         {
+int curbufIsChanged(void)         {
   return
     !bt_dontwrite(curbuf) &&
     (curbuf->b_changed || file_ff_differs(curbuf, TRUE));
@@ -2937,9 +2872,7 @@ int curbufIsChanged()         {
  * For undotree(): Append the list of undo blocks at "first_uhp" to "list".
  * Recursive.
  */
-void u_eval_tree(first_uhp, list)
-u_header_T  *first_uhp;
-list_T      *list;
+void u_eval_tree(u_header_T *first_uhp, list_T *list)
 {
   u_header_T  *uhp = first_uhp;
   dict_T      *dict;

--- a/src/version.c
+++ b/src/version.c
@@ -568,7 +568,7 @@ static char *(extra_patches[]) =
   NULL
 };
 
-int highest_patch()         {
+int highest_patch(void)         {
   int i;
   int h = 0;
 
@@ -581,8 +581,7 @@ int highest_patch()         {
 /*
  * Return TRUE if patch "n" has been included.
  */
-int has_patch(n)
-int n;
+int has_patch(int n)
 {
   int i;
 
@@ -592,8 +591,7 @@ int n;
   return FALSE;
 }
 
-void ex_version(eap)
-exarg_T     *eap;
+void ex_version(exarg_T *eap)
 {
   /*
    * Ignore a ":version 9.99" command.
@@ -607,7 +605,7 @@ exarg_T     *eap;
 /*
  * List all features aligned in columns, dictionary style.
  */
-static void list_features()                 {
+static void list_features(void)                 {
   int i;
   int ncol;
   int nrow;
@@ -662,7 +660,7 @@ static void list_features()                 {
   }
 }
 
-void list_version()          {
+void list_version(void)          {
   int i;
   int first;
   char        *s = "";
@@ -792,8 +790,7 @@ void list_version()          {
  * Output a string for the version message.  If it's going to wrap, output a
  * newline, unless the message is too long to fit on the screen anyway.
  */
-static void version_msg(s)
-char        *s;
+static void version_msg(char *s)
 {
   int len = (int)STRLEN(s);
 
@@ -810,7 +807,7 @@ static void do_intro_line __ARGS((int row, char_u *mesg, int add_version,
 /*
  * Show the intro message when not editing a file.
  */
-void maybe_intro_message()          {
+void maybe_intro_message(void)          {
   if (bufempty()
       && curbuf->b_fname == NULL
       && firstwin->w_next == NULL
@@ -823,8 +820,10 @@ void maybe_intro_message()          {
  * Only used when starting Vim on an empty file, without a file name.
  * Or with the ":intro" command (for Sven :-).
  */
-void intro_message(colon)
-int colon;                      /* TRUE for ":intro" */
+void 
+intro_message (
+    int colon                      /* TRUE for ":intro" */
+)
 {
   int i;
   int row;
@@ -904,11 +903,7 @@ int colon;                      /* TRUE for ":intro" */
     msg_row = row;
 }
 
-static void do_intro_line(row, mesg, add_version, attr)
-int row;
-char_u      *mesg;
-int add_version;
-int attr;
+static void do_intro_line(int row, char_u *mesg, int add_version, int attr)
 {
   char_u vers[20];
   int col;
@@ -969,8 +964,7 @@ int attr;
 /*
  * ":intro": clear screen, display intro screen and wait for return.
  */
-void ex_intro(eap)
-exarg_T     *eap UNUSED;
+void ex_intro(exarg_T *eap)
 {
   screenclear();
   intro_message(TRUE);

--- a/src/vim.h
+++ b/src/vim.h
@@ -72,14 +72,6 @@ Error: configure did not run properly.Check auto/config.log.
 # endif
 #endif
 
-/* Mark unused function arguments with UNUSED, so that gcc -Wunused-parameter
- * can be used to check for mistakes. */
-#ifdef HAVE_ATTRIBUTE_UNUSED
-# define UNUSED __attribute__((unused))
-#else
-# define UNUSED
-#endif
-
 # ifdef HAVE_LOCALE_H
 #  include <locale.h>
 # endif

--- a/src/window.c
+++ b/src/window.c
@@ -86,10 +86,12 @@ static char *m_onlyone = N_("Already only one window");
 /*
  * all CTRL-W window commands are handled here, called from normal_cmd().
  */
-void do_window(nchar, Prenum, xchar)
-int nchar;
-long Prenum;
-int xchar;                  /* extra char from ":wincmd gx" or NUL */
+void 
+do_window (
+    int nchar,
+    long Prenum,
+    int xchar                  /* extra char from ":wincmd gx" or NUL */
+)
 {
   long Prenum1;
   win_T       *wp;
@@ -510,9 +512,7 @@ wingotofile:
  *
  * return FAIL for failure, OK otherwise
  */
-int win_split(size, flags)
-int size;
-int flags;
+int win_split(int size, int flags)
 {
   /* When the ":tab" modifier was used open a new tab page instead. */
   if (may_open_tabpage() == OK)
@@ -541,11 +541,7 @@ int flags;
  * top/left/right/bottom.
  * return FAIL for failure, OK otherwise
  */
-int win_split_ins(size, flags, new_wp, dir)
-int size;
-int flags;
-win_T       *new_wp;
-int dir;
+int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 {
   win_T       *wp = new_wp;
   win_T       *oldwin;
@@ -936,10 +932,7 @@ int dir;
  * WSP_NEWLOC may be specified in flags to prevent the location list from
  * being copied.
  */
-static void win_init(newp, oldp, flags)
-win_T       *newp;
-win_T       *oldp;
-int flags UNUSED;
+static void win_init(win_T *newp, win_T *oldp, int flags)
 {
   int i;
 
@@ -989,9 +982,7 @@ int flags UNUSED;
  * Initialize window "newp" from window"old".
  * Only the essential things are copied.
  */
-static void win_init_some(newp, oldp)
-win_T       *newp;
-win_T       *oldp;
+static void win_init_some(win_T *newp, win_T *oldp)
 {
   /* Use the same argument list. */
   newp->w_alist = oldp->w_alist;
@@ -1006,8 +997,7 @@ win_T       *oldp;
 /*
  * Check if "win" is a pointer to an existing window.
  */
-int win_valid(win)
-win_T       *win;
+int win_valid(win_T *win)
 {
   win_T       *wp;
 
@@ -1022,7 +1012,7 @@ win_T       *win;
 /*
  * Return the number of windows.
  */
-int win_count()         {
+int win_count(void)         {
   win_T       *wp;
   int count = 0;
 
@@ -1037,9 +1027,11 @@ int win_count()         {
  * Must be called when there is just one window, filling the whole screen
  * (excluding the command line).
  */
-int make_windows(count, vertical)
-int count;
-int vertical UNUSED;              /* split windows vertically if TRUE */
+int 
+make_windows (
+    int count,
+    int vertical              /* split windows vertically if TRUE */
+)
 {
   int maxcount;
   int todo;
@@ -1094,8 +1086,7 @@ int vertical UNUSED;              /* split windows vertically if TRUE */
 /*
  * Exchange current and next window
  */
-static void win_exchange(Prenum)
-long Prenum;
+static void win_exchange(long Prenum)
 {
   frame_T     *frp;
   frame_T     *frp2;
@@ -1185,9 +1176,7 @@ long Prenum;
  * rotate windows: if upwards TRUE the second window becomes the first one
  *		   if upwards FALSE the first window becomes the second one
  */
-static void win_rotate(upwards, count)
-int upwards;
-int count;
+static void win_rotate(int upwards, int count)
 {
   win_T       *wp1;
   win_T       *wp2;
@@ -1260,9 +1249,7 @@ int count;
 /*
  * Move the current window to the very top/bottom/left/right of the screen.
  */
-static void win_totop(size, flags)
-int size;
-int flags;
+static void win_totop(int size, int flags)
 {
   int dir;
   int height = curwin->w_height;
@@ -1292,8 +1279,7 @@ int flags;
  * Move window "win1" to below/right of "win2" and make "win1" the current
  * window.  Only works within the same frame!
  */
-void win_move_after(win1, win2)
-win_T       *win1, *win2;
+void win_move_after(win_T *win1, win_T *win2)
 {
   int height;
 
@@ -1346,11 +1332,13 @@ win_T       *win1, *win2;
  * 'next_curwin' will soon be the current window, make sure it has enough
  * rows.
  */
-void win_equal(next_curwin, current, dir)
-win_T       *next_curwin;       /* pointer to current window to be or NULL */
-int current;                    /* do only frame with current window */
-int dir;                        /* 'v' for vertically, 'h' for horizontally,
+void 
+win_equal (
+    win_T *next_curwin,       /* pointer to current window to be or NULL */
+    int current,                    /* do only frame with current window */
+    int dir                        /* 'v' for vertically, 'h' for horizontally,
                                    'b' for both, 0 for using p_ead */
+)
 {
   if (dir == 0)
     dir = *p_ead;
@@ -1365,16 +1353,17 @@ int dir;                        /* 'v' for vertically, 'h' for horizontally,
  * The window "next_curwin" (if not NULL) should at least get the size from
  * 'winheight' and 'winwidth' if possible.
  */
-static void win_equal_rec(next_curwin, current, topfr, dir, col, row, width,
-    height)
-win_T       *next_curwin;       /* pointer to current window to be or NULL */
-int current;                    /* do only frame with current window */
-frame_T     *topfr;             /* frame to set size off */
-int dir;                        /* 'v', 'h' or 'b', see win_equal() */
-int col;                        /* horizontal position for frame */
-int row;                        /* vertical position for frame */
-int width;                      /* new width of frame */
-int height;                     /* new height of frame */
+static void 
+win_equal_rec (
+    win_T *next_curwin,       /* pointer to current window to be or NULL */
+    int current,                    /* do only frame with current window */
+    frame_T *topfr,             /* frame to set size off */
+    int dir,                        /* 'v', 'h' or 'b', see win_equal() */
+    int col,                        /* horizontal position for frame */
+    int row,                        /* vertical position for frame */
+    int width,                      /* new width of frame */
+    int height                     /* new height of frame */
+)
 {
   int n, m;
   int extra_sep = 0;
@@ -1646,9 +1635,11 @@ int height;                     /* new height of frame */
 /*
  * close all windows for buffer 'buf'
  */
-void close_windows(buf, keep_curwin)
-buf_T       *buf;
-int keep_curwin;                    /* don't close "curwin" */
+void 
+close_windows (
+    buf_T *buf,
+    int keep_curwin                    /* don't close "curwin" */
+)
 {
   win_T       *wp;
   tabpage_T   *tp, *nexttp;
@@ -1697,7 +1688,7 @@ int keep_curwin;                    /* don't close "curwin" */
  * "aucmd_win").
  * Returns FALSE if there is a window, possibly in another tab page.
  */
-static int last_window()                {
+static int last_window(void)                {
   return one_window() && first_tabpage->tp_next == NULL;
 }
 
@@ -1705,7 +1696,7 @@ static int last_window()                {
  * Return TRUE if there is only one window other than "aucmd_win" in the
  * current tab page.
  */
-int one_window()         {
+int one_window(void)         {
   win_T       *wp;
   int seen_one = FALSE;
 
@@ -1724,10 +1715,7 @@ int one_window()         {
  * Close the possibly last window in a tab page.
  * Returns TRUE when the window was closed already.
  */
-static int close_last_window_tabpage(win, free_buf, prev_curtab)
-win_T       *win;
-int free_buf;
-tabpage_T   *prev_curtab;
+static int close_last_window_tabpage(win_T *win, int free_buf, tabpage_T *prev_curtab)
 {
   if (firstwin == lastwin) {
     buf_T   *old_curbuf = curbuf;
@@ -1770,9 +1758,7 @@ tabpage_T   *prev_curtab;
  * Called by :quit, :close, :xit, :wq and findtag().
  * Returns FAIL when the window was not closed.
  */
-int win_close(win, free_buf)
-win_T       *win;
-int free_buf;
+int win_close(win_T *win, int free_buf)
 {
   win_T       *wp;
   int other_buffer = FALSE;
@@ -1941,10 +1927,7 @@ int free_buf;
  * Caller must check if buffer is hidden and whether the tabline needs to be
  * updated.
  */
-void win_close_othertab(win, free_buf, tp)
-win_T       *win;
-int free_buf;
-tabpage_T   *tp;
+void win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
 {
   win_T       *wp;
   int dir;
@@ -1998,10 +1981,12 @@ tabpage_T   *tp;
  * Free the memory used for a window.
  * Returns a pointer to the window that got the freed up space.
  */
-static win_T * win_free_mem(win, dirp, tp)
-win_T       *win;
-int         *dirp;              /* set to 'v' or 'h' for direction if 'ea' */
-tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
+static win_T *
+win_free_mem (
+    win_T *win,
+    int *dirp,              /* set to 'v' or 'h' for direction if 'ea' */
+    tabpage_T *tp                /* tab page "win" is in, NULL for current */
+)
 {
   frame_T     *frp;
   win_T       *wp;
@@ -2021,7 +2006,7 @@ tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void win_free_all()          {
+void win_free_all(void)          {
   int dummy;
 
   while (first_tabpage->tp_next != NULL)
@@ -2042,10 +2027,12 @@ void win_free_all()          {
  * Remove a window and its frame from the tree of frames.
  * Returns a pointer to the window that got the freed up space.
  */
-win_T * winframe_remove(win, dirp, tp)
-win_T       *win;
-int         *dirp UNUSED;       /* set to 'v' or 'h' for direction if 'ea' */
-tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
+win_T *
+winframe_remove (
+    win_T *win,
+    int *dirp,       /* set to 'v' or 'h' for direction if 'ea' */
+    tabpage_T *tp                /* tab page "win" is in, NULL for current */
+)
 {
   frame_T     *frp, *frp2, *frp3;
   frame_T     *frp_close = win->w_frame;
@@ -2181,9 +2168,11 @@ tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
  * This makes opening a window and closing it immediately keep the same window
  * layout.
  */
-static frame_T * win_altframe(win, tp)
-win_T       *win;
-tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
+static frame_T *
+win_altframe (
+    win_T *win,
+    tabpage_T *tp                /* tab page "win" is in, NULL for current */
+)
 {
   frame_T     *frp;
   int b;
@@ -2205,7 +2194,7 @@ tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
 /*
  * Return the tabpage that will be used if the current one is closed.
  */
-static tabpage_T * alt_tabpage()                        {
+static tabpage_T *alt_tabpage(void)                        {
   tabpage_T   *tp;
 
   /* Use the next tab page if possible. */
@@ -2221,8 +2210,7 @@ static tabpage_T * alt_tabpage()                        {
 /*
  * Find the left-upper window in frame "frp".
  */
-static win_T * frame2win(frp)
-frame_T     *frp;
+static win_T *frame2win(frame_T *frp)
 {
   while (frp->fr_win == NULL)
     frp = frp->fr_child;
@@ -2232,9 +2220,7 @@ frame_T     *frp;
 /*
  * Return TRUE if frame "frp" contains window "wp".
  */
-static int frame_has_win(frp, wp)
-frame_T     *frp;
-win_T       *wp;
+static int frame_has_win(frame_T *frp, win_T *wp)
 {
   frame_T     *p;
 
@@ -2251,12 +2237,14 @@ win_T       *wp;
  * Set a new height for a frame.  Recursively sets the height for contained
  * frames and windows.  Caller must take care of positions.
  */
-static void frame_new_height(topfrp, height, topfirst, wfh)
-frame_T     *topfrp;
-int height;
-int topfirst;                   /* resize topmost contained frame first */
-int wfh;                        /* obey 'winfixheight' when there is a choice;
+static void 
+frame_new_height (
+    frame_T *topfrp,
+    int height,
+    int topfirst,                   /* resize topmost contained frame first */
+    int wfh                        /* obey 'winfixheight' when there is a choice;
                                    may cause the height not to be set */
+)
 {
   frame_T     *frp;
   int extra_lines;
@@ -2338,8 +2326,7 @@ int wfh;                        /* obey 'winfixheight' when there is a choice;
  * Return TRUE if height of frame "frp" should not be changed because of
  * the 'winfixheight' option.
  */
-static int frame_fixed_height(frp)
-frame_T     *frp;
+static int frame_fixed_height(frame_T *frp)
 {
   /* frame with one window: fixed height if 'winfixheight' set. */
   if (frp->fr_win != NULL)
@@ -2366,8 +2353,7 @@ frame_T     *frp;
  * Return TRUE if width of frame "frp" should not be changed because of
  * the 'winfixwidth' option.
  */
-static int frame_fixed_width(frp)
-frame_T     *frp;
+static int frame_fixed_width(frame_T *frp)
 {
   /* frame with one window: fixed width if 'winfixwidth' set. */
   if (frp->fr_win != NULL)
@@ -2394,8 +2380,7 @@ frame_T     *frp;
  * Add a status line to windows at the bottom of "frp".
  * Note: Does not check if there is room!
  */
-static void frame_add_statusline(frp)
-frame_T     *frp;
+static void frame_add_statusline(frame_T *frp)
 {
   win_T       *wp;
 
@@ -2422,12 +2407,14 @@ frame_T     *frp;
  * Set width of a frame.  Handles recursively going through contained frames.
  * May remove separator line for windows at the right side (for win_close()).
  */
-static void frame_new_width(topfrp, width, leftfirst, wfw)
-frame_T     *topfrp;
-int width;
-int leftfirst;                  /* resize leftmost contained frame first */
-int wfw;                        /* obey 'winfixwidth' when there is a choice;
+static void 
+frame_new_width (
+    frame_T *topfrp,
+    int width,
+    int leftfirst,                  /* resize leftmost contained frame first */
+    int wfw                        /* obey 'winfixwidth' when there is a choice;
                                    may cause the width not to be set */
+)
 {
   frame_T     *frp;
   int extra_cols;
@@ -2516,8 +2503,7 @@ int wfw;                        /* obey 'winfixwidth' when there is a choice;
  * Add the vertical separator to windows at the right side of "frp".
  * Note: Does not check if there is room!
  */
-static void frame_add_vsep(frp)
-frame_T     *frp;
+static void frame_add_vsep(frame_T *frp)
 {
   win_T       *wp;
 
@@ -2544,8 +2530,7 @@ frame_T     *frp;
 /*
  * Set frame width from the window it contains.
  */
-static void frame_fix_width(wp)
-win_T       *wp;
+static void frame_fix_width(win_T *wp)
 {
   wp->w_frame->fr_width = wp->w_width + wp->w_vsep_width;
 }
@@ -2553,8 +2538,7 @@ win_T       *wp;
 /*
  * Set frame height from the window it contains.
  */
-static void frame_fix_height(wp)
-win_T       *wp;
+static void frame_fix_height(win_T *wp)
 {
   wp->w_frame->fr_height = wp->w_height + wp->w_status_height;
 }
@@ -2566,9 +2550,7 @@ win_T       *wp;
  * When "next_curwin" is NOWIN, don't use at least one line for the current
  * window.
  */
-static int frame_minheight(topfrp, next_curwin)
-frame_T     *topfrp;
-win_T       *next_curwin;
+static int frame_minheight(frame_T *topfrp, win_T *next_curwin)
 {
   frame_T     *frp;
   int m;
@@ -2608,9 +2590,11 @@ win_T       *next_curwin;
  * When "next_curwin" is NOWIN, don't use at least one column for the current
  * window.
  */
-static int frame_minwidth(topfrp, next_curwin)
-frame_T     *topfrp;
-win_T       *next_curwin;       /* use p_wh and p_wiw for next_curwin */
+static int 
+frame_minwidth (
+    frame_T *topfrp,
+    win_T *next_curwin       /* use p_wh and p_wiw for next_curwin */
+)
 {
   frame_T     *frp;
   int m, n;
@@ -2651,9 +2635,11 @@ win_T       *next_curwin;       /* use p_wh and p_wiw for next_curwin */
  *
  * Used by ":bdel" and ":only".
  */
-void close_others(message, forceit)
-int message;
-int forceit;                        /* always hide all other windows */
+void 
+close_others (
+    int message,
+    int forceit                        /* always hide all other windows */
+)
 {
   win_T       *wp;
   win_T       *nextwp;
@@ -2702,12 +2688,11 @@ int forceit;                        /* always hide all other windows */
  * Init the current window "curwin".
  * Called when a new file is being edited.
  */
-void curwin_init()          {
+void curwin_init(void)          {
   win_init_empty(curwin);
 }
 
-void win_init_empty(wp)
-win_T *wp;
+void win_init_empty(win_T *wp)
 {
   redraw_win_later(wp, NOT_VALID);
   wp->w_lines_valid = 0;
@@ -2733,7 +2718,7 @@ win_T *wp;
  * Called from main().
  * Return FAIL when something goes wrong (out of memory).
  */
-int win_alloc_first()         {
+int win_alloc_first(void)         {
   if (win_alloc_firstwin(NULL) == FAIL)
     return FAIL;
 
@@ -2750,7 +2735,7 @@ int win_alloc_first()         {
  * Init "aucmd_win".  This can only be done after the first
  * window is fully initialized, thus it can't be in win_alloc_first().
  */
-void win_alloc_aucmd_win()          {
+void win_alloc_aucmd_win(void)          {
   aucmd_win = win_alloc(NULL, TRUE);
   if (aucmd_win != NULL) {
     win_init_some(aucmd_win, curwin);
@@ -2766,8 +2751,7 @@ void win_alloc_aucmd_win()          {
  * FEAT_WINDOWS).
  * Return FAIL when something goes wrong (out of memory).
  */
-static int win_alloc_firstwin(oldwin)
-win_T       *oldwin;
+static int win_alloc_firstwin(win_T *oldwin)
 {
   curwin = win_alloc(NULL, FALSE);
   if (oldwin == NULL) {
@@ -2816,7 +2800,7 @@ static void new_frame(win_T *wp)                 {
 /*
  * Initialize the window and frame size to the maximum.
  */
-void win_init_size()          {
+void win_init_size(void)          {
   firstwin->w_height = ROWS_AVAIL;
   topframe->fr_height = ROWS_AVAIL;
   firstwin->w_width = Columns;
@@ -2827,7 +2811,7 @@ void win_init_size()          {
  * Allocate a new tabpage_T and init the values.
  * Returns NULL when out of memory.
  */
-static tabpage_T * alloc_tabpage()                        {
+static tabpage_T *alloc_tabpage(void)                        {
   tabpage_T   *tp;
 
 
@@ -2849,8 +2833,7 @@ static tabpage_T * alloc_tabpage()                        {
   return tp;
 }
 
-void free_tabpage(tp)
-tabpage_T   *tp;
+void free_tabpage(tabpage_T *tp)
 {
   int idx;
 
@@ -2873,8 +2856,7 @@ tabpage_T   *tp;
  * Otherwise put it just before tab page "after".
  * Return FAIL or OK.
  */
-int win_new_tabpage(after)
-int after;
+int win_new_tabpage(int after)
 {
   tabpage_T   *tp = curtab;
   tabpage_T   *newtp;
@@ -2933,7 +2915,7 @@ int after;
  * like with ":split".
  * Returns OK if a new tab page was created, FAIL otherwise.
  */
-int may_open_tabpage()         {
+int may_open_tabpage(void)         {
   int n = (cmdmod.tab == 0) ? postponed_split_tab : cmdmod.tab;
 
   if (n != 0) {
@@ -2948,8 +2930,7 @@ int may_open_tabpage()         {
  * Create up to "maxcount" tabpages with empty windows.
  * Returns the number of resulting tab pages.
  */
-int make_tabpages(maxcount)
-int maxcount;
+int make_tabpages(int maxcount)
 {
   int count = maxcount;
   int todo;
@@ -2977,8 +2958,7 @@ int maxcount;
 /*
  * Return TRUE when "tpc" points to a valid tab page.
  */
-int valid_tabpage(tpc)
-tabpage_T   *tpc;
+int valid_tabpage(tabpage_T *tpc)
 {
   tabpage_T   *tp;
 
@@ -2991,8 +2971,7 @@ tabpage_T   *tpc;
 /*
  * Find tab page "n" (first one is 1).  Returns NULL when not found.
  */
-tabpage_T * find_tabpage(n)
-int n;
+tabpage_T *find_tabpage(int n)
 {
   tabpage_T   *tp;
   int i = 1;
@@ -3006,8 +2985,7 @@ int n;
  * Get index of tab page "tp".  First one has index 1.
  * When not found returns number of tab pages plus one.
  */
-int tabpage_index(ftp)
-tabpage_T   *ftp;
+int tabpage_index(tabpage_T *ftp)
 {
   int i = 1;
   tabpage_T   *tp;
@@ -3023,10 +3001,12 @@ tabpage_T   *ftp;
  * FAIL.
  * Careful: When OK is returned need to get a new tab page very very soon!
  */
-static int leave_tabpage(new_curbuf, trigger_leave_autocmds)
-buf_T       *new_curbuf UNUSED;        /* what is going to be the new curbuf,
+static int 
+leave_tabpage (
+    buf_T *new_curbuf,        /* what is going to be the new curbuf,
                                           NULL if unknown */
-int trigger_leave_autocmds UNUSED;
+    int trigger_leave_autocmds
+)
 {
   tabpage_T   *tp = curtab;
 
@@ -3061,12 +3041,7 @@ int trigger_leave_autocmds UNUSED;
  * Only trigger *Enter autocommands when trigger_enter_autocmds is TRUE.
  * Only trigger *Leave autocommands when trigger_leave_autocmds is TRUE.
  */
-static void enter_tabpage(tp, old_curbuf, trigger_enter_autocmds,
-    trigger_leave_autocmds)
-tabpage_T   *tp;
-buf_T       *old_curbuf UNUSED;
-int trigger_enter_autocmds UNUSED;
-int trigger_leave_autocmds UNUSED;
+static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, int trigger_enter_autocmds, int trigger_leave_autocmds)
 {
   int old_off = tp->tp_firstwin->w_winrow;
   win_T       *next_prevwin = tp->tp_prevwin;
@@ -3115,8 +3090,7 @@ int trigger_leave_autocmds UNUSED;
  * Go to tab page "n".  For ":tab N" and "Ngt".
  * When "n" is 9999 go to the last tab page.
  */
-void goto_tabpage(n)
-int n;
+void goto_tabpage(int n)
 {
   tabpage_T   *tp;
   tabpage_T   *ttp;
@@ -3177,10 +3151,7 @@ int n;
  * Only trigger *Leave autocommands when trigger_leave_autocmds is TRUE.
  * Note: doesn't update the GUI tab.
  */
-void goto_tabpage_tp(tp, trigger_enter_autocmds, trigger_leave_autocmds)
-tabpage_T   *tp;
-int trigger_enter_autocmds;
-int trigger_leave_autocmds;
+void goto_tabpage_tp(tabpage_T *tp, int trigger_enter_autocmds, int trigger_leave_autocmds)
 {
   /* Don't repeat a message in another tab page. */
   set_keep_msg(NULL, 0);
@@ -3200,9 +3171,7 @@ int trigger_leave_autocmds;
  * Enter window "wp" in tab page "tp".
  * Also updates the GUI tab.
  */
-void goto_tabpage_win(tp, wp)
-tabpage_T   *tp;
-win_T       *wp;
+void goto_tabpage_win(tabpage_T *tp, win_T *wp)
 {
   goto_tabpage_tp(tp, TRUE, TRUE);
   if (curtab == tp && win_valid(wp)) {
@@ -3213,8 +3182,7 @@ win_T       *wp;
 /*
  * Move the current tab page to before tab page "nr".
  */
-void tabpage_move(nr)
-int nr;
+void tabpage_move(int nr)
 {
   int n = nr;
   tabpage_T   *tp;
@@ -3257,8 +3225,7 @@ int nr;
  * When jumping to another window on the same buffer, adjust its cursor
  * position to keep the same Visual area.
  */
-void win_goto(wp)
-win_T       *wp;
+void win_goto(win_T *wp)
 {
   win_T       *owp = curwin;
 
@@ -3290,8 +3257,7 @@ win_T       *wp;
 /*
  * Find the tabpage for window "win".
  */
-tabpage_T * win_find_tabpage(win)
-win_T       *win;
+tabpage_T *win_find_tabpage(win_T *win)
 {
   win_T       *wp;
   tabpage_T   *tp;
@@ -3308,9 +3274,11 @@ win_T       *win;
 /*
  * Move to window above or below "count" times.
  */
-static void win_goto_ver(up, count)
-int up;                         /* TRUE to go to win above */
-long count;
+static void 
+win_goto_ver (
+    int up,                         /* TRUE to go to win above */
+    long count
+)
 {
   frame_T     *fr;
   frame_T     *nfr;
@@ -3365,9 +3333,11 @@ end:
 /*
  * Move to left or right window.
  */
-static void win_goto_hor(left, count)
-int left;                       /* TRUE to go to left win */
-long count;
+static void 
+win_goto_hor (
+    int left,                       /* TRUE to go to left win */
+    long count
+)
 {
   frame_T     *fr;
   frame_T     *nfr;
@@ -3422,9 +3392,7 @@ end:
 /*
  * Make window "wp" the current window.
  */
-void win_enter(wp, undo_sync)
-win_T       *wp;
-int undo_sync;
+void win_enter(win_T *wp, int undo_sync)
 {
   win_enter_ext(wp, undo_sync, FALSE, TRUE, TRUE);
 }
@@ -3434,13 +3402,7 @@ int undo_sync;
  * Can be called with "curwin_invalid" TRUE, which means that curwin has just
  * been closed and isn't valid.
  */
-static void win_enter_ext(wp, undo_sync, curwin_invalid, trigger_enter_autocmds,
-    trigger_leave_autocmds)
-win_T       *wp;
-int undo_sync;
-int curwin_invalid;
-int trigger_enter_autocmds UNUSED;
-int trigger_leave_autocmds UNUSED;
+static void win_enter_ext(win_T *wp, int undo_sync, int curwin_invalid, int trigger_enter_autocmds, int trigger_leave_autocmds)
 {
   int other_buffer = FALSE;
 
@@ -3536,8 +3498,7 @@ int trigger_leave_autocmds UNUSED;
  * Jump to the first open window that contains buffer "buf", if one exists.
  * Returns a pointer to the window found, otherwise NULL.
  */
-win_T * buf_jump_open_win(buf)
-buf_T       *buf;
+win_T *buf_jump_open_win(buf_T *buf)
 {
   win_T       *wp;
 
@@ -3554,8 +3515,7 @@ buf_T       *buf;
  * if one exists.
  * Returns a pointer to the window found, otherwise NULL.
  */
-win_T * buf_jump_open_tab(buf)
-buf_T       *buf;
+win_T *buf_jump_open_tab(buf_T *buf)
 {
   win_T       *wp;
   tabpage_T   *tp;
@@ -3585,9 +3545,7 @@ buf_T       *buf;
  * Allocate a window structure and link it in the window list when "hidden" is
  * FALSE.
  */
-static win_T * win_alloc(after, hidden)
-win_T       *after UNUSED;
-int hidden UNUSED;
+static win_T *win_alloc(win_T *after, int hidden)
 {
   win_T       *new_wp;
 
@@ -3646,9 +3604,11 @@ int hidden UNUSED;
 /*
  * Remove window 'wp' from the window list and free the structure.
  */
-static void win_free(wp, tp)
-win_T       *wp;
-tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
+static void 
+win_free (
+    win_T *wp,
+    tabpage_T *tp                /* tab page "win" is in, NULL for current */
+)
 {
   int i;
   buf_T       *buf;
@@ -3712,8 +3672,7 @@ tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
 /*
  * Append window "wp" in the window list after window "after".
  */
-void win_append(after, wp)
-win_T       *after, *wp;
+void win_append(win_T *after, win_T *wp)
 {
   win_T       *before;
 
@@ -3737,9 +3696,11 @@ win_T       *after, *wp;
 /*
  * Remove a window from the window list.
  */
-void win_remove(wp, tp)
-win_T       *wp;
-tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
+void 
+win_remove (
+    win_T *wp,
+    tabpage_T *tp                /* tab page "win" is in, NULL for current */
+)
 {
   if (wp->w_prev != NULL)
     wp->w_prev->w_next = wp->w_next;
@@ -3758,8 +3719,7 @@ tabpage_T   *tp;                /* tab page "win" is in, NULL for current */
 /*
  * Append frame "frp" in a frame list after frame "after".
  */
-static void frame_append(after, frp)
-frame_T     *after, *frp;
+static void frame_append(frame_T *after, frame_T *frp)
 {
   frp->fr_next = after->fr_next;
   after->fr_next = frp;
@@ -3771,8 +3731,7 @@ frame_T     *after, *frp;
 /*
  * Insert frame "frp" in a frame list before frame "before".
  */
-static void frame_insert(before, frp)
-frame_T     *before, *frp;
+static void frame_insert(frame_T *before, frame_T *frp)
 {
   frp->fr_next = before;
   frp->fr_prev = before->fr_prev;
@@ -3786,8 +3745,7 @@ frame_T     *before, *frp;
 /*
  * Remove a frame from a frame list.
  */
-static void frame_remove(frp)
-frame_T     *frp;
+static void frame_remove(frame_T *frp)
 {
   if (frp->fr_prev != NULL)
     frp->fr_prev->fr_next = frp->fr_next;
@@ -3802,8 +3760,7 @@ frame_T     *frp;
  * Allocate w_lines[] for window "wp".
  * Return FAIL for failure, OK for success.
  */
-int win_alloc_lines(wp)
-win_T       *wp;
+int win_alloc_lines(win_T *wp)
 {
   wp->w_lines_valid = 0;
   wp->w_lines = (wline_T *)alloc_clear((unsigned)(Rows * sizeof(wline_T)));
@@ -3815,8 +3772,7 @@ win_T       *wp;
 /*
  * free lsize arrays for a window
  */
-void win_free_lsize(wp)
-win_T       *wp;
+void win_free_lsize(win_T *wp)
 {
   vim_free(wp->w_lines);
   wp->w_lines = NULL;
@@ -3826,7 +3782,7 @@ win_T       *wp;
  * Called from win_new_shellsize() after Rows changed.
  * This only does the current tab page, others must be done when made active.
  */
-void shell_new_rows()          {
+void shell_new_rows(void)          {
   int h = (int)ROWS_AVAIL;
 
   if (firstwin == NULL)         /* not initialized yet */
@@ -3849,7 +3805,7 @@ void shell_new_rows()          {
 /*
  * Called from win_new_shellsize() after Columns changed.
  */
-void shell_new_columns()          {
+void shell_new_columns(void)          {
   if (firstwin == NULL)         /* not initialized yet */
     return;
 
@@ -3865,8 +3821,7 @@ void shell_new_columns()          {
 /*
  * Save the size of all windows in "gap".
  */
-void win_size_save(gap)
-garray_T    *gap;
+void win_size_save(garray_T *gap)
 
 {
   win_T       *wp;
@@ -3884,8 +3839,7 @@ garray_T    *gap;
  * Restore window sizes, but only if the number of windows is still the same.
  * Does not free the growarray.
  */
-void win_size_restore(gap)
-garray_T    *gap;
+void win_size_restore(garray_T *gap)
 {
   win_T       *wp;
   int i;
@@ -3906,7 +3860,7 @@ garray_T    *gap;
  * frames.
  * Returns the row just after the last window.
  */
-int win_comp_pos()         {
+int win_comp_pos(void)         {
   int row = tabline_height();
   int col = 0;
 
@@ -3920,10 +3874,7 @@ int win_comp_pos()         {
  * "*row" and "*col" are the top-left position of the frame.  They are updated
  * to the bottom-right position plus one.
  */
-static void frame_comp_pos(topfrp, row, col)
-frame_T     *topfrp;
-int         *row;
-int         *col;
+static void frame_comp_pos(frame_T *topfrp, int *row, int *col)
 {
   win_T       *wp;
   frame_T     *frp;
@@ -3961,8 +3912,7 @@ int         *col;
  * Set current window height and take care of repositioning other windows to
  * fit around it.
  */
-void win_setheight(height)
-int height;
+void win_setheight(int height)
 {
   win_setheight_win(height, curwin);
 }
@@ -3971,9 +3921,7 @@ int height;
  * Set the window height of window "win" and take care of repositioning other
  * windows to fit around it.
  */
-void win_setheight_win(height, win)
-int height;
-win_T       *win;
+void win_setheight_win(int height, win_T *win)
 {
   int row;
 
@@ -4018,9 +3966,7 @@ win_T       *win;
  * Check for the minimal height of the FR_ROW frame.
  * At the top level we can also use change the command line height.
  */
-static void frame_setheight(curfrp, height)
-frame_T     *curfrp;
-int height;
+static void frame_setheight(frame_T *curfrp, int height)
 {
   int room;                     /* total number of lines available */
   int take;                     /* number of lines taken from other windows */
@@ -4168,15 +4114,12 @@ int height;
  * Set current window width and take care of repositioning other windows to
  * fit around it.
  */
-void win_setwidth(width)
-int width;
+void win_setwidth(int width)
 {
   win_setwidth_win(width, curwin);
 }
 
-void win_setwidth_win(width, wp)
-int width;
-win_T       *wp;
+void win_setwidth_win(int width, win_T *wp)
 {
   /* Always keep current window at least one column wide, even when
    * 'winminwidth' is zero. */
@@ -4202,9 +4145,7 @@ win_T       *wp;
  *
  * Strategy is similar to frame_setheight().
  */
-static void frame_setwidth(curfrp, width)
-frame_T     *curfrp;
-int width;
+static void frame_setwidth(frame_T *curfrp, int width)
 {
   int room;                     /* total number of lines available */
   int take;                     /* number of lines taken from other windows */
@@ -4328,7 +4269,7 @@ int width;
 /*
  * Check 'winminheight' for a valid value.
  */
-void win_setminheight()          {
+void win_setminheight(void)          {
   int room;
   int first = TRUE;
   win_T       *wp;
@@ -4352,9 +4293,7 @@ void win_setminheight()          {
 /*
  * Status line of dragwin is dragged "offset" lines down (negative is up).
  */
-void win_drag_status_line(dragwin, offset)
-win_T       *dragwin;
-int offset;
+void win_drag_status_line(win_T *dragwin, int offset)
 {
   frame_T     *curfr;
   frame_T     *fr;
@@ -4468,9 +4407,7 @@ int offset;
 /*
  * Separator line of dragwin is dragged "offset" lines right (negative is left).
  */
-void win_drag_vsep_line(dragwin, offset)
-win_T       *dragwin;
-int offset;
+void win_drag_vsep_line(win_T *dragwin, int offset)
 {
   frame_T     *curfr;
   frame_T     *fr;
@@ -4562,8 +4499,7 @@ int offset;
 /*
  * Set wp->w_fraction for the current w_wrow and w_height.
  */
-static void set_fraction(wp)
-win_T       *wp;
+static void set_fraction(win_T *wp)
 {
   wp->w_fraction = ((long)wp->w_wrow * FRACTION_MULT
                     + FRACTION_MULT / 2) / (long)wp->w_height;
@@ -4574,9 +4510,7 @@ win_T       *wp;
  * This takes care of the things inside the window, not what happens to the
  * window position, the frame or to other windows.
  */
-void win_new_height(wp, height)
-win_T       *wp;
-int height;
+void win_new_height(win_T *wp, int height)
 {
   linenr_T lnum;
   int sline, line_size;
@@ -4688,9 +4622,7 @@ int height;
 /*
  * Set the width of a window.
  */
-void win_new_width(wp, width)
-win_T       *wp;
-int width;
+void win_new_width(win_T *wp, int width)
 {
   wp->w_width = width;
   wp->w_lines_valid = 0;
@@ -4704,8 +4636,7 @@ int width;
   wp->w_redr_status = TRUE;
 }
 
-void win_comp_scroll(wp)
-win_T       *wp;
+void win_comp_scroll(win_T *wp)
 {
   wp->w_p_scr = ((unsigned)wp->w_height >> 1);
   if (wp->w_p_scr == 0)
@@ -4715,7 +4646,7 @@ win_T       *wp;
 /*
  * command_height: called whenever p_ch has been changed
  */
-void command_height()          {
+void command_height(void)          {
   int h;
   frame_T     *frp;
   int old_p_ch = curtab->tp_ch_used;
@@ -4782,9 +4713,7 @@ void command_height()          {
  * Resize frame "frp" to be "n" lines higher (negative for less high).
  * Also resize the frames it is contained in.
  */
-static void frame_add_height(frp, n)
-frame_T     *frp;
-int n;
+static void frame_add_height(frame_T *frp, int n)
 {
   frame_new_height(frp, frp->fr_height + n, FALSE, FALSE);
   for (;; ) {
@@ -4799,17 +4728,17 @@ int n;
  * Add or remove a status line for the bottom window(s), according to the
  * value of 'laststatus'.
  */
-void last_status(morewin)
-int morewin;                    /* pretend there are two or more windows */
+void 
+last_status (
+    int morewin                    /* pretend there are two or more windows */
+)
 {
   /* Don't make a difference between horizontal or vertical split. */
   last_status_rec(topframe, (p_ls == 2
                              || (p_ls == 1 && (morewin || lastwin != firstwin))));
 }
 
-static void last_status_rec(fr, statusline)
-frame_T     *fr;
-int statusline;
+static void last_status_rec(frame_T *fr, int statusline)
 {
   frame_T     *fp;
   win_T       *wp;
@@ -4861,7 +4790,7 @@ int statusline;
 /*
  * Return the number of lines used by the tab page line.
  */
-int tabline_height()         {
+int tabline_height(void)         {
   switch (p_stal) {
   case 0: return 0;
   case 1: return (first_tabpage->tp_next == NULL) ? 0 : 1;
@@ -4874,9 +4803,7 @@ int tabline_height()         {
  * If Visual mode is active, use the selected text if it's in one line.
  * Returns the name in allocated memory, NULL for failure.
  */
-char_u * grab_file_name(count, file_lnum)
-long count;
-linenr_T    *file_lnum;
+char_u *grab_file_name(long count, linenr_T *file_lnum)
 {
   if (VIsual_active) {
     int len;
@@ -4905,10 +4832,7 @@ linenr_T    *file_lnum;
  * FNAME_HYP	    check for hypertext link
  * FNAME_INCL	    apply "includeexpr"
  */
-char_u * file_name_at_cursor(options, count, file_lnum)
-int options;
-long count;
-linenr_T    *file_lnum;
+char_u *file_name_at_cursor(int options, long count, linenr_T *file_lnum)
 {
   return file_name_in_line(ml_get_curline(),
       curwin->w_cursor.col, options, count, curbuf->b_ffname,
@@ -4919,13 +4843,15 @@ linenr_T    *file_lnum;
  * Return the name of the file under or after ptr[col].
  * Otherwise like file_name_at_cursor().
  */
-char_u * file_name_in_line(line, col, options, count, rel_fname, file_lnum)
-char_u      *line;
-int col;
-int options;
-long count;
-char_u      *rel_fname;         /* file we are searching relative to */
-linenr_T    *file_lnum;         /* line number after the file name */
+char_u *
+file_name_in_line (
+    char_u *line,
+    int col,
+    int options,
+    long count,
+    char_u *rel_fname,         /* file we are searching relative to */
+    linenr_T *file_lnum         /* line number after the file name */
+)
 {
   char_u      *ptr;
   int len;
@@ -4996,9 +4922,7 @@ linenr_T    *file_lnum;         /* line number after the file name */
 
 static char_u *eval_includeexpr __ARGS((char_u *ptr, int len));
 
-static char_u * eval_includeexpr(ptr, len)
-char_u      *ptr;
-int len;
+static char_u *eval_includeexpr(char_u *ptr, int len)
 {
   char_u      *res;
 
@@ -5013,12 +4937,14 @@ int len;
  * Return the name of the file ptr[len] in 'path'.
  * Otherwise like file_name_at_cursor().
  */
-char_u * find_file_name_in_path(ptr, len, options, count, rel_fname)
-char_u      *ptr;
-int len;
-int options;
-long count;
-char_u      *rel_fname;         /* file we are searching relative to */
+char_u *
+find_file_name_in_path (
+    char_u *ptr,
+    int len,
+    int options,
+    long count,
+    char_u *rel_fname         /* file we are searching relative to */
+)
 {
   char_u      *file_name;
   int c;
@@ -5076,8 +5002,7 @@ char_u      *rel_fname;         /* file we are searching relative to */
  * Also check for ":\\", which MS Internet Explorer accepts, return
  * URL_BACKSLASH.
  */
-static int path_is_url(p)
-char_u  *p;
+static int path_is_url(char_u *p)
 {
   if (STRNCMP(p, "://", (size_t)3) == 0)
     return URL_SLASH;
@@ -5091,8 +5016,7 @@ char_u  *p;
  * Return URL_BACKSLASH for "name:\\".
  * Return zero otherwise.
  */
-int path_with_url(fname)
-char_u *fname;
+int path_with_url(char_u *fname)
 {
   char_u *p;
 
@@ -5104,8 +5028,7 @@ char_u *fname;
 /*
  * Return TRUE if "name" is a full (absolute) path name or URL.
  */
-int vim_isAbsName(name)
-char_u      *name;
+int vim_isAbsName(char_u *name)
 {
   return path_with_url(name) != 0 || mch_isFullName(name);
 }
@@ -5115,10 +5038,13 @@ char_u      *name;
  *
  * return FAIL for failure, OK otherwise
  */
-int vim_FullName(fname, buf, len, force)
-char_u      *fname, *buf;
-int len;
-int force;                  /* force expansion even when already absolute */
+int 
+vim_FullName (
+    char_u *fname,
+    char_u *buf,
+    int len,
+    int force                  /* force expansion even when already absolute */
+)
 {
   int retval = OK;
   int url;
@@ -5141,7 +5067,7 @@ int force;                  /* force expansion even when already absolute */
  * Return the minimal number of rows that is needed on the screen to display
  * the current number of windows.
  */
-int min_rows()         {
+int min_rows(void)         {
   int total;
   tabpage_T   *tp;
   int n;
@@ -5165,7 +5091,7 @@ int min_rows()         {
  * counting a help or preview window, unless it is the current window.
  * Does not count "aucmd_win".
  */
-int only_one_window()         {
+int only_one_window(void)         {
   int count = 0;
   win_T       *wp;
 
@@ -5189,8 +5115,7 @@ int only_one_window()         {
  * current buffer, and before applying autocommands.
  * When "do_curwin" is TRUE, also check current window.
  */
-void check_lnums(do_curwin)
-int do_curwin;
+void check_lnums(int do_curwin)
 {
   win_T       *wp;
 
@@ -5221,16 +5146,13 @@ int do_curwin;
 /*
  * Create a snapshot of the current frame sizes.
  */
-void make_snapshot(idx)
-int idx;
+void make_snapshot(int idx)
 {
   clear_snapshot(curtab, idx);
   make_snapshot_rec(topframe, &curtab->tp_snapshot[idx]);
 }
 
-static void make_snapshot_rec(fr, frp)
-frame_T     *fr;
-frame_T     **frp;
+static void make_snapshot_rec(frame_T *fr, frame_T **frp)
 {
   *frp = (frame_T *)alloc_clear((unsigned)sizeof(frame_T));
   if (*frp == NULL)
@@ -5249,16 +5171,13 @@ frame_T     **frp;
 /*
  * Remove any existing snapshot.
  */
-static void clear_snapshot(tp, idx)
-tabpage_T   *tp;
-int idx;
+static void clear_snapshot(tabpage_T *tp, int idx)
 {
   clear_snapshot_rec(tp->tp_snapshot[idx]);
   tp->tp_snapshot[idx] = NULL;
 }
 
-static void clear_snapshot_rec(fr)
-frame_T     *fr;
+static void clear_snapshot_rec(frame_T *fr)
 {
   if (fr != NULL) {
     clear_snapshot_rec(fr->fr_next);
@@ -5272,9 +5191,11 @@ frame_T     *fr;
  * This is only done if the screen size didn't change and the window layout is
  * still the same.
  */
-void restore_snapshot(idx, close_curwin)
-int idx;
-int close_curwin;                   /* closing current window */
+void 
+restore_snapshot (
+    int idx,
+    int close_curwin                   /* closing current window */
+)
 {
   win_T       *wp;
 
@@ -5295,9 +5216,7 @@ int close_curwin;                   /* closing current window */
  * Check if frames "sn" and "fr" have the same layout, same following frames
  * and same children.
  */
-static int check_snapshot_rec(sn, fr)
-frame_T     *sn;
-frame_T     *fr;
+static int check_snapshot_rec(frame_T *sn, frame_T *fr)
 {
   if (sn->fr_layout != fr->fr_layout
       || (sn->fr_next == NULL) != (fr->fr_next == NULL)
@@ -5315,9 +5234,7 @@ frame_T     *fr;
  * following frames and children.
  * Returns a pointer to the old current window, or NULL.
  */
-static win_T * restore_snapshot_rec(sn, fr)
-frame_T     *sn;
-frame_T     *fr;
+static win_T *restore_snapshot_rec(frame_T *sn, frame_T *fr)
 {
   win_T       *wp = NULL;
   win_T       *wp2;
@@ -5353,12 +5270,7 @@ frame_T     *fr;
  * triggered, another tabpage access is limited.
  * Returns FAIL if switching to "win" failed.
  */
-int switch_win(save_curwin, save_curtab, win, tp, no_display)
-win_T       **save_curwin UNUSED;
-tabpage_T   **save_curtab UNUSED;
-win_T       *win UNUSED;
-tabpage_T   *tp UNUSED;
-int no_display UNUSED;
+int switch_win(win_T **save_curwin, tabpage_T **save_curtab, win_T *win, tabpage_T *tp, int no_display)
 {
   block_autocmds();
   *save_curwin = curwin;
@@ -5387,10 +5299,7 @@ int no_display UNUSED;
  * When "no_display" is TRUE the display won't be affected, no redraw is
  * triggered.
  */
-void restore_win(save_curwin, save_curtab, no_display)
-win_T       *save_curwin UNUSED;
-tabpage_T   *save_curtab UNUSED;
-int no_display UNUSED;
+void restore_win(win_T *save_curwin, tabpage_T *save_curtab, int no_display)
 {
   if (save_curtab != NULL && valid_tabpage(save_curtab)) {
     if (no_display) {
@@ -5413,9 +5322,7 @@ int no_display UNUSED;
  * Make "buf" the current buffer.  restore_buffer() MUST be called to undo.
  * No autocommands will be executed.  Use aucmd_prepbuf() if there are any.
  */
-void switch_buffer(save_curbuf, buf)
-buf_T *buf;
-buf_T **save_curbuf;
+void switch_buffer(buf_T **save_curbuf, buf_T *buf)
 {
   block_autocmds();
   *save_curbuf = curbuf;
@@ -5428,8 +5335,7 @@ buf_T **save_curbuf;
 /*
  * Restore the current buffer after using switch_buffer().
  */
-void restore_buffer(save_curbuf)
-buf_T *save_curbuf;
+void restore_buffer(buf_T *save_curbuf)
 {
   unblock_autocmds();
   /* Check for valid buffer, just in case. */
@@ -5450,12 +5356,7 @@ buf_T *save_curbuf;
  * If no particular ID is desired, -1 must be specified for 'id'.
  * Return ID of added match, -1 on failure.
  */
-int match_add(wp, grp, pat, prio, id)
-win_T       *wp;
-char_u      *grp;
-char_u      *pat;
-int prio;
-int id;
+int match_add(win_T *wp, char_u *grp, char_u *pat, int prio, int id)
 {
   matchitem_T *cur;
   matchitem_T *prev;
@@ -5530,10 +5431,7 @@ int id;
  * Delete match with ID 'id' in the match list of window 'wp'.
  * Print error messages if 'perr' is TRUE.
  */
-int match_delete(wp, id, perr)
-win_T       *wp;
-int id;
-int perr;
+int match_delete(win_T *wp, int id, int perr)
 {
   matchitem_T *cur = wp->w_match_head;
   matchitem_T *prev = cur;
@@ -5567,8 +5465,7 @@ int perr;
 /*
  * Delete all matches in the match list of window 'wp'.
  */
-void clear_matches(wp)
-win_T       *wp;
+void clear_matches(win_T *wp)
 {
   matchitem_T *m;
 
@@ -5586,9 +5483,7 @@ win_T       *wp;
  * Get match from ID 'id' in window 'wp'.
  * Return NULL if match not found.
  */
-matchitem_T * get_match(wp, id)
-win_T       *wp;
-int id;
+matchitem_T *get_match(win_T *wp, int id)
 {
   matchitem_T *cur = wp->w_match_head;
 
@@ -5601,9 +5496,7 @@ int id;
 /*
  * Return TRUE if "topfrp" and its children are at the right height.
  */
-static int frame_check_height(topfrp, height)
-frame_T *topfrp;
-int height;
+static int frame_check_height(frame_T *topfrp, int height)
 {
   frame_T *frp;
 
@@ -5621,9 +5514,7 @@ int height;
 /*
  * Return TRUE if "topfrp" and its children are at the right width.
  */
-static int frame_check_width(topfrp, width)
-frame_T *topfrp;
-int width;
+static int frame_check_width(frame_T *topfrp, int width)
 {
   frame_T *frp;
 


### PR DESCRIPTION
My stab at issue #64 by Gaelan who is working line-by-line and taking a lot more care.

Some notes:
- I used [cproto](http://invisible-island.net/cproto/) to do the conversion and have not verified every single change; manual tweaks were made only when errors arose.
- I modified the cproto grammar to accept vim specific typedefs, which it for some reason did not pick up on automatically.
- Two files were troublesome (`mbyte.c` and `os_unix.c`) and so I simply skipped them for now (they are still in the old style). This is not a problem because the two styles can coexist without issue.
- Comments in parameter declarations were preserved, but use of macros like `UNUSED` were simply removed altogether.
- Because these changes are not complete I am leaving this in a branch so others can help vet the changes for correctness and continue the work before we decide whether or not to include the changes at all.

The point about the `UNUSED` macro may or may not be an issue; here is my rationale for removing it:
- The macro was specific to compilers which defined a specific `__attribute__`, even though there are solutions which are more general; these general solutions, however, require a macro parameter and cannot be used in the format parameter list so the conversion is nontrivial and will probably require manual intervention anyway. (One example of such a macro is  [here](http://stackoverflow.com/questions/3599160/unused-parameter-warnings-in-c-code#3599170))
- Many compilers offer a means of ignoring warning on unused parameters (for example GCCs `-Wno-unused-parameter`) which makes the addition of macros in the code unnecessary.
- While the `UNUSED` macro is certainly good documentation, it could easily become stale and lead to confusion. If it is solely included for documentation it could just as well be a comment.

Let me know what you think.
