### PR TITLE
Fixed nvim homebrew formula

### DIFF
--- a/neovim.rb
+++ b/neovim.rb
@@ -12,5 +12,6 @@ class Neovim < Formula
   def install
     system "make", "PREFIX=#{prefix}", "cmake"
     system "make", "PREFIX=#{prefix}"
+    system "make", "PREFIX=#{prefix}", "install"
   end
 end


### PR DESCRIPTION
I did a fake `make install` to move the binary `nvim`
to `#{prefix}/bin/nvim`, which completes the build for homebrew.

Once we get a sensible `make install` with man pages and stuff, we can switch to that.

Closes #107.
