### PR TITLE
Add several mch_* unit tests, port mch_isdir to libuv.

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -52,6 +52,7 @@
 #include "ui.h"
 #include "undo.h"
 #include "window.h"
+#include "os/os.h"
 
 static int linelen(int *has_tab);
 static void do_filter(linenr_T line1, linenr_T line2, exarg_T *eap,

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -39,6 +39,7 @@
 #include "term.h"
 #include "undo.h"
 #include "window.h"
+#include "os/os.h"
 
 static void cmd_source(char_u *fname, exarg_T *eap);
 

--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,7 @@
 #include "ui.h"
 #include "version.h"
 #include "window.h"
+#include "os/os.h"
 
 /* Maximum number of commands from + or -c arguments. */
 #define MAX_ARG_CMDS 10

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -160,3 +160,22 @@ int mch_is_full_name(char_u *fname)
   return *fname == '/' || *fname == '~';
 }
 
+/*
+ * return TRUE if "name" is a directory
+ * return FALSE if "name" is not a directory
+ * return FALSE for error
+ */
+int mch_isdir(char_u *name)
+{
+  uv_fs_t request;
+  if (0 != uv_fs_stat(uv_default_loop(), &request, (const char*) name, NULL)) {
+    return FALSE;
+  }
+
+  if (!S_ISDIR(request.statbuf.st_mode)) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -8,5 +8,6 @@ int mch_chdir(char *path);
 int mch_dirname(char_u *buf, int len);
 int mch_full_name (char_u *fname, char_u *buf, int len, int force);
 int mch_is_full_name (char_u *fname);
+int mch_isdir(char_u *name);
 
 #endif

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1339,12 +1339,12 @@ int mch_isdir(char_u *name)
 #endif
 }
 
-static int executable_file(char_u *name);
+int executable_file(char_u *name);
 
 /*
  * Return 1 if "name" is an executable file, 0 if not or it doesn't exist.
  */
-static int executable_file(char_u *name)
+int executable_file(char_u *name)
 {
   struct stat st;
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1319,26 +1319,6 @@ void mch_hide(char_u *name)
   /* can't hide a file */
 }
 
-/*
- * return TRUE if "name" is a directory
- * return FALSE if "name" is not a directory
- * return FALSE for error
- */
-int mch_isdir(char_u *name)
-{
-  struct stat statb;
-
-  if (*name == NUL)         /* Some stat()s don't flag "" as an error. */
-    return FALSE;
-  if (stat((char *)name, &statb))
-    return FALSE;
-#ifdef _POSIX_SOURCE
-  return S_ISDIR(statb.st_mode) ? TRUE : FALSE;
-#else
-  return (statb.st_mode & S_IFMT) == S_IFDIR ? TRUE : FALSE;
-#endif
-}
-
 int executable_file(char_u *name);
 
 /*

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -37,7 +37,6 @@ vim_acl_T mch_get_acl(char_u *fname);
 void mch_set_acl(char_u *fname, vim_acl_T aclent);
 void mch_free_acl(vim_acl_T aclent);
 void mch_hide(char_u *name);
-int mch_isdir(char_u *name);
 int mch_can_exe(char_u *name);
 int mch_nodetype(char_u *name);
 void mch_early_init(void);

--- a/src/spell.c
+++ b/src/spell.c
@@ -325,6 +325,7 @@
 #include "term.h"
 #include "ui.h"
 #include "undo.h"
+#include "os/os.h"
 
 #ifndef UNIX            /* it's in os_unix_defs.h for Unix */
 # include <time.h>      /* for time_t */

--- a/src/undo.c
+++ b/src/undo.c
@@ -98,6 +98,7 @@
 #include "quickfix.h"
 #include "screen.h"
 #include "sha256.h"
+#include "os/os.h"
 
 static long get_undolevel(void);
 static void u_unch_branch(u_header_T *uhp);

--- a/test/unit/os_unix.moon
+++ b/test/unit/os_unix.moon
@@ -74,10 +74,8 @@ describe 'os_unix function', ->
     it 'returns false when given a regular file without executable bit set', ->
       -- This is a critical test since Windows does not have any executable
       -- bit. Thus executable_file returns TRUE on every regular file on
-      -- Windows. This test must probably differentiate between Windows and
-      -- other systems, which have an executable bit.
-      pending 'Test executable_file with a regular file which is not
-          executable. Need a solution which also works on Windows.'
+      -- Windows and this test will fail.
+      eq FALSE, (executable_file 'unit-test-directory/test.file')
 
   describe 'mch_can_exe', ->
     mch_can_exe = (name) ->

--- a/test/unit/os_unix.moon
+++ b/test/unit/os_unix.moon
@@ -1,0 +1,40 @@
+{:cimport, :eq, :ffi} = require 'test.unit.helpers'
+
+cstr = ffi.typeof 'char[?]'
+os = cimport './src/os_unix.h'
+
+describe 'os_unix function', ->
+  describe 'mch_isdir', ->
+    TRUE = 1
+    FALSE = 0
+
+    ffi.cdef('int mch_isdir(char * name);')
+
+    mch_isdir = (name) ->
+      name = cstr (string.len name), name
+      os.mch_isdir(name)
+
+    setup ->
+      lfs.mkdir 'empty-test-directory'
+      lfs.touch 'empty-test-directory/test.file'
+
+    teardown ->
+      lfs.rmdir 'empty-test-directory'
+
+    it 'returns false if an empty string is given', ->
+      eq FALSE, (mch_isdir '')
+
+    it 'returns false if a nonexisting directory is given', ->
+      eq FALSE, (mch_isdir 'non-existing-directory')
+
+    it 'returns false if an existing file is given', ->
+      eq FALSE, (mch_isdir 'non-existing-directory/test.file')
+
+    it 'returns true if the current directory is given', ->
+      eq TRUE, (mch_isdir '.')
+
+    it 'returns true if the parent directory is given', ->
+      eq TRUE, (mch_isdir '..')
+
+    it 'returns true if an newly created directory is given', ->
+      eq TRUE, (mch_isdir 'empty-test-directory')

--- a/test/unit/os_unix.moon
+++ b/test/unit/os_unix.moon
@@ -1,25 +1,43 @@
-{:cimport, :eq, :ffi} = require 'test.unit.helpers'
+{:cimport, :eq, :ffi, :lib, :cstr} = require 'test.unit.helpers'
 
-cstr = ffi.typeof 'char[?]'
-os = cimport './src/os_unix.h'
+-- os = cimport './src/os_unix.h'
+os = lib
+ffi.cdef [[
+enum BOOLEAN {
+  TRUE = 1, FALSE = 0
+};
+int mch_isdir(char_u * name);
+int executable_file(char_u *name);
+int mch_can_exe(char_u *name);
+]]
+
+{:TRUE, :FALSE} = lib
 
 describe 'os_unix function', ->
+  setup ->
+    lfs.mkdir 'unit-test-directory'
+    lfs.touch 'unit-test-directory/test.file'
+
+    -- Since the tests are executed, they are called by an executable. We use
+    -- that to unit test several functions.
+    export absolute_executable = arg[0]
+
+    -- Split absolute_executable into a directory and the actual file name and
+    -- append the directory to $PATH.
+    export directory, executable = if (string.find absolute_executable, '/')
+      string.match(absolute_executable, '^(.*)/(.*)$')
+    else
+      string.match(absolute_executable, '^(.*)\\(.*)$')
+
+    package.path = package.path .. ';' .. directory
+
+  teardown ->
+    lfs.rmdir 'unit-test-directory'
+
   describe 'mch_isdir', ->
-    TRUE = 1
-    FALSE = 0
-
-    ffi.cdef('int mch_isdir(char * name);')
-
     mch_isdir = (name) ->
       name = cstr (string.len name), name
       os.mch_isdir(name)
-
-    setup ->
-      lfs.mkdir 'empty-test-directory'
-      lfs.touch 'empty-test-directory/test.file'
-
-    teardown ->
-      lfs.rmdir 'empty-test-directory'
 
     it 'returns false if an empty string is given', ->
       eq FALSE, (mch_isdir '')
@@ -36,5 +54,51 @@ describe 'os_unix function', ->
     it 'returns true if the parent directory is given', ->
       eq TRUE, (mch_isdir '..')
 
-    it 'returns true if an newly created directory is given', ->
-      eq TRUE, (mch_isdir 'empty-test-directory')
+    it 'returns true if an arbitrary directory is given', ->
+      eq TRUE, (mch_isdir 'unit-test-directory')
+
+  describe 'executable_file', ->
+    executable_file = (name) ->
+      name = cstr (string.len name), name
+      os.executable_file name
+
+    it 'returns false when given a directory', ->
+      eq FALSE, (executable_file 'unit-test-directory')
+
+    it 'returns false when the given file does not exists', ->
+      eq FALSE, (executable_file 'does-not-exist.file')
+
+    it 'returns true when given an executable regular file', ->
+      eq TRUE, (executable_file absolute_executable)
+
+    it 'returns false when given a regular file without executable bit set', ->
+      -- This is a critical test since Windows does not have any executable
+      -- bit. Thus executable_file returns TRUE on every regular file on
+      -- Windows. This test must probably differentiate between Windows and
+      -- other systems, which have an executable bit.
+      pending 'Test executable_file with a regular file which is not
+          executable. Need a solution which also works on Windows.'
+
+  describe 'mch_can_exe', ->
+    mch_can_exe = (name) ->
+      name = cstr (string.len name), name
+      os.mch_can_exe name
+
+    it 'returns false when given a directory', ->
+      eq FALSE, (mch_can_exe 'unit-test-directory')
+
+    it 'returns true when given an executable in the current directory', ->
+      old_dir = lfs.currentdir!
+      lfs.chdir directory
+      eq TRUE, (mch_can_exe executable)
+      lfs.chdir old_dir
+
+    it 'returns true when given an executable inside $PATH', ->
+      eq TRUE, (mch_can_exe executable)
+
+    it 'returns true when given an executable relative to the current dir', ->
+      old_dir = lfs.currentdir!
+      lfs.chdir directory
+      relative_executable = './' .. executable
+      eq TRUE, (mch_can_exe relative_executable)
+      lfs.chdir old_dir

--- a/test/unit/os_unix.moon
+++ b/test/unit/os_unix.moon
@@ -19,7 +19,7 @@ describe 'os_unix function', ->
     lfs.touch 'unit-test-directory/test.file'
 
     -- Since the tests are executed, they are called by an executable. We use
-    -- that to unit test several functions.
+    -- that executable for several asserts.
     export absolute_executable = arg[0]
 
     -- Split absolute_executable into a directory and the actual file name and


### PR DESCRIPTION
Addressing #281.

@tarruda I've added a [test](https://github.com/lslah/neovim/commit/5f7dd5171bd42272a3f909b1c261256c188b7868#diff-2f98e7003b1b21823fec5cf48245414cL74) which'll probably fail in a windows environment, since I have no clue how to write it properly.

I'm not sure, how we handle windows currently. Is it our first aim to get everything done in a unix-like-environment and take care of windows afterwards (when most platform-specific code is hidden behind libuv anyway)? Regarding the tests: Does that mean I don't have to care about windows now? Should I delete/uncomment the test, make it pending or just add a comment, that it could cause trouble under windows?

Sorry, that I am bothering you with a lot of details, but I want to write my code the intended way right from the beginning.
