### PR TITLE
Add missing brew dependency : wget/gettext

### DIFF
--- a/neovim.rb
+++ b/neovim.rb
@@ -8,6 +8,8 @@ class Neovim < Formula
   depends_on 'cmake'
   depends_on 'libtool'
   depends_on 'automake'
+  depends_on 'wget'
+  depends_on 'gettext'
 
   def install
     system "make", "PREFIX=#{prefix}", "cmake"


### PR DESCRIPTION
It seems wget and gettext are required to build neovim.
