### PR TITLE
Remove implicit declaration of vim_strrchr and vim_strncpy

### DIFF
--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -15,6 +15,7 @@
 
 #include "os.h"
 #include "../message.h"
+#include "../misc2.h"
 
 int mch_chdir(char *path) {
   if (p_verbose >= 5) {


### PR DESCRIPTION
Function from misc2.c are used in os/fs.c but the header was not included.
