### PR TITLE
Adding darwin platform to common.sh build script

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -4,10 +4,14 @@ if [ "$unameval" = 'Linux' ]; then
 	platform='linux'
 elif [ "$unameval" = 'FreeBSD' ]; then
 	platform='freebsd'
+elif [ "$unameval" = 'Darwin' ]; then
+	platform='darwin'
 fi
 
 sha1sumcmd='sha1sum'
 if [ "$platform" = 'freebsd' ]; then
+	sha1sumcmd='shasum'
+elif [ "$platform" = 'darwin' ]; then
 	sha1sumcmd='shasum'
 fi
 


### PR DESCRIPTION
This is in lieu of: https://github.com/neovim/neovim/pull/237
To build on osx you need either: `shasum` or `sha1sum`, `shasum` is already included on osx so this just adds darwin to the script.
