### PR TITLE
use shared libuv library if not using the bundled version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include local.mk
 
-CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=.deps/usr
+CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=.deps/usr -DLibUV_USE_STATIC=YES
 
 # Extra CMake flags which extend the default set
 CMAKE_EXTRA_FLAGS :=

--- a/cmake/FindLibUV.cmake
+++ b/cmake/FindLibUV.cmake
@@ -4,6 +4,9 @@
 #  LibUV_FOUND - system has libuv
 #  LibUV_INCLUDE_DIRS - the libuv include directories
 #  LibUV_LIBRARIES - link these to use libuv
+#
+# Set the LibUV_USE_STATIC variable to specify if static libraries should
+# be preferred to shared ones.
 
 include(LibFindMacros)
 
@@ -12,9 +15,16 @@ find_path(LibUV_INCLUDE_DIR
     NAMES uv.h
 )
 
+set(_uv_names uv)
+
+# If we're asked to use static linkage, add libuv.a as a preferred library name.
+if(LibUV_USE_STATIC)
+    list(INSERT _uv_names 0 libuv.a)
+endif(LibUV_USE_STATIC)
+
 # The library itself. Note that we prefer the static version.
 find_library(LibUV_LIBRARY
-    NAMES libuv.a uv
+    NAMES ${_uv_names}
 )
 
 # Set the include dir variables and the libraries and let libfind_process do the rest.


### PR DESCRIPTION
If a system libuv is used rather than the bundled one, use shared linkage to
allow for upgrades.

Closes #171.
