### PR TITLE
Use CMAKE_C_FLAGS variable to set compiler flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,12 @@ set(NEOVIM_VERSION_PATCH 0)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-add_definitions(-DHAVE_CONFIG_H -Wall -std=gnu99)
+# If the C compiler is some GNU-alike, use the gnu99 standard and enable all warnings.
+if(CMAKE_COMPILER_IS_GNUCC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=gnu99")
+endif(CMAKE_COMPILER_IS_GNUCC)
+
+add_definitions(-DHAVE_CONFIG_H)
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   # cmake automatically appends -g to the compiler flags
   set(DEBUG 1)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * [Status](#status)
 * [Dependencies](#dependencies)
   * [For Debian/Ubuntu](#for-debianubuntu)
-  * [For CentOS/RHEL](#centosrhel)
+  * [For CentOS/RHEL](#for-centos-rhel)
   * [For FreeBSD 10](#for-freebsd-10)
   * [For Arch Linux](#for-arch-linux)
   * [For OS X](#for-os-x)
@@ -278,6 +278,7 @@ and what is currently being worked on:
 
     sudo apt-get install libtool autoconf automake cmake libncurses5-dev g++
 
+<a name="for-centos-rhel"></a>
 ### CentOS/RHEL
 
 If you're using CentOS/RHEL 6 you need at least autoconf version 2.69 for

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 * [Status](#status)
 * [Dependencies](#dependencies)
   * [For Debian/Ubuntu](#for-debianubuntu)
+  * [For CentOS/RHEL](#centosrhel)
   * [For FreeBSD 10](#for-freebsd-10)
   * [For Arch Linux](#for-arch-linux)
   * [For OS X](#for-os-x)
@@ -276,6 +277,11 @@ and what is currently being worked on:
 ### Ubuntu/Debian
 
     sudo apt-get install libtool autoconf automake cmake libncurses5-dev g++
+
+### CentOS/RHEL
+
+If you're using CentOS/RHEL 6 you need at least autoconf version 2.69 for
+compiling the libuv dependency. See joyent/libuv#1158.
 
 <a name="for-freebsd-10"></a>
 ### FreeBSD 10


### PR DESCRIPTION
If the compiler is some GNU-alike variant, set the compiler flags to use the
gnu99 dialect of C and enable all warnings.

Non-GNU compilers may have to have their own magic added to set dialect and
enable warnings.

Closes #179.
