### PR TITLE
address low-hanging fruit in port to libuv

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1,0 +1,26 @@
+/* vi:set ts=8 sts=4 sw=4:
+ *
+ * VIM - Vi IMproved	by Bram Moolenaar
+ *
+ * Do ":help uganda"  in Vim to read copying and usage conditions.
+ * Do ":help credits" in Vim to see a list of people who contributed.
+ * See README.txt for an overview of the Vim source code.
+ */
+
+/*
+ * io.c -- filesystem access, event loop etc.
+ */
+
+#include "vim.h"
+
+#include "uv.h"
+
+int mch_chdir(char *path)
+{
+  if (p_verbose >= 5) {
+    verbose_enter();
+    smsg((char_u *)"chdir(%s)", path);
+    verbose_leave();
+  }
+  return uv_chdir(path);
+}

--- a/src/os.c
+++ b/src/os.c
@@ -1,0 +1,27 @@
+/* vi:set ts=8 sts=4 sw=4:
+ *
+ * VIM - Vi IMproved	by Bram Moolenaar
+ *
+ * Do ":help uganda"  in Vim to read copying and usage conditions.
+ * Do ":help credits" in Vim to see a list of people who contributed.
+ * See README.txt for an overview of the Vim source code.
+ */
+
+/*
+ * os.c -- OS-level calls to query hardware, etc.
+ */
+
+#include "vim.h"
+
+#include "uv.h"
+
+/*
+ * Return total amount of memory available in Kbyte.
+ * Doesn't change when memory has been allocated.
+ */
+long_u mch_total_mem(int special)
+{
+  /* We need to return memory in *Kbytes* but uv_get_total_memory() returns the
+   * number of bytes of total memory. */
+  return uv_get_total_memory() >> 10;
+}

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -32,8 +32,6 @@
 
 #include "os_unixx.h"       /* unix includes for os_unix.c only */
 
-#include "uv.h"
-
 #ifdef HAVE_SELINUX
 # include <selinux/selinux.h>
 static int selinux_enabled = -1;
@@ -222,16 +220,6 @@ static struct signalinfo {
   {-1,            "Unknown!", FALSE}
 };
 
-int mch_chdir(char *path)
-{
-  if (p_verbose >= 5) {
-    verbose_enter();
-    smsg((char_u *)"chdir(%s)", path);
-    verbose_leave();
-  }
-  return uv_chdir(path);
-}
-
 /*
  * Write s[len] to the screen.
  */
@@ -331,17 +319,6 @@ static void handle_resize()                 {
  */
 int mch_char_avail()         {
   return WaitForChar(0L);
-}
-
-/*
- * Return total amount of memory available in Kbyte.
- * Doesn't change when memory has been allocated.
- */
-long_u mch_total_mem(int special)
-{
-  /* We need to return memory in *Kbytes* but uv_get_total_memory() returns the
-   * number of bytes of total memory. */
-  return uv_get_total_memory() >> 10;
 }
 
 void mch_delay(long msec, int ignoreinput)

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -32,6 +32,7 @@
 
 #include "os_unixx.h"       /* unix includes for os_unix.c only */
 
+#include "uv.h"
 
 #ifdef HAVE_SELINUX
 # include <selinux/selinux.h>

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -229,7 +229,7 @@ int mch_chdir(char *path)
     smsg((char_u *)"chdir(%s)", path);
     verbose_leave();
   }
-  return chdir(path);
+  return uv_chdir(path);
 }
 
 /*

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -149,17 +149,6 @@
 # undef __ARGS
 #endif
 
-#if (defined(HAVE_SYS_RESOURCE_H) && defined(HAVE_GETRLIMIT)) \
-  || (defined(HAVE_SYS_SYSINFO_H) && defined(HAVE_SYSINFO)) \
-  || defined(HAVE_SYSCTL) || defined(HAVE_SYSCONF)
-# define HAVE_TOTAL_MEM
-#endif
-
-
-
-
-
-
 /*
  * Unix system-dependent file names
  */


### PR DESCRIPTION
As noted in #3, os_unix.c will eventually be ported to libuv. Grab the low-hanging fruit for that task by using the exact like-for-like functionality provided by libuv which can be used to replace some code in os_unix.c. Specifically `mch_chdir()` and `mch_total_mem()`.

The longest journey begins with the smallest step :).
