### PR TITLE
use CMake's built in pthread detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,15 @@ else()
   set(DEBUG 0)
 endif()
 
+# Determine platform's threading library. Set CMAKE_THREAD_PREFER_PTHREAD
+# explicitly to indicate a strong preference for pthread. It is an error to not
+# have pthread installed even if, for example, the Win32 threading API is found.
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+find_package(Threads REQUIRED)
+if(NOT CMAKE_USE_PTHREADS_INIT)
+  message(SEND_ERROR "The pthread library must be installed on your system.")
+endif(NOT CMAKE_USE_PTHREADS_INIT)
+
 # add dependencies to include/lib directories
 link_directories ("${PROJECT_SOURCE_DIR}/.deps/usr/lib")
 include_directories ("${PROJECT_SOURCE_DIR}/.deps/usr/include") 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ file( GLOB IO_SOURCES io/*.c )
 
 add_executable (vim ${NEOVIM_SOURCES} ${IO_SOURCES}) 
 
-target_link_libraries (vim m uv pthread)
+target_link_libraries (vim m uv ${CMAKE_THREAD_LIBS_INIT})
 
 include(CheckLibraryExists)
 check_library_exists(termcap tgetent "" HAVE_LIBTERMCAP)


### PR DESCRIPTION
CMake ships with a standard FindThreads module which can be used to a) test for a threading library and b) confirm that it is pthread. It also allows the hard-coding of the threading library name to be removed from `src/CMakeLists.txt`.

Make it an error not to have a pthread library installed and indicate to CMake that we strongly prefer pthread to any other platform threading library.
