### PR TITLE
Makefile: use "make -C build" idiom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=.deps/usr
 CMAKE_EXTRA_FLAGS :=
 
 build/bin/nvim: deps
-	cd build && make
+	${MAKE} -C build
 
 test: build/bin/nvim
 	cd src/testdir && make
@@ -27,7 +27,7 @@ clean:
 	done
 
 install: build/bin/nvim
-	cd build && make install
+	${MAKE} -C build install
 
 .PHONY: test deps cmake install
 


### PR DESCRIPTION
Change an explicit `cd build && make` into the more usual `${MAKE} -C build` style of invoking make in a subdirectory. This should mean that `make -jN` from the top-level Makefile should work.

Closes #162.
