### PR TITLE
Add a "modified by" message to :version and :intro to comply with the license

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -24,6 +24,8 @@
 
 #include "version.h"
 
+#define MODIFIED_BY "the Neovim contributors"
+
 char            *Version = VIM_VERSION_SHORT;
 static char     *mediumVersion = VIM_VERSION_MEDIUM;
 


### PR DESCRIPTION
The Vim License states:
"3) A message must be added, at least in the output of the ":version"
       command and in the intro screen, such that the user of the modified Vim
       is able to see that it was modified.  When distributing as mentioned
       under 2)e) adding the message is only required for as far as this does
       not conflict with the license used for the changes."

Turns out this is a really simple change as Vim has a built in MODIFIED_BY preprocessor directive to do just this.
