### PR TITLE
Following GitHub convention by adding a CONTRIBUTING.md file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Neovim
+
+## Thank you
+
+Thanks for considering contributing to neovim. To make the process as smooth
+as possible we would ask you to follow the guidelines below.
+
+## Help with contributing
+
+See [Communicating](https://github.com/neovim/neovim/wiki/Communicating).
+Raise documentation issues.
+
+## Guidelines
+
+### Finding something to do
+
+Neovim uses [waffle.io](https://waffle.io/neovim/neovim), so check there
+first.
+
+You can also ask for an issues to be assigned to you.
+Ideally wait until we assign it to you to minimize
+work duplication.
+
+### Reporting an issue
+
+- Search existing issues before raising a new one.
+- Include as much detail as possible. In particular, we need to know which
+  OS you're using.
+
+### Pull requests
+
+- Make it clear in the issue tracker what you are working on, so that
+someone else doesn't duplicate the work.
+- Use a feature branch, not master.
+- Rebase your feature branch onto origin/master before raising the PR.
+- Keep up to date with changes in master so your PR is easy to merge.
+- Be descriptive in your PR message: what is it for, why is it needed, etc.
+- Make sure the tests pass (TODO: we need to make this easier with travis etc.)
+- Squash related commits as much as possible.
+
+### Coding style
+
+- Try to match the existing indent style. (TODO: specify)
+- Don't abuse the pre-processor.
+- Don't mix platform-specific stuff into the main code.
+- TODO: commit messages?


### PR DESCRIPTION
Adding `CONTRIBUTING.md` with the content from the contributing page of the wiki. GitHub recognizes this file and links to it when people try to contribute to a repository. This will help ensure that people understand the contribution guidelines set out for this project before they contribute.
