### PR TITLE
[RFC] Remove VI option defaults

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1158,205 +1158,180 @@ static struct vimoption
   {"runtimepath", "rtp",  P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_rtp, PV_NONE, (char_u *)DFLT_RUNTIMEPATH
    SCRIPTID_INIT},
-  {"scroll",      "scr",  P_NUM|P_NO_MKRC|P_VI_DEF,
-   (char_u *)VAR_WIN, PV_SCROLL,
-   {(char_u *)12L, (char_u *)0L} SCRIPTID_INIT},
-  {"scrollbind",  "scb",  P_BOOL|P_VI_DEF,
-   (char_u *)VAR_WIN, PV_SCBIND,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"scrolljump",  "sj",   P_NUM|P_VI_DEF|P_VIM,
-   (char_u *)&p_sj, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"scrolloff",   "so",   P_NUM|P_VI_DEF|P_VIM|P_RALL,
-   (char_u *)&p_so, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"scrollopt",   "sbo",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_sbo, PV_NONE,
-   {(char_u *)"ver,jump", (char_u *)0L}
+  {"scroll",      "scr",  P_NUM|P_NO_MKRC,
+   (char_u *)VAR_WIN, PV_SCROLL, (char_u *)12L
    SCRIPTID_INIT},
-  {"sections",    "sect", P_STRING|P_VI_DEF,
-   (char_u *)&p_sections, PV_NONE,
-   {(char_u *)"SHNHH HUnhsh", (char_u *)0L}
+  {"scrollbind",  "scb",  P_BOOL,
+   (char_u *)VAR_WIN, PV_SCBIND, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"secure",      NULL,   P_BOOL|P_VI_DEF|P_SECURE,
-   (char_u *)&p_secure, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"selection",   "sel",  P_STRING|P_VI_DEF,
-   (char_u *)&p_sel, PV_NONE,
-   {(char_u *)"inclusive", (char_u *)0L}
+  {"scrolljump",  "sj",   P_NUM,
+   (char_u *)&p_sj, PV_NONE, (char_u *)1L
    SCRIPTID_INIT},
-  {"selectmode",  "slm",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_slm, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"sessionoptions", "ssop", P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"scrolloff",   "so",   P_NUM|P_RALL,
+   (char_u *)&p_so, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"scrollopt",   "sbo",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_sbo, PV_NONE, (char_u *)"ver,jump"
+   SCRIPTID_INIT},
+  {"sections",    "sect", P_STRING,
+   (char_u *)&p_sections, PV_NONE, (char_u *)"SHNHH HUnhsh"
+   SCRIPTID_INIT},
+  {"secure",      NULL,   P_BOOL|P_SECURE,
+   (char_u *)&p_secure, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"selection",   "sel",  P_STRING,
+   (char_u *)&p_sel, PV_NONE, (char_u *)"inclusive"
+   SCRIPTID_INIT},
+  {"selectmode",  "slm",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_slm, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"sessionoptions", "ssop", P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_ssop, PV_NONE,
-   {(char_u *)"blank,buffers,curdir,folds,help,options,tabpages,winsize",
-    (char_u *)0L}
+   (char_u *)"blank,buffers,curdir,folds,help,options,tabpages,winsize"
    SCRIPTID_INIT},
-  {"shell",       "sh",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+  {"shell",       "sh",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_sh, PV_NONE,
-   {
-     (char_u *)"sh",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"shellcmdflag","shcf", P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)&p_shcf, PV_NONE,
-   {
-     (char_u *)"-c",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"shellpipe",   "sp",   P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)&p_sp, PV_NONE,
-   {
-#if defined(UNIX)
-     (char_u *)"| tee",
-#else
-     (char_u *)">",
-#endif
-     (char_u *)0L
-   }
+   (char_u *)"sh"
    SCRIPTID_INIT},
-  {"shellquote",  "shq",  P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)&p_shq, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"shellredir",  "srr",  P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)&p_srr, PV_NONE,
-   {(char_u *)">", (char_u *)0L} SCRIPTID_INIT},
-  {"shellslash",  "ssl",   P_BOOL|P_VI_DEF,
+  {"shellcmdflag","shcf", P_STRING|P_SECURE,
+   (char_u *)&p_shcf, PV_NONE, (char_u *)"-c"
+   SCRIPTID_INIT},
+  {"shellpipe",   "sp",   P_STRING|P_SECURE,
+   (char_u *)&p_sp, PV_NONE,
+#if defined(UNIX)
+   (char_u *)"| tee"
+#else
+   (char_u *)">"
+#endif
+   SCRIPTID_INIT},
+  {"shellquote",  "shq",  P_STRING|P_SECURE,
+   (char_u *)&p_shq, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"shellredir",  "srr",  P_STRING|P_SECURE,
+   (char_u *)&p_srr, PV_NONE, (char_u *)">"
+   SCRIPTID_INIT},
+  {"shellslash",  "ssl",   P_BOOL,
 #ifdef BACKSLASH_IN_FILENAME
    (char_u *)&p_ssl, PV_NONE,
 #else
    (char_u *)NULL, PV_NONE,
 #endif
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
+   (char_u *)FALSE
+   SCRIPTID_INIT},
   {"shelltemp",   "stmp", P_BOOL,
-   (char_u *)&p_stmp, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"shellxquote", "sxq",  P_STRING|P_VI_DEF|P_SECURE,
+   (char_u *)&p_stmp, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"shellxquote", "sxq",  P_STRING|P_SECURE,
    (char_u *)&p_sxq, PV_NONE,
-   {
-     (char_u *)"",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"shellxescape", "sxe", P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)&p_sxe, PV_NONE,
-   {
-     (char_u *)"",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"shiftround",  "sr",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_sr, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"shiftwidth",  "sw",   P_NUM|P_VI_DEF,
-   (char_u *)&p_sw, PV_SW,
-   {(char_u *)8L, (char_u *)0L} SCRIPTID_INIT},
-  {"shortmess",   "shm",  P_STRING|P_VIM|P_FLAGLIST,
-   (char_u *)&p_shm, PV_NONE,
-   {(char_u *)"", (char_u *)"filnxtToO"}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"showbreak",   "sbr",  P_STRING|P_VI_DEF|P_RALL,
-   (char_u *)&p_sbr, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"showcmd",     "sc",   P_BOOL|P_VIM,
+  {"shellxescape", "sxe", P_STRING|P_SECURE,
+   (char_u *)&p_sxe, PV_NONE, (char_u *)""
+    SCRIPTID_INIT},
+  {"shiftround",  "sr",   P_BOOL,
+   (char_u *)&p_sr, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"shiftwidth",  "sw",   P_NUM,
+   (char_u *)&p_sw, PV_SW, (char_u *)8L
+   SCRIPTID_INIT},
+  {"shortmess",   "shm",  P_STRING|P_FLAGLIST,
+   (char_u *)&p_shm, PV_NONE, (char_u *)"filnxtToO"
+   SCRIPTID_INIT},
+  {"showbreak",   "sbr",  P_STRING|P_RALL,
+   (char_u *)&p_sbr, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"showcmd",     "sc",   P_BOOL,
    (char_u *)&p_sc, PV_NONE,
-   {(char_u *)FALSE,
 #ifdef UNIX
-    (char_u *)FALSE
+   (char_u *)FALSE
 #else
-      (char_u *) TRUE
+   (char_u *)TRUE
 #endif
-   } SCRIPTID_INIT},
-  {"showfulltag", "sft",  P_BOOL|P_VI_DEF,
-   (char_u *)&p_sft, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"showmatch",   "sm",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_sm, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"showmode",    "smd",  P_BOOL|P_VIM,
-   (char_u *)&p_smd, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"showtabline", "stal", P_NUM|P_VI_DEF|P_RALL,
-   (char_u *)&p_stal, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"sidescroll",  "ss",   P_NUM|P_VI_DEF,
-   (char_u *)&p_ss, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"sidescrolloff", "siso", P_NUM|P_VI_DEF|P_VIM|P_RBUF,
-   (char_u *)&p_siso, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"slowopen",    "slow", P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"smartcase",   "scs",  P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_scs, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"smartindent", "si",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_si, PV_SI,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"smarttab",    "sta",  P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_sta, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"softtabstop", "sts",  P_NUM|P_VI_DEF|P_VIM,
-   (char_u *)&p_sts, PV_STS,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"sourceany",   NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"spell",       NULL,   P_BOOL|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_SPELL,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"spellcapcheck", "spc", P_STRING|P_ALLOCED|P_VI_DEF|P_RBUF,
+   SCRIPTID_INIT},
+  {"showfulltag", "sft",  P_BOOL,
+   (char_u *)&p_sft, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"showmatch",   "sm",   P_BOOL,
+   (char_u *)&p_sm, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"showmode",    "smd",  P_BOOL,
+   (char_u *)&p_smd, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"showtabline", "stal", P_NUM|P_RALL,
+   (char_u *)&p_stal, PV_NONE, (char_u *)1L
+   SCRIPTID_INIT},
+  {"sidescroll",  "ss",   P_NUM,
+   (char_u *)&p_ss, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"sidescrolloff", "siso", P_NUM|P_RBUF,
+   (char_u *)&p_siso, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"slowopen",    "slow", P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"smartcase",   "scs",  P_BOOL,
+   (char_u *)&p_scs, PV_NONE, (char_u *)FALSE SCRIPTID_INIT},
+  {"smartindent", "si",   P_BOOL,
+   (char_u *)&p_si, PV_SI, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"smarttab",    "sta",  P_BOOL,
+   (char_u *)&p_sta, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"softtabstop", "sts",  P_NUM,
+   (char_u *)&p_sts, PV_STS, (char_u *)0L
+   SCRIPTID_INIT},
+  {"sourceany",   NULL,   P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"spell",       NULL,   P_BOOL|P_RWIN,
+   (char_u *)VAR_WIN, PV_SPELL, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"spellcapcheck", "spc", P_STRING|P_ALLOCED|P_RBUF,
    (char_u *)&p_spc, PV_SPC,
-   {(char_u *)"[.?!]\\_[\\])'\"	 ]\\+", (char_u *)0L}
+   (char_u *)"[.?!]\\_[\\])'\"	 ]\\+"
    SCRIPTID_INIT},
-  {"spellfile",   "spf",  P_STRING|P_EXPAND|P_ALLOCED|P_VI_DEF|P_SECURE|P_COMMA,
-   (char_u *)&p_spf, PV_SPF,
-   {(char_u *)"", (char_u *)0L}
+  {"spellfile",   "spf",  P_STRING|P_EXPAND|P_ALLOCED|P_SECURE|P_COMMA,
+   (char_u *)&p_spf, PV_SPF, (char_u *)""
    SCRIPTID_INIT},
-  {"spelllang",   "spl",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_RBUF|P_EXPAND,
-   (char_u *)&p_spl, PV_SPL,
-   {(char_u *)"en", (char_u *)0L}
+  {"spelllang",   "spl",  P_STRING|P_ALLOCED|P_COMMA|P_RBUF|P_EXPAND,
+   (char_u *)&p_spl, PV_SPL, (char_u *)"en"
    SCRIPTID_INIT},
-  {"spellsuggest", "sps", P_STRING|P_VI_DEF|P_EXPAND|P_SECURE|P_COMMA,
-   (char_u *)&p_sps, PV_NONE,
-   {(char_u *)"best", (char_u *)0L}
+  {"spellsuggest", "sps", P_STRING|P_EXPAND|P_SECURE|P_COMMA,
+   (char_u *)&p_sps, PV_NONE, (char_u *)"best"
    SCRIPTID_INIT},
-  {"splitbelow",  "sb",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_sb, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"splitright",  "spr",  P_BOOL|P_VI_DEF,
-   (char_u *)&p_spr, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"startofline", "sol",  P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_sol, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"statusline","stl",  P_STRING|P_VI_DEF|P_ALLOCED|P_RSTAT,
-   (char_u *)&p_stl, PV_STL,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"suffixes",    "su",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"splitbelow",  "sb",   P_BOOL,
+   (char_u *)&p_sb, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"splitright",  "spr",  P_BOOL,
+   (char_u *)&p_spr, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"startofline", "sol",  P_BOOL,
+   (char_u *)&p_sol, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"statusline","stl",  P_STRING|P_ALLOCED|P_RSTAT,
+   (char_u *)&p_stl, PV_STL, (char_u *)""
+   SCRIPTID_INIT},
+  {"suffixes",    "su",   P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_su, PV_NONE,
-   {(char_u *)".bak,~,.o,.h,.info,.swp,.obj",
-    (char_u *)0L} SCRIPTID_INIT},
-  {"suffixesadd", "sua",  P_STRING|P_VI_DEF|P_ALLOCED|P_COMMA|P_NODUP,
-   (char_u *)&p_sua, PV_SUA,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)".bak,~,.o,.h,.info,.swp,.obj"
    SCRIPTID_INIT},
-  {"swapfile",    "swf",  P_BOOL|P_VI_DEF|P_RSTAT,
-   (char_u *)&p_swf, PV_SWF,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"swapsync",    "sws",  P_STRING|P_VI_DEF,
-   (char_u *)&p_sws, PV_NONE,
-   {(char_u *)"fsync", (char_u *)0L} SCRIPTID_INIT},
-  {"switchbuf",   "swb",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_swb, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"synmaxcol",   "smc",  P_NUM|P_VI_DEF|P_RBUF,
-   (char_u *)&p_smc, PV_SMC,
-   {(char_u *)3000L, (char_u *)0L}
+  {"suffixesadd", "sua",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
+   (char_u *)&p_sua, PV_SUA, (char_u *)""
    SCRIPTID_INIT},
-  {"syntax",      "syn",  P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB|P_NFNAME,
-   (char_u *)&p_syn, PV_SYN,
-   {(char_u *)"", (char_u *)0L}
+  {"swapfile",    "swf",  P_BOOL|P_RSTAT,
+   (char_u *)&p_swf, PV_SWF, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"swapsync",    "sws",  P_STRING,
+   (char_u *)&p_sws, PV_NONE, (char_u *)"fsync"
+   SCRIPTID_INIT},
+  {"switchbuf",   "swb",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_swb, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"synmaxcol",   "smc",  P_NUM|P_RBUF,
+   (char_u *)&p_smc, PV_SMC, (char_u *)3000L
+   SCRIPTID_INIT},
+  {"syntax",      "syn",  P_STRING|P_ALLOCED|P_NOGLOB|P_NFNAME,
+   (char_u *)&p_syn, PV_SYN, (char_u *)""
    SCRIPTID_INIT},
   {"tabline",     "tal",  P_STRING|P_VI_DEF|P_RALL,
    (char_u *)&p_tal, PV_NONE,

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1333,244 +1333,223 @@ static struct vimoption
   {"syntax",      "syn",  P_STRING|P_ALLOCED|P_NOGLOB|P_NFNAME,
    (char_u *)&p_syn, PV_SYN, (char_u *)""
    SCRIPTID_INIT},
-  {"tabline",     "tal",  P_STRING|P_VI_DEF|P_RALL,
-   (char_u *)&p_tal, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"tabpagemax",  "tpm",  P_NUM|P_VI_DEF,
-   (char_u *)&p_tpm, PV_NONE,
-   {(char_u *)10L, (char_u *)0L} SCRIPTID_INIT},
-  {"tabstop",     "ts",   P_NUM|P_VI_DEF|P_RBUF,
-   (char_u *)&p_ts, PV_TS,
-   {(char_u *)8L, (char_u *)0L} SCRIPTID_INIT},
-  {"tagbsearch",  "tbs",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_tbs, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L}
+  {"tabline",     "tal",  P_STRING|P_RALL,
+   (char_u *)&p_tal, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"taglength",   "tl",   P_NUM|P_VI_DEF,
-   (char_u *)&p_tl, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"tagrelative", "tr",   P_BOOL|P_VIM,
-   (char_u *)&p_tr, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"tags",        "tag",  P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
+  {"tabpagemax",  "tpm",  P_NUM,
+   (char_u *)&p_tpm, PV_NONE, (char_u *)10L
+   SCRIPTID_INIT},
+  {"tabstop",     "ts",   P_NUM|P_RBUF,
+   (char_u *)&p_ts, PV_TS, (char_u *)8L
+   SCRIPTID_INIT},
+  {"tagbsearch",  "tbs",   P_BOOL,
+   (char_u *)&p_tbs, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"taglength",   "tl",   P_NUM,
+   (char_u *)&p_tl, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"tagrelative", "tr",   P_BOOL,
+   (char_u *)&p_tr, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"tags",        "tag",  P_STRING|P_EXPAND|P_COMMA|P_NODUP,
    (char_u *)&p_tags, PV_TAGS,
-   {
-     (char_u *)"./tags,tags",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"tagstack",    "tgst", P_BOOL|P_VI_DEF,
-   (char_u *)&p_tgst, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"term",        NULL,   P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|
-   P_RALL,
-   (char_u *)&T_NAME, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"termbidi", "tbidi",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_tbidi, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"termencoding", "tenc", P_STRING|P_VI_DEF|P_RCLR,
-   (char_u *)&p_tenc, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)"./tags,tags"
    SCRIPTID_INIT},
-  {"terse",       NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)&p_terse, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"textwidth",   "tw",   P_NUM|P_VI_DEF|P_VIM|P_RBUF,
-   (char_u *)&p_tw, PV_TW,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"thesaurus",   "tsr",  P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_tsr, PV_TSR,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"tildeop",     "top",  P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_to, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"timeout",     "to",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_timeout, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"timeoutlen",  "tm",   P_NUM|P_VI_DEF,
-   (char_u *)&p_tm, PV_NONE,
-   {(char_u *)1000L, (char_u *)0L} SCRIPTID_INIT},
-  {"title",       NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)&p_title, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"titlelen",    NULL,   P_NUM|P_VI_DEF,
-   (char_u *)&p_titlelen, PV_NONE,
-   {(char_u *)85L, (char_u *)0L} SCRIPTID_INIT},
-  {"titleold",    NULL,   P_STRING|P_VI_DEF|P_GETTEXT|P_SECURE|P_NO_MKRC,
+  {"tagstack",    "tgst", P_BOOL,
+   (char_u *)&p_tgst, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"term",        NULL,   P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|P_RALL,
+   (char_u *)&T_NAME, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"termbidi", "tbidi",   P_BOOL,
+   (char_u *)&p_tbidi, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"termencoding", "tenc", P_STRING|P_RCLR,
+   (char_u *)&p_tenc, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"terse",       NULL,   P_BOOL,
+   (char_u *)&p_terse, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"textwidth",   "tw",   P_NUM|P_RBUF,
+   (char_u *)&p_tw, PV_TW, (char_u *)0L
+   SCRIPTID_INIT},
+  {"thesaurus",   "tsr",  P_STRING|P_EXPAND|P_COMMA|P_NODUP,
+   (char_u *)&p_tsr, PV_TSR, (char_u *)""
+   SCRIPTID_INIT},
+  {"tildeop",     "top",  P_BOOL,
+   (char_u *)&p_to, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"timeout",     "to",   P_BOOL,
+   (char_u *)&p_timeout, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"timeoutlen",  "tm",   P_NUM,
+   (char_u *)&p_tm, PV_NONE, (char_u *)1000L
+   SCRIPTID_INIT},
+  {"title",       NULL,   P_BOOL,
+   (char_u *)&p_title, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"titlelen",    NULL,   P_NUM,
+   (char_u *)&p_titlelen, PV_NONE, (char_u *)85L
+   SCRIPTID_INIT},
+  {"titleold",    NULL,   P_STRING|P_GETTEXT|P_SECURE|P_NO_MKRC,
    (char_u *)&p_titleold, PV_NONE,
-   {(char_u *)N_("Thanks for flying Vim"),
-    (char_u *)0L}
+   (char_u *)N_("Thanks for flying Vim")
    SCRIPTID_INIT},
-  {"titlestring", NULL,   P_STRING|P_VI_DEF,
-   (char_u *)&p_titlestring, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"ttimeout",    NULL,   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_ttimeout, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"ttimeoutlen", "ttm",  P_NUM|P_VI_DEF,
-   (char_u *)&p_ttm, PV_NONE,
-   {(char_u *)-1L, (char_u *)0L} SCRIPTID_INIT},
-  {"ttybuiltin",  "tbi",  P_BOOL|P_VI_DEF,
-   (char_u *)&p_tbi, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"ttyfast",     "tf",   P_BOOL|P_NO_MKRC|P_VI_DEF,
-   (char_u *)&p_tf, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"ttymouse",    "ttym", P_STRING|P_NODEFAULT|P_NO_MKRC|P_VI_DEF,
+  {"titlestring", NULL,   P_STRING,
+   (char_u *)&p_titlestring, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"ttimeout",    NULL,   P_BOOL,
+   (char_u *)&p_ttimeout, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"ttimeoutlen", "ttm",  P_NUM,
+   (char_u *)&p_ttm, PV_NONE, (char_u *)-1L
+   SCRIPTID_INIT},
+  {"ttybuiltin",  "tbi",  P_BOOL,
+   (char_u *)&p_tbi, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"ttyfast",     "tf",   P_BOOL|P_NO_MKRC,
+   (char_u *)&p_tf, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"ttymouse",    "ttym", P_STRING|P_NODEFAULT|P_NO_MKRC,
 #if defined(FEAT_MOUSE) && defined(UNIX)
    (char_u *)&p_ttym, PV_NONE,
 #else
    (char_u *)NULL, PV_NONE,
 #endif
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"ttyscroll",   "tsl",  P_NUM|P_VI_DEF,
-   (char_u *)&p_ttyscroll, PV_NONE,
-   {(char_u *)999L, (char_u *)0L} SCRIPTID_INIT},
-  {"ttytype",     "tty",  P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|
-   P_RALL,
-   (char_u *)&T_NAME, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"undodir",     "udir", P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE|P_VI_DEF,
-   (char_u *)&p_udir, PV_NONE,
-   {(char_u *)".", (char_u *)0L}
+   (char_u *)""
    SCRIPTID_INIT},
-  {"undofile",    "udf",  P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_udf, PV_UDF,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"undolevels",  "ul",   P_NUM|P_VI_DEF,
+  {"ttyscroll",   "tsl",  P_NUM,
+   (char_u *)&p_ttyscroll, PV_NONE, (char_u *)999L
+   SCRIPTID_INIT},
+  {"ttytype",     "tty",  P_STRING|P_EXPAND|P_NODEFAULT|P_NO_MKRC|P_RALL,
+   (char_u *)&T_NAME, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"undodir",     "udir", P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
+   (char_u *)&p_udir, PV_NONE, (char_u *)"."
+   SCRIPTID_INIT},
+  {"undofile",    "udf",  P_BOOL,
+   (char_u *)&p_udf, PV_UDF, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"undolevels",  "ul",   P_NUM,
    (char_u *)&p_ul, PV_UL,
-   {
 #if defined(UNIX) || defined(WIN3264)
-     (char_u *)1000L,
+   (char_u *)1000L
 #else
-     (char_u *)100L,
+   (char_u *)100L
 #endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"undoreload",  "ur",   P_NUM|P_VI_DEF,
-   (char_u *)&p_ur, PV_NONE,
-   { (char_u *)10000L, (char_u *)0L} SCRIPTID_INIT},
-  {"updatecount", "uc",   P_NUM|P_VI_DEF,
-   (char_u *)&p_uc, PV_NONE,
-   {(char_u *)200L, (char_u *)0L} SCRIPTID_INIT},
-  {"updatetime",  "ut",   P_NUM|P_VI_DEF,
-   (char_u *)&p_ut, PV_NONE,
-   {(char_u *)4000L, (char_u *)0L} SCRIPTID_INIT},
-  {"verbose",     "vbs",  P_NUM|P_VI_DEF,
-   (char_u *)&p_verbose, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"verbosefile", "vfile", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
-   (char_u *)&p_vfile, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"viewdir",     "vdir", P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
-   (char_u *)&p_vdir, PV_NONE,
-   {(char_u *)DFLT_VDIR, (char_u *)0L}
    SCRIPTID_INIT},
-  {"viewoptions", "vop",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_vop, PV_NONE,
-   {(char_u *)"folds,options,cursor", (char_u *)0L}
+  {"undoreload",  "ur",   P_NUM,
+   (char_u *)&p_ur, PV_NONE, (char_u *)10000L
+   SCRIPTID_INIT},
+  {"updatecount", "uc",   P_NUM,
+   (char_u *)&p_uc, PV_NONE, (char_u *)200L
+   SCRIPTID_INIT},
+  {"updatetime",  "ut",   P_NUM,
+   (char_u *)&p_ut, PV_NONE, (char_u *)4000L
+   SCRIPTID_INIT},
+  {"verbose",     "vbs",  P_NUM,
+   (char_u *)&p_verbose, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"verbosefile", "vfile", P_STRING|P_EXPAND|P_SECURE,
+   (char_u *)&p_vfile, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"viewdir",     "vdir", P_STRING|P_EXPAND|P_SECURE,
+   (char_u *)&p_vdir, PV_NONE, (char_u *)DFLT_VDIR
+   SCRIPTID_INIT},
+  {"viewoptions", "vop",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_vop, PV_NONE, (char_u *)"folds,options,cursor"
    SCRIPTID_INIT},
   {"viminfo",     "vi",   P_STRING|P_COMMA|P_NODUP|P_SECURE,
-   (char_u *)&p_viminfo, PV_NONE,
-   {(char_u *)"", (char_u *)"'100,<50,s10,h"}
+   (char_u *)&p_viminfo, PV_NONE, (char_u *)"'100,<50,s10,h"
    SCRIPTID_INIT},
-  {"virtualedit", "ve",   P_STRING|P_COMMA|P_NODUP|P_VI_DEF|P_VIM|P_CURSWANT,
-   (char_u *)&p_ve, PV_NONE,
-   {(char_u *)"", (char_u *)""}
+  {"virtualedit", "ve",   P_STRING|P_COMMA|P_NODUP|P_CURSWANT,
+   (char_u *)&p_ve, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"visualbell",  "vb",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_vb, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"w300",        NULL,   P_NUM|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"w1200",       NULL,   P_NUM|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"w9600",       NULL,   P_NUM|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"warn",        NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)&p_warn, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"weirdinvert", "wiv",  P_BOOL|P_VI_DEF|P_RCLR,
-   (char_u *)&p_wiv, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"whichwrap",   "ww",   P_STRING|P_VIM|P_COMMA|P_FLAGLIST,
-   (char_u *)&p_ww, PV_NONE,
-   {(char_u *)"", (char_u *)"b,s"} SCRIPTID_INIT},
-  {"wildchar",    "wc",   P_NUM|P_VIM,
-   (char_u *)&p_wc, PV_NONE,
-   {(char_u *)(long)Ctrl_E, (char_u *)(long)TAB}
+  {"visualbell",  "vb",   P_BOOL,
+   (char_u *)&p_vb, PV_NONE, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"wildcharm",   "wcm",  P_NUM|P_VI_DEF,
-   (char_u *)&p_wcm, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"wildignore",  "wig",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_wig, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"wildignorecase", "wic", P_BOOL|P_VI_DEF,
-   (char_u *)&p_wic, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"wildmenu",    "wmnu", P_BOOL|P_VI_DEF,
-   (char_u *)&p_wmnu, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"wildmode",    "wim",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_wim, PV_NONE,
-   {(char_u *)"full", (char_u *)0L} SCRIPTID_INIT},
-  {"wildoptions", "wop",  P_STRING|P_VI_DEF,
-   (char_u *)&p_wop, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+  {"w300",        NULL,   P_NUM,
+   (char_u *)NULL, PV_NONE, (char_u *)0L
    SCRIPTID_INIT},
-  {"winaltkeys",  "wak",  P_STRING|P_VI_DEF,
-   (char_u *)&p_wak, PV_NONE,
-   {(char_u *)"menu", (char_u *)0L}
+  {"w1200",       NULL,   P_NUM,
+   (char_u *)NULL, PV_NONE, (char_u *)0L
    SCRIPTID_INIT},
-  {"window",      "wi",   P_NUM|P_VI_DEF,
-   (char_u *)&p_window, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"winheight",   "wh",   P_NUM|P_VI_DEF,
-   (char_u *)&p_wh, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"winfixheight", "wfh", P_BOOL|P_VI_DEF|P_RSTAT,
-   (char_u *)VAR_WIN, PV_WFH,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"winfixwidth", "wfw", P_BOOL|P_VI_DEF|P_RSTAT,
-   (char_u *)VAR_WIN, PV_WFW,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"winminheight", "wmh", P_NUM|P_VI_DEF,
-   (char_u *)&p_wmh, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"winminwidth", "wmw", P_NUM|P_VI_DEF,
-   (char_u *)&p_wmw, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"winwidth",   "wiw",   P_NUM|P_VI_DEF,
-   (char_u *)&p_wiw, PV_NONE,
-   {(char_u *)20L, (char_u *)0L} SCRIPTID_INIT},
-  {"wrap",        NULL,   P_BOOL|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_WRAP,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"wrapmargin",  "wm",   P_NUM|P_VI_DEF,
-   (char_u *)&p_wm, PV_WM,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"wrapscan",    "ws",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_ws, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"write",       NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)&p_write, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"writeany",    "wa",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_wa, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"writebackup", "wb",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_wb, PV_NONE,
-   {
-     (char_u *)TRUE,
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"writedelay",  "wd",   P_NUM|P_VI_DEF,
-   (char_u *)&p_wd, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
+  {"w9600",       NULL,   P_NUM,
+   (char_u *)NULL, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"warn",        NULL,   P_BOOL,
+   (char_u *)&p_warn, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"weirdinvert", "wiv",  P_BOOL|P_RCLR,
+   (char_u *)&p_wiv, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"whichwrap",   "ww",   P_STRING|P_COMMA|P_FLAGLIST,
+   (char_u *)&p_ww, PV_NONE, (char_u *)"b,s"
+   SCRIPTID_INIT},
+  {"wildchar",    "wc",   P_NUM,
+   (char_u *)&p_wc, PV_NONE, (char_u *)(long)TAB
+   SCRIPTID_INIT},
+  {"wildcharm",   "wcm",  P_NUM,
+   (char_u *)&p_wcm, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"wildignore",  "wig",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_wig, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"wildignorecase", "wic", P_BOOL,
+   (char_u *)&p_wic, PV_NONE, (char_u *)FALSE SCRIPTID_INIT},
+  {"wildmenu",    "wmnu", P_BOOL,
+   (char_u *)&p_wmnu, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"wildmode",    "wim",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_wim, PV_NONE, (char_u *)"full" SCRIPTID_INIT},
+  {"wildoptions", "wop",  P_STRING,
+   (char_u *)&p_wop, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"winaltkeys",  "wak",  P_STRING,
+   (char_u *)&p_wak, PV_NONE, (char_u *)"menu"
+   SCRIPTID_INIT},
+  {"window",      "wi",   P_NUM,
+   (char_u *)&p_window, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"winheight",   "wh",   P_NUM,
+   (char_u *)&p_wh, PV_NONE, (char_u *)1L
+   SCRIPTID_INIT},
+  {"winfixheight", "wfh", P_BOOL|P_RSTAT,
+   (char_u *)VAR_WIN, PV_WFH, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"winfixwidth", "wfw", P_BOOL|P_RSTAT,
+   (char_u *)VAR_WIN, PV_WFW, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"winminheight", "wmh", P_NUM,
+   (char_u *)&p_wmh, PV_NONE, (char_u *)1L
+   SCRIPTID_INIT},
+  {"winminwidth", "wmw", P_NUM,
+   (char_u *)&p_wmw, PV_NONE, (char_u *)1L
+   SCRIPTID_INIT},
+  {"winwidth",   "wiw",   P_NUM,
+   (char_u *)&p_wiw, PV_NONE, (char_u *)20L
+   SCRIPTID_INIT},
+  {"wrap",        NULL,   P_BOOL|P_RWIN,
+   (char_u *)VAR_WIN, PV_WRAP, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"wrapmargin",  "wm",   P_NUM,
+   (char_u *)&p_wm, PV_WM, (char_u *)0L
+   SCRIPTID_INIT},
+  {"wrapscan",    "ws",   P_BOOL,
+   (char_u *)&p_ws, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"write",       NULL,   P_BOOL,
+   (char_u *)&p_write, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"writeany",    "wa",   P_BOOL,
+   (char_u *)&p_wa, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"writebackup", "wb",   P_BOOL,
+   (char_u *)&p_wb, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"writedelay",  "wd",   P_NUM,
+   (char_u *)&p_wd, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
 
   /* terminal output codes */
 #define p_term(sss, vvv)   {sss, NULL, P_STRING|P_VI_DEF|P_RALL|P_SECURE, \

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -777,204 +777,180 @@ static struct vimoption
   {"guitabtooltip",  "gtt", P_STRING|P_RWIN,
    (char_u *)NULL, PV_NONE, (char_u *)NULL
    SCRIPTID_INIT},
-  {"hardtabs",    "ht",   P_NUM|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"helpfile",    "hf",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
-   (char_u *)&p_hf, PV_NONE,
-   {(char_u *)DFLT_HELPFILE, (char_u *)0L}
+  {"hardtabs",    "ht",   P_NUM,
+   (char_u *)NULL, PV_NONE, (char_u *)0L
    SCRIPTID_INIT},
-  {"helpheight",  "hh",   P_NUM|P_VI_DEF,
-   (char_u *)&p_hh, PV_NONE,
-   {(char_u *)20L, (char_u *)0L} SCRIPTID_INIT},
-  {"helplang",    "hlg",  P_STRING|P_VI_DEF|P_COMMA,
-   (char_u *)&p_hlg, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+  {"helpfile",    "hf",   P_STRING|P_EXPAND|P_SECURE,
+   (char_u *)&p_hf, PV_NONE, (char_u *)DFLT_HELPFILE
    SCRIPTID_INIT},
-  {"hidden",      "hid",  P_BOOL|P_VI_DEF,
-   (char_u *)&p_hid, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"highlight",   "hl",   P_STRING|P_VI_DEF|P_RCLR|P_COMMA|P_NODUP,
-   (char_u *)&p_hl, PV_NONE,
-   {(char_u *)HIGHLIGHT_INIT, (char_u *)0L}
+  {"helpheight",  "hh",   P_NUM,
+   (char_u *)&p_hh, PV_NONE, (char_u *)20L
    SCRIPTID_INIT},
-  {"history",     "hi",   P_NUM|P_VIM,
-   (char_u *)&p_hi, PV_NONE,
-   {(char_u *)0L, (char_u *)20L} SCRIPTID_INIT},
-  {"hkmap",       "hk",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_hkmap, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"hkmapp",      "hkp",  P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_hkmapp, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"hlsearch",    "hls",  P_BOOL|P_VI_DEF|P_VIM|P_RALL,
-   (char_u *)&p_hls, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"icon",        NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)&p_icon, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"iconstring",  NULL,   P_STRING|P_VI_DEF,
-   (char_u *)&p_iconstring, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"ignorecase",  "ic",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_ic, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"imactivatefunc","imaf",P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+  {"helplang",    "hlg",  P_STRING|P_COMMA,
+   (char_u *)&p_hlg, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"imactivatekey","imak",P_STRING|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"imcmdline",   "imc",  P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"imdisable",   "imd",  P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L}
+  {"hidden",      "hid",  P_BOOL,
+   (char_u *)&p_hid, PV_NONE, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"iminsert",    "imi",  P_NUM|P_VI_DEF,
+  {"highlight",   "hl",   P_STRING|P_RCLR|P_COMMA|P_NODUP,
+   (char_u *)&p_hl, PV_NONE, (char_u *)HIGHLIGHT_INIT
+   SCRIPTID_INIT},
+  {"history",     "hi",   P_NUM,
+   (char_u *)&p_hi, PV_NONE, (char_u *)20L
+   SCRIPTID_INIT},
+  {"hkmap",       "hk",   P_BOOL,
+   (char_u *)&p_hkmap, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"hkmapp",      "hkp",  P_BOOL,
+   (char_u *)&p_hkmapp, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"hlsearch",    "hls",  P_BOOL|P_RALL,
+   (char_u *)&p_hls, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"icon",        NULL,   P_BOOL,
+   (char_u *)&p_icon, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"iconstring",  NULL,   P_STRING,
+   (char_u *)&p_iconstring, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"ignorecase",  "ic",   P_BOOL,
+   (char_u *)&p_ic, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"imactivatefunc","imaf",P_STRING|P_SECURE,
+   (char_u *)NULL, PV_NONE, (char_u *)NULL
+   SCRIPTID_INIT},
+  {"imactivatekey","imak",P_STRING,
+   (char_u *)NULL, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"imcmdline",   "imc",  P_BOOL,
+   (char_u *)NULL, PV_NONE,
+   (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"imdisable",   "imd",  P_BOOL,
+   (char_u *)NULL, PV_NONE,
+   (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"iminsert",    "imi",  P_NUM,
    (char_u *)&p_iminsert, PV_IMI,
 #ifdef B_IMODE_IM
-   {(char_u *)B_IMODE_IM, (char_u *)0L}
+   (char_u *)B_IMODE_IM
 #else
-   {(char_u *)B_IMODE_NONE, (char_u *)0L}
+   (char_u *)B_IMODE_NONE
 #endif
    SCRIPTID_INIT},
-  {"imsearch",    "ims",  P_NUM|P_VI_DEF,
+  {"imsearch",    "ims",  P_NUM,
    (char_u *)&p_imsearch, PV_IMS,
 #ifdef B_IMODE_IM
-   {(char_u *)B_IMODE_IM, (char_u *)0L}
+   (char_u *)B_IMODE_IM
 #else
-   {(char_u *)B_IMODE_NONE, (char_u *)0L}
+   (char_u *)B_IMODE_NONE
 #endif
    SCRIPTID_INIT},
-  {"imstatusfunc","imsf",P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+  {"imstatusfunc","imsf",P_STRING|P_SECURE,
+   (char_u *)NULL, PV_NONE, (char_u *)NULL
    SCRIPTID_INIT},
-  {"include",     "inc",  P_STRING|P_ALLOCED|P_VI_DEF,
+  {"include",     "inc",  P_STRING|P_ALLOCED,
    (char_u *)&p_inc, PV_INC,
-   {(char_u *)"^\\s*#\\s*include", (char_u *)0L}
+   (char_u *)"^\\s*#\\s*include"
    SCRIPTID_INIT},
-  {"includeexpr", "inex", P_STRING|P_ALLOCED|P_VI_DEF,
-   (char_u *)&p_inex, PV_INEX,
-   {(char_u *)"", (char_u *)0L}
+  {"includeexpr", "inex", P_STRING|P_ALLOCED,
+   (char_u *)&p_inex, PV_INEX, (char_u *)""
    SCRIPTID_INIT},
-  {"incsearch",   "is",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_is, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"indentexpr", "inde",  P_STRING|P_ALLOCED|P_VI_DEF|P_VIM,
-   (char_u *)&p_inde, PV_INDE,
-   {(char_u *)"", (char_u *)0L}
+  {"incsearch",   "is",   P_BOOL,
+   (char_u *)&p_is, PV_NONE, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"indentkeys", "indk",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
+  {"indentexpr", "inde",  P_STRING|P_ALLOCED,
+   (char_u *)&p_inde, PV_INDE, (char_u *)""
+   SCRIPTID_INIT},
+  {"indentkeys", "indk",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
    (char_u *)&p_indk, PV_INDK,
-   {(char_u *)"0{,0},:,0#,!^F,o,O,e", (char_u *)0L}
+   (char_u *)"0{,0},:,0#,!^F,o,O,e"
    SCRIPTID_INIT},
-  {"infercase",   "inf",  P_BOOL|P_VI_DEF,
-   (char_u *)&p_inf, PV_INF,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"insertmode",  "im",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_im, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"isfname",     "isf",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"infercase",   "inf",  P_BOOL,
+   (char_u *)&p_inf, PV_INF, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"insertmode",  "im",   P_BOOL,
+   (char_u *)&p_im, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"isfname",     "isf",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_isf, PV_NONE,
-   {
 #ifdef BACKSLASH_IN_FILENAME
      /* Excluded are: & and ^ are special in cmd.exe
      * ( and ) are used in text separating fnames */
-     (char_u *)"@,48-57,/,\\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=",
+     (char_u *)"@,48-57,/,\\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,="
 #else
-     (char_u *)"@,48-57,/,.,-,_,+,,,#,$,%,~,=",
+     (char_u *)"@,48-57,/,.,-,_,+,,,#,$,%,~,="
 #endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"isident",     "isi",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_isi, PV_NONE,
-   {
-     (char_u *)"@,48-57,_,192-255",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"iskeyword",   "isk",  P_STRING|P_ALLOCED|P_VIM|P_COMMA|P_NODUP,
-   (char_u *)&p_isk, PV_ISK,
-   {
-     (char_u *)"@,48-57,_",
-     ISK_LATIN1
-   } SCRIPTID_INIT},
-  {"isprint",     "isp",  P_STRING|P_VI_DEF|P_RALL|P_COMMA|P_NODUP,
+   SCRIPTID_INIT},
+  {"isident",     "isi",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_isi, PV_NONE, (char_u *)"@,48-57,_,192-255"
+   SCRIPTID_INIT},
+  {"iskeyword",   "isk",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
+   (char_u *)&p_isk, PV_ISK, ISK_LATIN1
+   SCRIPTID_INIT},
+  {"isprint",     "isp",  P_STRING|P_RALL|P_COMMA|P_NODUP,
    (char_u *)&p_isp, PV_NONE,
-   {
 #if defined(MSWIN)
-     (char_u *)"@,~-255",
+     (char_u *)"@,~-255"
 #else
-     ISP_LATIN1,
+     ISP_LATIN1
 #endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"joinspaces",  "js",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_js, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"keymap",      "kmp",  P_STRING|P_ALLOCED|P_VI_DEF|P_RBUF|P_RSTAT|P_NFNAME|
+   SCRIPTID_INIT},
+  {"joinspaces",  "js",   P_BOOL,
+   (char_u *)&p_js, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"keymap",      "kmp",  P_STRING|P_ALLOCED|P_RBUF|P_RSTAT|P_NFNAME|
    P_PRI_MKRC,
-   (char_u *)&p_keymap, PV_KMAP,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)&p_keymap, PV_KMAP, (char_u *)""
    SCRIPTID_INIT},
-  {"keymodel",    "km",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_km, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"keywordprg",  "kp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+  {"keymodel",    "km",   P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_km, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"keywordprg",  "kp",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_kp, PV_KP,
-   {
 #  ifdef USEMAN_S
-     (char_u *)"man -s",
+     (char_u *)"man -s"
 #  else
-     (char_u *)"man",
+     (char_u *)"man"
 #  endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"langmap",     "lmap", P_STRING|P_VI_DEF|P_COMMA|P_NODUP|P_SECURE,
+   SCRIPTID_INIT},
+  {"langmap",     "lmap", P_STRING|P_COMMA|P_NODUP|P_SECURE,
    (char_u *)&p_langmap, PV_NONE,
-   {(char_u *)"",                               /* unmatched } */
-    (char_u *)0L} SCRIPTID_INIT},
-  {"langmenu",    "lm",   P_STRING|P_VI_DEF|P_NFNAME,
-   (char_u *)&p_lm, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"laststatus",  "ls",   P_NUM|P_VI_DEF|P_RALL,
-   (char_u *)&p_ls, PV_NONE,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"lazyredraw",  "lz",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_lz, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"linebreak",   "lbr",  P_BOOL|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_LBR,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"lines",       NULL,   P_NUM|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|P_RCLR,
-   (char_u *)&Rows, PV_NONE,
-   {
-     (char_u *)24L,
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"linespace",   "lsp",  P_NUM|P_VI_DEF|P_RCLR,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)0L, (char_u *)0L}
+   (char_u *)""                               /* unmatched } */
    SCRIPTID_INIT},
-  {"lisp",        NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)&p_lisp, PV_LISP,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"lispwords",   "lw",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_lispwords, PV_LW,
-   {(char_u *)LISPWORD_VALUE, (char_u *)0L}
+  {"langmenu",    "lm",   P_STRING|P_NFNAME,
+   (char_u *)&p_lm, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"list",        NULL,   P_BOOL|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_LIST,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"listchars",   "lcs",  P_STRING|P_VI_DEF|P_RALL|P_COMMA|P_NODUP,
-   (char_u *)&p_lcs, PV_NONE,
-   {(char_u *)"eol:$", (char_u *)0L} SCRIPTID_INIT},
-  {"loadplugins", "lpl",  P_BOOL|P_VI_DEF,
-   (char_u *)&p_lpl, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
+  {"laststatus",  "ls",   P_NUM|P_RALL,
+   (char_u *)&p_ls, PV_NONE, (char_u *)1L
+   SCRIPTID_INIT},
+  {"lazyredraw",  "lz",   P_BOOL,
+   (char_u *)&p_lz, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"linebreak",   "lbr",  P_BOOL|P_RWIN,
+   (char_u *)VAR_WIN, PV_LBR, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"lines",       NULL,   P_NUM|P_NODEFAULT|P_NO_MKRC|P_RCLR,
+   (char_u *)&Rows, PV_NONE, (char_u *)24L
+   SCRIPTID_INIT},
+  {"linespace",   "lsp",  P_NUM|P_RCLR,
+   (char_u *)NULL, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"lisp",        NULL,   P_BOOL,
+   (char_u *)&p_lisp, PV_LISP, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"lispwords",   "lw",   P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_lispwords, PV_LW, (char_u *)LISPWORD_VALUE
+   SCRIPTID_INIT},
+  {"list",        NULL,   P_BOOL|P_RWIN,
+   (char_u *)VAR_WIN, PV_LIST, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"listchars",   "lcs",  P_STRING|P_RALL|P_COMMA|P_NODUP,
+   (char_u *)&p_lcs, PV_NONE, (char_u *)"eol:$"
+   SCRIPTID_INIT},
+  {"loadplugins", "lpl",  P_BOOL,
+   (char_u *)&p_lpl, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
   {"magic",       NULL,   P_BOOL|P_VI_DEF,
    (char_u *)&p_magic, PV_NONE,
    {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -569,249 +569,213 @@ static struct vimoption
   {"cursorline",   "cul", P_BOOL|P_RWIN,
    (char_u *)VAR_WIN, PV_CUL, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"debug",       NULL,   P_STRING|P_VI_DEF,
-   (char_u *)&p_debug, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"define",      "def",  P_STRING|P_ALLOCED|P_VI_DEF|P_CURSWANT,
-   (char_u *)&p_def, PV_DEF,
-   {(char_u *)"^\\s*#\\s*define", (char_u *)0L}
+  {"debug",       NULL,   P_STRING,
+   (char_u *)&p_debug, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"delcombine", "deco",  P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_deco, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"dictionary",  "dict", P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_dict, PV_DICT,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"diff",        NULL,   P_BOOL|P_VI_DEF|P_RWIN|P_NOGLOB,
-   (char_u *)VAR_WIN, PV_DIFF,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"diffexpr",    "dex",  P_STRING|P_VI_DEF|P_SECURE|P_CURSWANT,
-   (char_u *)&p_dex, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+  {"define",      "def",  P_STRING|P_ALLOCED|P_CURSWANT,
+   (char_u *)&p_def, PV_DEF, (char_u *)"^\\s*#\\s*define"
    SCRIPTID_INIT},
-  {"diffopt",     "dip",  P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN|P_COMMA|P_NODUP,
-   (char_u *)&p_dip, PV_NONE,
-   {(char_u *)"filler", (char_u *)NULL}
+  {"delcombine", "deco",  P_BOOL,
+   (char_u *)&p_deco, PV_NONE, (char_u *)FALSE SCRIPTID_INIT},
+  {"dictionary",  "dict", P_STRING|P_EXPAND|P_COMMA|P_NODUP,
+   (char_u *)&p_dict, PV_DICT, (char_u *)""
    SCRIPTID_INIT},
-  {"digraph",     "dg",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_dg, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"directory",   "dir",  P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP|P_SECURE,
-   (char_u *)&p_dir, PV_NONE,
-   {(char_u *)DFLT_DIR, (char_u *)0L} SCRIPTID_INIT},
-  {"display",     "dy",   P_STRING|P_VI_DEF|P_COMMA|P_RALL|P_NODUP,
-   (char_u *)&p_dy, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"eadirection", "ead",  P_STRING|P_VI_DEF,
-   (char_u *)&p_ead, PV_NONE,
-   {(char_u *)"both", (char_u *)0L}
+  {"diff",        NULL,   P_BOOL|P_RWIN|P_NOGLOB,
+   (char_u *)VAR_WIN, PV_DIFF, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"edcompatible","ed",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_ed, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"encoding",    "enc",  P_STRING|P_VI_DEF|P_RCLR|P_NO_ML,
-   (char_u *)&p_enc, PV_NONE,
-   {(char_u *)ENC_DFLT, (char_u *)0L}
+  {"diffexpr",    "dex",  P_STRING|P_SECURE|P_CURSWANT,
+   (char_u *)&p_dex, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"endofline",   "eol",  P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
-   (char_u *)&p_eol, PV_EOL,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"equalalways", "ea",   P_BOOL|P_VI_DEF|P_RALL,
-   (char_u *)&p_ea, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"equalprg",    "ep",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
-   (char_u *)&p_ep, PV_EP,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"errorbells",  "eb",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_eb, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"errorfile",   "ef",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
-   (char_u *)&p_ef, PV_NONE,
-   {(char_u *)DFLT_ERRORFILE, (char_u *)0L}
+  {"diffopt",     "dip",  P_STRING|P_ALLOCED|P_RWIN|P_COMMA|P_NODUP,
+   (char_u *)&p_dip, PV_NONE, (char_u *)"filler"
    SCRIPTID_INIT},
-  {"errorformat", "efm",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_efm, PV_EFM,
-   {(char_u *)DFLT_EFM, (char_u *)0L}
+  {"digraph",     "dg",   P_BOOL,
+   (char_u *)&p_dg, PV_NONE, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"esckeys",     "ek",   P_BOOL|P_VIM,
-   (char_u *)&p_ek, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"eventignore", "ei",   P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_ei, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"expandtab",   "et",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_et, PV_ET,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"exrc",        "ex",   P_BOOL|P_VI_DEF|P_SECURE,
-   (char_u *)&p_exrc, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"fileencoding","fenc", P_STRING|P_ALLOCED|P_VI_DEF|P_RSTAT|P_RBUF|P_NO_MKRC,
-   (char_u *)&p_fenc, PV_FENC,
-   {(char_u *)"", (char_u *)0L}
+  {"directory",   "dir",  P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
+   (char_u *)&p_dir, PV_NONE, (char_u *)DFLT_DIR
    SCRIPTID_INIT},
-  {"fileencodings","fencs", P_STRING|P_VI_DEF|P_COMMA,
-   (char_u *)&p_fencs, PV_NONE,
-   {(char_u *)"ucs-bom", (char_u *)0L}
+  {"display",     "dy",   P_STRING|P_COMMA|P_RALL|P_NODUP,
+   (char_u *)&p_dy, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"fileformat",  "ff",   P_STRING|P_ALLOCED|P_VI_DEF|P_RSTAT|P_NO_MKRC|
+  {"eadirection", "ead",  P_STRING,
+   (char_u *)&p_ead, PV_NONE, (char_u *)"both"
+   SCRIPTID_INIT},
+  {"edcompatible","ed",   P_BOOL,
+   (char_u *)&p_ed, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"encoding",    "enc",  P_STRING|P_RCLR|P_NO_ML,
+   (char_u *)&p_enc, PV_NONE, (char_u *)ENC_DFLT
+   SCRIPTID_INIT},
+  {"endofline",   "eol",  P_BOOL|P_NO_MKRC|P_RSTAT,
+   (char_u *)&p_eol, PV_EOL, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"equalalways", "ea",   P_BOOL|P_RALL,
+   (char_u *)&p_ea, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"equalprg",    "ep",   P_STRING|P_EXPAND|P_SECURE,
+   (char_u *)&p_ep, PV_EP, (char_u *)""
+   SCRIPTID_INIT},
+  {"errorbells",  "eb",   P_BOOL,
+   (char_u *)&p_eb, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"errorfile",   "ef",   P_STRING|P_EXPAND|P_SECURE,
+   (char_u *)&p_ef, PV_NONE, (char_u *)DFLT_ERRORFILE
+   SCRIPTID_INIT},
+  {"errorformat", "efm",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_efm, PV_EFM, (char_u *)DFLT_EFM
+   SCRIPTID_INIT},
+  {"esckeys",     "ek",   P_BOOL,
+   (char_u *)&p_ek, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"eventignore", "ei",   P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_ei, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"expandtab",   "et",   P_BOOL,
+   (char_u *)&p_et, PV_ET, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"exrc",        "ex",   P_BOOL|P_SECURE,
+   (char_u *)&p_exrc, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"fileencoding","fenc", P_STRING|P_ALLOCED|P_RSTAT|P_RBUF|P_NO_MKRC,
+   (char_u *)&p_fenc, PV_FENC, (char_u *)""
+   SCRIPTID_INIT},
+  {"fileencodings","fencs", P_STRING|P_COMMA,
+   (char_u *)&p_fencs, PV_NONE, (char_u *)"ucs-bom"
+   SCRIPTID_INIT},
+  {"fileformat",  "ff",   P_STRING|P_ALLOCED|P_RSTAT|P_NO_MKRC|
    P_CURSWANT,
-   (char_u *)&p_ff, PV_FF,
-   {(char_u *)DFLT_FF, (char_u *)0L} SCRIPTID_INIT},
-  {"fileformats", "ffs",  P_STRING|P_VIM|P_COMMA|P_NODUP,
-   (char_u *)&p_ffs, PV_NONE,
-   {(char_u *)DFLT_FFS_VI, (char_u *)DFLT_FFS_VIM}
+   (char_u *)&p_ff, PV_FF, (char_u *)DFLT_FF
    SCRIPTID_INIT},
-  {"fileignorecase", "fic", P_BOOL|P_VI_DEF,
+  {"fileformats", "ffs",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_ffs, PV_NONE, (char_u *)DFLT_FFS_VIM
+   SCRIPTID_INIT},
+  {"fileignorecase", "fic", P_BOOL,
    (char_u *)&p_fic, PV_NONE,
-   {
 #ifdef CASE_INSENSITIVE_FILENAME
-     (char_u *)TRUE,
+     (char_u *)TRUE
 #else
-     (char_u *)FALSE,
+     (char_u *)FALSE
 #endif
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"filetype",    "ft",   P_STRING|P_ALLOCED|P_VI_DEF|P_NOGLOB|P_NFNAME,
-   (char_u *)&p_ft, PV_FT,
-   {(char_u *)"", (char_u *)0L}
    SCRIPTID_INIT},
-  {"fillchars",   "fcs",  P_STRING|P_VI_DEF|P_RALL|P_COMMA|P_NODUP,
-   (char_u *)&p_fcs, PV_NONE,
-   {(char_u *)"vert:|,fold:-", (char_u *)0L}
+  {"filetype",    "ft",   P_STRING|P_ALLOCED|P_NOGLOB|P_NFNAME,
+   (char_u *)&p_ft, PV_FT, (char_u *)""
    SCRIPTID_INIT},
-  {"fkmap",       "fk",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_fkmap, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"flash",       "fl",   P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"foldclose",   "fcl",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP|P_RWIN,
-   (char_u *)&p_fcl, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"foldcolumn",  "fdc",  P_NUM|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_FDC,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"foldenable",  "fen",  P_BOOL|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_FEN,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"foldexpr",    "fde",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_FDE,
-   {(char_u *)"0", (char_u *)NULL}
+  {"fillchars",   "fcs",  P_STRING|P_RALL|P_COMMA|P_NODUP,
+   (char_u *)&p_fcs, PV_NONE, (char_u *)"vert:|,fold:-"
    SCRIPTID_INIT},
-  {"foldignore",  "fdi",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_FDI,
-   {(char_u *)"#", (char_u *)NULL} SCRIPTID_INIT},
-  {"foldlevel",   "fdl",  P_NUM|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_FDL,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"foldlevelstart","fdls", P_NUM|P_VI_DEF|P_CURSWANT,
-   (char_u *)&p_fdls, PV_NONE,
-   {(char_u *)-1L, (char_u *)0L} SCRIPTID_INIT},
-  {"foldmarker",  "fmr",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|
-   P_RWIN|P_COMMA|P_NODUP,
-   (char_u *)VAR_WIN, PV_FMR,
-   {(char_u *)"{{{,}}}", (char_u *)NULL}
+  {"fkmap",       "fk",   P_BOOL,
+   (char_u *)&p_fkmap, PV_NONE, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"foldmethod",  "fdm",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_FDM,
-   {(char_u *)"manual", (char_u *)NULL} SCRIPTID_INIT},
-  {"foldminlines","fml",  P_NUM|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_FML,
-   {(char_u *)1L, (char_u *)0L} SCRIPTID_INIT},
-  {"foldnestmax", "fdn",  P_NUM|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_FDN,
-   {(char_u *)20L, (char_u *)0L} SCRIPTID_INIT},
-  {"foldopen",    "fdo",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP|P_CURSWANT,
+  {"flash",       "fl",   P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"foldclose",   "fcl",  P_STRING|P_COMMA|P_NODUP|P_RWIN,
+   (char_u *)&p_fcl, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"foldcolumn",  "fdc",  P_NUM|P_RWIN,
+   (char_u *)VAR_WIN, PV_FDC, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"foldenable",  "fen",  P_BOOL|P_RWIN,
+   (char_u *)VAR_WIN, PV_FEN, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"foldexpr",    "fde",  P_STRING|P_ALLOCED|P_RWIN,
+   (char_u *)VAR_WIN, PV_FDE, (char_u *)"0"
+   SCRIPTID_INIT},
+  {"foldignore",  "fdi",  P_STRING|P_ALLOCED|P_RWIN,
+   (char_u *)VAR_WIN, PV_FDI, (char_u *)"#"
+   SCRIPTID_INIT},
+  {"foldlevel",   "fdl",  P_NUM|P_RWIN,
+   (char_u *)VAR_WIN, PV_FDL, (char_u *)0L
+   SCRIPTID_INIT},
+  {"foldlevelstart","fdls", P_NUM|P_CURSWANT,
+   (char_u *)&p_fdls, PV_NONE, (char_u *)-1L
+   SCRIPTID_INIT},
+  {"foldmarker",  "fmr",  P_STRING|P_ALLOCED|P_RWIN|P_COMMA|P_NODUP,
+   (char_u *)VAR_WIN, PV_FMR, (char_u *)"{{{,}}}"
+   SCRIPTID_INIT},
+  {"foldmethod",  "fdm",  P_STRING|P_ALLOCED|P_RWIN,
+   (char_u *)VAR_WIN, PV_FDM, (char_u *)"manual"
+   SCRIPTID_INIT},
+  {"foldminlines","fml",  P_NUM|P_RWIN,
+   (char_u *)VAR_WIN, PV_FML, (char_u *)1L
+   SCRIPTID_INIT},
+  {"foldnestmax", "fdn",  P_NUM|P_RWIN,
+   (char_u *)VAR_WIN, PV_FDN, (char_u *)20L
+   SCRIPTID_INIT},
+  {"foldopen",    "fdo",  P_STRING|P_COMMA|P_NODUP|P_CURSWANT,
    (char_u *)&p_fdo, PV_NONE,
-   {(char_u *)"block,hor,mark,percent,quickfix,search,tag,undo",
-    (char_u *)0L} SCRIPTID_INIT},
-  {"foldtext",    "fdt",  P_STRING|P_ALLOCED|P_VIM|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_FDT,
-   {(char_u *)"foldtext()", (char_u *)NULL}
+   (char_u *)"block,hor,mark,percent,quickfix,search,tag,undo"
    SCRIPTID_INIT},
-  {"formatexpr", "fex",   P_STRING|P_ALLOCED|P_VI_DEF|P_VIM,
-   (char_u *)&p_fex, PV_FEX,
-   {(char_u *)"", (char_u *)0L}
+  {"foldtext",    "fdt",  P_STRING|P_ALLOCED|P_RWIN,
+   (char_u *)VAR_WIN, PV_FDT, (char_u *)"foldtext()"
    SCRIPTID_INIT},
-  {"formatoptions","fo",  P_STRING|P_ALLOCED|P_VIM|P_FLAGLIST,
-   (char_u *)&p_fo, PV_FO,
-   {(char_u *)DFLT_FO_VI, (char_u *)DFLT_FO_VIM}
+  {"formatexpr", "fex",   P_STRING|P_ALLOCED,
+   (char_u *)&p_fex, PV_FEX, (char_u *)""
    SCRIPTID_INIT},
-  {"formatlistpat","flp", P_STRING|P_ALLOCED|P_VI_DEF,
+  {"formatoptions","fo",  P_STRING|P_ALLOCED|P_FLAGLIST,
+   (char_u *)&p_fo, PV_FO, (char_u *)DFLT_FO_VIM
+   SCRIPTID_INIT},
+  {"formatlistpat","flp", P_STRING|P_ALLOCED,
    (char_u *)&p_flp, PV_FLP,
-   {(char_u *)"^\\s*\\d\\+[\\]:.)}\\t ]\\s*",
-    (char_u *)0L} SCRIPTID_INIT},
-  {"formatprg",   "fp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
-   (char_u *)&p_fp, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"fsync",       "fs",   P_BOOL|P_SECURE|P_VI_DEF,
+   (char_u *)"^\\s*\\d\\+[\\]:.)}\\t ]\\s*"
+   SCRIPTID_INIT},
+  {"formatprg",   "fp",   P_STRING|P_EXPAND|P_SECURE,
+   (char_u *)&p_fp, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"fsync",       "fs",   P_BOOL|P_SECURE,
 #ifdef HAVE_FSYNC
-   (char_u *)&p_fs, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L}
+   (char_u *)&p_fs, PV_NONE, (char_u *)TRUE
 #else
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L}
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
 #endif
    SCRIPTID_INIT},
-  {"gdefault",    "gd",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_gd, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"graphic",     "gr",   P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"grepformat",  "gfm",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_gefm, PV_NONE,
-   {(char_u *)DFLT_GREPFORMAT, (char_u *)0L}
+  {"gdefault",    "gd",   P_BOOL,
+   (char_u *)&p_gd, PV_NONE, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"grepprg",     "gp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+  {"graphic",     "gr",   P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"grepformat",  "gfm",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_gefm, PV_NONE, (char_u *)DFLT_GREPFORMAT
+   SCRIPTID_INIT},
+  {"grepprg",     "gp",   P_STRING|P_EXPAND|P_SECURE,
    (char_u *)&p_gp, PV_GP,
-   {
 #  ifdef UNIX
      /* Add an extra file name so that grep will always
       * insert a file name in the match line. */
-     (char_u *)"grep -n $* /dev/null",
+     (char_u *)"grep -n $* /dev/null"
 #  else
-     (char_u *)"grep -n ",
+     (char_u *)"grep -n "
 #  endif
-     (char_u *)0L
-   }
    SCRIPTID_INIT},
-  {"guicursor",    "gcr",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
+  {"guicursor",    "gcr",  P_STRING|P_COMMA|P_NODUP,
    (char_u *)&p_guicursor, PV_NONE,
-   {
-     (char_u *)"n-v-c:block,o:hor50,i-ci:hor15,r-cr:hor30,sm:block",
-     (char_u *)0L
-   }
+   (char_u *)"n-v-c:block,o:hor50,i-ci:hor15,r-cr:hor30,sm:block"
    SCRIPTID_INIT},
-  {"guifont",     "gfn",  P_STRING|P_VI_DEF|P_RCLR|P_COMMA|P_NODUP,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+  {"guifont",     "gfn",  P_STRING|P_RCLR|P_COMMA|P_NODUP,
+   (char_u *)NULL, PV_NONE, (char_u *)NULL
    SCRIPTID_INIT},
-  {"guifontset",  "gfs",  P_STRING|P_VI_DEF|P_RCLR|P_COMMA,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+  {"guifontset",  "gfs",  P_STRING|P_RCLR|P_COMMA,
+   (char_u *)NULL, PV_NONE, (char_u *)NULL
    SCRIPTID_INIT},
-  {"guifontwide", "gfw",  P_STRING|P_VI_DEF|P_RCLR|P_COMMA|P_NODUP,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+  {"guifontwide", "gfw",  P_STRING|P_RCLR|P_COMMA|P_NODUP,
+   (char_u *)NULL, PV_NONE, (char_u *)NULL
    SCRIPTID_INIT},
-  {"guiheadroom", "ghr",  P_NUM|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)50L, (char_u *)0L} SCRIPTID_INIT},
-  {"guioptions",  "go",   P_STRING|P_VI_DEF|P_RALL|P_FLAGLIST,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+  {"guiheadroom", "ghr",  P_NUM,
+   (char_u *)NULL, PV_NONE, (char_u *)50L
    SCRIPTID_INIT},
-  {"guipty",      NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"guitablabel",  "gtl", P_STRING|P_VI_DEF|P_RWIN,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+  {"guioptions",  "go",   P_STRING|P_RALL|P_FLAGLIST,
+   (char_u *)NULL, PV_NONE, (char_u *)NULL
    SCRIPTID_INIT},
-  {"guitabtooltip",  "gtt", P_STRING|P_VI_DEF|P_RWIN,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+  {"guipty",      NULL,   P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"guitablabel",  "gtl", P_STRING|P_RWIN,
+   (char_u *)NULL, PV_NONE, (char_u *)NULL
+   SCRIPTID_INIT},
+  {"guitabtooltip",  "gtt", P_STRING|P_RWIN,
+   (char_u *)NULL, PV_NONE, (char_u *)NULL
    SCRIPTID_INIT},
   {"hardtabs",    "ht",   P_NUM|P_VI_DEF,
    (char_u *)NULL, PV_NONE,

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -951,244 +951,212 @@ static struct vimoption
   {"loadplugins", "lpl",  P_BOOL,
    (char_u *)&p_lpl, PV_NONE, (char_u *)TRUE
    SCRIPTID_INIT},
-  {"magic",       NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)&p_magic, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"makeef",      "mef",  P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
-   (char_u *)&p_mef, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+  {"magic",       NULL,   P_BOOL,
+   (char_u *)&p_magic, PV_NONE, (char_u *)TRUE
    SCRIPTID_INIT},
-  {"makeprg",     "mp",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
-   (char_u *)&p_mp, PV_MP,
-   {(char_u *)"make", (char_u *)0L}
+  {"makeef",      "mef",  P_STRING|P_EXPAND|P_SECURE,
+   (char_u *)&p_mef, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"matchpairs",  "mps",  P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_mps, PV_MPS,
-   {(char_u *)"(:),{:},[:]", (char_u *)0L}
+  {"makeprg",     "mp",   P_STRING|P_EXPAND|P_SECURE,
+   (char_u *)&p_mp, PV_MP, (char_u *)"make"
    SCRIPTID_INIT},
-  {"matchtime",   "mat",  P_NUM|P_VI_DEF,
-   (char_u *)&p_mat, PV_NONE,
-   {(char_u *)5L, (char_u *)0L} SCRIPTID_INIT},
-  {"maxcombine",  "mco",  P_NUM|P_VI_DEF|P_CURSWANT,
-   (char_u *)&p_mco, PV_NONE,
-   {(char_u *)2, (char_u *)0L} SCRIPTID_INIT},
-  {"maxfuncdepth", "mfd", P_NUM|P_VI_DEF,
-   (char_u *)&p_mfd, PV_NONE,
-   {(char_u *)100L, (char_u *)0L} SCRIPTID_INIT},
-  {"maxmapdepth", "mmd",  P_NUM|P_VI_DEF,
-   (char_u *)&p_mmd, PV_NONE,
-   {(char_u *)1000L, (char_u *)0L} SCRIPTID_INIT},
-  {"maxmem",      "mm",   P_NUM|P_VI_DEF,
-   (char_u *)&p_mm, PV_NONE,
-   {(char_u *)DFLT_MAXMEM, (char_u *)0L}
+  {"matchpairs",  "mps",  P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
+   (char_u *)&p_mps, PV_MPS, (char_u *)"(:),{:},[:]"
    SCRIPTID_INIT},
-  {"maxmempattern","mmp", P_NUM|P_VI_DEF,
-   (char_u *)&p_mmp, PV_NONE,
-   {(char_u *)1000L, (char_u *)0L} SCRIPTID_INIT},
-  {"maxmemtot",   "mmt",  P_NUM|P_VI_DEF,
-   (char_u *)&p_mmt, PV_NONE,
-   {(char_u *)DFLT_MAXMEMTOT, (char_u *)0L}
+  {"matchtime",   "mat",  P_NUM,
+   (char_u *)&p_mat, PV_NONE, (char_u *)5L
    SCRIPTID_INIT},
-  {"menuitems",   "mis",  P_NUM|P_VI_DEF,
-   (char_u *)&p_mis, PV_NONE,
-   {(char_u *)25L, (char_u *)0L} SCRIPTID_INIT},
-  {"mesg",        NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"mkspellmem",  "msm",  P_STRING|P_VI_DEF|P_EXPAND|P_SECURE,
-   (char_u *)&p_msm, PV_NONE,
-   {(char_u *)"460000,2000,500", (char_u *)0L}
+  {"maxcombine",  "mco",  P_NUM|P_CURSWANT,
+   (char_u *)&p_mco, PV_NONE, (char_u *)2
    SCRIPTID_INIT},
-  {"modeline",    "ml",   P_BOOL|P_VIM,
-   (char_u *)&p_ml, PV_ML,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"modelines",   "mls",  P_NUM|P_VI_DEF,
-   (char_u *)&p_mls, PV_NONE,
-   {(char_u *)5L, (char_u *)0L} SCRIPTID_INIT},
-  {"modifiable",  "ma",   P_BOOL|P_VI_DEF|P_NOGLOB,
-   (char_u *)&p_ma, PV_MA,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"modified",    "mod",  P_BOOL|P_NO_MKRC|P_VI_DEF|P_RSTAT,
-   (char_u *)&p_mod, PV_MOD,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"more",        NULL,   P_BOOL|P_VIM,
-   (char_u *)&p_more, PV_NONE,
-   {(char_u *)FALSE, (char_u *)TRUE} SCRIPTID_INIT},
-  {"mouse",       NULL,   P_STRING|P_VI_DEF|P_FLAGLIST,
-   (char_u *)&p_mouse, PV_NONE,
-   {
-     (char_u *)"",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"mousefocus",   "mousef", P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"mousehide",   "mh",   P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"mousemodel",  "mousem", P_STRING|P_VI_DEF,
-   (char_u *)&p_mousem, PV_NONE,
-   {
-     (char_u *)"extend",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"mouseshape",  "mouses",  P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)NULL, (char_u *)0L}
+  {"maxfuncdepth", "mfd", P_NUM,
+   (char_u *)&p_mfd, PV_NONE, (char_u *)100L
    SCRIPTID_INIT},
-  {"mousetime",   "mouset",   P_NUM|P_VI_DEF,
-   (char_u *)&p_mouset, PV_NONE,
-   {(char_u *)500L, (char_u *)0L} SCRIPTID_INIT},
-  {"novice",      NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"nrformats",   "nf",   P_STRING|P_ALLOCED|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_nf, PV_NF,
-   {(char_u *)"octal,hex", (char_u *)0L}
+  {"maxmapdepth", "mmd",  P_NUM,
+   (char_u *)&p_mmd, PV_NONE, (char_u *)1000L
    SCRIPTID_INIT},
-  {"number",      "nu",   P_BOOL|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_NU,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"numberwidth", "nuw",  P_NUM|P_RWIN|P_VIM,
-   (char_u *)VAR_WIN, PV_NUW,
-   {(char_u *)8L, (char_u *)4L} SCRIPTID_INIT},
-  {"omnifunc",    "ofu",  P_STRING|P_ALLOCED|P_VI_DEF|P_SECURE,
-   (char_u *)&p_ofu, PV_OFU,
-   {(char_u *)"", (char_u *)0L}
+  {"maxmem",      "mm",   P_NUM,
+   (char_u *)&p_mm, PV_NONE, (char_u *)DFLT_MAXMEM
    SCRIPTID_INIT},
-  {"open",        NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"opendevice",  "odev", P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)FALSE}
+  {"maxmempattern","mmp", P_NUM,
+   (char_u *)&p_mmp, PV_NONE, (char_u *)1000L
    SCRIPTID_INIT},
-  {"operatorfunc", "opfunc", P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)&p_opfunc, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"optimize",    "opt",  P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"paragraphs",  "para", P_STRING|P_VI_DEF,
+  {"maxmemtot",   "mmt",  P_NUM,
+   (char_u *)&p_mmt, PV_NONE, (char_u *)DFLT_MAXMEMTOT
+   SCRIPTID_INIT},
+  {"menuitems",   "mis",  P_NUM,
+   (char_u *)&p_mis, PV_NONE, (char_u *)25L
+   SCRIPTID_INIT},
+  {"mesg",        NULL,   P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"mkspellmem",  "msm",  P_STRING|P_EXPAND|P_SECURE,
+   (char_u *)&p_msm, PV_NONE, (char_u *)"460000,2000,500"
+   SCRIPTID_INIT},
+  {"modeline",    "ml",   P_BOOL,
+   (char_u *)&p_ml, PV_ML, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"modelines",   "mls",  P_NUM,
+   (char_u *)&p_mls, PV_NONE, (char_u *)5L
+   SCRIPTID_INIT},
+  {"modifiable",  "ma",   P_BOOL|P_NOGLOB,
+   (char_u *)&p_ma, PV_MA, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"modified",    "mod",  P_BOOL|P_NO_MKRC|P_RSTAT,
+   (char_u *)&p_mod, PV_MOD, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"more",        NULL,   P_BOOL,
+   (char_u *)&p_more, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"mouse",       NULL,   P_STRING|P_FLAGLIST,
+   (char_u *)&p_mouse, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"mousefocus",   "mousef", P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"mousehide",   "mh",   P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"mousemodel",  "mousem", P_STRING,
+   (char_u *)&p_mousem, PV_NONE, (char_u *)"extend"
+   SCRIPTID_INIT},
+  {"mouseshape",  "mouses",  P_STRING|P_COMMA|P_NODUP,
+   (char_u *)NULL, PV_NONE, (char_u *)NULL
+   SCRIPTID_INIT},
+  {"mousetime",   "mouset",   P_NUM,
+   (char_u *)&p_mouset, PV_NONE, (char_u *)500L
+   SCRIPTID_INIT},
+  {"novice",      NULL,   P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"nrformats",   "nf",   P_STRING|P_ALLOCED|P_COMMA|P_NODUP,
+   (char_u *)&p_nf, PV_NF, (char_u *)"octal,hex"
+   SCRIPTID_INIT},
+  {"number",      "nu",   P_BOOL|P_RWIN,
+   (char_u *)VAR_WIN, PV_NU, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"numberwidth", "nuw",  P_NUM|P_RWIN,
+   (char_u *)VAR_WIN, PV_NUW, (char_u *)4L
+   SCRIPTID_INIT},
+  {"omnifunc",    "ofu",  P_STRING|P_ALLOCED|P_SECURE,
+   (char_u *)&p_ofu, PV_OFU, (char_u *)""
+   SCRIPTID_INIT},
+  {"open",        NULL,   P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"opendevice",  "odev", P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"operatorfunc", "opfunc", P_STRING|P_SECURE,
+   (char_u *)&p_opfunc, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"optimize",    "opt",  P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"paragraphs",  "para", P_STRING,
    (char_u *)&p_para, PV_NONE,
-   {(char_u *)"IPLPPPQPP TPHPLIPpLpItpplpipbp",
-    (char_u *)0L} SCRIPTID_INIT},
-  {"paste",       NULL,   P_BOOL|P_VI_DEF|P_PRI_MKRC,
-   (char_u *)&p_paste, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"pastetoggle", "pt",   P_STRING|P_VI_DEF,
-   (char_u *)&p_pt, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"patchexpr",   "pex",  P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)&p_pex, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)"IPLPPPQPP TPHPLIPpLpItpplpipbp"
    SCRIPTID_INIT},
-  {"patchmode",   "pm",   P_STRING|P_VI_DEF|P_NFNAME,
-   (char_u *)&p_pm, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"path",        "pa",   P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
+  {"paste",       NULL,   P_BOOL|P_PRI_MKRC,
+   (char_u *)&p_paste, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"pastetoggle", "pt",   P_STRING,
+   (char_u *)&p_pt, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"patchexpr",   "pex",  P_STRING|P_SECURE,
+   (char_u *)&p_pex, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"patchmode",   "pm",   P_STRING|P_NFNAME,
+   (char_u *)&p_pm, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"path",        "pa",   P_STRING|P_EXPAND|P_COMMA|P_NODUP,
    (char_u *)&p_path, PV_PATH,
-   {
-     (char_u *)".,/usr/include,,",
-     (char_u *)0L
-   } SCRIPTID_INIT},
-  {"preserveindent", "pi", P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_pi, PV_PI,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"previewheight", "pvh", P_NUM|P_VI_DEF,
-   (char_u *)&p_pvh, PV_NONE,
-   {(char_u *)12L, (char_u *)0L} SCRIPTID_INIT},
-  {"previewwindow", "pvw", P_BOOL|P_VI_DEF|P_RSTAT|P_NOGLOB,
-   (char_u *)VAR_WIN, PV_PVW,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"printdevice", "pdev", P_STRING|P_VI_DEF|P_SECURE,
-   (char_u *)&p_pdev, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+   (char_u *)".,/usr/include,,"
    SCRIPTID_INIT},
-  {"printencoding", "penc", P_STRING|P_VI_DEF,
-   (char_u *)&p_penc, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+  {"preserveindent", "pi", P_BOOL,
+   (char_u *)&p_pi, PV_PI, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"printexpr", "pexpr",  P_STRING|P_VI_DEF,
-   (char_u *)&p_pexpr, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+  {"previewheight", "pvh", P_NUM,
+   (char_u *)&p_pvh, PV_NONE, (char_u *)12L
    SCRIPTID_INIT},
-  {"printfont", "pfn",    P_STRING|P_VI_DEF,
-   (char_u *)&p_pfn, PV_NONE,
-   {
-     (char_u *)"courier",
-     (char_u *)0L
-   }
+  {"previewwindow", "pvw", P_BOOL|P_RSTAT|P_NOGLOB,
+   (char_u *)VAR_WIN, PV_PVW, (char_u *)FALSE
    SCRIPTID_INIT},
-  {"printheader", "pheader",  P_STRING|P_VI_DEF|P_GETTEXT,
+  {"printdevice", "pdev", P_STRING|P_SECURE,
+   (char_u *)&p_pdev, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"printencoding", "penc", P_STRING,
+   (char_u *)&p_penc, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"printexpr", "pexpr",  P_STRING,
+   (char_u *)&p_pexpr, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"printfont", "pfn",    P_STRING,
+   (char_u *)&p_pfn, PV_NONE, (char_u *)"courier"
+   SCRIPTID_INIT},
+  {"printheader", "pheader",  P_STRING|P_GETTEXT,
    (char_u *)&p_header, PV_NONE,
-   {(char_u *)N_("%<%f%h%m%=Page %N"), (char_u *)0L}
+   (char_u *)N_("%<%f%h%m%=Page %N")
    SCRIPTID_INIT},
-  {"printmbcharset", "pmbcs",  P_STRING|P_VI_DEF,
-   (char_u *)&p_pmcs, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+  {"printmbcharset", "pmbcs",  P_STRING,
+   (char_u *)&p_pmcs, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"printmbfont", "pmbfn",  P_STRING|P_VI_DEF,
-   (char_u *)&p_pmfn, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+  {"printmbfont", "pmbfn",  P_STRING,
+   (char_u *)&p_pmfn, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"printoptions", "popt", P_STRING|P_VI_DEF|P_COMMA|P_NODUP,
-   (char_u *)&p_popt, PV_NONE,
-   {(char_u *)"", (char_u *)0L}
+  {"printoptions", "popt", P_STRING|P_COMMA|P_NODUP,
+   (char_u *)&p_popt, PV_NONE, (char_u *)""
    SCRIPTID_INIT},
-  {"prompt",      NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)&p_prompt, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"pumheight",   "ph",   P_NUM|P_VI_DEF,
-   (char_u *)&p_ph, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"quoteescape", "qe",   P_STRING|P_ALLOCED|P_VI_DEF,
-   (char_u *)&p_qe, PV_QE,
-   {(char_u *)"\\", (char_u *)0L}
+  {"prompt",      NULL,   P_BOOL,
+   (char_u *)&p_prompt, PV_NONE, (char_u *)TRUE
    SCRIPTID_INIT},
-  {"readonly",    "ro",   P_BOOL|P_VI_DEF|P_RSTAT|P_NOGLOB,
-   (char_u *)&p_ro, PV_RO,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"redraw",      NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"redrawtime",  "rdt",  P_NUM|P_VI_DEF,
-   (char_u *)&p_rdt, PV_NONE,
-   {(char_u *)2000L, (char_u *)0L} SCRIPTID_INIT},
-  {"regexpengine", "re",  P_NUM|P_VI_DEF,
-   (char_u *)&p_re, PV_NONE,
-   {(char_u *)0L, (char_u *)0L} SCRIPTID_INIT},
-  {"relativenumber", "rnu", P_BOOL|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_RNU,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"remap",       NULL,   P_BOOL|P_VI_DEF,
-   (char_u *)&p_remap, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"report",      NULL,   P_NUM|P_VI_DEF,
-   (char_u *)&p_report, PV_NONE,
-   {(char_u *)2L, (char_u *)0L} SCRIPTID_INIT},
-  {"restorescreen", "rs", P_BOOL|P_VI_DEF,
-   (char_u *)NULL, PV_NONE,
-   {(char_u *)TRUE, (char_u *)0L} SCRIPTID_INIT},
-  {"revins",      "ri",   P_BOOL|P_VI_DEF|P_VIM,
-   (char_u *)&p_ri, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"rightleft",   "rl",   P_BOOL|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_RL,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"rightleftcmd", "rlc", P_STRING|P_ALLOCED|P_VI_DEF|P_RWIN,
-   (char_u *)VAR_WIN, PV_RLC,
-   {(char_u *)"search", (char_u *)NULL}
+  {"pumheight",   "ph",   P_NUM,
+   (char_u *)&p_ph, PV_NONE, (char_u *)0L
    SCRIPTID_INIT},
-  {"ruler",       "ru",   P_BOOL|P_VI_DEF|P_VIM|P_RSTAT,
-   (char_u *)&p_ru, PV_NONE,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
-  {"rulerformat", "ruf",  P_STRING|P_VI_DEF|P_ALLOCED|P_RSTAT,
-   (char_u *)&p_ruf, PV_NONE,
-   {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
-  {"runtimepath", "rtp",  P_STRING|P_VI_DEF|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
-   (char_u *)&p_rtp, PV_NONE,
-   {(char_u *)DFLT_RUNTIMEPATH, (char_u *)0L}
+  {"quoteescape", "qe",   P_STRING|P_ALLOCED,
+   (char_u *)&p_qe, PV_QE, (char_u *)"\\"
+   SCRIPTID_INIT},
+  {"readonly",    "ro",   P_BOOL|P_RSTAT|P_NOGLOB,
+   (char_u *)&p_ro, PV_RO, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"redraw",      NULL,   P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"redrawtime",  "rdt",  P_NUM,
+   (char_u *)&p_rdt, PV_NONE, (char_u *)2000L
+   SCRIPTID_INIT},
+  {"regexpengine", "re",  P_NUM,
+   (char_u *)&p_re, PV_NONE, (char_u *)0L
+   SCRIPTID_INIT},
+  {"relativenumber", "rnu", P_BOOL|P_RWIN,
+   (char_u *)VAR_WIN, PV_RNU, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"remap",       NULL,   P_BOOL,
+   (char_u *)&p_remap, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"report",      NULL,   P_NUM,
+   (char_u *)&p_report, PV_NONE, (char_u *)2L
+   SCRIPTID_INIT},
+  {"restorescreen", "rs", P_BOOL,
+   (char_u *)NULL, PV_NONE, (char_u *)TRUE
+   SCRIPTID_INIT},
+  {"revins",      "ri",   P_BOOL,
+   (char_u *)&p_ri, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"rightleft",   "rl",   P_BOOL|P_RWIN,
+   (char_u *)VAR_WIN, PV_RL, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"rightleftcmd", "rlc", P_STRING|P_ALLOCED|P_RWIN,
+   (char_u *)VAR_WIN, PV_RLC, (char_u *)"search"
+   SCRIPTID_INIT},
+  {"ruler",       "ru",   P_BOOL|P_RSTAT,
+   (char_u *)&p_ru, PV_NONE, (char_u *)FALSE
+   SCRIPTID_INIT},
+  {"rulerformat", "ruf",  P_STRING|P_ALLOCED|P_RSTAT,
+   (char_u *)&p_ruf, PV_NONE, (char_u *)""
+   SCRIPTID_INIT},
+  {"runtimepath", "rtp",  P_STRING|P_EXPAND|P_COMMA|P_NODUP|P_SECURE,
+   (char_u *)&p_rtp, PV_NONE, (char_u *)DFLT_RUNTIMEPATH
    SCRIPTID_INIT},
   {"scroll",      "scr",  P_NUM|P_NO_MKRC|P_VI_DEF,
    (char_u *)VAR_WIN, PV_SCROLL,


### PR DESCRIPTION
This PR removes all the VI defaults, essentially making compatible mode a no-op.
