### PR TITLE
If Ninja is available, use it instead of make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,27 @@
 CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=Debug
 
+BUILD_TYPE := $(shell (type ninja > /dev/null 2>&1 && echo "Ninja") || \
+    echo "Unix Makefiles")
+
+ifeq (Ninja,$(BUILD_TYPE))
+    ifneq ($(shell cmake --help 2>/dev/null | grep Ninja),)
+        HAS_CNINJA := $(shell type cninja 2>/dev/null)
+        ifeq ($(HAS_CNINJA),)
+            BUILD_TOOL := ninja
+        else
+            BUILD_TOOL := cninja
+        endif
+    else
+        # User's version of CMake doesn't support Ninja
+        BUILD_TOOL := make
+        BUILD_TYPE := Unix Makefiles
+    endif
+else
+    BUILD_TOOL := make
+endif
+
 build/src/vim: deps
-	cd build && make
+	cd build && $(BUILD_TOOL)
 
 test: build/src/vim
 	cd src/testdir && make
@@ -13,7 +33,7 @@ deps: .deps/usr/lib/libuv.a
 
 cmake: clean
 	mkdir build
-	cd build && cmake $(CMAKE_FLAGS) ../
+	cd build && cmake -G "$(BUILD_TYPE)" $(CMAKE_FLAGS) ../
 
 clean:
 	rm -rf build


### PR DESCRIPTION
Fall back to make if the user's version of CMake doesn't support Ninja.
Also, use cninja to launch the build, if it's available.  Otherwise,
just use ninja.  You can find cninja at
https://github.com/frankmiller/cninja.
