### PR TITLE
README: add note on RHEL/CentOS 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * [Status](#status)
 * [Dependencies](#dependencies)
   * [For Debian/Ubuntu](#for-debianubuntu)
-  * [For CentOS/RHEL](#centosrhel)
+  * [For CentOS/RHEL](#for-centos-rhel)
   * [For FreeBSD 10](#for-freebsd-10)
   * [For Arch Linux](#for-arch-linux)
   * [For OS X](#for-os-x)
@@ -278,6 +278,7 @@ and what is currently being worked on:
 
     sudo apt-get install libtool autoconf automake cmake libncurses5-dev g++
 
+<a name="for-centos-rhel"></a>
 ### CentOS/RHEL
 
 If you're using CentOS/RHEL 6 you need at least autoconf version 2.69 for

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 * [Status](#status)
 * [Dependencies](#dependencies)
   * [For Debian/Ubuntu](#for-debianubuntu)
+  * [For CentOS/RHEL](#centosrhel)
   * [For FreeBSD 10](#for-freebsd-10)
   * [For Arch Linux](#for-arch-linux)
   * [For OS X](#for-os-x)
@@ -276,6 +277,11 @@ and what is currently being worked on:
 ### Ubuntu/Debian
 
     sudo apt-get install libtool autoconf automake cmake libncurses5-dev g++
+
+### CentOS/RHEL
+
+If you're using CentOS/RHEL 6 you need at least autoconf version 2.69 for
+compiling the libuv dependency. See joyent/libuv#1158.
 
 <a name="for-freebsd-10"></a>
 ### FreeBSD 10


### PR DESCRIPTION
Add note on autoconf >2.69 being required for compilation under RHEL/CentOS.

Closes #178.
