### PR TITLE
[RFC] Revert "Port mch_isdir to libuv."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c
 script: ./scripts/travis.sh
 before_install:
-  - sudo apt-get update
   - sudo apt-get install valgrind
 compiler:
   - clang

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,11 +1,11 @@
 #!/bin/sh -e
 
-# export VALGRIND_CHECK=1
+export VALGRIND_CHECK=1
 make cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$PWD/dist"
 make
 make unittest
 echo "Running tests with valgrind..."
-if ! make test > /dev/null; then
+if ! make test; then
 	if ls src/testdir/valgrind.* > /dev/null 2>&1; then
 		echo "Memory leak detected" >&2 
 		cat src/testdir/valgrind.*

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -175,11 +175,16 @@ int mch_is_absolute_path(char_u *fname)
 int mch_isdir(char_u *name)
 {
   uv_fs_t request;
-  if (0 != uv_fs_stat(uv_default_loop(), &request, (const char*) name, NULL)) {
+  int result = uv_fs_stat(uv_default_loop(), &request, (const char*) name, NULL);
+  uint64_t mode = request.statbuf.st_mode;
+
+  uv_fs_req_cleanup(&request);
+
+  if (0 != result) {
     return FALSE;
   }
 
-  if (!S_ISDIR(request.statbuf.st_mode)) {
+  if (!S_ISDIR(mode)) {
     return FALSE;
   }
 

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -28,7 +28,7 @@ SCRIPTS := test1.out test2.out test3.out test4.out test5.out test6.out \
 SCRIPTS_GUI := test16.out
 
 ifdef VALGRIND_CHECK
-VALGRIND = valgrind --suppressions=../../.valgrind.supp --leak-check=full --error-exitcode=111 --log-file=valgrind.$*
+VALGRIND = valgrind --suppressions=../../.valgrind.supp --leak-check=full --error-exitcode=123 --log-file=valgrind.$*
 endif
 
 ifdef TESTNUM


### PR DESCRIPTION
Revert commit 8bb672e6a088eb77d98d182bd46551986b52eb49 which caused a memory
leak error. This commit was merged from pr #290 and wasn't detected because
travis wasn't running the tests on valgrind(fixed now).

Valgrind slows test runs by a factor of 20, but it's worth because memory leak
errors are sometimes a pain to find.
