### PR TITLE
[wip] clean up makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,9 +325,17 @@ certificates or have not set them up correctly:
 
 ## Building
 
-To generate the `Makefile`s:
+If you just want to build it:
 
-    make cmake
+    make
+
+This will compile the bundled versions of the dependencies.
+If you care deeply about using the system-provided versions of the
+dependencies use
+
+    make USE_BUNDLED_DEPS=false
+
+instead.
 
 To build and run the tests:
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,8 +1,7 @@
 #!/bin/sh -e
 
 # export VALGRIND_CHECK=1
-make cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$PWD/dist"
-make
+make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$PWD/dist"
 make unittest
 echo "Running tests with valgrind..."
 if ! make test > /dev/null; then


### PR DESCRIPTION
- remove repeated paths
- switch to one-step build: `make`
- remove confusing dependencies of `clean` and `deps` from `cmake` target
- add `USE_BUNDLED_DEPS=false` option for those who want it
