### PR TITLE
Only include libintl's include dir if libintl was found.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,9 @@ endif(NOT CMAKE_USE_PTHREADS_INIT)
 check_library_exists(rt clock_gettime "time.h" HAVE_CLOCK_GETTIME)
 
 find_package(LibIntl)
-include_directories(${LibIntl_INCLUDE_DIR})
+if(LibIntl_FOUND)
+  include_directories(${LibIntl_INCLUDE_DIR})
+endif()
 
 # Require libuv
 find_package(LibUV REQUIRED)


### PR DESCRIPTION
This prevents an error from CMake when libintl is not found.  It's not a
required library, so we must wrap the inclusion in a conditional.  It
was already done for the library.
