### PR TITLE
Remove dead code

### DIFF
--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -5,7 +5,6 @@ void mch_write(char_u *s, int len);
 int mch_inchar(char_u *buf, int maxlen, long wtime, int tb_change_cnt);
 int mch_char_avail(void);
 void mch_delay(long msec, int ignoreinput);
-int mch_stackcheck(char *p);
 void mch_startjmp(void);
 void mch_endjmp(void);
 void mch_didjmp(void);

--- a/src/structs.h
+++ b/src/structs.h
@@ -292,32 +292,6 @@ struct u_header {
 #define UH_EMPTYBUF 0x02        /* buffer was empty */
 
 /*
- * structures used in undo.c
- */
-#if SIZEOF_INT > 2
-# define ALIGN_LONG     /* longword alignment and use filler byte */
-# define ALIGN_SIZE (sizeof(long))
-#else
-# define ALIGN_SIZE (sizeof(short))
-#endif
-
-#define ALIGN_MASK (ALIGN_SIZE - 1)
-
-typedef struct m_info minfo_T;
-
-/*
- * structure used to link chunks in one of the free chunk lists.
- */
-struct m_info {
-#ifdef ALIGN_LONG
-  long_u m_size;                /* size of the chunk (including m_info) */
-#else
-  short_u m_size;               /* size of the chunk (including m_info) */
-#endif
-  minfo_T     *m_next;          /* pointer to next free chunk in the list */
-};
-
-/*
  * things used in memfile.c
  */
 


### PR DESCRIPTION
This is a rebase of #236.

HAVE_STACK_LIMIT definition was commented out in the original Mercurial repo:
https://code.google.com/p/vim/source/detail?r=7e70fc748752

...and then completely removed:
https://code.google.com/p/vim/source/detail?r=6768ebd0bc04

Custom undo memory allocator was removed:
https://code.google.com/p/vim/source/detail?r=290ee42cae85
