### PR TITLE
[RFC] Changed splash screen, --version messages and comments (VIM to NeoVIM).

### DIFF
--- a/src/version_defs.h
+++ b/src/version_defs.h
@@ -25,7 +25,7 @@
 #define VIM_VERSION_PATCHLEVEL           0
 #define VIM_VERSION_PATCHLEVEL_STR      "0"
 /* Used by MacOS port should be one of: development, alpha, beta, final */
-#define VIM_VERSION_RELEASE             final
+#define VIM_VERSION_RELEASE             development
 
 /*
  * VIM_VERSION_NODOT is used for the runtime directory name.
@@ -36,5 +36,8 @@
 #define VIM_VERSION_NODOT       "vim74"
 #define VIM_VERSION_SHORT       "7.4"
 #define VIM_VERSION_MEDIUM      "7.4"
-#define VIM_VERSION_LONG        "VIM - Vi IMproved 7.4 (2013 Aug 10)"
-#define VIM_VERSION_LONG_DATE   "VIM - Vi IMproved 7.4 (2013 Aug 10, compiled "
+#define VIM_VERSION_LONG        "VIM - Vi IMproved 7.4 (2014)"
+#define VIM_VERSION_LONG_DATE   "VIM - Vi IMproved 7.4 (2014, compiled "
+
+/* Displayed on splash screen. */
+#define MODIFIED_BY "the Neovim contributors."


### PR DESCRIPTION
An attempt at #92 which
- replaces "VIM - Vi IMproved" with "NeoVIM - New Vi IMproved"
- adds "the http://neovim.org/ contributors." as MODIFIED_BY to be displayed on splash screen.

Wording is up in the air, but the vim license explicitly requires we differentiate ourselves from the main distribution, i.e. by defining MODIFIED_BY.
