### PR TITLE
Delete local function strerror and USE_GETCWD define.

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1228,22 +1228,6 @@ long mch_get_pid()          {
   return (long)getpid();
 }
 
-#if !defined(HAVE_STRERROR) && defined(USE_GETCWD)
-static char *strerror __ARGS((int));
-
-static char * strerror(int err)
-{
-  extern int sys_nerr;
-  extern char     *sys_errlist[];
-  static char er[20];
-
-  if (err > 0 && err < sys_nerr)
-    return sys_errlist[err];
-  sprintf(er, "Error %d", err);
-  return er;
-}
-#endif
-
 #if defined(USE_FNAME_CASE) || defined(PROTO)
 /*
  * Set the case of the file name, if it already exists.  This will cause the

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -42,16 +42,6 @@
  * Sun defines FILE on SunOS 4.x.x, Solaris has a typedef for FILE
  */
 
-/*
- * Using getcwd() is preferred, because it checks for a buffer overflow.
- * Don't use getcwd() on systems do use system("sh -c pwd").  There is an
- * autoconf check for this.
- * Use getcwd() anyway if getwd() isn't present.
- */
-#if defined(HAVE_GETCWD) && !(defined(BAD_GETCWD) && defined(HAVE_GETWD))
-# define USE_GETCWD
-#endif
-
 #ifndef __ARGS
 /* The AIX VisualAge cc compiler defines __EXTENDED__ instead of __STDC__
  * because it includes pre-ansi features. */


### PR DESCRIPTION
Both are useless after porting mch_dirname to libuv.

Following up #136.
