### PR TITLE
Use _NSGetEnviron on Mac OS X to gain access to environ.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,9 +1,14 @@
 include(CheckTypeSize)
+include(CheckIncludeFiles)
+include(CheckSymbolExists)
 
 check_type_size("int" SIZEOF_INT)
 check_type_size("long" SIZEOF_LONG)
 check_type_size("time_t" SIZEOF_TIME_T)
 check_type_size("off_t" SIZEOF_OFF_T)
+
+check_include_files(crt_externs.h HAVE_CRT_EXTERNS_H)
+check_symbol_exists(_NSGetEnviron "crt_externs.h" HAVE__NSGETENVIRON)
 
 # generate configuration header and update include directories
 configure_file (

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -12,7 +12,9 @@
 #define SIZEOF_OFF_T @SIZEOF_OFF_T@
 
 #define _FILE_OFFSET_BITS 64
+#cmakedefine HAVE__NSGETENVIRON
 #define HAVE_BCMP 1
+#cmakedefine HAVE_CRT_EXTERNS_H
 #define HAVE_DATE_TIME 1
 #define HAVE_DIRENT_H 1
 #define HAVE_DLFCN_H 1

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -45,6 +45,10 @@
 #include "window.h"
 #include "os/os.h"
 
+#ifdef HAVE_CRT_EXTERNS_H
+#include <crt_externs.h>
+#endif
+
 static char_u *vim_version_dir __ARGS((char_u *vimdir));
 static char_u *remove_tail __ARGS((char_u *p, char_u *pend, char_u *name));
 static void init_users __ARGS((void));
@@ -3642,6 +3646,7 @@ void vim_setenv(char_u *name, char_u *val)
   }
 }
 
+
 /*
  * Function given to ExpandGeneric() to obtain an environment variable name.
  */
@@ -3653,9 +3658,11 @@ char_u *get_env_name(expand_T *xp, int idx)
    */
   return NULL;
 # else
-# ifndef __WIN32__
+# if !defined(__WIN32__) && !defined(HAVE__NSGETENVIRON)
   /* Borland C++ 5.2 has this in a header file. */
   extern char         **environ;
+# else
+  char **environ = *_NSGetEnviron();
 # endif
 # define ENVNAMELEN 100
   static char_u name[ENVNAMELEN];


### PR DESCRIPTION
When building nvim as a shared library for testing, environ is not
exposed.  In order to gain access to the environment variables, you must
get a pointer to them from _NSGetEnviron().

It appears that this may affect the FreeBSD platform too.
