### PR TITLE
add editorconfig file for neovim

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = false
+trim_trailing_whitespace = false
+
+[*.c]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) is a cross-editor configuration file which specifies a project indent style, newline, etc, etc. This is a minimal "document the current standard" file which should be updated once #104 is decided.

It seems somewhat perverse to include a cross-editor configuration file for neovim when it is probably one of the few projects where one knows which editor the developers will be using. That being said, vim (and by extension neovim) has good support for EditorConfig.
