### PR TITLE
Some cleanup of growable arrays

### DIFF
--- a/src/garray.c
+++ b/src/garray.c
@@ -1,112 +1,152 @@
-/*
+/**
  * Functions for handling growing arrays.
  */
+#include <assert.h>
 
 #include "vim.h"
 #include "ascii.h"
 #include "misc2.h"
 #include "garray.h"
-//#include "globals.h"
 #include "memline.h"
 
-/*
+/**
  * Clear an allocated growing array.
+ *
+ * The allocated memory will be freed, and it's size set to zero.
+ * Note that this does not reset the current itemsize and growsize.
+ *
+ * It's bug to call this on an array that hasn't been initialized with ga_init
+ * or ga_init2.
  */
 void ga_clear(garray_T *gap)
 {
+  assert(gap);
   vim_free(gap->ga_data);
   ga_init(gap);
 }
 
-/*
+/**
  * Clear a growing array that contains a list of strings.
+ *
+ * It's a bug to call this function if gap isn't a list of strings.
  */
 void ga_clear_strings(garray_T *gap)
 {
-  int i;
-
-  for (i = 0; i < gap->ga_len; ++i)
+  assert(gap);
+  for (int i = 0; i < gap->ga_len; ++i)
     vim_free(((char_u **)(gap->ga_data))[i]);
   ga_clear(gap);
 }
 
-/*
- * Initialize a growing array.	Don't forget to set ga_itemsize and
- * ga_growsize!  Or use ga_init2().
+/**
+ * Initialize a growing array.
+ *
+ * Don't forget to set ga_itemsize and ga_growsize! Or use \sa ga_init2().
  */
 void ga_init(garray_T *gap)
 {
-  gap->ga_data = NULL;
+  assert(gap);
+  gap->ga_data   = NULL;
   gap->ga_maxlen = 0;
-  gap->ga_len = 0;
+  gap->ga_len    = 0;
 }
 
+/**
+ * Initialize a growing array.
+ * */
 void ga_init2(garray_T *gap, int itemsize, int growsize)
 {
+  assert(gap);
   ga_init(gap);
   gap->ga_itemsize = itemsize;
   gap->ga_growsize = growsize;
 }
 
-/*
- * Make room in growing array "gap" for at least "n" items.
- * Return FAIL for failure, OK otherwise.
+/**
+ * Grow array to be able to hold at least 'n' new items.
+ *
+ * \returns FAIL if it fails to allocate enough memory. OK otherwise.
  */
 int ga_grow(garray_T *gap, int n)
 {
-  size_t old_len;
-  size_t new_len;
-  char_u      *pp;
+  assert(gap);
+  assert(n >= 0);
 
-  if (gap->ga_maxlen - gap->ga_len < n) {
-    if (n < gap->ga_growsize)
-      n = gap->ga_growsize;
-    new_len = gap->ga_itemsize * (gap->ga_len + n);
-    pp = (gap->ga_data == NULL)
-         ? alloc((unsigned)new_len) : vim_realloc(gap->ga_data, new_len);
-    if (pp == NULL)
-      return FAIL;
-    old_len = gap->ga_itemsize * gap->ga_maxlen;
-    vim_memset(pp + old_len, 0, new_len - old_len);
-    gap->ga_maxlen = gap->ga_len + n;
-    gap->ga_data = pp;
-  }
+  if (gap->ga_maxlen - gap->ga_len >= n)
+    return OK; // We already have enough room
+
+  if (n < gap->ga_growsize)
+    n = gap->ga_growsize;
+  size_t new_len = gap->ga_itemsize * (gap->ga_len + n);
+
+  char_u *pp = (gap->ga_data == NULL)
+       ? alloc((unsigned)new_len) : vim_realloc(gap->ga_data, new_len);
+  if (!pp)
+    return FAIL;
+
+  size_t old_len = gap->ga_itemsize * gap->ga_maxlen;
+  vim_memset(pp + old_len, 0, new_len - old_len);
+  gap->ga_maxlen = gap->ga_len + n;
+  gap->ga_data   = pp;
+
   return OK;
 }
 
-/*
- * For a growing array that contains a list of strings: concatenate all the
- * strings with a separating comma.
- * Returns NULL when out of memory.
+/**
+ * Concatenate a list of strings by ","
+ *
+ * A rewly allocated string will be returned.
+ *
+ * Examples:
+ *   NULL -> NULL
+ *   [] -> NULL
+ *   [""] -> ""
+ *   ["", ""] -> ","
+ *   ["a"] -> "a"
+ *   ["a", "b"] -> "a,b"
+ *   ["", "a", ""] -> ",a,"
+ *
+ * \returns NULL when out of memory, or the list was empty.
  */
-char_u *ga_concat_strings(garray_T *gap)
+char_u *ga_concat_strings(garray_T const *const gap)
 {
-  int i;
+  if (!gap || gap->ga_len == 0)
+    return NULL; // nothing to do
+
+#define GAP_STR ((char_u **)(gap->ga_data))
   int len = 0;
-  char_u      *s;
+  for (int i = 0; i < gap->ga_len; ++i)
+    len += (int)STRLEN(GAP_STR[i]);
+  // make room for "," between each string.
+  // -1 because we won't add a trailing "," on the last item.
+  len += gap->ga_len - 1;
 
-  for (i = 0; i < gap->ga_len; ++i)
-    len += (int)STRLEN(((char_u **)(gap->ga_data))[i]) + 1;
+  char_u *s = alloc(len);
+  // TODO (simensdjo): We've run out of memory, but we're not notifying anyone.
+  if (!s)
+    return NULL;
 
-  s = alloc(len + 1);
-  if (s != NULL) {
-    *s = NUL;
-    for (i = 0; i < gap->ga_len; ++i) {
-      if (*s != NUL)
-        STRCAT(s, ",");
-      STRCAT(s, ((char_u **)(gap->ga_data))[i]);
-    }
+  *s = NUL;
+  STRCAT(s, GAP_STR[0]);
+  for (int i = 1; i < gap->ga_len; ++i) {
+    STRCAT(s, ",");
+    STRCAT(s, GAP_STR[i]);
   }
+#undef GAP_STR
   return s;
 }
 
-/*
+/**
  * Concatenate a string to a growarray which contains characters.
+ *
  * Note: Does NOT copy the NUL at the end!
  */
-void ga_concat(garray_T *gap, char_u *s)
+void ga_concat(garray_T *gap, char_u const *const s)
 {
+  assert(gap);
   int len = (int)STRLEN(s);
+  if (len == 0)
+    return; // nothing to do
 
   if (ga_grow(gap, len) == OK) {
     mch_memmove((char *)gap->ga_data + gap->ga_len, s, (size_t)len);
@@ -114,11 +154,12 @@ void ga_concat(garray_T *gap, char_u *s)
   }
 }
 
-/*
+/**
  * Append one byte to a growarray which contains bytes.
  */
 void ga_append(garray_T *gap, int c)
 {
+  assert(gap);
   if (ga_grow(gap, 1) == OK) {
     *((char *)gap->ga_data + gap->ga_len) = c;
     ++gap->ga_len;
@@ -126,16 +167,24 @@ void ga_append(garray_T *gap, int c)
 }
 
 #if (defined(UNIX) && !defined(USE_SYSTEM)) || defined(WIN3264)
-/*
- * Append the text in "gap" below the cursor line and clear "gap".
+/**
+ * Append the text in "gap" below the cursor line.
+ *
+ * Note: Sets "gap" length to 0, but does not clear the associated memory
+ * If gap includes a trailing CR, it will not be added to the cursor line.
  */
 void append_ga_line(garray_T *gap)
 {
+  assert(gap);
+  assert(curbuf);
   /* Remove trailing CR. */
   if (gap->ga_len > 0
       && !curbuf->b_p_bin
       && ((char_u *)gap->ga_data)[gap->ga_len - 1] == CAR)
+  {
     --gap->ga_len;
+  }
+
   ga_append(gap, NUL);
   ml_append(curwin->w_cursor.lnum++, gap->ga_data, 0, FALSE);
   gap->ga_len = 0;

--- a/src/garray.c
+++ b/src/garray.c
@@ -101,6 +101,7 @@ int ga_grow(garray_T *gap, int n)
  *   NULL -> NULL
  *   [] -> NULL
  *   [""] -> ""
+ *   ["", ""] -> ","
  *   ["a"] -> "a"
  *   ["a", "b"] -> "a,b"
  *   ["", "a", ""] -> ",a,"

--- a/src/garray.c
+++ b/src/garray.c
@@ -116,10 +116,12 @@ char_u *ga_concat_strings(garray_T const *const gap)
   int len = 0;
   for (int i = 0; i < gap->ga_len; ++i)
     len += (int)STRLEN(GAP_STR[i]);
-  len += gap->ga_len; // make room for "," between
+  // make room for "," between each string.
+  // -1 because we won't add a trailing "," on the last item.
+  len += gap->ga_len - 1;
 
+  char_u *s = alloc(len);
   // TODO (simensdjo): We've run out of memory, but we're not notifying anyone.
-  char_u *s = alloc(len + 1);
   if (!s)
     return NULL;
 

--- a/src/garray.c
+++ b/src/garray.c
@@ -142,7 +142,7 @@ void ga_concat(garray_T *gap, char_u const *const s)
 {
   assert(gap);
   int len = (int)STRLEN(s);
-  if(len == 0)
+  if (len == 0)
     return; // nothing to do
 
   if (ga_grow(gap, len) == OK) {

--- a/src/garray.c
+++ b/src/garray.c
@@ -1,112 +1,149 @@
-/*
+/**
  * Functions for handling growing arrays.
  */
+#include <assert.h>
 
 #include "vim.h"
 #include "ascii.h"
 #include "misc2.h"
 #include "garray.h"
-//#include "globals.h"
 #include "memline.h"
 
-/*
+/**
  * Clear an allocated growing array.
+ *
+ * The allocated memory will be freed, and it's size set to zero.
+ * Note that this does not reset the current itemsize and growsize.
+ *
+ * It's bug to call this on an array that hasn't been initialized with ga_init
+ * or ga_init2.
  */
 void ga_clear(garray_T *gap)
 {
+  assert(gap);
   vim_free(gap->ga_data);
   ga_init(gap);
 }
 
-/*
+/**
  * Clear a growing array that contains a list of strings.
+ *
+ * It's a bug to call this function if gap isn't a list of strings.
  */
 void ga_clear_strings(garray_T *gap)
 {
-  int i;
-
-  for (i = 0; i < gap->ga_len; ++i)
+  assert(gap);
+  for (int i = 0; i < gap->ga_len; ++i)
     vim_free(((char_u **)(gap->ga_data))[i]);
   ga_clear(gap);
 }
 
-/*
- * Initialize a growing array.	Don't forget to set ga_itemsize and
- * ga_growsize!  Or use ga_init2().
+/**
+ * Initialize a growing array.
+ *
+ * Don't forget to set ga_itemsize and ga_growsize! Or use \sa ga_init2().
  */
 void ga_init(garray_T *gap)
 {
-  gap->ga_data = NULL;
+  assert(gap);
+  gap->ga_data   = NULL;
   gap->ga_maxlen = 0;
-  gap->ga_len = 0;
+  gap->ga_len    = 0;
 }
 
+/**
+ * Initialize a growing array.
+ * */
 void ga_init2(garray_T *gap, int itemsize, int growsize)
 {
+  assert(gap);
   ga_init(gap);
   gap->ga_itemsize = itemsize;
   gap->ga_growsize = growsize;
 }
 
-/*
- * Make room in growing array "gap" for at least "n" items.
- * Return FAIL for failure, OK otherwise.
+/**
+ * Grow array to be able to hold at least 'n' new items.
+ *
+ * \returns FAIL if it fails to allocate enough memory. OK otherwise.
  */
 int ga_grow(garray_T *gap, int n)
 {
-  size_t old_len;
-  size_t new_len;
-  char_u      *pp;
+  assert(gap);
+  assert(n >= 0);
 
-  if (gap->ga_maxlen - gap->ga_len < n) {
-    if (n < gap->ga_growsize)
-      n = gap->ga_growsize;
-    new_len = gap->ga_itemsize * (gap->ga_len + n);
-    pp = (gap->ga_data == NULL)
-         ? alloc((unsigned)new_len) : vim_realloc(gap->ga_data, new_len);
-    if (pp == NULL)
-      return FAIL;
-    old_len = gap->ga_itemsize * gap->ga_maxlen;
-    vim_memset(pp + old_len, 0, new_len - old_len);
-    gap->ga_maxlen = gap->ga_len + n;
-    gap->ga_data = pp;
-  }
+  if (gap->ga_maxlen - gap->ga_len >= n)
+    return OK; // We already have enough room
+
+  if (n < gap->ga_growsize)
+    n = gap->ga_growsize;
+  size_t new_len = gap->ga_itemsize * (gap->ga_len + n);
+
+  char_u *pp = (gap->ga_data == NULL)
+       ? alloc((unsigned)new_len) : vim_realloc(gap->ga_data, new_len);
+  if (!pp)
+    return FAIL;
+
+  size_t old_len = gap->ga_itemsize * gap->ga_maxlen;
+  vim_memset(pp + old_len, 0, new_len - old_len);
+  gap->ga_maxlen = gap->ga_len + n;
+  gap->ga_data   = pp;
+
   return OK;
 }
 
-/*
- * For a growing array that contains a list of strings: concatenate all the
- * strings with a separating comma.
- * Returns NULL when out of memory.
+/**
+ * Concatenate a list of strings by ","
+ *
+ * A rewly allocated string will be returned.
+ *
+ * Examples:
+ *   NULL -> NULL
+ *   [] -> NULL
+ *   [""] -> ""
+ *   ["a"] -> "a"
+ *   ["a", "b"] -> "a,b"
+ *   ["", "a", ""] -> ",a,"
+ *
+ * \returns NULL when out of memory, or the list was empty.
  */
-char_u *ga_concat_strings(garray_T *gap)
+char_u *ga_concat_strings(garray_T const *const gap)
 {
-  int i;
+  if(!gap || gap->ga_len == 0)
+    return NULL; // nothing to do
+
+#define GAP_STR ((char_u **)(gap->ga_data))
   int len = 0;
-  char_u      *s;
+  for (int i = 0; i < gap->ga_len; ++i)
+    len += (int)STRLEN(GAP_STR[i]);
+  len += gap->ga_len; // make room for "," between
 
-  for (i = 0; i < gap->ga_len; ++i)
-    len += (int)STRLEN(((char_u **)(gap->ga_data))[i]) + 1;
+  // TODO (simensdjo): We've run out of memory, but we're not notifying anyone.
+  char_u *s = alloc(len + 1);
+  if (!s)
+    return NULL;
 
-  s = alloc(len + 1);
-  if (s != NULL) {
-    *s = NUL;
-    for (i = 0; i < gap->ga_len; ++i) {
-      if (*s != NUL)
-        STRCAT(s, ",");
-      STRCAT(s, ((char_u **)(gap->ga_data))[i]);
-    }
+  *s = NUL;
+  STRCAT(s, GAP_STR[0]);
+  for (int i = 1; i < gap->ga_len; ++i) {
+    STRCAT(s, ",");
+    STRCAT(s, GAP_STR[i]);
   }
+#undef GAP_STR
   return s;
 }
 
-/*
+/**
  * Concatenate a string to a growarray which contains characters.
+ *
  * Note: Does NOT copy the NUL at the end!
  */
-void ga_concat(garray_T *gap, char_u *s)
+void ga_concat(garray_T *gap, char_u const *const s)
 {
+  assert(gap);
   int len = (int)STRLEN(s);
+  if(len == 0)
+    return; // nothing to do
 
   if (ga_grow(gap, len) == OK) {
     mch_memmove((char *)gap->ga_data + gap->ga_len, s, (size_t)len);
@@ -114,11 +151,12 @@ void ga_concat(garray_T *gap, char_u *s)
   }
 }
 
-/*
+/**
  * Append one byte to a growarray which contains bytes.
  */
 void ga_append(garray_T *gap, int c)
 {
+  assert(gap);
   if (ga_grow(gap, 1) == OK) {
     *((char *)gap->ga_data + gap->ga_len) = c;
     ++gap->ga_len;
@@ -126,16 +164,24 @@ void ga_append(garray_T *gap, int c)
 }
 
 #if (defined(UNIX) && !defined(USE_SYSTEM)) || defined(WIN3264)
-/*
- * Append the text in "gap" below the cursor line and clear "gap".
+/**
+ * Append the text in "gap" below the cursor line.
+ *
+ * Note: Sets "gap" length to 0, but does not clear the associated memory
+ * If gap includes a trailing CR, it will not be added to the cursor line.
  */
 void append_ga_line(garray_T *gap)
 {
+  assert(gap);
+  assert(curbuf);
   /* Remove trailing CR. */
   if (gap->ga_len > 0
       && !curbuf->b_p_bin
       && ((char_u *)gap->ga_data)[gap->ga_len - 1] == CAR)
+  {
     --gap->ga_len;
+  }
+
   ga_append(gap, NUL);
   ml_append(curwin->w_cursor.lnum++, gap->ga_data, 0, FALSE);
   gap->ga_len = 0;

--- a/src/garray.c
+++ b/src/garray.c
@@ -109,7 +109,7 @@ int ga_grow(garray_T *gap, int n)
  */
 char_u *ga_concat_strings(garray_T const *const gap)
 {
-  if(!gap || gap->ga_len == 0)
+  if (!gap || gap->ga_len == 0)
     return NULL; // nothing to do
 
 #define GAP_STR ((char_u **)(gap->ga_data))

--- a/src/garray.h
+++ b/src/garray.h
@@ -6,8 +6,8 @@ void ga_clear_strings __ARGS((garray_T *gap));
 void ga_init __ARGS((garray_T *gap));
 void ga_init2 __ARGS((garray_T *gap, int itemsize, int growsize));
 int ga_grow __ARGS((garray_T *gap, int n));
-char_u *ga_concat_strings __ARGS((garray_T *gap));
-void ga_concat __ARGS((garray_T *gap, char_u *s));
+char_u *ga_concat_strings __ARGS((garray_T const *const gap));
+void ga_concat __ARGS((garray_T *gap, char_u const *const s));
 void ga_append __ARGS((garray_T *gap, int c));
 void append_ga_line __ARGS((garray_T *gap));
 


### PR DESCRIPTION
NOTE: I haven't coded C for 15 years, so this probably requires some review. The documentation is not following doxygen rules - will fix this once we have doxygen documentation generation in the makefiles.

What has been done:
- moved declarations closer to where they are used
- assertions
- documentation
- added const where possible
- some early returns to avoid doing unecessary work
