### PR TITLE
Use cmake module instead of shared for nvim-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ build/
 *.swp
 *~
 *.pyc
+*.o
+*.so
 src/po/vim.pot
 
 src/po/*.ck

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND NEOVIM_SOURCES "${PROJECT_BINARY_DIR}/config/auto/pathdef.c")
 file( GLOB OS_SOURCES os/*.c )
 
 add_executable (nvim ${NEOVIM_SOURCES} ${OS_SOURCES})
-add_library (nvim-test SHARED ${NEOVIM_SOURCES} ${OS_SOURCES}) 
+add_library (nvim-test MODULE ${NEOVIM_SOURCES} ${OS_SOURCES})
 
 # The libraries we link against for nvim
 set(NVIM_LINK_LIBRARIES m ${LibUV_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
On a Mac using shared creates libnvim-test.dylib which cannot be found
by the hardcoded .so extension in helpers.moon, causing the unittests to
fail. However, using module creates libnvim-test.so, allowing the tests
to run. There will still be problems running the tests on windows,
because both shared and module create a dll file which will not be found
in helpers.moon.
