### PR TITLE
Remove final build warning

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -966,9 +966,7 @@ static void parse_command_name(mparm_T *parmp)
   }
 }
 
-static bool parse_char_i(input, val)
-  char_u      **input;
-  char val;
+static bool parse_char_i(char_u **input, char val)
 {
   if (TOLOWER_ASC(**input) == val) {
     *input += 1;  /* or (*input)++ WITH parens */


### PR DESCRIPTION
This commit removes a K&R promoted parameter warning, the final warning
I have when building.

I realize that this creates only one function that is written in a
different style, but I thought it might be worth it to have a warning
free build.
