### PR TITLE
vim_strsize and vim_strnsize should return 0 size for null-strings.

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -600,6 +600,8 @@ int ptr2cells(char_u *p)
 /*
  * Return the number of character cells string "s" will take on the screen,
  * counting TABs as two characters: "^I".
+ *
+ * If s is empty or NULL, 0 will be returned.
  */
 int vim_strsize(char_u *s)
 {
@@ -609,11 +611,14 @@ int vim_strsize(char_u *s)
 /*
  * Return the number of character cells string "s[len]" will take on the
  * screen, counting TABs as two characters: "^I".
+ *
+ * If s is empty or NULL, 0 will be returned.
  */
 int vim_strnsize(char_u *s, int len)
 {
-  int size = 0;
+  if (!s) return 0;
 
+  int size = 0;
   while (*s != NUL && --len >= 0) {
     if (has_mbyte) {
       int l = (*mb_ptr2len)(s);


### PR DESCRIPTION
This avoids dereferencing a null pointer as well as being consisntent with
empty strings. Calls to these functions no longer need null guards.

Note that this is not the only solution. Another would be to use an assertion instead, giving the same behavior as we have today.

See the discussion on "assert vs return 0" here: https://groups.google.com/forum/#!topic/neovim/AqZxA314ntE
