### PR TITLE
Add install target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: c
-script: make cmake && make test
+script: make cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$PWD/dist" && make test && make install

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ clean:
 		rm -f src/testdir/$$file.vim; \
 	done
 
-.PHONY: test deps cmake
+install: build/bin/nvim
+	cd build && make install
+
+.PHONY: test deps cmake install
 
 .DEFAULT: build/bin/nvim

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=Debug
 
+# Extra CMake flags which extend the default set
+CMAKE_EXTRA_FLAGS :=
+
 build/bin/nvim: deps
 	cd build && make
 
@@ -15,7 +18,7 @@ deps: .deps/usr/lib/libuv.a
 
 cmake: clean
 	mkdir build
-	cd build && cmake $(CMAKE_FLAGS) ../
+	cd build && cmake $(CMAKE_FLAGS) $(CMAKE_EXTRA_FLAGS) ../
 
 clean:
 	rm -rf build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,3 +31,5 @@ else()
 endif()
 
 include_directories ("${PROJECT_SOURCE_DIR}/src/proto") 
+
+install(TARGETS nvim RUNTIME DESTINATION bin)


### PR DESCRIPTION
Add an install target to CMake. Also add a compatibility install target to the top-level Makefile but it's a bit ugly. Installation location is set via the standard `CMAKE_INSTALL_PREFIX` variable.

Since it's trivial, add `make install` as a step which must succeed in Travis too.

I would not cry if only d63ad0d were cherry-picked but the remaining commits help maintain the use of the top-level Makefile as the "start of all things".

Closes #89.
