### PR TITLE
Arch linux link in TOC had the wrong indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   * [For Debian/Ubuntu](#for-debianubuntu)
   * [For FreeBSD 10](#for-freebsd-10)
   * [For OS X](#for-os-x)
-* [For Arch Linux](#for-arch-linux)
+  * [For Arch Linux](#for-arch-linux)
 * [Building](#building)
 * [Community](#community)
 * [Contributing](#contributing)


### PR DESCRIPTION
One other minor fix for the table of contents, the arch linux link was not indented properly, which this fixes.
