### PR TITLE
os_unix: Use libuv uv_cwd instead of getcwd/getwd.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -12,6 +12,7 @@
  */
 
 #include "vim.h"
+#include "os/os.h"
 
 
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -12,6 +12,7 @@
  */
 
 #include "vim.h"
+#include "os/os.h"
 
 
 #if defined(HAVE_UTIME) && defined(HAVE_UTIME_H)

--- a/src/mark.c
+++ b/src/mark.c
@@ -12,6 +12,7 @@
  */
 
 #include "vim.h"
+#include "os/os.h"
 
 /*
  * This file contains routines to maintain and manipulate marks.

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -23,3 +23,17 @@ int mch_chdir(char *path) {
   }
   return uv_chdir(path);
 }
+
+/*
+ * Get name of current directory into buffer 'buf' of length 'len' bytes.
+ * Return OK for success, FAIL for failure.
+ */
+int mch_dirname(char_u *buf, int len)
+{
+  int errno;
+  if ((errno = uv_cwd((char *)buf, len)) != 0) {
+      STRCPY(buf, uv_strerror(errno));
+      return FAIL;
+  }
+  return OK;
+}

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -5,5 +5,6 @@
 
 long_u mch_total_mem(int special);
 int mch_chdir(char *path);
+int mch_dirname(char_u *buf, int len);
 
 #endif

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1245,24 +1245,6 @@ static char * strerror(int err)
 #endif
 
 /*
- * Get name of current directory into buffer 'buf' of length 'len' bytes.
- * Return OK for success, FAIL for failure.
- */
-int mch_dirname(char_u *buf, int len)
-{
-#if defined(USE_GETCWD)
-  if (getcwd((char *)buf, len) == NULL) {
-    STRCPY(buf, strerror(errno));
-    return FAIL;
-  }
-  return OK;
-#else
-  return getwd((char *)buf) != NULL ? OK : FAIL;
-#endif
-}
-
-
-/*
  * Get absolute file name into "buf[len]".
  *
  * return FAIL for failure, OK for success

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -27,7 +27,6 @@ int mch_get_user_name __ARGS((char_u *s, int len));
 int mch_get_uname __ARGS((uid_t uid, char_u *s, int len));
 void mch_get_host_name __ARGS((char_u *s, int len));
 long mch_get_pid __ARGS((void));
-int mch_dirname __ARGS((char_u *buf, int len));
 void slash_adjust __ARGS((char_u *p));
 int mch_FullName __ARGS((char_u *fname, char_u *buf, int len, int force));
 int mch_isFullName __ARGS((char_u *fname));

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -12,6 +12,7 @@
  */
 
 #include "vim.h"
+#include "os/os.h"
 
 
 struct dir_stack_T {


### PR DESCRIPTION
#135
