### PR TITLE
decouple third-party directory from build system unless desired

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Build/deps dir
 build/
-.deps/
+third-party/dist/
 
 *.rej
 *.orig

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,108 @@
+# Installation instructions
+
+Neovim has very few external dependencies which *must* be installed. It ships
+with uncommon dependencies bundled into the ``third-party`` directories. These
+are used for the "simple" compilation method outlined below.
+
+Those dependencies which must be installed are:
+
+* A working compiler, usually GCC
+* CMake
+* Autotools
+
+Those dependencies which *may* be installed are:
+
+* [libuv](https://github.com/joyent/libuv).
+
+## Building neovim
+
+There are many ways to build neovim depending on your needs and the amount of
+customization you require.
+
+### The all-in-one build script
+
+This method makes use of the dependencies bundled with the source tree and is
+provided as a convenience to those whose platforms do not provide packages for
+the dependencies and who do not wish to install them separately. Compilation is
+via a Makefile in the ``scripts/`` directory. In the top-level directory simply:
+
+```console
+$ make -C scripts/ build
+```
+
+To run the tests:
+```console
+$ make -C scripts/ test
+```
+
+There is also a top-level Makefile which will forward ``build`` and ``test`` to
+the ``scripts/Makefile``. This is purely for compatibility with some existing
+build scripts and will be removed.
+
+### CMake
+
+If you are packaging neovim or if you already have all the dependencies
+installed on your system, a standard CMake-based build may be used. This is the
+recommended option for developers since it will rapidly show any regressions
+between updated dependencies and neovim.
+
+```console
+$ mkdir build && cd build
+$ cmake .. && make              # For normal 'make'-based builds.
+$ cmake -G Ninja .. && ninja    # For faster builds using the 'ninja' utility.
+```
+
+### Homebrew on Mac
+
+    brew install neovim/neovim/neovim
+
+
+## Installing Dependencies
+
+This section gives some advice about installing the dependencies on various
+platforms.
+
+<a name="for-debianubuntu"></a>
+### Ubuntu/Debian
+
+    sudo apt-get install libtool autoconf automake cmake libncurses5-dev g++
+
+Versions of Ubuntu prior to trusty (14.04) do not provide a libuv package. You
+may either compile it from source or use the "simple" build method above.
+
+<a name="for-centos-rhel"></a>
+### CentOS/RHEL
+
+If you're using CentOS/RHEL 6 you need at least autoconf version 2.69 for
+compiling the libuv dependency. See joyent/libuv#1158.
+
+<a name="for-freebsd-10"></a>
+### FreeBSD 10
+
+    sudo pkg install cmake libtool sha
+
+<a name="for-arch-linux"></a>
+### Arch Linux
+
+    sudo pacman -S base-devel cmake ncurses
+
+<a name="for-os-x"></a>
+### OS X
+
+* Install [Xcode](https://developer.apple.com/) and [Homebrew](http://brew.sh)
+  or [MacPorts](http://www.macports.org)
+* Install sha1sum
+
+If you run into wget certificate errors, you may be missing the root SSL
+certificates or have not set them up correctly:
+
+  Via MacPorts:
+
+      sudo port install curl-ca-bundle libtool automake cmake
+      echo CA_CERTIFICATE=/opt/local/share/curl/curl-ca-bundle.crt >> ~/.wgetrc
+
+  Via Homebrew:
+
+      brew install curl-ca-bundle libtool automake cmake
+      echo CA_CERTIFICATE=$(brew --prefix curl-ca-bundle)/share/ca-bundle.crt >> ~/.wgetrc
+

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,14 @@
--include local.mk
+# This is a compatibility Makefile for neovim which is intended to make life
+# easier for some older build scripts. Its use is deprecated and it will be
+# removed.
 
-CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=.deps/usr -DLibUV_USE_STATIC=YES
+build:
+	$(MAKE) -C scripts/ build
 
-# Extra CMake flags which extend the default set
-CMAKE_EXTRA_FLAGS :=
+cmake:
+	$(MAKE) -C scripts/ cmake
 
-build/bin/nvim: deps
-	${MAKE} -C build
+test:
+	$(MAKE) -C scripts/ test
 
-test: build/bin/nvim
-	cd src/testdir && make
-
-deps: .deps/usr/lib/libuv.a
-
-.deps/usr/lib/libuv.a:
-	sh -e scripts/compile-libuv.sh
-
-cmake: clean deps
-	mkdir build
-	cd build && cmake $(CMAKE_FLAGS) $(CMAKE_EXTRA_FLAGS) ../
-
-clean:
-	rm -rf build
-	cd src/testdir && make clean
-
-install: build/bin/nvim
-	${MAKE} -C build install
-
-.PHONY: test deps cmake install
-
-.DEFAULT: build/bin/nvim
+.PHONY: build cmake test

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,7 @@ cmake:
 test:
 	$(MAKE) -C scripts/ test
 
-.PHONY: build cmake test
+test:
+	$(MAKE) -C scripts/ install
+
+.PHONY: build cmake test install

--- a/README.md
+++ b/README.md
@@ -317,15 +317,43 @@ certificates or have not set them up correctly:
 
 ## Building
 
-To generate the `Makefile`s:
+There are many ways to build neovim depending on your needs and the amount of
+customization you require.
 
-    make cmake
+### The all-in-one build script
 
-To build and run the tests:
+This method makes use of the dependencies bundled with the source tree and is
+provided as a convenience to those whose platforms do not provide packages for
+the dependencies and who do not wish to install them separately. Compilation is
+via a Makefile in the ``scripts/`` directory. In the top-level directory simply:
 
-    make test
+```console
+$ make -C scripts/ build
+```
 
-Using Homebrew on Mac:
+To run the tests:
+```console
+$ make -C scripts/ test
+```
+
+There is also a top-level Makefile which will forward ``build`` and ``test`` to
+the ``scripts/Makefile``. This is purely for compatibility with some existing
+build scripts and will be removed.
+
+### CMake
+
+If you are packaging neovim or if you already have all the dependencies
+installed on your system, a standard CMake-based build may be used. This is the
+recommended option for developers since it will rapidly show any regressions
+between updated dependencies and neovim.
+
+```console
+$ mkdir build && cd build
+$ cmake .. && make              # For normal 'make'-based builds.
+$ cmake -G Ninja .. && ninja    # For faster builds using the 'ninja' utility.
+```
+
+### Homebrew on Mac
 
     brew install neovim/neovim/neovim
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/neovim/neovim.png?branch=master)](https://travis-ci.org/neovim/neovim)
 [![Stories in Ready](https://badge.waffle.io/neovim/neovim.png?label=ready)](https://waffle.io/neovim/neovim)
 
+**Installation instructions can be found in the [INSTALL.md](INSTALL.md) file.**
+
 * [Introduction](#introduction)
 * [Problem](#problem)
 * [Solution](#solution)
@@ -13,13 +15,6 @@
   * [New GUI architecture](#new-gui-architecture)
   * [Development on github](#development-on-github)
 * [Status](#status)
-* [Dependencies](#dependencies)
-  * [For Debian/Ubuntu](#for-debianubuntu)
-  * [For CentOS/RHEL](#for-centos-rhel)
-  * [For FreeBSD 10](#for-freebsd-10)
-  * [For Arch Linux](#for-arch-linux)
-  * [For OS X](#for-os-x)
-* [Building](#building)
 * [Community](#community)
 * [Contributing](#contributing)
 * [License](#license)
@@ -270,93 +265,6 @@ and what is currently being worked on:
 [unifdef]: http://freecode.com/projects/unifdef
 [uncrustify]: http://uncrustify.sourceforge.net/
 [CMake]: http://cmake.org/
-
-## Dependencies
-
-<a name="for-debianubuntu"></a>
-### Ubuntu/Debian
-
-    sudo apt-get install libtool autoconf automake cmake libncurses5-dev g++
-
-<a name="for-centos-rhel"></a>
-### CentOS/RHEL
-
-If you're using CentOS/RHEL 6 you need at least autoconf version 2.69 for
-compiling the libuv dependency. See joyent/libuv#1158.
-
-<a name="for-freebsd-10"></a>
-### FreeBSD 10
-
-    sudo pkg install cmake libtool sha
-
-<a name="for-arch-linux"></a>
-### Arch Linux
-
-    sudo pacman -S base-devel cmake ncurses
-
-<a name="for-os-x"></a>
-### OS X
-
-* Install [Xcode](https://developer.apple.com/) and [Homebrew](http://brew.sh)
-  or [MacPorts](http://www.macports.org)
-* Install sha1sum
-
-If you run into wget certificate errors, you may be missing the root SSL
-certificates or have not set them up correctly:
-
-  Via MacPorts:
-
-      sudo port install curl-ca-bundle libtool automake cmake
-      echo CA_CERTIFICATE=/opt/local/share/curl/curl-ca-bundle.crt >> ~/.wgetrc
-
-  Via Homebrew:
-
-      brew install curl-ca-bundle libtool automake cmake
-      echo CA_CERTIFICATE=$(brew --prefix curl-ca-bundle)/share/ca-bundle.crt >> ~/.wgetrc
-
-
-## Building
-
-There are many ways to build neovim depending on your needs and the amount of
-customization you require.
-
-### The all-in-one build script
-
-This method makes use of the dependencies bundled with the source tree and is
-provided as a convenience to those whose platforms do not provide packages for
-the dependencies and who do not wish to install them separately. Compilation is
-via a Makefile in the ``scripts/`` directory. In the top-level directory simply:
-
-```console
-$ make -C scripts/ build
-```
-
-To run the tests:
-```console
-$ make -C scripts/ test
-```
-
-There is also a top-level Makefile which will forward ``build`` and ``test`` to
-the ``scripts/Makefile``. This is purely for compatibility with some existing
-build scripts and will be removed.
-
-### CMake
-
-If you are packaging neovim or if you already have all the dependencies
-installed on your system, a standard CMake-based build may be used. This is the
-recommended option for developers since it will rapidly show any regressions
-between updated dependencies and neovim.
-
-```console
-$ mkdir build && cd build
-$ cmake .. && make              # For normal 'make'-based builds.
-$ cmake -G Ninja .. && ninja    # For faster builds using the 'ninja' utility.
-```
-
-### Homebrew on Mac
-
-    brew install neovim/neovim/neovim
-
 ## Community
 
 Join the community on IRC in #neovim on Freenode or the [mailing list](https://groups.google.com/forum/#!forum/neovim)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -29,7 +29,7 @@ clean:
 	${MAKE} -C ../src/testdir clean
 
 install: ../build/bin/nvim
-	${MAKE} -C build install
+	${MAKE} -C ../build install
 
 .PHONY: test deps cmake install build
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,0 +1,36 @@
+-include local.mk
+
+CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=third-party/dist -DLibUV_USE_STATIC=YES
+
+# Extra CMake flags which extend the default set
+CMAKE_EXTRA_FLAGS :=
+
+build: ../build/bin/nvim
+
+../build/bin/nvim: deps cmake
+	${MAKE} -C ../build
+
+test: ../build/bin/nvim
+	${MAKE} -C ../src/testdir
+
+deps: libuv
+
+libuv: ../third-party/dist/lib/libuv.a
+
+../third-party/dist/lib/libuv.a:
+	sh -e compile-libuv.sh
+
+cmake: clean deps
+	mkdir -p ../build
+	cd ../build && cmake $(CMAKE_FLAGS) $(CMAKE_EXTRA_FLAGS) ../
+
+clean:
+	rm -rf ../build
+	${MAKE} -C ../src/testdir clean
+
+install: ../build/bin/nvim
+	${MAKE} -C build install
+
+.PHONY: test deps cmake install build
+
+.DEFAULT: build

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -11,9 +11,9 @@ if [ "$platform" = 'freebsd' ]; then
 	sha1sumcmd='shasum'
 fi
 
-pkgroot="$(pwd)"
-deps="$pkgroot/.deps"
-prefix="$deps/usr"
+pkgroot="$(pwd)/"
+deps="$pkgroot/../third-party/dist"
+prefix="$deps/"
 export PATH="$prefix/bin:$PATH"
 
 download() {

--- a/scripts/compile-libuv.sh
+++ b/scripts/compile-libuv.sh
@@ -1,6 +1,6 @@
-. scripts/common.sh
+. ./common.sh
 
-uv_dir="third-party/libuv"
+uv_dir="../third-party/libuv"
 
 cd "$uv_dir"
 sh autogen.sh

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,10 +1,12 @@
 #!/bin/sh -e
 
+MAKE="make -C scripts/"
+
 export VALGRIND_CHECK=1
-make -C scripts/ cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$PWD/dist"
-make -C scripts/
+$MAKE cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$PWD/dist"
+$MAKE
 echo "Running tests with valgrind..."
-if ! make test > /dev/null; then
+if ! $MAKE test > /dev/null; then
 	if ls src/testdir/valgrind.* > /dev/null 2>&1; then
 		echo "Memory leak detected" >&2
 		cat src/testdir/valgrind.*
@@ -16,4 +18,4 @@ if ! make test > /dev/null; then
 	fi
 	exit 1
 fi
-make -C scripts/ install
+$MAKE install

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -16,4 +16,4 @@ if ! make test > /dev/null; then
 	fi
 	exit 1
 fi
-make install
+make -C scripts/ install

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,18 +1,18 @@
 #!/bin/sh -e
 
 export VALGRIND_CHECK=1
-make cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$PWD/dist"
-make
+make -C scripts/ cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$PWD/dist"
+make -C scripts/
 echo "Running tests with valgrind..."
 if ! make test > /dev/null; then
 	if ls src/testdir/valgrind.* > /dev/null 2>&1; then
-		echo "Memory leak detected" >&2 
+		echo "Memory leak detected" >&2
 		cat src/testdir/valgrind.*
 	else
-		echo "Failed tests:" >&2 
+		echo "Failed tests:" >&2
 		for t in src/testdir/*.failed; do
 			echo ${t%%.*}
-		done	
+		done
 	fi
 	exit 1
 fi


### PR DESCRIPTION
As per discussion in #194, this PR makes the use of system-provided dependencies the default method and moves the convenience scripts for compiling software in the `third-party` directory to the `scripts/` directory. The `scripts/` directory is becoming increasingly misnamed but that's not the
focus of this PR.

Move the build-related information from README.md into a separate INSTALL.md file to make it easier to find.

Addresses #131 by making the use of 'ninja' or 'make' entirely up to the person building the source and not necessarily encouraging either by mandating use of a Makefile. Also update the build information to give examples of using both.

The ongoing issue #154 may want to take note of this PR as it will affect the homebrew script. Add a compatibility shim top-level Makefile so that homebrew doesn't break for the moment. When #154 is closed, it may be time to remove it for good.

Update the Travis build to use the convenience scripts but in their new location.

Since the third-party compilation scripts now install everything to the (non-hidden) `third-party/dist`, update the build scripts to cope.
