### PR TITLE
Be pedantic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # If the C compiler is some GNU-alike, use the gnu99 standard and enable all warnings.
 if(CMAKE_COMPILER_IS_GNUCC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=gnu99")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -Wno-unused-parameter -std=gnu99")
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=gnu99")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -Wno-unused-parameter -std=gnu99")
 endif(CMAKE_COMPILER_IS_GNUCC)
 
 add_definitions(-DHAVE_CONFIG_H)

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4209,15 +4209,14 @@ void msg_add_lines(int insert_space, long lnum, off_t nchars)
 
   if (insert_space)
     *p++ = ' ';
-  if (shortmess(SHM_LINES))
-    sprintf((char *)p,
+  if (shortmess(SHM_LINES)) {
 #ifdef LONG_LONG_OFF_T
-        "%ldL, %lldC", lnum, nchars
+     sprintf((char *)p, "%ldL, %lldC", lnum, nchars);
 #else
-        /* Explicit typecast avoids warning on Mac OS X 10.6 */
-        "%ldL, %ldC", lnum, (long)nchars
+     /* Explicit typecast avoids warning on Mac OS X 10.6 */
+     sprintf((char *)p, "%ldL, %ldC", lnum, (long)nchars);
 #endif
-        );
+  }
   else {
     if (lnum == 1)
       STRCPY(p, _("1 line, "));
@@ -4226,15 +4225,13 @@ void msg_add_lines(int insert_space, long lnum, off_t nchars)
     p += STRLEN(p);
     if (nchars == 1)
       STRCPY(p, _("1 character"));
-    else
-      sprintf((char *)p,
+    else {
 #ifdef LONG_LONG_OFF_T
-          _("%lld characters"), nchars
+      sprintf((char *)p, _("%lld characters"), nchars);
 #else
-          /* Explicit typecast avoids warning on Mac OS X 10.6 */
-          _("%ld characters"), (long)nchars
+      sprintf((char *)p, _("%ld characters"), (long)nchars);
 #endif
-          );
+    }
   }
 }
 

--- a/src/hangulin.c
+++ b/src/hangulin.c
@@ -1407,9 +1407,9 @@ static void convert_ks_to_3(const char_u *src, int *fp, int *mp, int *lp)
   int low = *(src + 1);
   int c;
   int i;
+  const ssize_t tablesize = sizeof(ks_table1) / sizeof(ks_table1[0]);
 
-  if ((i = han_index(h, low)) >= 0
-      && i < sizeof(ks_table1)/sizeof(ks_table1[0])) {
+  if ((i = han_index(h, low)) >= 0 && i < tablesize) {
     *fp = ks_table1[i][0];
     *mp = ks_table1[i][1];
     *lp = ks_table1[i][2];

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -6932,6 +6932,9 @@ static regengine_T bt_regengine =
 #ifdef REGEXP_DEBUG
   ,(char_u *)""
 #endif
+#ifdef DEBUG
+  ,NULL
+#endif
 };
 
 
@@ -6949,6 +6952,9 @@ static regengine_T nfa_regengine =
   nfa_regexec_multi
 #ifdef REGEXP_DEBUG
   ,(char_u *)""
+#endif
+#ifdef DEBUG
+  , NULL
 #endif
 };
 

--- a/src/term.c
+++ b/src/term.c
@@ -2225,12 +2225,14 @@ static void term_color(char_u *s, int n)
       && (STRCMP(s + i + 1, "%p1%dm") == 0
           || STRCMP(s + i + 1, "%dm") == 0)
       && (s[i] == '3' || s[i] == '4')) {
-    sprintf(buf,
+    const char *fmt =
 #ifdef TERMINFO
-        "%s%s%%p1%%dm",
+        "%s%s%%p1%%dm";
 #else
-        "%s%s%%dm",
+        "%s%s%%dm";
 #endif
+    sprintf(buf,
+        fmt,
         i == 2 ? IF_EB("\033[", ESC_STR "[") : "\233",
         s[i] == '3' ? (n >= 16 ? "38;5;" : "9")
         : (n >= 16 ? "48;5;" : "10"));


### PR DESCRIPTION
Enable the `-pedantic` and `-Wextra` switches but disable `-Wunused-arguments` for now (too many instances, most of which are perfectly valid because they have to conform to a function pointer interface).

Fix some warnings that cropped up while compiling with both gcc 4.9 and clang 3.4 on OSX 10.9.2.

Putting it up here for review.
