### PR TITLE
Fix a 'garbage value' warning found by Clang's static analyzer

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -4096,11 +4096,11 @@ static int fmt_check_par(linenr_T lnum, int *leader_len, char_u **leader_flags, 
  */
 int paragraph_start(linenr_T lnum)
 {
-  char_u      *p;
+  char_u *p;
   int leader_len = 0;                   /* leader len of current line */
-  char_u      *leader_flags = NULL;     /* flags for leader of current line */
-  int next_leader_len;                  /* leader len of next line */
-  char_u      *next_leader_flags;       /* flags for leader of next line */
+  char_u *leader_flags = NULL;          /* flags for leader of current line */
+  int next_leader_len = 0;              /* leader len of next line */
+  char_u *next_leader_flags = NULL;     /* flags for leader of next line */
   int do_comments;                      /* format comments */
 
   if (lnum <= 1)

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -2519,7 +2519,7 @@ static void reginsert_nr(int op, long val, char_u *opnd)
   *place++ = op;
   *place++ = NUL;
   *place++ = NUL;
-  place = re_put_long(place, (long_u)val);
+  re_put_long(place, (long_u)val);
 }
 
 /*

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -523,7 +523,6 @@ static char_u *nfa_get_match_text(nfa_state_T *start)
 
   ret = alloc(len);
   if (ret != NULL) {
-    len = 0;
     p = start->out->out;     /* skip first char, it goes into regstart */
     s = ret;
     while (p->c > 0) {


### PR DESCRIPTION
This commit fixes #167
- Initialize lists in paragraph_start()
- Remove two dead stores

I reviewed all warnings/errors generated by Clang's static analyzer on Xcode. Many `NULL dereference` bugs are not worth removing as they are virtually impossible to reproduce as they happen inside deeply nested blocks inside really long functions.

The dead stores are not worth removing as many of them actually make sense. Most them are preventive resets of variables (e.g. some_list = NULL, len = 0).

I found the cases I've fixed worth fixing. `fmt_check_par()` is called inside `paragraph_start()` and checks whether `???_flags` are `NULL` or `???_len` are `0`.
