### PR TITLE
Compile libuv with -fPIC.

### DIFF
--- a/scripts/compile-libuv.sh
+++ b/scripts/compile-libuv.sh
@@ -4,7 +4,7 @@ uv_dir="third-party/libuv"
 
 cd "$uv_dir"
 sh autogen.sh
-./configure --prefix="$prefix"
+./configure --prefix="$prefix" --with-pic
 make
 make install
 rm "$prefix/lib/"libuv*.{so,dylib} "$prefix/lib/"libuv*.{so,dylib}.* || true


### PR DESCRIPTION
This is needed so that th unit tests library compiles on 64-bit machines
correctly.
