### PR TITLE
[RDY] move code handling operating system usernames into os/users.c

### DIFF
--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -31,6 +31,7 @@
 #include "syntax.h"
 #include "term.h"
 #include "ui.h"
+#include "os/os.h"
 
 /*
  * To implement printing on a platform, the following functions must be
@@ -2500,8 +2501,9 @@ int mch_print_begin(prt_settings_T *psettings)
    */
   prt_dsc_start();
   prt_dsc_textline("Title", (char *)psettings->jobname);
-  if (!get_user_name((char_u *)buffer, 256))
+  if (mch_get_user_name(buffer, 256) == FAIL) {
     STRCPY(buffer, "Unknown");
+  }
   prt_dsc_textline("For", buffer);
   prt_dsc_textline("Creator", VIM_VERSION_LONG);
   /* Note: to ensure Clean8bit I don't think we can use LC_TIME */

--- a/src/memline.c
+++ b/src/memline.c
@@ -1739,7 +1739,7 @@ static time_t swapfile_info(char_u *fname)
   time_t x = (time_t)0;
   char            *p;
 #ifdef UNIX
-  char_u uname[B0_UNAME_SIZE];
+  char uname[B0_UNAME_SIZE];
 #endif
 
   /* print the swap file date */
@@ -1748,7 +1748,7 @@ static time_t swapfile_info(char_u *fname)
     /* print name of owner of the file */
     if (mch_get_uname(st.st_uid, uname, B0_UNAME_SIZE) == OK) {
       MSG_PUTS(_("          owned by: "));
-      msg_outtrans(uname);
+      msg_outtrans((char_u *)uname);
       MSG_PUTS(_("   dated: "));
     } else
 #endif

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2895,25 +2895,14 @@ expand_env_esc (
         *var = NUL;
 # ifdef UNIX
         /*
-         * If the system supports getpwnam(), use it.
-         * Otherwise, or if getpwnam() fails, the shell is used to
-         * expand ~user.  This is slower and may fail if the shell
+         * Use mch_get_user_directory() to get the user directory.
+         * If this function fails, the shell is used to
+         * expand ~user. This is slower and may fail if the shell
          * does not support ~user (old versions of /bin/sh).
          */
-#  if defined(HAVE_GETPWNAM) && defined(HAVE_PWD_H)
-        {
-          struct passwd *pw;
-
-          /* Note: memory allocated by getpwnam() is never freed.
-           * Calling endpwent() apparently doesn't help. */
-          pw = getpwnam((char *)dst + 1);
-          if (pw != NULL)
-            var = (char_u *)pw->pw_dir;
-          else
-            var = NULL;
-        }
+        var = (char_u *)mch_get_user_directory((char *)dst + 1);
+        mustfree = TRUE;
         if (var == NULL)
-#  endif
         {
           expand_T xpc;
 

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3256,34 +3256,17 @@ char_u *get_env_name(expand_T *xp, int idx)
  * Find all user names for user completion.
  * Done only once and then cached.
  */
-static void init_users(void)                 {
+static void init_users(void)
+{
   static int lazy_init_done = FALSE;
 
-  if (lazy_init_done)
+  if (lazy_init_done) {
     return;
+  }
 
   lazy_init_done = TRUE;
-  ga_init2(&ga_users, sizeof(char_u *), 20);
-
-# if defined(HAVE_GETPWENT) && defined(HAVE_PWD_H)
-  {
-    char_u*         user;
-    struct passwd*  pw;
-
-    setpwent();
-    while ((pw = getpwent()) != NULL)
-      /* pw->pw_name shouldn't be NULL but just in case... */
-      if (pw->pw_name != NULL) {
-        if (ga_grow(&ga_users, 1) == FAIL)
-          break;
-        user = vim_strsave((char_u*)pw->pw_name);
-        if (user == NULL)
-          break;
-        ((char_u **)(ga_users.ga_data))[ga_users.ga_len++] = user;
-      }
-    endpwent();
-  }
-# endif
+  
+  mch_get_usernames(&ga_users);
 }
 
 /*

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1886,7 +1886,7 @@ int vim_chdir(char_u *new_dir)
 int get_user_name(char_u *buf, int len)
 {
   if (username == NULL) {
-    if (mch_get_user_name(buf, len) == FAIL)
+    if (mch_get_user_name((char *)buf, len) == FAIL)
       return FAIL;
     username = vim_strsave(buf);
   } else

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -47,8 +47,6 @@
 #include "window.h"
 #include "os/os.h"
 
-static char_u   *username = NULL; /* cached result of mch_get_user_name() */
-
 static int coladvance2(pos_T *pos, int addspaces, int finetune,
                        colnr_T wcol);
 
@@ -935,7 +933,6 @@ void free_all_mem(void)          {
   clear_sb_text();            /* free any scrollback text */
 
   /* Free some global vars. */
-  vim_free(username);
   vim_free(last_cmdline);
   vim_free(new_last_cmdline);
   set_keep_msg(NULL, 0);
@@ -1874,24 +1871,6 @@ int vim_chdir(char_u *new_dir)
   r = mch_chdir((char *)dir_name);
   vim_free(dir_name);
   return r;
-}
-
-/*
- * Get user name from machine-specific function.
- * Returns the user name in "buf[len]".
- * Some systems are quite slow in obtaining the user name (Windows NT), thus
- * cache the result.
- * Returns OK or FAIL.
- */
-int get_user_name(char_u *buf, int len)
-{
-  if (username == NULL) {
-    if (mch_get_user_name((char *)buf, len) == FAIL)
-      return FAIL;
-    username = vim_strsave(buf);
-  } else
-    vim_strncpy(buf, username, len - 1);
-  return OK;
 }
 
 #ifndef HAVE_QSORT

--- a/src/misc2.h
+++ b/src/misc2.h
@@ -66,7 +66,6 @@ int same_directory(char_u *f1, char_u *f2);
 int vim_chdirfile(char_u *fname);
 int illegal_slash(char *name);
 int vim_chdir(char_u *new_dir);
-int get_user_name(char_u *buf, int len);
 void sort_strings(char_u **files, int count);
 int pathcmp(const char *p, const char *q, int maxlen);
 int filewritable(char_u *fname);

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -16,5 +16,6 @@ char *mch_getenvname_at_index(size_t index);
 int mch_get_usernames(garray_T *usernames);
 int mch_get_user_name(char *s, size_t len);
 int mch_get_uname(uid_t uid, char *s, size_t len);
+char *mch_get_user_directory(const char *name);
 
 #endif

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -14,5 +14,7 @@ const char *mch_getenv(const char *name);
 int mch_setenv(const char *name, const char *value, int overwrite);
 char *mch_getenvname_at_index(size_t index);
 int mch_get_usernames(garray_T *usernames);
+int mch_get_user_name(char *s, size_t len);
+int mch_get_uname(uid_t uid, char *s, size_t len);
 
 #endif

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -13,5 +13,6 @@ int mch_can_exe(const char_u *name);
 const char *mch_getenv(const char *name);
 int mch_setenv(const char *name, const char *value, int overwrite);
 char *mch_getenvname_at_index(size_t index);
+int mch_get_usernames(garray_T *usernames);
 
 #endif

--- a/src/os/users.c
+++ b/src/os/users.c
@@ -1,0 +1,57 @@
+/* vi:set ts=2 sts=2 sw=2:
+ *
+ * VIM - Vi IMproved	by Bram Moolenaar
+ *
+ * Do ":help uganda"  in Vim to read copying and usage conditions.
+ * Do ":help credits" in Vim to see a list of people who contributed.
+ * See README.txt for an overview of the Vim source code.
+ */
+
+/*
+ * users.c -- operating system user information
+ */
+
+#include <uv.h>
+
+#include "os.h"
+#include "../garray.h"
+#include "../misc2.h"
+#ifdef HAVE_PWD_H
+# include <pwd.h>
+#endif
+
+/*
+ * Initialize users garray and fill it with os usernames.
+ * Return Ok for success, FAIL for failure.
+ */
+int mch_get_usernames(garray_T *users)
+{
+  if (users == NULL) {
+    return FALSE;
+  }
+  ga_init2(users, sizeof(char *), 20);
+
+# if defined(HAVE_GETPWENT) && defined(HAVE_PWD_H)
+  char *user;
+  struct passwd *pw;
+
+  setpwent();
+  while ((pw = getpwent()) != NULL) {
+    /* pw->pw_name shouldn't be NULL but just in case... */
+    if (pw->pw_name != NULL) {
+      if (ga_grow(users, 1) == FAIL) {
+        return FAIL;
+      }
+      user = (char *)vim_strsave((char_u*)pw->pw_name);
+      if (user == NULL) {
+        return FAIL;
+      }
+      ((char **)(users->ga_data))[users->ga_len++] = user;
+    }
+  }
+  endpwent();
+# endif
+
+  return OK;
+}
+

--- a/src/os/users.c
+++ b/src/os/users.c
@@ -55,3 +55,32 @@ int mch_get_usernames(garray_T *users)
   return OK;
 }
 
+/*
+ * Insert user name in s[len].
+ * Return OK if a name found.
+ */
+int mch_get_user_name(char *s, size_t len)
+{
+  return mch_get_uname(getuid(), s, len);
+}
+
+/*
+ * Insert user name for "uid" in s[len].
+ * Return OK if a name found.
+ * If the name is not found, write the uid into s[len] and return FAIL.
+ */
+int mch_get_uname(uid_t uid, char *s, size_t len)
+{
+#if defined(HAVE_PWD_H) && defined(HAVE_GETPWUID)
+  struct passwd *pw;
+
+  if ((pw = getpwuid(uid)) != NULL
+      && pw->pw_name != NULL && *(pw->pw_name) != NUL) {
+    vim_strncpy((char_u *)s, (char_u *)pw->pw_name, len - 1);
+    return OK;
+  }
+#endif
+  snprintf(s, len, "%d", (int)uid);
+  return FAIL; // a number is not a name
+}
+

--- a/src/os/users.c
+++ b/src/os/users.c
@@ -84,3 +84,25 @@ int mch_get_uname(uid_t uid, char *s, size_t len)
   return FAIL; // a number is not a name
 }
 
+/*
+ * Returns the user directory for the given username.
+ * The caller has to free() the returned string.
+ * If the username is not found, NULL is returned.
+ */
+char *mch_get_user_directory(const char *name)
+{
+#if defined(HAVE_GETPWNAM) && defined(HAVE_PWD_H)
+  struct passwd *pw;
+  if (name == NULL) {
+    return NULL;
+  }
+  pw = getpwnam(name);
+  if (pw != NULL) {
+    // save the string from the static passwd entry into malloced memory
+    char *user_directory = (char *)vim_strsave((char_u *)pw->pw_dir);
+    return user_directory;
+  }
+#endif
+  return NULL;
+}
+

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1078,34 +1078,6 @@ int vim_is_fastterm(char_u *name)
 }
 
 /*
- * Insert user name in s[len].
- * Return OK if a name found.
- */
-int mch_get_user_name(char_u *s, int len)
-{
-  return mch_get_uname(getuid(), s, len);
-}
-
-/*
- * Insert user name for "uid" in s[len].
- * Return OK if a name found.
- */
-int mch_get_uname(uid_t uid, char_u *s, int len)
-{
-#if defined(HAVE_PWD_H) && defined(HAVE_GETPWUID)
-  struct passwd   *pw;
-
-  if ((pw = getpwuid(uid)) != NULL
-      && pw->pw_name != NULL && *(pw->pw_name) != NUL) {
-    vim_strncpy(s, (char_u *)pw->pw_name, len - 1);
-    return OK;
-  }
-#endif
-  sprintf((char *)s, "%d", (int)uid);       /* assumes s is long enough */
-  return FAIL;                              /* a number is not a name */
-}
-
-/*
  * Insert host name is s[len].
  */
 

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -24,8 +24,6 @@ int use_xterm_mouse(void);
 int vim_is_iris(char_u *name);
 int vim_is_vt300(char_u *name);
 int vim_is_fastterm(char_u *name);
-int mch_get_user_name(char_u *s, int len);
-int mch_get_uname(uid_t uid, char_u *s, int len);
 void mch_get_host_name(char_u *s, int len);
 long mch_get_pid(void);
 void slash_adjust(char_u *p);

--- a/src/os_unix_defs.h
+++ b/src/os_unix_defs.h
@@ -121,10 +121,6 @@
 
 #define BASENAMELEN     (MAXNAMLEN - 5)
 
-#ifdef HAVE_PWD_H
-# include <pwd.h>
-#endif
-
 /*
  * Unix system-dependent file names
  */

--- a/test/unit/os/users.moon
+++ b/test/unit/os/users.moon
@@ -1,0 +1,52 @@
+{:cimport, :internalize, :eq, :ffi, :lib, :cstr} = require 'test.unit.helpers'
+
+-- fs = cimport './src/os/os.h'
+-- remove these statements once 'cimport' is working properly for misc1.h
+users = lib
+ffi.cdef [[
+typedef struct growarray {
+  int ga_len;
+  int ga_maxlen;
+  int ga_itemsize;
+  int ga_growsize;
+  void    *ga_data;
+} garray_T;
+int mch_get_usernames(garray_T *usernames);
+]]
+
+NULL = ffi.cast 'void*', 0
+OK = 1
+FAIL = 0
+
+garray_new = () ->
+  ffi.new 'garray_T[1]'
+
+garray_get_len = (array) ->
+  array[0].ga_len
+
+garray_get_item = (array, index) ->
+  (ffi.cast 'void **', array[0].ga_data)[index]
+
+
+describe 'users function', ->
+
+  describe 'mch_get_usernames', ->
+
+    -- will probably not work on windows
+    current_username = os.getenv 'USER'
+
+    it 'returns FAIL if called with NULL', ->
+      eq FAIL, users.mch_get_usernames NULL
+
+    it 'fills the names garray with os usernames and returns OK', ->
+      ga_users = garray_new!
+      eq OK, users.mch_get_usernames ga_users
+      user_count = garray_get_len ga_users
+      assert.is_true user_count > 0
+      current_username_found = false
+      for i = 0, user_count - 1
+        name = ffi.string (garray_get_item ga_users, i)
+        if name == current_username
+          current_username_found = true
+      assert.is_true current_username_found
+

--- a/test/unit/os/users.moon
+++ b/test/unit/os/users.moon
@@ -14,6 +14,7 @@ typedef struct growarray {
 int mch_get_usernames(garray_T *usernames);
 int mch_get_user_name(char *s, size_t len);
 int mch_get_uname(int uid, char *s, size_t len);
+char *mch_get_user_directory(const char *name);
 int getuid(void);
 ]]
 
@@ -74,4 +75,16 @@ describe 'users function', ->
       user_id = 2342
       eq FAIL, users.mch_get_uname(user_id, name_out, 100)
       eq '2342', ffi.string name_out
+
+  describe 'mch_get_user_directory', ->
+
+    it 'should return NULL if called with NULL', ->
+      eq NULL, users.mch_get_user_directory NULL
+
+    it 'should return $HOME for the current user', ->
+      home = os.getenv('HOME')
+      eq home, ffi.string (users.mch_get_user_directory current_username)
+
+    it 'should return NULL if the user is not found', ->
+      eq NULL, users.mch_get_user_directory 'neovim_user_not_found_test'
 


### PR DESCRIPTION
This is not done yet. In `misc1.c` there is some code in the function `expand_env_esc()` that uses `getpwnam()`, which i will move to `os/users.c` as well.
