### PR TITLE
[RDY] Clean up arabic.c/h and farsi.c/h

### DIFF
--- a/src/arabic.c
+++ b/src/arabic.c
@@ -40,56 +40,54 @@ static int A_is_ok(int c);
 static int A_is_valid(int c);
 static int A_is_special(int c);
 
-
 /*
  * Returns True if c is an ISO-8859-6 shaped ARABIC letter (user entered)
  */
 static int A_is_a(int cur_c)
 {
   switch (cur_c) {
-  case a_HAMZA:
-  case a_ALEF_MADDA:
-  case a_ALEF_HAMZA_ABOVE:
-  case a_WAW_HAMZA:
-  case a_ALEF_HAMZA_BELOW:
-  case a_YEH_HAMZA:
-  case a_ALEF:
-  case a_BEH:
-  case a_TEH_MARBUTA:
-  case a_TEH:
-  case a_THEH:
-  case a_JEEM:
-  case a_HAH:
-  case a_KHAH:
-  case a_DAL:
-  case a_THAL:
-  case a_REH:
-  case a_ZAIN:
-  case a_SEEN:
-  case a_SHEEN:
-  case a_SAD:
-  case a_DAD:
-  case a_TAH:
-  case a_ZAH:
-  case a_AIN:
-  case a_GHAIN:
-  case a_TATWEEL:
-  case a_FEH:
-  case a_QAF:
-  case a_KAF:
-  case a_LAM:
-  case a_MEEM:
-  case a_NOON:
-  case a_HEH:
-  case a_WAW:
-  case a_ALEF_MAKSURA:
-  case a_YEH:
-    return TRUE;
+    case a_HAMZA:
+    case a_ALEF_MADDA:
+    case a_ALEF_HAMZA_ABOVE:
+    case a_WAW_HAMZA:
+    case a_ALEF_HAMZA_BELOW:
+    case a_YEH_HAMZA:
+    case a_ALEF:
+    case a_BEH:
+    case a_TEH_MARBUTA:
+    case a_TEH:
+    case a_THEH:
+    case a_JEEM:
+    case a_HAH:
+    case a_KHAH:
+    case a_DAL:
+    case a_THAL:
+    case a_REH:
+    case a_ZAIN:
+    case a_SEEN:
+    case a_SHEEN:
+    case a_SAD:
+    case a_DAD:
+    case a_TAH:
+    case a_ZAH:
+    case a_AIN:
+    case a_GHAIN:
+    case a_TATWEEL:
+    case a_FEH:
+    case a_QAF:
+    case a_KAF:
+    case a_LAM:
+    case a_MEEM:
+    case a_NOON:
+    case a_HEH:
+    case a_WAW:
+    case a_ALEF_MAKSURA:
+    case a_YEH:
+      return TRUE;
   }
 
   return FALSE;
 }
-
 
 /*
  * Returns True if c is an Isolated Form-B ARABIC letter
@@ -97,48 +95,47 @@ static int A_is_a(int cur_c)
 static int A_is_s(int cur_c)
 {
   switch (cur_c) {
-  case a_s_HAMZA:
-  case a_s_ALEF_MADDA:
-  case a_s_ALEF_HAMZA_ABOVE:
-  case a_s_WAW_HAMZA:
-  case a_s_ALEF_HAMZA_BELOW:
-  case a_s_YEH_HAMZA:
-  case a_s_ALEF:
-  case a_s_BEH:
-  case a_s_TEH_MARBUTA:
-  case a_s_TEH:
-  case a_s_THEH:
-  case a_s_JEEM:
-  case a_s_HAH:
-  case a_s_KHAH:
-  case a_s_DAL:
-  case a_s_THAL:
-  case a_s_REH:
-  case a_s_ZAIN:
-  case a_s_SEEN:
-  case a_s_SHEEN:
-  case a_s_SAD:
-  case a_s_DAD:
-  case a_s_TAH:
-  case a_s_ZAH:
-  case a_s_AIN:
-  case a_s_GHAIN:
-  case a_s_FEH:
-  case a_s_QAF:
-  case a_s_KAF:
-  case a_s_LAM:
-  case a_s_MEEM:
-  case a_s_NOON:
-  case a_s_HEH:
-  case a_s_WAW:
-  case a_s_ALEF_MAKSURA:
-  case a_s_YEH:
-    return TRUE;
+    case a_s_HAMZA:
+    case a_s_ALEF_MADDA:
+    case a_s_ALEF_HAMZA_ABOVE:
+    case a_s_WAW_HAMZA:
+    case a_s_ALEF_HAMZA_BELOW:
+    case a_s_YEH_HAMZA:
+    case a_s_ALEF:
+    case a_s_BEH:
+    case a_s_TEH_MARBUTA:
+    case a_s_TEH:
+    case a_s_THEH:
+    case a_s_JEEM:
+    case a_s_HAH:
+    case a_s_KHAH:
+    case a_s_DAL:
+    case a_s_THAL:
+    case a_s_REH:
+    case a_s_ZAIN:
+    case a_s_SEEN:
+    case a_s_SHEEN:
+    case a_s_SAD:
+    case a_s_DAD:
+    case a_s_TAH:
+    case a_s_ZAH:
+    case a_s_AIN:
+    case a_s_GHAIN:
+    case a_s_FEH:
+    case a_s_QAF:
+    case a_s_KAF:
+    case a_s_LAM:
+    case a_s_MEEM:
+    case a_s_NOON:
+    case a_s_HEH:
+    case a_s_WAW:
+    case a_s_ALEF_MAKSURA:
+    case a_s_YEH:
+      return TRUE;
   }
 
   return FALSE;
 }
-
 
 /*
  * Returns True if c is a Final shape of an ARABIC letter
@@ -146,50 +143,49 @@ static int A_is_s(int cur_c)
 static int A_is_f(int cur_c)
 {
   switch (cur_c) {
-  case a_f_ALEF_MADDA:
-  case a_f_ALEF_HAMZA_ABOVE:
-  case a_f_WAW_HAMZA:
-  case a_f_ALEF_HAMZA_BELOW:
-  case a_f_YEH_HAMZA:
-  case a_f_ALEF:
-  case a_f_BEH:
-  case a_f_TEH_MARBUTA:
-  case a_f_TEH:
-  case a_f_THEH:
-  case a_f_JEEM:
-  case a_f_HAH:
-  case a_f_KHAH:
-  case a_f_DAL:
-  case a_f_THAL:
-  case a_f_REH:
-  case a_f_ZAIN:
-  case a_f_SEEN:
-  case a_f_SHEEN:
-  case a_f_SAD:
-  case a_f_DAD:
-  case a_f_TAH:
-  case a_f_ZAH:
-  case a_f_AIN:
-  case a_f_GHAIN:
-  case a_f_FEH:
-  case a_f_QAF:
-  case a_f_KAF:
-  case a_f_LAM:
-  case a_f_MEEM:
-  case a_f_NOON:
-  case a_f_HEH:
-  case a_f_WAW:
-  case a_f_ALEF_MAKSURA:
-  case a_f_YEH:
-  case a_f_LAM_ALEF_MADDA_ABOVE:
-  case a_f_LAM_ALEF_HAMZA_ABOVE:
-  case a_f_LAM_ALEF_HAMZA_BELOW:
-  case a_f_LAM_ALEF:
-    return TRUE;
+    case a_f_ALEF_MADDA:
+    case a_f_ALEF_HAMZA_ABOVE:
+    case a_f_WAW_HAMZA:
+    case a_f_ALEF_HAMZA_BELOW:
+    case a_f_YEH_HAMZA:
+    case a_f_ALEF:
+    case a_f_BEH:
+    case a_f_TEH_MARBUTA:
+    case a_f_TEH:
+    case a_f_THEH:
+    case a_f_JEEM:
+    case a_f_HAH:
+    case a_f_KHAH:
+    case a_f_DAL:
+    case a_f_THAL:
+    case a_f_REH:
+    case a_f_ZAIN:
+    case a_f_SEEN:
+    case a_f_SHEEN:
+    case a_f_SAD:
+    case a_f_DAD:
+    case a_f_TAH:
+    case a_f_ZAH:
+    case a_f_AIN:
+    case a_f_GHAIN:
+    case a_f_FEH:
+    case a_f_QAF:
+    case a_f_KAF:
+    case a_f_LAM:
+    case a_f_MEEM:
+    case a_f_NOON:
+    case a_f_HEH:
+    case a_f_WAW:
+    case a_f_ALEF_MAKSURA:
+    case a_f_YEH:
+    case a_f_LAM_ALEF_MADDA_ABOVE:
+    case a_f_LAM_ALEF_HAMZA_ABOVE:
+    case a_f_LAM_ALEF_HAMZA_BELOW:
+    case a_f_LAM_ALEF:
+      return TRUE;
   }
   return FALSE;
 }
-
 
 /*
  * Change shape - from ISO-8859-6/Isolated to Form-B Isolated
@@ -199,124 +195,160 @@ static int chg_c_a2s(int cur_c)
   int tempc;
 
   switch (cur_c) {
-  case a_HAMZA:
-    tempc = a_s_HAMZA;
-    break;
-  case a_ALEF_MADDA:
-    tempc = a_s_ALEF_MADDA;
-    break;
-  case a_ALEF_HAMZA_ABOVE:
-    tempc = a_s_ALEF_HAMZA_ABOVE;
-    break;
-  case a_WAW_HAMZA:
-    tempc = a_s_WAW_HAMZA;
-    break;
-  case a_ALEF_HAMZA_BELOW:
-    tempc = a_s_ALEF_HAMZA_BELOW;
-    break;
-  case a_YEH_HAMZA:
-    tempc = a_s_YEH_HAMZA;
-    break;
-  case a_ALEF:
-    tempc = a_s_ALEF;
-    break;
-  case a_TEH_MARBUTA:
-    tempc = a_s_TEH_MARBUTA;
-    break;
-  case a_DAL:
-    tempc = a_s_DAL;
-    break;
-  case a_THAL:
-    tempc = a_s_THAL;
-    break;
-  case a_REH:
-    tempc = a_s_REH;
-    break;
-  case a_ZAIN:
-    tempc = a_s_ZAIN;
-    break;
-  case a_TATWEEL:                       /* exceptions */
-    tempc = cur_c;
-    break;
-  case a_WAW:
-    tempc = a_s_WAW;
-    break;
-  case a_ALEF_MAKSURA:
-    tempc = a_s_ALEF_MAKSURA;
-    break;
-  case a_BEH:
-    tempc = a_s_BEH;
-    break;
-  case a_TEH:
-    tempc = a_s_TEH;
-    break;
-  case a_THEH:
-    tempc = a_s_THEH;
-    break;
-  case a_JEEM:
-    tempc = a_s_JEEM;
-    break;
-  case a_HAH:
-    tempc = a_s_HAH;
-    break;
-  case a_KHAH:
-    tempc = a_s_KHAH;
-    break;
-  case a_SEEN:
-    tempc = a_s_SEEN;
-    break;
-  case a_SHEEN:
-    tempc = a_s_SHEEN;
-    break;
-  case a_SAD:
-    tempc = a_s_SAD;
-    break;
-  case a_DAD:
-    tempc = a_s_DAD;
-    break;
-  case a_TAH:
-    tempc = a_s_TAH;
-    break;
-  case a_ZAH:
-    tempc = a_s_ZAH;
-    break;
-  case a_AIN:
-    tempc = a_s_AIN;
-    break;
-  case a_GHAIN:
-    tempc = a_s_GHAIN;
-    break;
-  case a_FEH:
-    tempc = a_s_FEH;
-    break;
-  case a_QAF:
-    tempc = a_s_QAF;
-    break;
-  case a_KAF:
-    tempc = a_s_KAF;
-    break;
-  case a_LAM:
-    tempc = a_s_LAM;
-    break;
-  case a_MEEM:
-    tempc = a_s_MEEM;
-    break;
-  case a_NOON:
-    tempc = a_s_NOON;
-    break;
-  case a_HEH:
-    tempc = a_s_HEH;
-    break;
-  case a_YEH:
-    tempc = a_s_YEH;
-    break;
-  default:
-    tempc = 0;
+    case a_HAMZA:
+      tempc = a_s_HAMZA;
+      break;
+
+    case a_ALEF_MADDA:
+      tempc = a_s_ALEF_MADDA;
+      break;
+
+    case a_ALEF_HAMZA_ABOVE:
+      tempc = a_s_ALEF_HAMZA_ABOVE;
+      break;
+
+    case a_WAW_HAMZA:
+      tempc = a_s_WAW_HAMZA;
+      break;
+
+    case a_ALEF_HAMZA_BELOW:
+      tempc = a_s_ALEF_HAMZA_BELOW;
+      break;
+
+    case a_YEH_HAMZA:
+      tempc = a_s_YEH_HAMZA;
+      break;
+
+    case a_ALEF:
+      tempc = a_s_ALEF;
+      break;
+
+    case a_TEH_MARBUTA:
+      tempc = a_s_TEH_MARBUTA;
+      break;
+
+    case a_DAL:
+      tempc = a_s_DAL;
+      break;
+
+    case a_THAL:
+      tempc = a_s_THAL;
+      break;
+
+    case a_REH:
+      tempc = a_s_REH;
+      break;
+
+    case a_ZAIN:
+      tempc = a_s_ZAIN;
+      break;
+
+    case a_TATWEEL: /* exceptions */
+      tempc = cur_c;
+      break;
+
+    case a_WAW:
+      tempc = a_s_WAW;
+      break;
+
+    case a_ALEF_MAKSURA:
+      tempc = a_s_ALEF_MAKSURA;
+      break;
+
+    case a_BEH:
+      tempc = a_s_BEH;
+      break;
+
+    case a_TEH:
+      tempc = a_s_TEH;
+      break;
+
+    case a_THEH:
+      tempc = a_s_THEH;
+      break;
+
+    case a_JEEM:
+      tempc = a_s_JEEM;
+      break;
+
+    case a_HAH:
+      tempc = a_s_HAH;
+      break;
+
+    case a_KHAH:
+      tempc = a_s_KHAH;
+      break;
+
+    case a_SEEN:
+      tempc = a_s_SEEN;
+      break;
+
+    case a_SHEEN:
+      tempc = a_s_SHEEN;
+      break;
+
+    case a_SAD:
+      tempc = a_s_SAD;
+      break;
+
+    case a_DAD:
+      tempc = a_s_DAD;
+      break;
+
+    case a_TAH:
+      tempc = a_s_TAH;
+      break;
+
+    case a_ZAH:
+      tempc = a_s_ZAH;
+      break;
+
+    case a_AIN:
+      tempc = a_s_AIN;
+      break;
+
+    case a_GHAIN:
+      tempc = a_s_GHAIN;
+      break;
+
+    case a_FEH:
+      tempc = a_s_FEH;
+      break;
+
+    case a_QAF:
+      tempc = a_s_QAF;
+      break;
+
+    case a_KAF:
+      tempc = a_s_KAF;
+      break;
+
+    case a_LAM:
+      tempc = a_s_LAM;
+      break;
+
+    case a_MEEM:
+      tempc = a_s_MEEM;
+      break;
+
+    case a_NOON:
+      tempc = a_s_NOON;
+      break;
+
+    case a_HEH:
+      tempc = a_s_HEH;
+      break;
+
+    case a_YEH:
+      tempc = a_s_YEH;
+      break;
+
+    default:
+      tempc = 0;
   }
 
   return tempc;
 }
-
 
 /*
  * Change shape - from ISO-8859-6/Isolated to Initial
@@ -326,124 +358,160 @@ static int chg_c_a2i(int cur_c)
   int tempc;
 
   switch (cur_c) {
-  case a_YEH_HAMZA:
-    tempc = a_i_YEH_HAMZA;
-    break;
-  case a_HAMZA:                         /* exceptions */
-    tempc = a_s_HAMZA;
-    break;
-  case a_ALEF_MADDA:                    /* exceptions */
-    tempc = a_s_ALEF_MADDA;
-    break;
-  case a_ALEF_HAMZA_ABOVE:              /* exceptions */
-    tempc = a_s_ALEF_HAMZA_ABOVE;
-    break;
-  case a_WAW_HAMZA:                     /* exceptions */
-    tempc = a_s_WAW_HAMZA;
-    break;
-  case a_ALEF_HAMZA_BELOW:              /* exceptions */
-    tempc = a_s_ALEF_HAMZA_BELOW;
-    break;
-  case a_ALEF:                          /* exceptions */
-    tempc = a_s_ALEF;
-    break;
-  case a_TEH_MARBUTA:                   /* exceptions */
-    tempc = a_s_TEH_MARBUTA;
-    break;
-  case a_DAL:                           /* exceptions */
-    tempc = a_s_DAL;
-    break;
-  case a_THAL:                          /* exceptions */
-    tempc = a_s_THAL;
-    break;
-  case a_REH:                           /* exceptions */
-    tempc = a_s_REH;
-    break;
-  case a_ZAIN:                          /* exceptions */
-    tempc = a_s_ZAIN;
-    break;
-  case a_TATWEEL:                       /* exceptions */
-    tempc = cur_c;
-    break;
-  case a_WAW:                           /* exceptions */
-    tempc = a_s_WAW;
-    break;
-  case a_ALEF_MAKSURA:                  /* exceptions */
-    tempc = a_s_ALEF_MAKSURA;
-    break;
-  case a_BEH:
-    tempc = a_i_BEH;
-    break;
-  case a_TEH:
-    tempc = a_i_TEH;
-    break;
-  case a_THEH:
-    tempc = a_i_THEH;
-    break;
-  case a_JEEM:
-    tempc = a_i_JEEM;
-    break;
-  case a_HAH:
-    tempc = a_i_HAH;
-    break;
-  case a_KHAH:
-    tempc = a_i_KHAH;
-    break;
-  case a_SEEN:
-    tempc = a_i_SEEN;
-    break;
-  case a_SHEEN:
-    tempc = a_i_SHEEN;
-    break;
-  case a_SAD:
-    tempc = a_i_SAD;
-    break;
-  case a_DAD:
-    tempc = a_i_DAD;
-    break;
-  case a_TAH:
-    tempc = a_i_TAH;
-    break;
-  case a_ZAH:
-    tempc = a_i_ZAH;
-    break;
-  case a_AIN:
-    tempc = a_i_AIN;
-    break;
-  case a_GHAIN:
-    tempc = a_i_GHAIN;
-    break;
-  case a_FEH:
-    tempc = a_i_FEH;
-    break;
-  case a_QAF:
-    tempc = a_i_QAF;
-    break;
-  case a_KAF:
-    tempc = a_i_KAF;
-    break;
-  case a_LAM:
-    tempc = a_i_LAM;
-    break;
-  case a_MEEM:
-    tempc = a_i_MEEM;
-    break;
-  case a_NOON:
-    tempc = a_i_NOON;
-    break;
-  case a_HEH:
-    tempc = a_i_HEH;
-    break;
-  case a_YEH:
-    tempc = a_i_YEH;
-    break;
-  default:
-    tempc = 0;
+    case a_YEH_HAMZA:
+      tempc = a_i_YEH_HAMZA;
+      break;
+
+    case a_HAMZA: /* exceptions */
+      tempc = a_s_HAMZA;
+      break;
+
+    case a_ALEF_MADDA: /* exceptions */
+      tempc = a_s_ALEF_MADDA;
+      break;
+
+    case a_ALEF_HAMZA_ABOVE: /* exceptions */
+      tempc = a_s_ALEF_HAMZA_ABOVE;
+      break;
+
+    case a_WAW_HAMZA: /* exceptions */
+      tempc = a_s_WAW_HAMZA;
+      break;
+
+    case a_ALEF_HAMZA_BELOW: /* exceptions */
+      tempc = a_s_ALEF_HAMZA_BELOW;
+      break;
+
+    case a_ALEF: /* exceptions */
+      tempc = a_s_ALEF;
+      break;
+
+    case a_TEH_MARBUTA: /* exceptions */
+      tempc = a_s_TEH_MARBUTA;
+      break;
+
+    case a_DAL: /* exceptions */
+      tempc = a_s_DAL;
+      break;
+
+    case a_THAL: /* exceptions */
+      tempc = a_s_THAL;
+      break;
+
+    case a_REH: /* exceptions */
+      tempc = a_s_REH;
+      break;
+
+    case a_ZAIN: /* exceptions */
+      tempc = a_s_ZAIN;
+      break;
+
+    case a_TATWEEL: /* exceptions */
+      tempc = cur_c;
+      break;
+
+    case a_WAW: /* exceptions */
+      tempc = a_s_WAW;
+      break;
+
+    case a_ALEF_MAKSURA: /* exceptions */
+      tempc = a_s_ALEF_MAKSURA;
+      break;
+
+    case a_BEH:
+      tempc = a_i_BEH;
+      break;
+
+    case a_TEH:
+      tempc = a_i_TEH;
+      break;
+
+    case a_THEH:
+      tempc = a_i_THEH;
+      break;
+
+    case a_JEEM:
+      tempc = a_i_JEEM;
+      break;
+
+    case a_HAH:
+      tempc = a_i_HAH;
+      break;
+
+    case a_KHAH:
+      tempc = a_i_KHAH;
+      break;
+
+    case a_SEEN:
+      tempc = a_i_SEEN;
+      break;
+
+    case a_SHEEN:
+      tempc = a_i_SHEEN;
+      break;
+
+    case a_SAD:
+      tempc = a_i_SAD;
+      break;
+
+    case a_DAD:
+      tempc = a_i_DAD;
+      break;
+
+    case a_TAH:
+      tempc = a_i_TAH;
+      break;
+
+    case a_ZAH:
+      tempc = a_i_ZAH;
+      break;
+
+    case a_AIN:
+      tempc = a_i_AIN;
+      break;
+
+    case a_GHAIN:
+      tempc = a_i_GHAIN;
+      break;
+
+    case a_FEH:
+      tempc = a_i_FEH;
+      break;
+
+    case a_QAF:
+      tempc = a_i_QAF;
+      break;
+
+    case a_KAF:
+      tempc = a_i_KAF;
+      break;
+
+    case a_LAM:
+      tempc = a_i_LAM;
+      break;
+
+    case a_MEEM:
+      tempc = a_i_MEEM;
+      break;
+
+    case a_NOON:
+      tempc = a_i_NOON;
+      break;
+
+    case a_HEH:
+      tempc = a_i_HEH;
+      break;
+
+    case a_YEH:
+      tempc = a_i_YEH;
+      break;
+
+    default:
+      tempc = 0;
   }
 
   return tempc;
 }
-
 
 /*
  * Change shape - from ISO-8859-6/Isolated to Medial
@@ -453,124 +521,160 @@ static int chg_c_a2m(int cur_c)
   int tempc;
 
   switch (cur_c) {
-  case a_HAMZA:                         /* exception */
-    tempc = a_s_HAMZA;
-    break;
-  case a_ALEF_MADDA:                    /* exception */
-    tempc = a_f_ALEF_MADDA;
-    break;
-  case a_ALEF_HAMZA_ABOVE:              /* exception */
-    tempc = a_f_ALEF_HAMZA_ABOVE;
-    break;
-  case a_WAW_HAMZA:                     /* exception */
-    tempc = a_f_WAW_HAMZA;
-    break;
-  case a_ALEF_HAMZA_BELOW:              /* exception */
-    tempc = a_f_ALEF_HAMZA_BELOW;
-    break;
-  case a_YEH_HAMZA:
-    tempc = a_m_YEH_HAMZA;
-    break;
-  case a_ALEF:                          /* exception */
-    tempc = a_f_ALEF;
-    break;
-  case a_BEH:
-    tempc = a_m_BEH;
-    break;
-  case a_TEH_MARBUTA:                   /* exception */
-    tempc = a_f_TEH_MARBUTA;
-    break;
-  case a_TEH:
-    tempc = a_m_TEH;
-    break;
-  case a_THEH:
-    tempc = a_m_THEH;
-    break;
-  case a_JEEM:
-    tempc = a_m_JEEM;
-    break;
-  case a_HAH:
-    tempc = a_m_HAH;
-    break;
-  case a_KHAH:
-    tempc = a_m_KHAH;
-    break;
-  case a_DAL:                           /* exception */
-    tempc = a_f_DAL;
-    break;
-  case a_THAL:                          /* exception */
-    tempc = a_f_THAL;
-    break;
-  case a_REH:                           /* exception */
-    tempc = a_f_REH;
-    break;
-  case a_ZAIN:                          /* exception */
-    tempc = a_f_ZAIN;
-    break;
-  case a_SEEN:
-    tempc = a_m_SEEN;
-    break;
-  case a_SHEEN:
-    tempc = a_m_SHEEN;
-    break;
-  case a_SAD:
-    tempc = a_m_SAD;
-    break;
-  case a_DAD:
-    tempc = a_m_DAD;
-    break;
-  case a_TAH:
-    tempc = a_m_TAH;
-    break;
-  case a_ZAH:
-    tempc = a_m_ZAH;
-    break;
-  case a_AIN:
-    tempc = a_m_AIN;
-    break;
-  case a_GHAIN:
-    tempc = a_m_GHAIN;
-    break;
-  case a_TATWEEL:                       /* exception */
-    tempc = cur_c;
-    break;
-  case a_FEH:
-    tempc = a_m_FEH;
-    break;
-  case a_QAF:
-    tempc = a_m_QAF;
-    break;
-  case a_KAF:
-    tempc = a_m_KAF;
-    break;
-  case a_LAM:
-    tempc = a_m_LAM;
-    break;
-  case a_MEEM:
-    tempc = a_m_MEEM;
-    break;
-  case a_NOON:
-    tempc = a_m_NOON;
-    break;
-  case a_HEH:
-    tempc = a_m_HEH;
-    break;
-  case a_WAW:                           /* exception */
-    tempc = a_f_WAW;
-    break;
-  case a_ALEF_MAKSURA:                  /* exception */
-    tempc = a_f_ALEF_MAKSURA;
-    break;
-  case a_YEH:
-    tempc = a_m_YEH;
-    break;
-  default:
-    tempc = 0;
+    case a_HAMZA: /* exception */
+      tempc = a_s_HAMZA;
+      break;
+
+    case a_ALEF_MADDA: /* exception */
+      tempc = a_f_ALEF_MADDA;
+      break;
+
+    case a_ALEF_HAMZA_ABOVE: /* exception */
+      tempc = a_f_ALEF_HAMZA_ABOVE;
+      break;
+
+    case a_WAW_HAMZA: /* exception */
+      tempc = a_f_WAW_HAMZA;
+      break;
+
+    case a_ALEF_HAMZA_BELOW: /* exception */
+      tempc = a_f_ALEF_HAMZA_BELOW;
+      break;
+
+    case a_YEH_HAMZA:
+      tempc = a_m_YEH_HAMZA;
+      break;
+
+    case a_ALEF: /* exception */
+      tempc = a_f_ALEF;
+      break;
+
+    case a_BEH:
+      tempc = a_m_BEH;
+      break;
+
+    case a_TEH_MARBUTA: /* exception */
+      tempc = a_f_TEH_MARBUTA;
+      break;
+
+    case a_TEH:
+      tempc = a_m_TEH;
+      break;
+
+    case a_THEH:
+      tempc = a_m_THEH;
+      break;
+
+    case a_JEEM:
+      tempc = a_m_JEEM;
+      break;
+
+    case a_HAH:
+      tempc = a_m_HAH;
+      break;
+
+    case a_KHAH:
+      tempc = a_m_KHAH;
+      break;
+
+    case a_DAL: /* exception */
+      tempc = a_f_DAL;
+      break;
+
+    case a_THAL: /* exception */
+      tempc = a_f_THAL;
+      break;
+
+    case a_REH: /* exception */
+      tempc = a_f_REH;
+      break;
+
+    case a_ZAIN: /* exception */
+      tempc = a_f_ZAIN;
+      break;
+
+    case a_SEEN:
+      tempc = a_m_SEEN;
+      break;
+
+    case a_SHEEN:
+      tempc = a_m_SHEEN;
+      break;
+
+    case a_SAD:
+      tempc = a_m_SAD;
+      break;
+
+    case a_DAD:
+      tempc = a_m_DAD;
+      break;
+
+    case a_TAH:
+      tempc = a_m_TAH;
+      break;
+
+    case a_ZAH:
+      tempc = a_m_ZAH;
+      break;
+
+    case a_AIN:
+      tempc = a_m_AIN;
+      break;
+
+    case a_GHAIN:
+      tempc = a_m_GHAIN;
+      break;
+
+    case a_TATWEEL: /* exception */
+      tempc = cur_c;
+      break;
+
+    case a_FEH:
+      tempc = a_m_FEH;
+      break;
+
+    case a_QAF:
+      tempc = a_m_QAF;
+      break;
+
+    case a_KAF:
+      tempc = a_m_KAF;
+      break;
+
+    case a_LAM:
+      tempc = a_m_LAM;
+      break;
+
+    case a_MEEM:
+      tempc = a_m_MEEM;
+      break;
+
+    case a_NOON:
+      tempc = a_m_NOON;
+      break;
+
+    case a_HEH:
+      tempc = a_m_HEH;
+      break;
+
+    case a_WAW: /* exception */
+      tempc = a_f_WAW;
+      break;
+
+    case a_ALEF_MAKSURA: /* exception */
+      tempc = a_f_ALEF_MAKSURA;
+      break;
+
+    case a_YEH:
+      tempc = a_m_YEH;
+      break;
+
+    default:
+      tempc = 0;
   }
 
   return tempc;
 }
-
 
 /*
  * Change shape - from ISO-8859-6/Isolated to final
@@ -590,124 +694,160 @@ static int chg_c_a2f(int cur_c)
    */
 
   switch (cur_c) {
-  case a_HAMZA:                         /* exception */
-    tempc = a_s_HAMZA;
-    break;
-  case a_ALEF_MADDA:
-    tempc = a_f_ALEF_MADDA;
-    break;
-  case a_ALEF_HAMZA_ABOVE:
-    tempc = a_f_ALEF_HAMZA_ABOVE;
-    break;
-  case a_WAW_HAMZA:
-    tempc = a_f_WAW_HAMZA;
-    break;
-  case a_ALEF_HAMZA_BELOW:
-    tempc = a_f_ALEF_HAMZA_BELOW;
-    break;
-  case a_YEH_HAMZA:
-    tempc = a_f_YEH_HAMZA;
-    break;
-  case a_ALEF:
-    tempc = a_f_ALEF;
-    break;
-  case a_BEH:
-    tempc = a_f_BEH;
-    break;
-  case a_TEH_MARBUTA:
-    tempc = a_f_TEH_MARBUTA;
-    break;
-  case a_TEH:
-    tempc = a_f_TEH;
-    break;
-  case a_THEH:
-    tempc = a_f_THEH;
-    break;
-  case a_JEEM:
-    tempc = a_f_JEEM;
-    break;
-  case a_HAH:
-    tempc = a_f_HAH;
-    break;
-  case a_KHAH:
-    tempc = a_f_KHAH;
-    break;
-  case a_DAL:
-    tempc = a_f_DAL;
-    break;
-  case a_THAL:
-    tempc = a_f_THAL;
-    break;
-  case a_REH:
-    tempc = a_f_REH;
-    break;
-  case a_ZAIN:
-    tempc = a_f_ZAIN;
-    break;
-  case a_SEEN:
-    tempc = a_f_SEEN;
-    break;
-  case a_SHEEN:
-    tempc = a_f_SHEEN;
-    break;
-  case a_SAD:
-    tempc = a_f_SAD;
-    break;
-  case a_DAD:
-    tempc = a_f_DAD;
-    break;
-  case a_TAH:
-    tempc = a_f_TAH;
-    break;
-  case a_ZAH:
-    tempc = a_f_ZAH;
-    break;
-  case a_AIN:
-    tempc = a_f_AIN;
-    break;
-  case a_GHAIN:
-    tempc = a_f_GHAIN;
-    break;
-  case a_TATWEEL:                       /* exception */
-    tempc = cur_c;
-    break;
-  case a_FEH:
-    tempc = a_f_FEH;
-    break;
-  case a_QAF:
-    tempc = a_f_QAF;
-    break;
-  case a_KAF:
-    tempc = a_f_KAF;
-    break;
-  case a_LAM:
-    tempc = a_f_LAM;
-    break;
-  case a_MEEM:
-    tempc = a_f_MEEM;
-    break;
-  case a_NOON:
-    tempc = a_f_NOON;
-    break;
-  case a_HEH:
-    tempc = a_f_HEH;
-    break;
-  case a_WAW:
-    tempc = a_f_WAW;
-    break;
-  case a_ALEF_MAKSURA:
-    tempc = a_f_ALEF_MAKSURA;
-    break;
-  case a_YEH:
-    tempc = a_f_YEH;
-    break;
-  default:
-    tempc = 0;
+    case a_HAMZA: /* exception */
+      tempc = a_s_HAMZA;
+      break;
+
+    case a_ALEF_MADDA:
+      tempc = a_f_ALEF_MADDA;
+      break;
+
+    case a_ALEF_HAMZA_ABOVE:
+      tempc = a_f_ALEF_HAMZA_ABOVE;
+      break;
+
+    case a_WAW_HAMZA:
+      tempc = a_f_WAW_HAMZA;
+      break;
+
+    case a_ALEF_HAMZA_BELOW:
+      tempc = a_f_ALEF_HAMZA_BELOW;
+      break;
+
+    case a_YEH_HAMZA:
+      tempc = a_f_YEH_HAMZA;
+      break;
+
+    case a_ALEF:
+      tempc = a_f_ALEF;
+      break;
+
+    case a_BEH:
+      tempc = a_f_BEH;
+      break;
+
+    case a_TEH_MARBUTA:
+      tempc = a_f_TEH_MARBUTA;
+      break;
+
+    case a_TEH:
+      tempc = a_f_TEH;
+      break;
+
+    case a_THEH:
+      tempc = a_f_THEH;
+      break;
+
+    case a_JEEM:
+      tempc = a_f_JEEM;
+      break;
+
+    case a_HAH:
+      tempc = a_f_HAH;
+      break;
+
+    case a_KHAH:
+      tempc = a_f_KHAH;
+      break;
+
+    case a_DAL:
+      tempc = a_f_DAL;
+      break;
+
+    case a_THAL:
+      tempc = a_f_THAL;
+      break;
+
+    case a_REH:
+      tempc = a_f_REH;
+      break;
+
+    case a_ZAIN:
+      tempc = a_f_ZAIN;
+      break;
+
+    case a_SEEN:
+      tempc = a_f_SEEN;
+      break;
+
+    case a_SHEEN:
+      tempc = a_f_SHEEN;
+      break;
+
+    case a_SAD:
+      tempc = a_f_SAD;
+      break;
+
+    case a_DAD:
+      tempc = a_f_DAD;
+      break;
+
+    case a_TAH:
+      tempc = a_f_TAH;
+      break;
+
+    case a_ZAH:
+      tempc = a_f_ZAH;
+      break;
+
+    case a_AIN:
+      tempc = a_f_AIN;
+      break;
+
+    case a_GHAIN:
+      tempc = a_f_GHAIN;
+      break;
+
+    case a_TATWEEL: /* exception */
+      tempc = cur_c;
+      break;
+
+    case a_FEH:
+      tempc = a_f_FEH;
+      break;
+
+    case a_QAF:
+      tempc = a_f_QAF;
+      break;
+
+    case a_KAF:
+      tempc = a_f_KAF;
+      break;
+
+    case a_LAM:
+      tempc = a_f_LAM;
+      break;
+
+    case a_MEEM:
+      tempc = a_f_MEEM;
+      break;
+
+    case a_NOON:
+      tempc = a_f_NOON;
+      break;
+
+    case a_HEH:
+      tempc = a_f_HEH;
+      break;
+
+    case a_WAW:
+      tempc = a_f_WAW;
+      break;
+
+    case a_ALEF_MAKSURA:
+      tempc = a_f_ALEF_MAKSURA;
+      break;
+
+    case a_YEH:
+      tempc = a_f_YEH;
+      break;
+
+    default:
+      tempc = 0;
   }
 
   return tempc;
 }
-
 
 /*
  * Change shape - from Initial to Medial
@@ -717,82 +857,104 @@ static int chg_c_i2m(int cur_c)
   int tempc;
 
   switch (cur_c) {
-  case a_i_YEH_HAMZA:
-    tempc = a_m_YEH_HAMZA;
-    break;
-  case a_i_BEH:
-    tempc = a_m_BEH;
-    break;
-  case a_i_TEH:
-    tempc = a_m_TEH;
-    break;
-  case a_i_THEH:
-    tempc = a_m_THEH;
-    break;
-  case a_i_JEEM:
-    tempc = a_m_JEEM;
-    break;
-  case a_i_HAH:
-    tempc = a_m_HAH;
-    break;
-  case a_i_KHAH:
-    tempc = a_m_KHAH;
-    break;
-  case a_i_SEEN:
-    tempc = a_m_SEEN;
-    break;
-  case a_i_SHEEN:
-    tempc = a_m_SHEEN;
-    break;
-  case a_i_SAD:
-    tempc = a_m_SAD;
-    break;
-  case a_i_DAD:
-    tempc = a_m_DAD;
-    break;
-  case a_i_TAH:
-    tempc = a_m_TAH;
-    break;
-  case a_i_ZAH:
-    tempc = a_m_ZAH;
-    break;
-  case a_i_AIN:
-    tempc = a_m_AIN;
-    break;
-  case a_i_GHAIN:
-    tempc = a_m_GHAIN;
-    break;
-  case a_i_FEH:
-    tempc = a_m_FEH;
-    break;
-  case a_i_QAF:
-    tempc = a_m_QAF;
-    break;
-  case a_i_KAF:
-    tempc = a_m_KAF;
-    break;
-  case a_i_LAM:
-    tempc = a_m_LAM;
-    break;
-  case a_i_MEEM:
-    tempc = a_m_MEEM;
-    break;
-  case a_i_NOON:
-    tempc = a_m_NOON;
-    break;
-  case a_i_HEH:
-    tempc = a_m_HEH;
-    break;
-  case a_i_YEH:
-    tempc = a_m_YEH;
-    break;
-  default:
-    tempc = 0;
+    case a_i_YEH_HAMZA:
+      tempc = a_m_YEH_HAMZA;
+      break;
+
+    case a_i_BEH:
+      tempc = a_m_BEH;
+      break;
+
+    case a_i_TEH:
+      tempc = a_m_TEH;
+      break;
+
+    case a_i_THEH:
+      tempc = a_m_THEH;
+      break;
+
+    case a_i_JEEM:
+      tempc = a_m_JEEM;
+      break;
+
+    case a_i_HAH:
+      tempc = a_m_HAH;
+      break;
+
+    case a_i_KHAH:
+      tempc = a_m_KHAH;
+      break;
+
+    case a_i_SEEN:
+      tempc = a_m_SEEN;
+      break;
+
+    case a_i_SHEEN:
+      tempc = a_m_SHEEN;
+      break;
+
+    case a_i_SAD:
+      tempc = a_m_SAD;
+      break;
+
+    case a_i_DAD:
+      tempc = a_m_DAD;
+      break;
+
+    case a_i_TAH:
+      tempc = a_m_TAH;
+      break;
+
+    case a_i_ZAH:
+      tempc = a_m_ZAH;
+      break;
+
+    case a_i_AIN:
+      tempc = a_m_AIN;
+      break;
+
+    case a_i_GHAIN:
+      tempc = a_m_GHAIN;
+      break;
+
+    case a_i_FEH:
+      tempc = a_m_FEH;
+      break;
+
+    case a_i_QAF:
+      tempc = a_m_QAF;
+      break;
+
+    case a_i_KAF:
+      tempc = a_m_KAF;
+      break;
+
+    case a_i_LAM:
+      tempc = a_m_LAM;
+      break;
+
+    case a_i_MEEM:
+      tempc = a_m_MEEM;
+      break;
+
+    case a_i_NOON:
+      tempc = a_m_NOON;
+      break;
+
+    case a_i_HEH:
+      tempc = a_m_HEH;
+      break;
+
+    case a_i_YEH:
+      tempc = a_m_YEH;
+      break;
+
+    default:
+      tempc = 0;
   }
 
   return tempc;
 }
-
 
 /*
  * Change shape - from Final to Medial
@@ -802,104 +964,127 @@ static int chg_c_f2m(int cur_c)
   int tempc;
 
   switch (cur_c) {
-  /* NOTE: these encodings are multi-positional, no ?
-     case a_f_ALEF_MADDA:
-     case a_f_ALEF_HAMZA_ABOVE:
-     case a_f_ALEF_HAMZA_BELOW:
-   */
-  case a_f_YEH_HAMZA:
-    tempc = a_m_YEH_HAMZA;
-    break;
-  case a_f_WAW_HAMZA:                   /* exceptions */
-  case a_f_ALEF:
-  case a_f_TEH_MARBUTA:
-  case a_f_DAL:
-  case a_f_THAL:
-  case a_f_REH:
-  case a_f_ZAIN:
-  case a_f_WAW:
-  case a_f_ALEF_MAKSURA:
-    tempc = cur_c;
-    break;
-  case a_f_BEH:
-    tempc = a_m_BEH;
-    break;
-  case a_f_TEH:
-    tempc = a_m_TEH;
-    break;
-  case a_f_THEH:
-    tempc = a_m_THEH;
-    break;
-  case a_f_JEEM:
-    tempc = a_m_JEEM;
-    break;
-  case a_f_HAH:
-    tempc = a_m_HAH;
-    break;
-  case a_f_KHAH:
-    tempc = a_m_KHAH;
-    break;
-  case a_f_SEEN:
-    tempc = a_m_SEEN;
-    break;
-  case a_f_SHEEN:
-    tempc = a_m_SHEEN;
-    break;
-  case a_f_SAD:
-    tempc = a_m_SAD;
-    break;
-  case a_f_DAD:
-    tempc = a_m_DAD;
-    break;
-  case a_f_TAH:
-    tempc = a_m_TAH;
-    break;
-  case a_f_ZAH:
-    tempc = a_m_ZAH;
-    break;
-  case a_f_AIN:
-    tempc = a_m_AIN;
-    break;
-  case a_f_GHAIN:
-    tempc = a_m_GHAIN;
-    break;
-  case a_f_FEH:
-    tempc = a_m_FEH;
-    break;
-  case a_f_QAF:
-    tempc = a_m_QAF;
-    break;
-  case a_f_KAF:
-    tempc = a_m_KAF;
-    break;
-  case a_f_LAM:
-    tempc = a_m_LAM;
-    break;
-  case a_f_MEEM:
-    tempc = a_m_MEEM;
-    break;
-  case a_f_NOON:
-    tempc = a_m_NOON;
-    break;
-  case a_f_HEH:
-    tempc = a_m_HEH;
-    break;
-  case a_f_YEH:
-    tempc = a_m_YEH;
-    break;
-  /* NOTE: these encodings are multi-positional, no ?
-      case a_f_LAM_ALEF_MADDA_ABOVE:
-      case a_f_LAM_ALEF_HAMZA_ABOVE:
-      case a_f_LAM_ALEF_HAMZA_BELOW:
-      case a_f_LAM_ALEF:
-   */
-  default:
-    tempc = 0;
+    /* NOTE: these encodings are multi-positional, no ?
+       case a_f_ALEF_MADDA:
+       case a_f_ALEF_HAMZA_ABOVE:
+       case a_f_ALEF_HAMZA_BELOW:
+     */
+    case a_f_YEH_HAMZA:
+      tempc = a_m_YEH_HAMZA;
+      break;
+
+    case a_f_WAW_HAMZA: /* exceptions */
+    case a_f_ALEF:
+    case a_f_TEH_MARBUTA:
+    case a_f_DAL:
+    case a_f_THAL:
+    case a_f_REH:
+    case a_f_ZAIN:
+    case a_f_WAW:
+    case a_f_ALEF_MAKSURA:
+      tempc = cur_c;
+      break;
+
+    case a_f_BEH:
+      tempc = a_m_BEH;
+      break;
+
+    case a_f_TEH:
+      tempc = a_m_TEH;
+      break;
+
+    case a_f_THEH:
+      tempc = a_m_THEH;
+      break;
+
+    case a_f_JEEM:
+      tempc = a_m_JEEM;
+      break;
+
+    case a_f_HAH:
+      tempc = a_m_HAH;
+      break;
+
+    case a_f_KHAH:
+      tempc = a_m_KHAH;
+      break;
+
+    case a_f_SEEN:
+      tempc = a_m_SEEN;
+      break;
+
+    case a_f_SHEEN:
+      tempc = a_m_SHEEN;
+      break;
+
+    case a_f_SAD:
+      tempc = a_m_SAD;
+      break;
+
+    case a_f_DAD:
+      tempc = a_m_DAD;
+      break;
+
+    case a_f_TAH:
+      tempc = a_m_TAH;
+      break;
+
+    case a_f_ZAH:
+      tempc = a_m_ZAH;
+      break;
+
+    case a_f_AIN:
+      tempc = a_m_AIN;
+      break;
+
+    case a_f_GHAIN:
+      tempc = a_m_GHAIN;
+      break;
+
+    case a_f_FEH:
+      tempc = a_m_FEH;
+      break;
+
+    case a_f_QAF:
+      tempc = a_m_QAF;
+      break;
+
+    case a_f_KAF:
+      tempc = a_m_KAF;
+      break;
+
+    case a_f_LAM:
+      tempc = a_m_LAM;
+      break;
+
+    case a_f_MEEM:
+      tempc = a_m_MEEM;
+      break;
+
+    case a_f_NOON:
+      tempc = a_m_NOON;
+      break;
+
+    case a_f_HEH:
+      tempc = a_m_HEH;
+      break;
+
+    case a_f_YEH:
+      tempc = a_m_YEH;
+      break;
+
+    /* NOTE: these encodings are multi-positional, no ?
+        case a_f_LAM_ALEF_MADDA_ABOVE:
+        case a_f_LAM_ALEF_HAMZA_ABOVE:
+        case a_f_LAM_ALEF_HAMZA_BELOW:
+        case a_f_LAM_ALEF:
+     */
+    default:
+      tempc = 0;
   }
 
   return tempc;
 }
-
 
 /*
  * Change shape - from Combination (2 char) to an Isolated
@@ -909,25 +1094,28 @@ static int chg_c_laa2i(int hid_c)
   int tempc;
 
   switch (hid_c) {
-  case a_ALEF_MADDA:
-    tempc = a_s_LAM_ALEF_MADDA_ABOVE;
-    break;
-  case a_ALEF_HAMZA_ABOVE:
-    tempc = a_s_LAM_ALEF_HAMZA_ABOVE;
-    break;
-  case a_ALEF_HAMZA_BELOW:
-    tempc = a_s_LAM_ALEF_HAMZA_BELOW;
-    break;
-  case a_ALEF:
-    tempc = a_s_LAM_ALEF;
-    break;
-  default:
-    tempc = 0;
+    case a_ALEF_MADDA:
+      tempc = a_s_LAM_ALEF_MADDA_ABOVE;
+      break;
+
+    case a_ALEF_HAMZA_ABOVE:
+      tempc = a_s_LAM_ALEF_HAMZA_ABOVE;
+      break;
+
+    case a_ALEF_HAMZA_BELOW:
+      tempc = a_s_LAM_ALEF_HAMZA_BELOW;
+      break;
+
+    case a_ALEF:
+      tempc = a_s_LAM_ALEF;
+      break;
+
+    default:
+      tempc = 0;
   }
 
   return tempc;
 }
-
 
 /*
  * Change shape - from Combination-Isolated to Final
@@ -937,20 +1125,24 @@ static int chg_c_laa2f(int hid_c)
   int tempc;
 
   switch (hid_c) {
-  case a_ALEF_MADDA:
-    tempc = a_f_LAM_ALEF_MADDA_ABOVE;
-    break;
-  case a_ALEF_HAMZA_ABOVE:
-    tempc = a_f_LAM_ALEF_HAMZA_ABOVE;
-    break;
-  case a_ALEF_HAMZA_BELOW:
-    tempc = a_f_LAM_ALEF_HAMZA_BELOW;
-    break;
-  case a_ALEF:
-    tempc = a_f_LAM_ALEF;
-    break;
-  default:
-    tempc = 0;
+    case a_ALEF_MADDA:
+      tempc = a_f_LAM_ALEF_MADDA_ABOVE;
+      break;
+
+    case a_ALEF_HAMZA_ABOVE:
+      tempc = a_f_LAM_ALEF_HAMZA_ABOVE;
+      break;
+
+    case a_ALEF_HAMZA_BELOW:
+      tempc = a_f_LAM_ALEF_HAMZA_BELOW;
+      break;
+
+    case a_ALEF:
+      tempc = a_f_LAM_ALEF;
+      break;
+
+    default:
+      tempc = 0;
   }
 
   return tempc;
@@ -961,10 +1153,13 @@ static int chg_c_laa2f(int hid_c)
  */
 static int half_shape(int c)
 {
-  if (A_is_a(c))
+  if (A_is_a(c)) {
     return chg_c_a2i(c);
-  if (A_is_valid(c) && A_is_f(c))
+  }
+
+  if (A_is_valid(c) && A_is_f(c)) {
     return chg_c_f2m(c);
+  }
   return 0;
 }
 
@@ -977,7 +1172,8 @@ static int half_shape(int c)
  *		     (not shaped)
  * in:     "next_c"  is the next character (not shaped).
  */
-int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1, int next_c)
+int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1,
+                 int next_c)
 {
   int curr_c;
   int shape_c;
@@ -985,8 +1181,9 @@ int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1, int next_c)
   int prev_laa;
 
   /* Deal only with Arabic character, pass back all others */
-  if (!A_is_ok(c))
+  if (!A_is_ok(c)) {
     return c;
+  }
 
   /* half-shape current and previous character */
   shape_c = half_shape(prev_c);
@@ -998,31 +1195,34 @@ int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1, int next_c)
   prev_laa = A_firstc_laa(prev_c, prev_c1);
 
   if (curr_laa) {
-    if (A_is_valid(prev_c) && !A_is_f(shape_c)
-        && !A_is_s(shape_c) && !prev_laa)
+    if (A_is_valid(prev_c) && !A_is_f(shape_c) && !A_is_s(shape_c) &&
+        !prev_laa) {
       curr_c = chg_c_laa2f(curr_laa);
-    else
+    } else {
       curr_c = chg_c_laa2i(curr_laa);
+    }
 
     /* Remove the composing character */
     *c1p = 0;
-  } else if (!A_is_valid(prev_c) && A_is_valid(next_c))
+  } else if (!A_is_valid(prev_c) && A_is_valid(next_c)) {
     curr_c = chg_c_a2i(c);
-  else if (!shape_c || A_is_f(shape_c) || A_is_s(shape_c) || prev_laa)
+  } else if (!shape_c || A_is_f(shape_c) || A_is_s(shape_c) || prev_laa) {
     curr_c = A_is_valid(next_c) ? chg_c_a2i(c) : chg_c_a2s(c);
-  else if (A_is_valid(next_c))
+  } else if (A_is_valid(next_c)) {
     curr_c = A_is_iso(c) ? chg_c_a2m(c) : chg_c_i2m(c);
-  else if (A_is_valid(prev_c))
+  } else if (A_is_valid(prev_c)) {
     curr_c = chg_c_a2f(c);
-  else
+  } else {
     curr_c = chg_c_a2s(c);
+  }
 
   /* Sanity check -- curr_c should, in the future, never be 0.
    * We should, in the future, insert a fatal error here. */
-  if (curr_c == NUL)
+  if (curr_c == NUL) {
     curr_c = c;
+  }
 
-  if (curr_c != c && ccp != NULL) {
+  if ((curr_c != c) && (ccp != NULL)) {
     char_u buf[MB_MAXBYTES + 1];
 
     /* Update the first byte of the character. */
@@ -1034,21 +1234,18 @@ int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1, int next_c)
   return curr_c;
 }
 
-
 /*
  * A_firstc_laa returns first character of LAA combination if it exists
+ * in: "c" base character
+ * in: "c1" first composing character
  */
-static int 
-A_firstc_laa (
-    int c,          /* base character */
-    int c1         /* first composing character */
-)
+static int A_firstc_laa(int c, int c1)
 {
-  if (c1 != NUL && c == a_LAM && !A_is_harakat(c1))
+  if ((c1 != NUL) && (c == a_LAM) && !A_is_harakat(c1)) {
     return c1;
+  }
   return 0;
 }
-
 
 /*
  * A_is_harakat returns TRUE if 'c' is an Arabic Harakat character
@@ -1059,18 +1256,16 @@ static int A_is_harakat(int c)
   return c >= a_FATHATAN && c <= a_SUKUN;
 }
 
-
 /*
  * A_is_iso returns TRUE if 'c' is an Arabic ISO-8859-6 character
  *		(alphabet/number/punctuation)
  */
 static int A_is_iso(int c)
 {
-  return (c >= a_HAMZA && c <= a_GHAIN)
-         || (c >= a_TATWEEL && c <= a_HAMZA_BELOW)
-         || c == a_MINI_ALEF;
+  return (c >= a_HAMZA && c <= a_GHAIN) ||
+         (c >= a_TATWEEL && c <= a_HAMZA_BELOW) ||
+         c == a_MINI_ALEF;
 }
-
 
 /*
  * A_is_formb returns TRUE if 'c' is an Arabic 10646-1 FormB character
@@ -1078,12 +1273,11 @@ static int A_is_iso(int c)
  */
 static int A_is_formb(int c)
 {
-  return (c >= a_s_FATHATAN && c <= a_s_DAMMATAN)
-         || c == a_s_KASRATAN
-         || (c >= a_s_FATHA && c <= a_f_LAM_ALEF)
-         || c == a_BYTE_ORDER_MARK;
+  return (c >= a_s_FATHATAN && c <= a_s_DAMMATAN) ||
+         c == a_s_KASRATAN ||
+         (c >= a_s_FATHA && c <= a_f_LAM_ALEF) ||
+         c == a_BYTE_ORDER_MARK;
 }
-
 
 /*
  * A_is_ok returns TRUE if 'c' is an Arabic 10646 (8859-6 or Form-B)
@@ -1093,7 +1287,6 @@ static int A_is_ok(int c)
   return A_is_iso(c) || A_is_formb(c);
 }
 
-
 /*
  * A_is_valid returns TRUE if 'c' is an Arabic 10646 (8859-6 or Form-B)
  *		with some exceptions/exclusions
@@ -1102,7 +1295,6 @@ static int A_is_valid(int c)
 {
   return A_is_ok(c) && !A_is_special(c);
 }
-
 
 /*
  * A_is_special returns TRUE if 'c' is not a special Arabic character.

--- a/src/arabic.h
+++ b/src/arabic.h
@@ -6,6 +6,9 @@
  * Do ":help credits" in Vim to see a list of people who contributed.
  */
 
+#ifndef SRC_ARABIC_H_
+#define SRC_ARABIC_H_
+
 /*
  * Arabic characters are categorized into following types:
  *
@@ -256,3 +259,5 @@
 
 /* Range of Arabic characters that might be shaped. */
 #define ARABIC_CHAR(c)          ((c) >= a_HAMZA && (c) <= a_MINI_ALEF)
+
+#endif  // SRC_ARABIC_H_

--- a/src/farsi.c
+++ b/src/farsi.c
@@ -46,83 +46,108 @@ static int toF_Xor_X_(int c)
   int tempc;
 
   switch (c) {
-  case BE:
-    return _BE;
-  case PE:
-    return _PE;
-  case TE:
-    return _TE;
-  case SE:
-    return _SE;
-  case JIM:
-    return _JIM;
-  case CHE:
-    return _CHE;
-  case HE_J:
-    return _HE_J;
-  case XE:
-    return _XE;
-  case SIN:
-    return _SIN;
-  case SHIN:
-    return _SHIN;
-  case SAD:
-    return _SAD;
-  case ZAD:
-    return _ZAD;
-  case AYN:
-    return _AYN;
-  case AYN_:
-    return _AYN_;
-  case GHAYN:
-    return _GHAYN;
-  case GHAYN_:
-    return _GHAYN_;
-  case FE:
-    return _FE;
-  case GHAF:
-    return _GHAF;
-  case KAF:
-    return _KAF;
-  case GAF:
-    return _GAF;
-  case LAM:
-    return _LAM;
-  case MIM:
-    return _MIM;
-  case NOON:
-    return _NOON;
-  case YE:
-  case YE_:
-    return _YE;
-  case YEE:
-  case YEE_:
-    return _YEE;
-  case IE:
-  case IE_:
-    return _IE;
-  case F_HE:
-    tempc = _HE;
+    case BE:
+      return _BE;
 
-    if (p_ri && (curwin->w_cursor.col + 1
-                 < (colnr_T)STRLEN(ml_get_curline()))) {
-      inc_cursor();
+    case PE:
+      return _PE;
 
-      if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
-        tempc = _HE_;
+    case TE:
+      return _TE;
 
-      dec_cursor();
-    }
-    if (!p_ri && STRLEN(ml_get_curline())) {
-      dec_cursor();
+    case SE:
+      return _SE;
 
-      if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
-        tempc = _HE_;
+    case JIM:
+      return _JIM;
 
-      inc_cursor();
-    }
+    case CHE:
+      return _CHE;
 
-    return tempc;
+    case HE_J:
+      return _HE_J;
+
+    case XE:
+      return _XE;
+
+    case SIN:
+      return _SIN;
+
+    case SHIN:
+      return _SHIN;
+
+    case SAD:
+      return _SAD;
+
+    case ZAD:
+      return _ZAD;
+
+    case AYN:
+      return _AYN;
+
+    case AYN_:
+      return _AYN_;
+
+    case GHAYN:
+      return _GHAYN;
+
+    case GHAYN_:
+      return _GHAYN_;
+
+    case FE:
+      return _FE;
+
+    case GHAF:
+      return _GHAF;
+
+    case KAF:
+      return _KAF;
+
+    case GAF:
+      return _GAF;
+
+    case LAM:
+      return _LAM;
+
+    case MIM:
+      return _MIM;
+
+    case NOON:
+      return _NOON;
+
+    case YE:
+    case YE_:
+      return _YE;
+
+    case YEE:
+    case YEE_:
+      return _YEE;
+
+    case IE:
+    case IE_:
+      return _IE;
+
+    case F_HE:
+      tempc = _HE;
+
+      if (p_ri &&
+          (curwin->w_cursor.col + 1 < (colnr_T)STRLEN(ml_get_curline()))) {
+        inc_cursor();
+        if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+          tempc = _HE_;
+        }
+        dec_cursor();
+      }
+
+      if (!p_ri && STRLEN(ml_get_curline())) {
+        dec_cursor();
+        if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+          tempc = _HE_;
+        }
+        inc_cursor();
+      }
+
+      return tempc;
   }
   return 0;
 }
@@ -133,71 +158,98 @@ static int toF_Xor_X_(int c)
 int toF_TyA(int c)
 {
   switch (c) {
-  case ALEF_:
-    return ALEF;
-  case ALEF_U_H_:
-    return ALEF_U_H;
-  case _BE:
-    return BE;
-  case _PE:
-    return PE;
-  case _TE:
-    return TE;
-  case _SE:
-    return SE;
-  case _JIM:
-    return JIM;
-  case _CHE:
-    return CHE;
-  case _HE_J:
-    return HE_J;
-  case _XE:
-    return XE;
-  case _SIN:
-    return SIN;
-  case _SHIN:
-    return SHIN;
-  case _SAD:
-    return SAD;
-  case _ZAD:
-    return ZAD;
-  case _AYN:
-  case AYN_:
-  case _AYN_:
-    return AYN;
-  case _GHAYN:
-  case GHAYN_:
-  case _GHAYN_:
-    return GHAYN;
-  case _FE:
-    return FE;
-  case _GHAF:
-    return GHAF;
-  /* I am not sure what it is !!!	    case _KAF_H: */
-  case _KAF:
-    return KAF;
-  case _GAF:
-    return GAF;
-  case _LAM:
-    return LAM;
-  case _MIM:
-    return MIM;
-  case _NOON:
-    return NOON;
-  case _YE:
-  case YE_:
-    return YE;
-  case _YEE:
-  case YEE_:
-    return YEE;
-  case TEE_:
-    return TEE;
-  case _IE:
-  case IE_:
-    return IE;
-  case _HE:
-  case _HE_:
-    return F_HE;
+    case ALEF_:
+      return ALEF;
+
+    case ALEF_U_H_:
+      return ALEF_U_H;
+
+    case _BE:
+      return BE;
+
+    case _PE:
+      return PE;
+
+    case _TE:
+      return TE;
+
+    case _SE:
+      return SE;
+
+    case _JIM:
+      return JIM;
+
+    case _CHE:
+      return CHE;
+
+    case _HE_J:
+      return HE_J;
+
+    case _XE:
+      return XE;
+
+    case _SIN:
+      return SIN;
+
+    case _SHIN:
+      return SHIN;
+
+    case _SAD:
+      return SAD;
+
+    case _ZAD:
+      return ZAD;
+
+    case _AYN:
+    case AYN_:
+    case _AYN_:
+      return AYN;
+
+    case _GHAYN:
+    case GHAYN_:
+    case _GHAYN_:
+      return GHAYN;
+
+    case _FE:
+      return FE;
+
+    case _GHAF:
+      return GHAF;
+
+    /* I am not sure what it is !!!    case _KAF_H: */
+    case _KAF:
+      return KAF;
+
+    case _GAF:
+      return GAF;
+
+    case _LAM:
+      return LAM;
+
+    case _MIM:
+      return MIM;
+
+    case _NOON:
+      return NOON;
+
+    case _YE:
+    case YE_:
+      return YE;
+
+    case _YEE:
+    case YEE_:
+      return YEE;
+
+    case TEE_:
+      return TEE;
+
+    case _IE:
+    case IE_:
+      return IE;
+
+    case _HE:
+    case _HE_:
+      return F_HE;
   }
   return c;
 }
@@ -211,44 +263,45 @@ static int F_is_TyB_TyC_TyD(int src, int offset)
 {
   int c;
 
-  if (src == SRC_EDT)
+  if (src == SRC_EDT) {
     c = gchar_cursor();
-  else
-    c = cmd_gchar(AT_CURSOR+offset);
+  } else {
+    c = cmd_gchar(AT_CURSOR + offset);
+  }
 
   switch (c) {
-  case _LAM:
-  case _BE:
-  case _PE:
-  case _TE:
-  case _SE:
-  case _JIM:
-  case _CHE:
-  case _HE_J:
-  case _XE:
-  case _SIN:
-  case _SHIN:
-  case _SAD:
-  case _ZAD:
-  case _TA:
-  case _ZA:
-  case _AYN:
-  case _AYN_:
-  case _GHAYN:
-  case _GHAYN_:
-  case _FE:
-  case _GHAF:
-  case _KAF:
-  case _KAF_H:
-  case _GAF:
-  case _MIM:
-  case _NOON:
-  case _YE:
-  case _YEE:
-  case _IE:
-  case _HE_:
-  case _HE:
-    return TRUE;
+    case _LAM:
+    case _BE:
+    case _PE:
+    case _TE:
+    case _SE:
+    case _JIM:
+    case _CHE:
+    case _HE_J:
+    case _XE:
+    case _SIN:
+    case _SHIN:
+    case _SAD:
+    case _ZAD:
+    case _TA:
+    case _ZA:
+    case _AYN:
+    case _AYN_:
+    case _GHAYN:
+    case _GHAYN_:
+    case _FE:
+    case _GHAF:
+    case _KAF:
+    case _KAF_H:
+    case _GAF:
+    case _MIM:
+    case _NOON:
+    case _YE:
+    case _YEE:
+    case _IE:
+    case _HE_:
+    case _HE:
+      return TRUE;
   }
   return FALSE;
 }
@@ -259,17 +312,17 @@ static int F_is_TyB_TyC_TyD(int src, int offset)
 static int F_is_TyE(int c)
 {
   switch (c) {
-  case ALEF_A:
-  case ALEF_D_H:
-  case DAL:
-  case ZAL:
-  case RE:
-  case ZE:
-  case JE:
-  case WAW:
-  case WAW_H:
-  case HAMZE:
-    return TRUE;
+    case ALEF_A:
+    case ALEF_D_H:
+    case DAL:
+    case ZAL:
+    case RE:
+    case ZE:
+    case JE:
+    case WAW:
+    case WAW_H:
+    case HAMZE:
+      return TRUE;
   }
   return FALSE;
 }
@@ -280,18 +333,18 @@ static int F_is_TyE(int c)
 static int F_is_TyC_TyD(int c)
 {
   switch (c) {
-  case ALEF_:
-  case ALEF_U_H_:
-  case _AYN_:
-  case AYN_:
-  case _GHAYN_:
-  case GHAYN_:
-  case _HE_:
-  case YE_:
-  case IE_:
-  case TEE_:
-  case YEE_:
-    return TRUE;
+    case ALEF_:
+    case ALEF_U_H_:
+    case _AYN_:
+    case AYN_:
+    case _GHAYN_:
+    case GHAYN_:
+    case _HE_:
+    case YE_:
+    case IE_:
+    case TEE_:
+    case YEE_:
+      return TRUE;
   }
   return FALSE;
 }
@@ -302,17 +355,38 @@ static int F_is_TyC_TyD(int c)
 static int toF_TyB(int c)
 {
   switch (c) {
-  case ALEF_:     return ALEF;
-  case ALEF_U_H_:     return ALEF_U_H;
-  case _AYN_:     return _AYN;
-  case AYN_:      return AYN;           /* exception - there are many of them */
-  case _GHAYN_:   return _GHAYN;
-  case GHAYN_:    return GHAYN;         /* exception - there are many of them */
-  case _HE_:      return _HE;
-  case YE_:       return YE;
-  case IE_:       return IE;
-  case TEE_:      return TEE;
-  case YEE_:      return YEE;
+    case ALEF_:
+      return ALEF;
+
+    case ALEF_U_H_:
+      return ALEF_U_H;
+
+    case _AYN_:
+      return _AYN;
+
+    case AYN_:
+      return AYN; /* exception - there are many of them */
+
+    case _GHAYN_:
+      return _GHAYN;
+
+    case GHAYN_:
+      return GHAYN; /* exception - there are many of them */
+
+    case _HE_:
+      return _HE;
+
+    case YE_:
+      return YE;
+
+    case IE_:
+      return IE;
+
+    case TEE_:
+      return TEE;
+
+    case YEE_:
+      return YEE;
   }
   return c;
 }
@@ -324,15 +398,17 @@ static void put_curr_and_l_to_X(int c)
 {
   int tempc;
 
-  if (curwin->w_p_rl && p_ri)
+  if (curwin->w_p_rl && p_ri) {
     return;
+  }
 
   if ((curwin->w_cursor.col < (colnr_T)STRLEN(ml_get_curline()))) {
     if ((p_ri && curwin->w_cursor.col) || !p_ri) {
-      if (p_ri)
+      if (p_ri) {
         dec_cursor();
-      else
+      } else {
         inc_cursor();
+      }
 
       if (F_is_TyC_TyD((tempc = gchar_cursor()))) {
         pchar_cursor(toF_TyB(tempc));
@@ -340,10 +416,11 @@ static void put_curr_and_l_to_X(int c)
         AppendCharToRedobuff(tempc);
       }
 
-      if (p_ri)
+      if (p_ri) {
         inc_cursor();
-      else
+      } else {
         dec_cursor();
+      }
     }
   }
 
@@ -360,184 +437,226 @@ static void put_and_redo(int c)
 /*
 ** Change the char. under the cursor to a X_ or X type
 */
-static void chg_c_toX_orX(void)                 {
+static void chg_c_toX_orX(void)
+{
   int tempc, curc;
 
   switch ((curc = gchar_cursor())) {
-  case _BE:
-    tempc = BE;
-    break;
-  case _PE:
-    tempc = PE;
-    break;
-  case _TE:
-    tempc = TE;
-    break;
-  case _SE:
-    tempc = SE;
-    break;
-  case _JIM:
-    tempc = JIM;
-    break;
-  case _CHE:
-    tempc = CHE;
-    break;
-  case _HE_J:
-    tempc = HE_J;
-    break;
-  case _XE:
-    tempc = XE;
-    break;
-  case _SIN:
-    tempc = SIN;
-    break;
-  case _SHIN:
-    tempc = SHIN;
-    break;
-  case _SAD:
-    tempc = SAD;
-    break;
-  case _ZAD:
-    tempc = ZAD;
-    break;
-  case _FE:
-    tempc = FE;
-    break;
-  case _GHAF:
-    tempc = GHAF;
-    break;
-  case _KAF_H:
-  case _KAF:
-    tempc = KAF;
-    break;
-  case _GAF:
-    tempc = GAF;
-    break;
-  case _AYN:
-    tempc = AYN;
-    break;
-  case _AYN_:
-    tempc = AYN_;
-    break;
-  case _GHAYN:
-    tempc = GHAYN;
-    break;
-  case _GHAYN_:
-    tempc = GHAYN_;
-    break;
-  case _LAM:
-    tempc = LAM;
-    break;
-  case _MIM:
-    tempc = MIM;
-    break;
-  case _NOON:
-    tempc = NOON;
-    break;
-  case _HE:
-  case _HE_:
-    tempc = F_HE;
-    break;
-  case _YE:
-  case _IE:
-  case _YEE:
-    if (p_ri) {
-      inc_cursor();
-      if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
-        tempc = (curc == _YE ? YE_ :
-                 (curc == _IE ? IE_ : YEE_));
-      else
-        tempc = (curc == _YE ? YE :
-                 (curc == _IE ? IE : YEE));
-      dec_cursor();
-    } else   {
-      if (curwin->w_cursor.col) {
-        dec_cursor();
-        if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
+    case _BE:
+      tempc = BE;
+      break;
+
+    case _PE:
+      tempc = PE;
+      break;
+
+    case _TE:
+      tempc = TE;
+      break;
+
+    case _SE:
+      tempc = SE;
+      break;
+
+    case _JIM:
+      tempc = JIM;
+      break;
+
+    case _CHE:
+      tempc = CHE;
+      break;
+
+    case _HE_J:
+      tempc = HE_J;
+      break;
+
+    case _XE:
+      tempc = XE;
+      break;
+
+    case _SIN:
+      tempc = SIN;
+      break;
+
+    case _SHIN:
+      tempc = SHIN;
+      break;
+
+    case _SAD:
+      tempc = SAD;
+      break;
+
+    case _ZAD:
+      tempc = ZAD;
+      break;
+
+    case _FE:
+      tempc = FE;
+      break;
+
+    case _GHAF:
+      tempc = GHAF;
+      break;
+
+    case _KAF_H:
+    case _KAF:
+      tempc = KAF;
+      break;
+
+    case _GAF:
+      tempc = GAF;
+      break;
+
+    case _AYN:
+      tempc = AYN;
+      break;
+
+    case _AYN_:
+      tempc = AYN_;
+      break;
+
+    case _GHAYN:
+      tempc = GHAYN;
+      break;
+
+    case _GHAYN_:
+      tempc = GHAYN_;
+      break;
+
+    case _LAM:
+      tempc = LAM;
+      break;
+
+    case _MIM:
+      tempc = MIM;
+      break;
+
+    case _NOON:
+      tempc = NOON;
+      break;
+
+    case _HE:
+    case _HE_:
+      tempc = F_HE;
+      break;
+
+    case _YE:
+    case _IE:
+    case _YEE:
+      if (p_ri) {
+        inc_cursor();
+
+        if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
           tempc = (curc == _YE ? YE_ :
                    (curc == _IE ? IE_ : YEE_));
-        else
+        } else {
           tempc = (curc == _YE ? YE :
                    (curc == _IE ? IE : YEE));
-        inc_cursor();
-      } else
-        tempc = (curc == _YE ? YE :
-                 (curc == _IE ? IE : YEE));
-    }
-    break;
-  default:
-    tempc = 0;
+        }
+        dec_cursor();
+      } else {
+        if (curwin->w_cursor.col) {
+          dec_cursor();
+
+          if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+            tempc = (curc == _YE ? YE_ :
+                     (curc == _IE ? IE_ : YEE_));
+          } else {
+            tempc = (curc == _YE ? YE :
+                     (curc == _IE ? IE : YEE));
+          }
+          inc_cursor();
+        } else {
+          tempc = (curc == _YE ? YE :
+                   (curc == _IE ? IE : YEE));
+        }
+      }
+      break;
+
+    default:
+      tempc = 0;
   }
 
-  if (tempc)
+  if (tempc) {
     put_and_redo(tempc);
+  }
 }
 
 /*
 ** Change the char. under the cursor to a _X_ or X_ type
 */
-
-static void chg_c_to_X_orX_(void)                 {
+static void chg_c_to_X_orX_(void)
+{
   int tempc;
 
   switch (gchar_cursor()) {
-  case ALEF:
-    tempc = ALEF_;
-    break;
-  case ALEF_U_H:
-    tempc = ALEF_U_H_;
-    break;
-  case _AYN:
-    tempc = _AYN_;
-    break;
-  case AYN:
-    tempc = AYN_;
-    break;
-  case _GHAYN:
-    tempc = _GHAYN_;
-    break;
-  case GHAYN:
-    tempc = GHAYN_;
-    break;
-  case _HE:
-    tempc = _HE_;
-    break;
-  case YE:
-    tempc = YE_;
-    break;
-  case IE:
-    tempc = IE_;
-    break;
-  case TEE:
-    tempc = TEE_;
-    break;
-  case YEE:
-    tempc = YEE_;
-    break;
-  default:
-    tempc = 0;
+    case ALEF:
+      tempc = ALEF_;
+      break;
+
+    case ALEF_U_H:
+      tempc = ALEF_U_H_;
+      break;
+
+    case _AYN:
+      tempc = _AYN_;
+      break;
+
+    case AYN:
+      tempc = AYN_;
+      break;
+
+    case _GHAYN:
+      tempc = _GHAYN_;
+      break;
+
+    case GHAYN:
+      tempc = GHAYN_;
+      break;
+
+    case _HE:
+      tempc = _HE_;
+      break;
+
+    case YE:
+      tempc = YE_;
+      break;
+
+    case IE:
+      tempc = IE_;
+      break;
+
+    case TEE:
+      tempc = TEE_;
+      break;
+
+    case YEE:
+      tempc = YEE_;
+      break;
+
+    default:
+      tempc = 0;
   }
 
-  if (tempc)
+  if (tempc) {
     put_and_redo(tempc);
+  }
 }
 
 /*
 ** Change the char. under the cursor to a _X_ or _X type
 */
-static void chg_c_to_X_or_X(void)                 {
+static void chg_c_to_X_or_X(void)
+{
   int tempc;
 
   tempc = gchar_cursor();
 
   if (curwin->w_cursor.col + 1 < (colnr_T)STRLEN(ml_get_curline())) {
     inc_cursor();
-
     if ((tempc == F_HE) && (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))) {
       tempc = _HE_;
-
       dec_cursor();
-
       put_and_redo(tempc);
       return;
     }
@@ -545,837 +664,1192 @@ static void chg_c_to_X_or_X(void)                 {
     dec_cursor();
   }
 
-  if ((tempc = toF_Xor_X_(tempc)) != 0)
+  if ((tempc = toF_Xor_X_(tempc)) != 0) {
     put_and_redo(tempc);
+  }
 }
 
 /*
 ** Change the character left to the cursor to a _X_ or X_ type
 */
-static void chg_l_to_X_orX_(void)                 {
+static void chg_l_to_X_orX_(void)
+{
   int tempc;
 
-  if (curwin->w_cursor.col != 0 &&
-      (curwin->w_cursor.col + 1 == (colnr_T)STRLEN(ml_get_curline())))
+  if ((curwin->w_cursor.col != 0) &&
+      (curwin->w_cursor.col + 1 == (colnr_T)STRLEN(ml_get_curline()))) {
     return;
-
-  if (!curwin->w_cursor.col && p_ri)
-    return;
-
-  if (p_ri)
-    dec_cursor();
-  else
-    inc_cursor();
-
-  switch (gchar_cursor()) {
-  case ALEF:
-    tempc = ALEF_;
-    break;
-  case ALEF_U_H:
-    tempc = ALEF_U_H_;
-    break;
-  case _AYN:
-    tempc = _AYN_;
-    break;
-  case AYN:
-    tempc = AYN_;
-    break;
-  case _GHAYN:
-    tempc = _GHAYN_;
-    break;
-  case GHAYN:
-    tempc = GHAYN_;
-    break;
-  case _HE:
-    tempc = _HE_;
-    break;
-  case YE:
-    tempc = YE_;
-    break;
-  case IE:
-    tempc = IE_;
-    break;
-  case TEE:
-    tempc = TEE_;
-    break;
-  case YEE:
-    tempc = YEE_;
-    break;
-  default:
-    tempc = 0;
   }
 
-  if (tempc)
-    put_and_redo(tempc);
+  if (!curwin->w_cursor.col && p_ri) {
+    return;
+  }
 
-  if (p_ri)
-    inc_cursor();
-  else
+  if (p_ri) {
     dec_cursor();
+  } else {
+    inc_cursor();
+  }
+
+  switch (gchar_cursor()) {
+    case ALEF:
+      tempc = ALEF_;
+      break;
+
+    case ALEF_U_H:
+      tempc = ALEF_U_H_;
+      break;
+
+    case _AYN:
+      tempc = _AYN_;
+      break;
+
+    case AYN:
+      tempc = AYN_;
+      break;
+
+    case _GHAYN:
+      tempc = _GHAYN_;
+      break;
+
+    case GHAYN:
+      tempc = GHAYN_;
+      break;
+
+    case _HE:
+      tempc = _HE_;
+      break;
+
+    case YE:
+      tempc = YE_;
+      break;
+
+    case IE:
+      tempc = IE_;
+      break;
+
+    case TEE:
+      tempc = TEE_;
+      break;
+
+    case YEE:
+      tempc = YEE_;
+      break;
+
+    default:
+      tempc = 0;
+  }
+
+  if (tempc) {
+    put_and_redo(tempc);
+  }
+
+  if (p_ri) {
+    inc_cursor();
+  } else {
+    dec_cursor();
+  }
 }
 
 /*
 ** Change the character left to the cursor to a X or _X type
 */
-
-static void chg_l_toXor_X(void)                 {
+static void chg_l_toXor_X(void)
+{
   int tempc;
 
-  if (curwin->w_cursor.col != 0 &&
-      (curwin->w_cursor.col + 1 == (colnr_T)STRLEN(ml_get_curline())))
+  if ((curwin->w_cursor.col != 0) &&
+      (curwin->w_cursor.col + 1 == (colnr_T)STRLEN(ml_get_curline()))) {
     return;
-
-  if (!curwin->w_cursor.col && p_ri)
-    return;
-
-  if (p_ri)
-    dec_cursor();
-  else
-    inc_cursor();
-
-  switch (gchar_cursor()) {
-  case ALEF_:
-    tempc = ALEF;
-    break;
-  case ALEF_U_H_:
-    tempc = ALEF_U_H;
-    break;
-  case _AYN_:
-    tempc = _AYN;
-    break;
-  case AYN_:
-    tempc = AYN;
-    break;
-  case _GHAYN_:
-    tempc = _GHAYN;
-    break;
-  case GHAYN_:
-    tempc = GHAYN;
-    break;
-  case _HE_:
-    tempc = _HE;
-    break;
-  case YE_:
-    tempc = YE;
-    break;
-  case IE_:
-    tempc = IE;
-    break;
-  case TEE_:
-    tempc = TEE;
-    break;
-  case YEE_:
-    tempc = YEE;
-    break;
-  default:
-    tempc = 0;
   }
 
-  if (tempc)
-    put_and_redo(tempc);
+  if (!curwin->w_cursor.col && p_ri) {
+    return;
+  }
 
-  if (p_ri)
-    inc_cursor();
-  else
+  if (p_ri) {
     dec_cursor();
+  } else {
+    inc_cursor();
+  }
+
+  switch (gchar_cursor()) {
+    case ALEF_:
+      tempc = ALEF;
+      break;
+
+    case ALEF_U_H_:
+      tempc = ALEF_U_H;
+      break;
+
+    case _AYN_:
+      tempc = _AYN;
+      break;
+
+    case AYN_:
+      tempc = AYN;
+      break;
+
+    case _GHAYN_:
+      tempc = _GHAYN;
+      break;
+
+    case GHAYN_:
+      tempc = GHAYN;
+      break;
+
+    case _HE_:
+      tempc = _HE;
+      break;
+
+    case YE_:
+      tempc = YE;
+      break;
+
+    case IE_:
+      tempc = IE;
+      break;
+
+    case TEE_:
+      tempc = TEE;
+      break;
+
+    case YEE_:
+      tempc = YEE;
+      break;
+
+    default:
+      tempc = 0;
+  }
+
+  if (tempc) {
+    put_and_redo(tempc);
+  }
+
+  if (p_ri) {
+    inc_cursor();
+  } else {
+    dec_cursor();
+  }
 }
 
 /*
 ** Change the character right to the cursor to a _X or _X_ type
 */
-
-static void chg_r_to_Xor_X_(void)                 {
+static void chg_r_to_Xor_X_(void)
+{
   int tempc, c;
 
   if (curwin->w_cursor.col) {
-    if (!p_ri)
+    if (!p_ri) {
       dec_cursor();
+    }
 
     tempc = gchar_cursor();
-
-    if ((c = toF_Xor_X_(tempc)) != 0)
+    if ((c = toF_Xor_X_(tempc)) != 0) {
       put_and_redo(c);
+    }
 
-    if (!p_ri)
+    if (!p_ri) {
       inc_cursor();
-
+    }
   }
 }
 
 /*
 ** Map Farsi keyboard when in fkmap mode.
 */
-
 int fkmap(int c)
 {
   int tempc;
   static int revins;
 
-  if (IS_SPECIAL(c))
+  if (IS_SPECIAL(c)) {
     return c;
+  }
 
-  if (VIM_ISDIGIT(c) || ((c == '.' || c == '+' || c == '-' ||
-                          c == '^' || c == '%' || c == '#' ||
-                          c == '=')  && revins)) {
+  if (VIM_ISDIGIT(c) ||
+      (((c == '.') ||
+        (c == '+') ||
+        (c == '-') ||
+        (c == '^') ||
+        (c == '%') ||
+        (c == '#') ||
+        (c == '=')) && revins)) {
     if (!revins) {
       if (curwin->w_cursor.col) {
-        if (!p_ri)
+        if (!p_ri) {
           dec_cursor();
+        }
 
-        chg_c_toX_orX ();
-        chg_l_toXor_X ();
-
-        if (!p_ri)
+        chg_c_toX_orX();
+        chg_l_toXor_X();
+        if (!p_ri) {
           inc_cursor();
+        }
       }
     }
 
     arrow_used = TRUE;
     (void)stop_arrow();
 
-    if (!curwin->w_p_rl && revins)
+    if (!curwin->w_p_rl && revins) {
       inc_cursor();
+    }
 
     ++revins;
-    p_ri=1;
-  } else   {
+    p_ri = 1;
+  } else {
     if (revins) {
       arrow_used = TRUE;
       (void)stop_arrow();
 
       revins = 0;
       if (curwin->w_p_rl) {
-        while ((F_isdigit(gchar_cursor())
-                || (gchar_cursor() == F_PERIOD
-                    || gchar_cursor() == F_PLUS
-                    || gchar_cursor() == F_MINUS
-                    || gchar_cursor() == F_MUL
-                    || gchar_cursor() == F_DIVIDE
-                    || gchar_cursor() == F_PERCENT
-                    || gchar_cursor() == F_EQUALS))
-               && gchar_cursor() != NUL)
+        while ((F_isdigit(gchar_cursor()) ||
+                (gchar_cursor() == F_PERIOD ||
+                   gchar_cursor() == F_PLUS ||
+                   gchar_cursor() == F_MINUS ||
+                   gchar_cursor() == F_MUL ||
+                   gchar_cursor() == F_DIVIDE ||
+                   gchar_cursor() == F_PERCENT ||
+                   gchar_cursor() == F_EQUALS)) &&
+                   gchar_cursor() != NUL) {
           ++curwin->w_cursor.col;
+        }
       } else   {
-        if (curwin->w_cursor.col)
-          while ((F_isdigit(gchar_cursor())
-                  || (gchar_cursor() == F_PERIOD
-                      || gchar_cursor() == F_PLUS
-                      || gchar_cursor() == F_MINUS
-                      || gchar_cursor() == F_MUL
-                      || gchar_cursor() == F_DIVIDE
-                      || gchar_cursor() == F_PERCENT
-                      || gchar_cursor() == F_EQUALS))
-                 && --curwin->w_cursor.col)
-            ;
+        if (curwin->w_cursor.col) {
+          while ((F_isdigit(gchar_cursor()) ||
+                  (gchar_cursor() == F_PERIOD ||
+                   gchar_cursor() == F_PLUS ||
+                   gchar_cursor() == F_MINUS ||
+                   gchar_cursor() == F_MUL ||
+                   gchar_cursor() == F_DIVIDE ||
+                   gchar_cursor() == F_PERCENT ||
+                   gchar_cursor() == F_EQUALS)) &&
+                 --curwin->w_cursor.col) {
+          }
+        }
 
-        if (!F_isdigit(gchar_cursor()))
+        if (!F_isdigit(gchar_cursor())) {
           ++curwin->w_cursor.col;
+        }
       }
     }
   }
 
   if (!revins) {
-    if (curwin->w_p_rl)
-      p_ri=0;
-    if (!curwin->w_p_rl)
-      p_ri=1;
+    if (curwin->w_p_rl) {
+      p_ri = 0;
+    }
+
+    if (!curwin->w_p_rl) {
+      p_ri = 1;
+    }
   }
 
-  if ((c < 0x100) && (isalpha(c) || c == '&' ||   c == '^' || c == ';' ||
-                      c == '\''|| c == ',' || c == '[' ||
-                      c == ']' || c == '{' || c == '}'    ))
+  if ((c < 0x100) &&
+      (isalpha(c) ||
+       (c == '&') ||
+       (c == '^') ||
+       (c == ';') ||
+       (c == '\'') ||
+       (c == ',') ||
+       (c == '[') ||
+       (c == ']') ||
+       (c == '{') ||
+       (c == '}'))) {
     chg_r_to_Xor_X_();
+  }
 
   tempc = 0;
 
   switch (c) {
-  case '`':
-  case ' ':
-  case '.':
-  case '!':
-  case '"':
-  case '$':
-  case '%':
-  case '^':
-  case '&':
-  case '/':
-  case '(':
-  case ')':
-  case '=':
-  case '\\':
-  case '?':
-  case '+':
-  case '-':
-  case '_':
-  case '*':
-  case ':':
-  case '#':
-  case '~':
-  case '@':
-  case '<':
-  case '>':
-  case '{':
-  case '}':
-  case '|':
-  case '0':
-  case '1':
-  case '2':
-  case '3':
-  case '4':
-  case '5':
-  case '6':
-  case '7':
-  case '8':
-  case '9':
-  case 'B':
-  case 'E':
-  case 'F':
-  case 'H':
-  case 'I':
-  case 'K':
-  case 'L':
-  case 'M':
-  case 'O':
-  case 'P':
-  case 'Q':
-  case 'R':
-  case 'T':
-  case 'U':
-  case 'W':
-  case 'Y':
-  case  NL:
-  case  TAB:
+    case '`':
+    case ' ':
+    case '.':
+    case '!':
+    case '"':
+    case '$':
+    case '%':
+    case '^':
+    case '&':
+    case '/':
+    case '(':
+    case ')':
+    case '=':
+    case '\\':
+    case '?':
+    case '+':
+    case '-':
+    case '_':
+    case '*':
+    case ':':
+    case '#':
+    case '~':
+    case '@':
+    case '<':
+    case '>':
+    case '{':
+    case '}':
+    case '|':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case 'B':
+    case 'E':
+    case 'F':
+    case 'H':
+    case 'I':
+    case 'K':
+    case 'L':
+    case 'M':
+    case 'O':
+    case 'P':
+    case 'Q':
+    case 'R':
+    case 'T':
+    case 'U':
+    case 'W':
+    case 'Y':
+    case  NL:
+    case  TAB:
+      if (p_ri && (c == NL) && curwin->w_cursor.col) {
+        /*
+        ** If the char before the cursor is _X_ or X_ do not change
+        ** the one under the cursor with X type.
+        */
 
-    if (p_ri && c == NL && curwin->w_cursor.col) {
-      /*
-      ** If the char before the cursor is _X_ or X_ do not change
-      ** the one under the cursor with X type.
-      */
-
-      dec_cursor();
-
-      if (F_isalpha(gchar_cursor())) {
+        dec_cursor();
+        if (F_isalpha(gchar_cursor())) {
+          inc_cursor();
+          return NL;
+        }
         inc_cursor();
-        return NL;
       }
 
-      inc_cursor();
-    }
+      if (!p_ri) {
+        if (!curwin->w_cursor.col) {
+          switch (c) {
+            case '0':
+              return FARSI_0;
 
-    if (!p_ri)
-      if (!curwin->w_cursor.col) {
-        switch (c) {
-        case '0':   return FARSI_0;
-        case '1':   return FARSI_1;
-        case '2':   return FARSI_2;
-        case '3':   return FARSI_3;
-        case '4':   return FARSI_4;
-        case '5':   return FARSI_5;
-        case '6':   return FARSI_6;
-        case '7':   return FARSI_7;
-        case '8':   return FARSI_8;
-        case '9':   return FARSI_9;
-        case 'B':   return F_PSP;
-        case 'E':   return JAZR_N;
-        case 'F':   return ALEF_D_H;
-        case 'H':   return ALEF_A;
-        case 'I':   return TASH;
-        case 'K':   return F_LQUOT;
-        case 'L':   return F_RQUOT;
-        case 'M':   return HAMZE;
-        case 'O':   return '[';
-        case 'P':   return ']';
-        case 'Q':   return OO;
-        case 'R':   return MAD_N;
-        case 'T':   return OW;
-        case 'U':   return MAD;
-        case 'W':   return OW_OW;
-        case 'Y':   return JAZR;
-        case '`':   return F_PCN;
-        case '!':   return F_EXCL;
-        case '@':   return F_COMMA;
-        case '#':   return F_DIVIDE;
-        case '$':   return F_CURRENCY;
-        case '%':   return F_PERCENT;
-        case '^':   return F_MUL;
-        case '&':   return F_BCOMMA;
-        case '*':   return F_STAR;
-        case '(':   return F_LPARENT;
-        case ')':   return F_RPARENT;
-        case '-':   return F_MINUS;
-        case '_':   return F_UNDERLINE;
-        case '=':   return F_EQUALS;
-        case '+':   return F_PLUS;
-        case '\\':  return F_BSLASH;
-        case '|':   return F_PIPE;
-        case ':':   return F_DCOLON;
-        case '"':   return F_SEMICOLON;
-        case '.':   return F_PERIOD;
-        case '/':   return F_SLASH;
-        case '<':   return F_LESS;
-        case '>':   return F_GREATER;
-        case '?':   return F_QUESTION;
-        case ' ':   return F_BLANK;
+            case '1':
+              return FARSI_1;
+
+            case '2':
+              return FARSI_2;
+
+            case '3':
+              return FARSI_3;
+
+            case '4':
+              return FARSI_4;
+
+            case '5':
+              return FARSI_5;
+
+            case '6':
+              return FARSI_6;
+
+            case '7':
+              return FARSI_7;
+
+            case '8':
+              return FARSI_8;
+
+            case '9':
+              return FARSI_9;
+
+            case 'B':
+              return F_PSP;
+
+            case 'E':
+              return JAZR_N;
+
+            case 'F':
+              return ALEF_D_H;
+
+            case 'H':
+              return ALEF_A;
+
+            case 'I':
+              return TASH;
+
+            case 'K':
+              return F_LQUOT;
+
+            case 'L':
+              return F_RQUOT;
+
+            case 'M':
+              return HAMZE;
+
+            case 'O':
+              return '[';
+
+            case 'P':
+              return ']';
+
+            case 'Q':
+              return OO;
+
+            case 'R':
+              return MAD_N;
+
+            case 'T':
+              return OW;
+
+            case 'U':
+              return MAD;
+
+            case 'W':
+              return OW_OW;
+
+            case 'Y':
+              return JAZR;
+
+            case '`':
+              return F_PCN;
+
+            case '!':
+              return F_EXCL;
+
+            case '@':
+              return F_COMMA;
+
+            case '#':
+              return F_DIVIDE;
+
+            case '$':
+              return F_CURRENCY;
+
+            case '%':
+              return F_PERCENT;
+
+            case '^':
+              return F_MUL;
+
+            case '&':
+              return F_BCOMMA;
+
+            case '*':
+              return F_STAR;
+
+            case '(':
+              return F_LPARENT;
+
+            case ')':
+              return F_RPARENT;
+
+            case '-':
+              return F_MINUS;
+
+            case '_':
+              return F_UNDERLINE;
+
+            case '=':
+              return F_EQUALS;
+
+            case '+':
+              return F_PLUS;
+
+            case '\\':
+              return F_BSLASH;
+
+            case '|':
+              return F_PIPE;
+
+            case ':':
+              return F_DCOLON;
+
+            case '"':
+              return F_SEMICOLON;
+
+            case '.':
+              return F_PERIOD;
+
+            case '/':
+              return F_SLASH;
+
+            case '<':
+              return F_LESS;
+
+            case '>':
+              return F_GREATER;
+
+            case '?':
+              return F_QUESTION;
+
+            case ' ':
+              return F_BLANK;
+          }
+          break;
         }
-        break;
       }
-    if (!p_ri)
-      dec_cursor();
 
-    switch ((tempc = gchar_cursor())) {
-    case _BE:
-    case _PE:
-    case _TE:
-    case _SE:
-    case _JIM:
-    case _CHE:
-    case _HE_J:
-    case _XE:
-    case _SIN:
-    case _SHIN:
-    case _SAD:
-    case _ZAD:
-    case _FE:
-    case _GHAF:
-    case _KAF:
-    case _KAF_H:
-    case _GAF:
-    case _LAM:
-    case _MIM:
-    case _NOON:
-    case _HE:
-    case _HE_:
-    case _TA:
-    case _ZA:
-      put_curr_and_l_to_X(toF_TyA(tempc));
-      break;
-    case _AYN:
-    case _AYN_:
+      if (!p_ri) {
+        dec_cursor();
+      }
 
-      if (!p_ri)
-        if (!curwin->w_cursor.col) {
-          put_curr_and_l_to_X(AYN);
+      switch ((tempc = gchar_cursor())) {
+        case _BE:
+        case _PE:
+        case _TE:
+        case _SE:
+        case _JIM:
+        case _CHE:
+        case _HE_J:
+        case _XE:
+        case _SIN:
+        case _SHIN:
+        case _SAD:
+        case _ZAD:
+        case _FE:
+        case _GHAF:
+        case _KAF:
+        case _KAF_H:
+        case _GAF:
+        case _LAM:
+        case _MIM:
+        case _NOON:
+        case _HE:
+        case _HE_:
+        case _TA:
+        case _ZA:
+          put_curr_and_l_to_X(toF_TyA(tempc));
           break;
+
+        case _AYN:
+        case _AYN_:
+          if (!p_ri) {
+            if (!curwin->w_cursor.col) {
+              put_curr_and_l_to_X(AYN);
+              break;
+            }
+          }
+
+          if (p_ri) {
+            inc_cursor();
+          } else {
+            dec_cursor();
+          }
+
+          if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+            tempc = AYN_;
+          } else {
+            tempc = AYN;
+          }
+
+          if (p_ri) {
+            dec_cursor();
+          } else {
+            inc_cursor();
+          }
+
+          put_curr_and_l_to_X(tempc);
+          break;
+
+        case _GHAYN:
+        case _GHAYN_:
+
+          if (!p_ri) {
+            if (!curwin->w_cursor.col) {
+              put_curr_and_l_to_X(GHAYN);
+              break;
+            }
+          }
+
+          if (p_ri) {
+            inc_cursor();
+          } else {
+            dec_cursor();
+          }
+
+          if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+            tempc = GHAYN_;
+          } else {
+            tempc = GHAYN;
+          }
+
+          if (p_ri) {
+            dec_cursor();
+          } else {
+            inc_cursor();
+          }
+
+          put_curr_and_l_to_X(tempc);
+          break;
+
+        case _YE:
+        case _IE:
+        case _YEE:
+
+          if (!p_ri) {
+            if (!curwin->w_cursor.col) {
+              put_curr_and_l_to_X((tempc == _YE ? YE :
+                                   (tempc == _IE ? IE : YEE)));
+              break;
+            }
+          }
+
+          if (p_ri) {
+            inc_cursor();
+          } else {
+            dec_cursor();
+          }
+
+          if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+            tempc = (tempc == _YE ? YE_ :
+                     (tempc == _IE ? IE_ : YEE_));
+          } else {
+            tempc = (tempc == _YE ? YE :
+                     (tempc == _IE ? IE : YEE));
+          }
+
+          if (p_ri) {
+            dec_cursor();
+          } else {
+            inc_cursor();
+          }
+
+          put_curr_and_l_to_X(tempc);
+          break;
+      }
+
+      if (!p_ri) {
+        inc_cursor();
+      }
+
+      tempc = 0;
+
+      switch (c) {
+        case '0':
+          return FARSI_0;
+
+        case '1':
+          return FARSI_1;
+
+        case '2':
+          return FARSI_2;
+
+        case '3':
+          return FARSI_3;
+
+        case '4':
+          return FARSI_4;
+
+        case '5':
+          return FARSI_5;
+
+        case '6':
+          return FARSI_6;
+
+        case '7':
+          return FARSI_7;
+
+        case '8':
+          return FARSI_8;
+
+        case '9':
+          return FARSI_9;
+
+        case 'B':
+          return F_PSP;
+
+        case 'E':
+          return JAZR_N;
+
+        case 'F':
+          return ALEF_D_H;
+
+        case 'H':
+          return ALEF_A;
+
+        case 'I':
+          return TASH;
+
+        case 'K':
+          return F_LQUOT;
+
+        case 'L':
+          return F_RQUOT;
+
+        case 'M':
+          return HAMZE;
+
+        case 'O':
+          return '[';
+
+        case 'P':
+          return ']';
+
+        case 'Q':
+          return OO;
+
+        case 'R':
+          return MAD_N;
+
+        case 'T':
+          return OW;
+
+        case 'U':
+          return MAD;
+
+        case 'W':
+          return OW_OW;
+
+        case 'Y':
+          return JAZR;
+
+        case '`':
+          return F_PCN;
+
+        case '!':
+          return F_EXCL;
+
+        case '@':
+          return F_COMMA;
+
+        case '#':
+          return F_DIVIDE;
+
+        case '$':
+          return F_CURRENCY;
+
+        case '%':
+          return F_PERCENT;
+
+        case '^':
+          return F_MUL;
+
+        case '&':
+          return F_BCOMMA;
+
+        case '*':
+          return F_STAR;
+
+        case '(':
+          return F_LPARENT;
+
+        case ')':
+          return F_RPARENT;
+
+        case '-':
+          return F_MINUS;
+
+        case '_':
+          return F_UNDERLINE;
+
+        case '=':
+          return F_EQUALS;
+
+        case '+':
+          return F_PLUS;
+
+        case '\\':
+          return F_BSLASH;
+
+        case '|':
+          return F_PIPE;
+
+        case ':':
+          return F_DCOLON;
+
+        case '"':
+          return F_SEMICOLON;
+
+        case '.':
+          return F_PERIOD;
+
+        case '/':
+          return F_SLASH;
+
+        case '<':
+          return F_LESS;
+
+        case '>':
+          return F_GREATER;
+
+        case '?':
+          return F_QUESTION;
+
+        case ' ':
+          return F_BLANK;
+      }
+      break;
+
+    case 'a':
+      tempc = _SHIN;
+      break;
+
+    case 'A':
+      tempc = WAW_H;
+      break;
+
+    case 'b':
+      tempc = ZAL;
+      break;
+
+    case 'c':
+      tempc = ZE;
+      break;
+
+    case 'C':
+      tempc = JE;
+      break;
+
+    case 'd':
+      tempc = _YE;
+      break;
+
+    case 'D':
+      tempc = _YEE;
+      break;
+
+    case 'e':
+      tempc = _SE;
+      break;
+
+    case 'f':
+      tempc = _BE;
+      break;
+
+    case 'g':
+      tempc = _LAM;
+      break;
+
+    case 'G':
+      if (!curwin->w_cursor.col && STRLEN(ml_get_curline())) {
+        if (gchar_cursor() == _LAM) {
+          chg_c_toX_orX();
+        } else if (p_ri) {
+          chg_c_to_X_or_X();
+        }
+      }
+
+      if (!p_ri) {
+        if (!curwin->w_cursor.col) {
+          return ALEF_U_H;
+        }
+      }
+
+      if (!p_ri) {
+        dec_cursor();
+      }
+
+      if (gchar_cursor() == _LAM) {
+        chg_c_toX_orX();
+        chg_l_toXor_X();
+        tempc = ALEF_U_H;
+      } else if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+        tempc = ALEF_U_H_;
+        chg_l_toXor_X();
+      } else {
+        tempc = ALEF_U_H;
+      }
+
+      if (!p_ri) {
+        inc_cursor();
+      }
+
+      return tempc;
+
+    case 'h':
+      if (!curwin->w_cursor.col && STRLEN(ml_get_curline())) {
+        if (p_ri) {
+          chg_c_to_X_or_X();
+        }
+      }
+
+      if (!p_ri) {
+        if (!curwin->w_cursor.col) {
+          return ALEF;
+        }
+      }
+
+      if (!p_ri) {
+        dec_cursor();
+      }
+
+      if (gchar_cursor() == _LAM) {
+        chg_l_toXor_X();
+        del_char(FALSE);
+        AppendCharToRedobuff(K_BS);
+
+        if (!p_ri) {
+          dec_cursor();
         }
 
-      if (p_ri)
+        tempc = LA;
+      } else {
+        if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+          tempc = ALEF_;
+          chg_l_toXor_X();
+        } else {
+          tempc = ALEF;
+        }
+      }
+
+      if (!p_ri) {
         inc_cursor();
-      else
-        dec_cursor();
+      }
 
-      if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
-        tempc = AYN_;
-      else
-        tempc = AYN;
+      return tempc;
 
-      if (p_ri)
-        dec_cursor();
-      else
-        inc_cursor();
+    case 'i':
 
-      put_curr_and_l_to_X(tempc);
-
-      break;
-    case _GHAYN:
-    case _GHAYN_:
-
-      if (!p_ri)
-        if (!curwin->w_cursor.col) {
-          put_curr_and_l_to_X(GHAYN);
-          break;
+      if (!curwin->w_cursor.col && STRLEN(ml_get_curline())) {
+        if (!p_ri && !F_is_TyE(tempc)) {
+          chg_c_to_X_orX_();
         }
 
-      if (p_ri)
-        inc_cursor();
-      else
-        dec_cursor();
-
-      if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
-        tempc = GHAYN_;
-      else
-        tempc = GHAYN;
-
-      if (p_ri)
-        dec_cursor();
-      else
-        inc_cursor();
-
-      put_curr_and_l_to_X(tempc);
-      break;
-    case _YE:
-    case _IE:
-    case _YEE:
-      if (!p_ri)
-        if (!curwin->w_cursor.col) {
-          put_curr_and_l_to_X((tempc == _YE ? YE :
-                               (tempc == _IE ? IE : YEE)));
-          break;
+        if (p_ri) {
+          chg_c_to_X_or_X();
         }
+      }
 
-      if (p_ri)
-        inc_cursor();
-      else
+      if (!p_ri && !curwin->w_cursor.col) {
+        return _HE;
+      }
+
+      if (!p_ri) {
         dec_cursor();
+      }
 
-      if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
-        tempc = (tempc == _YE ? YE_ :
-                 (tempc == _IE ? IE_ : YEE_));
-      else
-        tempc = (tempc == _YE ? YE :
-                 (tempc == _IE ? IE : YEE));
-
-      if (p_ri)
-        dec_cursor();
-      else
-        inc_cursor();
-
-      put_curr_and_l_to_X(tempc);
-      break;
-    }
-
-    if (!p_ri)
-      inc_cursor();
-
-    tempc = 0;
-
-    switch (c) {
-    case '0':   return FARSI_0;
-    case '1':   return FARSI_1;
-    case '2':   return FARSI_2;
-    case '3':   return FARSI_3;
-    case '4':   return FARSI_4;
-    case '5':   return FARSI_5;
-    case '6':   return FARSI_6;
-    case '7':   return FARSI_7;
-    case '8':   return FARSI_8;
-    case '9':   return FARSI_9;
-    case 'B':   return F_PSP;
-    case 'E':   return JAZR_N;
-    case 'F':   return ALEF_D_H;
-    case 'H':   return ALEF_A;
-    case 'I':   return TASH;
-    case 'K':   return F_LQUOT;
-    case 'L':   return F_RQUOT;
-    case 'M':   return HAMZE;
-    case 'O':   return '[';
-    case 'P':   return ']';
-    case 'Q':   return OO;
-    case 'R':   return MAD_N;
-    case 'T':   return OW;
-    case 'U':   return MAD;
-    case 'W':   return OW_OW;
-    case 'Y':   return JAZR;
-    case '`':   return F_PCN;
-    case '!':   return F_EXCL;
-    case '@':   return F_COMMA;
-    case '#':   return F_DIVIDE;
-    case '$':   return F_CURRENCY;
-    case '%':   return F_PERCENT;
-    case '^':   return F_MUL;
-    case '&':   return F_BCOMMA;
-    case '*':   return F_STAR;
-    case '(':   return F_LPARENT;
-    case ')':   return F_RPARENT;
-    case '-':   return F_MINUS;
-    case '_':   return F_UNDERLINE;
-    case '=':   return F_EQUALS;
-    case '+':   return F_PLUS;
-    case '\\':  return F_BSLASH;
-    case '|':   return F_PIPE;
-    case ':':   return F_DCOLON;
-    case '"':   return F_SEMICOLON;
-    case '.':   return F_PERIOD;
-    case '/':   return F_SLASH;
-    case '<':   return F_LESS;
-    case '>':   return F_GREATER;
-    case '?':   return F_QUESTION;
-    case ' ':   return F_BLANK;
-    }
-    break;
-
-  case 'a':
-    tempc = _SHIN;
-    break;
-  case 'A':
-    tempc = WAW_H;
-    break;
-  case 'b':
-    tempc = ZAL;
-    break;
-  case 'c':
-    tempc = ZE;
-    break;
-  case 'C':
-    tempc = JE;
-    break;
-  case 'd':
-    tempc = _YE;
-    break;
-  case 'D':
-    tempc = _YEE;
-    break;
-  case 'e':
-    tempc = _SE;
-    break;
-  case 'f':
-    tempc = _BE;
-    break;
-  case 'g':
-    tempc = _LAM;
-    break;
-  case 'G':
-    if (!curwin->w_cursor.col  &&  STRLEN(ml_get_curline())) {
-
-      if (gchar_cursor() == _LAM)
-        chg_c_toX_orX ();
-      else if (p_ri)
-        chg_c_to_X_or_X ();
-    }
-
-    if (!p_ri)
-      if (!curwin->w_cursor.col)
-        return ALEF_U_H;
-
-    if (!p_ri)
-      dec_cursor();
-
-    if (gchar_cursor() == _LAM) {
-      chg_c_toX_orX ();
-      chg_l_toXor_X ();
-      tempc = ALEF_U_H;
-    } else if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))    {
-      tempc = ALEF_U_H_;
-      chg_l_toXor_X ();
-    } else
-      tempc = ALEF_U_H;
-
-    if (!p_ri)
-      inc_cursor();
-
-    return tempc;
-  case 'h':
-    if (!curwin->w_cursor.col  &&  STRLEN(ml_get_curline())) {
-      if (p_ri)
-        chg_c_to_X_or_X ();
-
-    }
-
-    if (!p_ri)
-      if (!curwin->w_cursor.col)
-        return ALEF;
-
-    if (!p_ri)
-      dec_cursor();
-
-    if (gchar_cursor() == _LAM) {
-      chg_l_toXor_X();
-      del_char(FALSE);
-      AppendCharToRedobuff(K_BS);
-
-      if (!p_ri)
-        dec_cursor();
-
-      tempc = LA;
-    } else   {
       if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
-        tempc = ALEF_;
-        chg_l_toXor_X ();
-      } else
-        tempc = ALEF;
-    }
+        tempc = _HE_;
+      } else {
+        tempc = _HE;
+      }
 
-    if (!p_ri)
-      inc_cursor();
+      if (!p_ri) {
+        inc_cursor();
+      }
+      break;
 
-    return tempc;
-  case 'i':
-    if (!curwin->w_cursor.col  &&  STRLEN(ml_get_curline())) {
-      if (!p_ri && !F_is_TyE(tempc))
-        chg_c_to_X_orX_ ();
-      if (p_ri)
-        chg_c_to_X_or_X ();
+    case 'j':
+      tempc = _TE;
+      break;
 
-    }
+    case 'J':
 
-    if (!p_ri && !curwin->w_cursor.col)
-      return _HE;
+      if (!curwin->w_cursor.col && STRLEN(ml_get_curline())) {
+        if (p_ri) {
+          chg_c_to_X_or_X();
+        }
+      }
 
-    if (!p_ri)
-      dec_cursor();
+      if (!p_ri) {
+        if (!curwin->w_cursor.col) {
+          return TEE;
+        }
+      }
 
-    if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
-      tempc = _HE_;
-    else
-      tempc = _HE;
+      if (!p_ri) {
+        dec_cursor();
+      }
 
-    if (!p_ri)
-      inc_cursor();
-    break;
-  case 'j':
-    tempc = _TE;
-    break;
-  case 'J':
-    if (!curwin->w_cursor.col  &&  STRLEN(ml_get_curline())) {
-      if (p_ri)
-        chg_c_to_X_or_X ();
+      if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+        tempc = TEE_;
+        chg_l_toXor_X();
+      } else {
+        tempc = TEE;
+      }
 
-    }
+      if (!p_ri) {
+        inc_cursor();
+      }
 
-    if (!p_ri)
-      if (!curwin->w_cursor.col)
-        return TEE;
+      return tempc;
 
-    if (!p_ri)
-      dec_cursor();
+    case 'k':
+      tempc = _NOON;
+      break;
 
-    if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
-      tempc = TEE_;
-      chg_l_toXor_X ();
-    } else
-      tempc = TEE;
+    case 'l':
+      tempc = _MIM;
+      break;
 
-    if (!p_ri)
-      inc_cursor();
+    case 'm':
+      tempc = _PE;
+      break;
 
-    return tempc;
-  case 'k':
-    tempc = _NOON;
-    break;
-  case 'l':
-    tempc = _MIM;
-    break;
-  case 'm':
-    tempc = _PE;
-    break;
-  case 'n':
-  case 'N':
-    tempc = DAL;
-    break;
-  case 'o':
-    tempc = _XE;
-    break;
-  case 'p':
-    tempc = _HE_J;
-    break;
-  case 'q':
-    tempc = _ZAD;
-    break;
-  case 'r':
-    tempc = _GHAF;
-    break;
-  case 's':
-    tempc = _SIN;
-    break;
-  case 'S':
-    tempc = _IE;
-    break;
-  case 't':
-    tempc = _FE;
-    break;
-  case 'u':
-    if (!curwin->w_cursor.col  &&  STRLEN(ml_get_curline())) {
-      if (!p_ri && !F_is_TyE(tempc))
-        chg_c_to_X_orX_ ();
-      if (p_ri)
-        chg_c_to_X_or_X ();
+    case 'n':
+    case 'N':
+      tempc = DAL;
+      break;
 
-    }
+    case 'o':
+      tempc = _XE;
+      break;
 
-    if (!p_ri && !curwin->w_cursor.col)
-      return _AYN;
+    case 'p':
+      tempc = _HE_J;
+      break;
 
-    if (!p_ri)
-      dec_cursor();
+    case 'q':
+      tempc = _ZAD;
+      break;
 
-    if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
-      tempc = _AYN_;
-    else
-      tempc = _AYN;
+    case 'r':
+      tempc = _GHAF;
+      break;
 
-    if (!p_ri)
-      inc_cursor();
-    break;
-  case 'v':
-  case 'V':
-    tempc = RE;
-    break;
-  case 'w':
-    tempc = _SAD;
-    break;
-  case 'x':
-  case 'X':
-    tempc = _TA;
-    break;
-  case 'y':
-    if (!curwin->w_cursor.col  &&  STRLEN(ml_get_curline())) {
-      if (!p_ri && !F_is_TyE(tempc))
-        chg_c_to_X_orX_ ();
-      if (p_ri)
-        chg_c_to_X_or_X ();
+    case 's':
+      tempc = _SIN;
+      break;
 
-    }
+    case 'S':
+      tempc = _IE;
+      break;
 
-    if (!p_ri && !curwin->w_cursor.col)
-      return _GHAYN;
+    case 't':
+      tempc = _FE;
+      break;
 
-    if (!p_ri)
-      dec_cursor();
+    case 'u':
+      if (!curwin->w_cursor.col && STRLEN(ml_get_curline())) {
+        if (!p_ri && !F_is_TyE(tempc)) {
+          chg_c_to_X_orX_();
+        }
 
-    if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR))
-      tempc = _GHAYN_;
-    else
-      tempc = _GHAYN;
+        if (p_ri) {
+          chg_c_to_X_or_X();
+        }
+      }
 
-    if (!p_ri)
-      inc_cursor();
+      if (!p_ri && !curwin->w_cursor.col) {
+        return _AYN;
+      }
 
-    break;
-  case 'z':
-    tempc = _ZA;
-    break;
-  case 'Z':
-    tempc = _KAF_H;
-    break;
-  case ';':
-    tempc = _KAF;
-    break;
-  case '\'':
-    tempc = _GAF;
-    break;
-  case ',':
-    tempc = WAW;
-    break;
-  case '[':
-    tempc = _JIM;
-    break;
-  case ']':
-    tempc = _CHE;
-    break;
+      if (!p_ri) {
+        dec_cursor();
+      }
+
+      if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+        tempc = _AYN_;
+      } else {
+        tempc = _AYN;
+      }
+
+      if (!p_ri) {
+        inc_cursor();
+      }
+      break;
+
+    case 'v':
+    case 'V':
+      tempc = RE;
+      break;
+
+    case 'w':
+      tempc = _SAD;
+      break;
+
+    case 'x':
+    case 'X':
+      tempc = _TA;
+      break;
+
+    case 'y':
+      if (!curwin->w_cursor.col && STRLEN(ml_get_curline())) {
+        if (!p_ri && !F_is_TyE(tempc)) {
+          chg_c_to_X_orX_();
+        }
+
+        if (p_ri) {
+          chg_c_to_X_or_X();
+        }
+      }
+
+      if (!p_ri && !curwin->w_cursor.col) {
+        return _GHAYN;
+      }
+
+      if (!p_ri) {
+        dec_cursor();
+      }
+
+      if (F_is_TyB_TyC_TyD(SRC_EDT, AT_CURSOR)) {
+        tempc = _GHAYN_;
+      } else {
+        tempc = _GHAYN;
+      }
+
+      if (!p_ri) {
+        inc_cursor();
+      }
+
+      break;
+
+    case 'z':
+      tempc = _ZA;
+      break;
+
+    case 'Z':
+      tempc = _KAF_H;
+      break;
+
+    case ';':
+      tempc = _KAF;
+      break;
+
+    case '\'':
+      tempc = _GAF;
+      break;
+
+    case ',':
+      tempc = WAW;
+      break;
+
+    case '[':
+      tempc = _JIM;
+      break;
+
+    case ']':
+      tempc = _CHE;
+      break;
   }
 
   if ((F_isalpha(tempc) || F_isdigit(tempc))) {
-    if (!curwin->w_cursor.col  &&  STRLEN(ml_get_curline())) {
-      if (!p_ri && !F_is_TyE(tempc))
-        chg_c_to_X_orX_ ();
-      if (p_ri)
-        chg_c_to_X_or_X ();
+    if (!curwin->w_cursor.col && STRLEN(ml_get_curline())) {
+      if (!p_ri && !F_is_TyE(tempc)) {
+        chg_c_to_X_orX_();
+      }
+
+      if (p_ri) {
+        chg_c_to_X_or_X();
+      }
     }
 
     if (curwin->w_cursor.col) {
-      if (!p_ri)
+      if (!p_ri) {
         dec_cursor();
+      }
 
-      if (F_is_TyE(tempc))
-        chg_l_toXor_X ();
-      else
-        chg_l_to_X_orX_ ();
+      if (F_is_TyE(tempc)) {
+        chg_l_toXor_X();
+      } else {
+        chg_l_to_X_orX_();
+      }
 
-      if (!p_ri)
+      if (!p_ri) {
         inc_cursor();
+      }
     }
   }
-  if (tempc)
+
+  if (tempc) {
     return tempc;
+  }
   return c;
 }
 
@@ -1385,48 +1859,94 @@ int fkmap(int c)
 static int toF_leading(int c)
 {
   switch (c) {
-  case ALEF_:     return ALEF;
-  case ALEF_U_H_:     return ALEF_U_H;
-  case BE:    return _BE;
-  case PE:    return _PE;
-  case TE:    return _TE;
-  case SE:    return _SE;
-  case JIM:   return _JIM;
-  case CHE:   return _CHE;
-  case HE_J:  return _HE_J;
-  case XE:    return _XE;
-  case SIN:   return _SIN;
-  case SHIN:  return _SHIN;
-  case SAD:   return _SAD;
-  case ZAD:   return _ZAD;
+    case ALEF_:
+      return ALEF;
 
-  case AYN:
-  case AYN_:
-  case _AYN_: return _AYN;
+    case ALEF_U_H_:
+      return ALEF_U_H;
 
-  case GHAYN:
-  case GHAYN_:
-  case _GHAYN_:   return _GHAYN;
+    case BE:
+      return _BE;
 
-  case FE:    return _FE;
-  case GHAF:  return _GHAF;
-  case KAF:   return _KAF;
-  case GAF:   return _GAF;
-  case LAM:   return _LAM;
-  case MIM:   return _MIM;
-  case NOON:  return _NOON;
+    case PE:
+      return _PE;
 
-  case _HE_:
-  case F_HE:      return _HE;
+    case TE:
+      return _TE;
 
-  case YE:
-  case YE_:       return _YE;
+    case SE:
+      return _SE;
 
-  case IE_:
-  case IE:        return _IE;
+    case JIM:
+      return _JIM;
 
-  case YEE:
-  case YEE_:      return _YEE;
+    case CHE:
+      return _CHE;
+
+    case HE_J:
+      return _HE_J;
+
+    case XE:
+      return _XE;
+
+    case SIN:
+      return _SIN;
+
+    case SHIN:
+      return _SHIN;
+
+    case SAD:
+      return _SAD;
+
+    case ZAD:
+      return _ZAD;
+
+    case AYN:
+    case AYN_:
+    case _AYN_:
+      return _AYN;
+
+    case GHAYN:
+    case GHAYN_:
+    case _GHAYN_:
+      return _GHAYN;
+
+    case FE:
+      return _FE;
+
+    case GHAF:
+      return _GHAF;
+
+    case KAF:
+      return _KAF;
+
+    case GAF:
+      return _GAF;
+
+    case LAM:
+      return _LAM;
+
+    case MIM:
+      return _MIM;
+
+    case NOON:
+      return _NOON;
+
+    case _HE_:
+    case F_HE:
+      return _HE;
+
+    case YE:
+    case YE_:
+      return _YE;
+
+    case IE_:
+    case IE:
+      return _IE;
+
+    case YEE:
+    case YEE_:
+      return _YEE;
   }
   return c;
 }
@@ -1437,50 +1957,97 @@ static int toF_leading(int c)
 static int toF_Rjoin(int c)
 {
   switch (c) {
-  case ALEF:  return ALEF_;
-  case ALEF_U_H:  return ALEF_U_H_;
-  case BE:    return _BE;
-  case PE:    return _PE;
-  case TE:    return _TE;
-  case SE:    return _SE;
-  case JIM:   return _JIM;
-  case CHE:   return _CHE;
-  case HE_J:  return _HE_J;
-  case XE:    return _XE;
-  case SIN:   return _SIN;
-  case SHIN:  return _SHIN;
-  case SAD:   return _SAD;
-  case ZAD:   return _ZAD;
+    case ALEF:
+      return ALEF_;
 
-  case AYN:
-  case AYN_:
-  case _AYN:  return _AYN_;
+    case ALEF_U_H:
+      return ALEF_U_H_;
 
-  case GHAYN:
-  case GHAYN_:
-  case _GHAYN_:   return _GHAYN_;
+    case BE:
+      return _BE;
 
-  case FE:    return _FE;
-  case GHAF:  return _GHAF;
-  case KAF:   return _KAF;
-  case GAF:   return _GAF;
-  case LAM:   return _LAM;
-  case MIM:   return _MIM;
-  case NOON:  return _NOON;
+    case PE:
+      return _PE;
 
-  case _HE:
-  case F_HE:      return _HE_;
+    case TE:
+      return _TE;
 
-  case YE:
-  case YE_:       return _YE;
+    case SE:
+      return _SE;
 
-  case IE_:
-  case IE:        return _IE;
+    case JIM:
+      return _JIM;
 
-  case TEE:       return TEE_;
+    case CHE:
+      return _CHE;
 
-  case YEE:
-  case YEE_:      return _YEE;
+    case HE_J:
+      return _HE_J;
+
+    case XE:
+      return _XE;
+
+    case SIN:
+      return _SIN;
+
+    case SHIN:
+      return _SHIN;
+
+    case SAD:
+      return _SAD;
+
+    case ZAD:
+      return _ZAD;
+
+    case AYN:
+    case AYN_:
+    case _AYN:
+      return _AYN_;
+
+    case GHAYN:
+    case GHAYN_:
+    case _GHAYN_:
+      return _GHAYN_;
+
+    case FE:
+      return _FE;
+
+    case GHAF:
+      return _GHAF;
+
+    case KAF:
+      return _KAF;
+
+    case GAF:
+      return _GAF;
+
+    case LAM:
+      return _LAM;
+
+    case MIM:
+      return _MIM;
+
+    case NOON:
+      return _NOON;
+
+    case _HE:
+    case F_HE:
+      return _HE_;
+
+    case YE:
+    case YE_:
+      return _YE;
+
+    case IE_:
+    case IE:
+      return _IE;
+
+    case TEE:
+      return TEE_;
+
+    case YEE:
+    case YEE_:
+      return _YEE;
   }
   return c;
 }
@@ -1491,68 +2058,68 @@ static int toF_Rjoin(int c)
 static int canF_Ljoin(int c)
 {
   switch (c) {
-  case _BE:
-  case BE:
-  case PE:
-  case _PE:
-  case TE:
-  case _TE:
-  case SE:
-  case _SE:
-  case JIM:
-  case _JIM:
-  case CHE:
-  case _CHE:
-  case HE_J:
-  case _HE_J:
-  case XE:
-  case _XE:
-  case SIN:
-  case _SIN:
-  case SHIN:
-  case _SHIN:
-  case SAD:
-  case _SAD:
-  case ZAD:
-  case _ZAD:
-  case _TA:
-  case _ZA:
-  case AYN:
-  case _AYN:
-  case _AYN_:
-  case AYN_:
-  case GHAYN:
-  case GHAYN_:
-  case _GHAYN_:
-  case _GHAYN:
-  case FE:
-  case _FE:
-  case GHAF:
-  case _GHAF:
-  case _KAF_H:
-  case KAF:
-  case _KAF:
-  case GAF:
-  case _GAF:
-  case LAM:
-  case _LAM:
-  case MIM:
-  case _MIM:
-  case NOON:
-  case _NOON:
-  case IE:
-  case _IE:
-  case IE_:
-  case YE:
-  case _YE:
-  case YE_:
-  case YEE:
-  case _YEE:
-  case YEE_:
-  case F_HE:
-  case _HE:
-  case _HE_:
-    return TRUE;
+    case _BE:
+    case BE:
+    case PE:
+    case _PE:
+    case TE:
+    case _TE:
+    case SE:
+    case _SE:
+    case JIM:
+    case _JIM:
+    case CHE:
+    case _CHE:
+    case HE_J:
+    case _HE_J:
+    case XE:
+    case _XE:
+    case SIN:
+    case _SIN:
+    case SHIN:
+    case _SHIN:
+    case SAD:
+    case _SAD:
+    case ZAD:
+    case _ZAD:
+    case _TA:
+    case _ZA:
+    case AYN:
+    case _AYN:
+    case _AYN_:
+    case AYN_:
+    case GHAYN:
+    case GHAYN_:
+    case _GHAYN_:
+    case _GHAYN:
+    case FE:
+    case _FE:
+    case GHAF:
+    case _GHAF:
+    case _KAF_H:
+    case KAF:
+    case _KAF:
+    case GAF:
+    case _GAF:
+    case LAM:
+    case _LAM:
+    case MIM:
+    case _MIM:
+    case NOON:
+    case _NOON:
+    case IE:
+    case _IE:
+    case IE_:
+    case YE:
+    case _YE:
+    case YE_:
+    case YEE:
+    case _YEE:
+    case YEE_:
+    case F_HE:
+    case _HE:
+    case _HE_:
+      return TRUE;
   }
   return FALSE;
 }
@@ -1563,24 +2130,23 @@ static int canF_Ljoin(int c)
 static int canF_Rjoin(int c)
 {
   switch (c) {
-  case ALEF:
-  case ALEF_:
-  case ALEF_U_H:
-  case ALEF_U_H_:
-  case DAL:
-  case ZAL:
-  case RE:
-  case JE:
-  case ZE:
-  case TEE:
-  case TEE_:
-  case WAW:
-  case WAW_H:
-    return TRUE;
+    case ALEF:
+    case ALEF_:
+    case ALEF_U_H:
+    case ALEF_U_H_:
+    case DAL:
+    case ZAL:
+    case RE:
+    case JE:
+    case ZE:
+    case TEE:
+    case TEE_:
+    case WAW:
+    case WAW_H:
+      return TRUE;
   }
 
   return canF_Ljoin(c);
-
 }
 
 /*
@@ -1589,20 +2155,20 @@ static int canF_Rjoin(int c)
 static int F_isterm(int c)
 {
   switch (c) {
-  case ALEF:
-  case ALEF_:
-  case ALEF_U_H:
-  case ALEF_U_H_:
-  case DAL:
-  case ZAL:
-  case RE:
-  case JE:
-  case ZE:
-  case WAW:
-  case WAW_H:
-  case TEE:
-  case TEE_:
-    return TRUE;
+    case ALEF:
+    case ALEF_:
+    case ALEF_U_H:
+    case ALEF_U_H_:
+    case DAL:
+    case ZAL:
+    case RE:
+    case JE:
+    case ZE:
+    case WAW:
+    case WAW_H:
+    case TEE:
+    case TEE_:
+      return TRUE;
   }
 
   return FALSE;
@@ -1613,72 +2179,101 @@ static int F_isterm(int c)
 */
 static int toF_ending(int c)
 {
-
   switch (c) {
-  case _BE:
-    return BE;
-  case _PE:
-    return PE;
-  case _TE:
-    return TE;
-  case _SE:
-    return SE;
-  case _JIM:
-    return JIM;
-  case _CHE:
-    return CHE;
-  case _HE_J:
-    return HE_J;
-  case _XE:
-    return XE;
-  case _SIN:
-    return SIN;
-  case _SHIN:
-    return SHIN;
-  case _SAD:
-    return SAD;
-  case _ZAD:
-    return ZAD;
-  case _AYN:
-    return AYN;
-  case _AYN_:
-    return AYN_;
-  case _GHAYN:
-    return GHAYN;
-  case _GHAYN_:
-    return GHAYN_;
-  case _FE:
-    return FE;
-  case _GHAF:
-    return GHAF;
-  case _KAF_H:
-  case _KAF:
-    return KAF;
-  case _GAF:
-    return GAF;
-  case _LAM:
-    return LAM;
-  case _MIM:
-    return MIM;
-  case _NOON:
-    return NOON;
-  case _YE:
-    return YE_;
-  case YE_:
-    return YE;
-  case _YEE:
-    return YEE_;
-  case YEE_:
-    return YEE;
-  case TEE:
-    return TEE_;
-  case _IE:
-    return IE_;
-  case IE_:
-    return IE;
-  case _HE:
-  case _HE_:
-    return F_HE;
+    case _BE:
+      return BE;
+
+    case _PE:
+      return PE;
+
+    case _TE:
+      return TE;
+
+    case _SE:
+      return SE;
+
+    case _JIM:
+      return JIM;
+
+    case _CHE:
+      return CHE;
+
+    case _HE_J:
+      return HE_J;
+
+    case _XE:
+      return XE;
+
+    case _SIN:
+      return SIN;
+
+    case _SHIN:
+      return SHIN;
+
+    case _SAD:
+      return SAD;
+
+    case _ZAD:
+      return ZAD;
+
+    case _AYN:
+      return AYN;
+
+    case _AYN_:
+      return AYN_;
+
+    case _GHAYN:
+      return GHAYN;
+
+    case _GHAYN_:
+      return GHAYN_;
+
+    case _FE:
+      return FE;
+
+    case _GHAF:
+      return GHAF;
+
+    case _KAF_H:
+    case _KAF:
+      return KAF;
+
+    case _GAF:
+      return GAF;
+
+    case _LAM:
+      return LAM;
+
+    case _MIM:
+      return MIM;
+
+    case _NOON:
+      return NOON;
+
+    case _YE:
+      return YE_;
+
+    case YE_:
+      return YE;
+
+    case _YEE:
+      return YEE_;
+
+    case YEE_:
+      return YEE;
+
+    case TEE:
+      return TEE_;
+
+    case _IE:
+      return IE_;
+
+    case IE_:
+      return IE;
+
+    case _HE:
+    case _HE_:
+      return F_HE;
   }
   return c;
 }
@@ -1686,30 +2281,33 @@ static int toF_ending(int c)
 /*
 ** Convert the Farsi 3342 standard into Farsi VIM.
 */
-void conv_to_pvim(void)          {
-  char_u      *ptr;
+void conv_to_pvim(void)
+{
+  char_u *ptr;
   int lnum, llen, i;
 
   for (lnum = 1; lnum <= curbuf->b_ml.ml_line_count; ++lnum) {
     ptr = ml_get((linenr_T)lnum);
-
     llen = (int)STRLEN(ptr);
-
-    for ( i = 0; i < llen-1; i++) {
-      if (canF_Ljoin(ptr[i]) && canF_Rjoin(ptr[i+1])) {
+    for (i = 0; i < llen - 1; i++) {
+      if (canF_Ljoin(ptr[i]) && canF_Rjoin(ptr[i + 1])) {
         ptr[i] = toF_leading(ptr[i]);
         ++i;
 
         while (canF_Rjoin(ptr[i]) && i < llen) {
           ptr[i] = toF_Rjoin(ptr[i]);
-          if (F_isterm(ptr[i]) || !F_isalpha(ptr[i]))
+          if (F_isterm(ptr[i]) || !F_isalpha(ptr[i])) {
             break;
+          }
           ++i;
         }
-        if (!F_isalpha(ptr[i]) || !canF_Rjoin(ptr[i]))
-          ptr[i-1] = toF_ending(ptr[i-1]);
-      } else
+
+        if (!F_isalpha(ptr[i]) || !canF_Rjoin(ptr[i])) {
+          ptr[i - 1] = toF_ending(ptr[i - 1]);
+        }
+      } else {
         ptr[i] = toF_TyA(ptr[i]);
+      }
     }
   }
 
@@ -1728,8 +2326,9 @@ void conv_to_pvim(void)          {
 /*
  * Convert the Farsi VIM into Farsi 3342 standard.
  */
-void conv_to_pstd(void)          {
-  char_u      *ptr;
+void conv_to_pstd(void)
+{
+  char_u *ptr;
   int lnum, llen, i;
 
   /*
@@ -1737,15 +2336,11 @@ void conv_to_pstd(void)          {
    */
 
   do_cmdline_cmd((char_u *)"%s/\232/\202\231/g");
-
   for (lnum = 1; lnum <= curbuf->b_ml.ml_line_count; ++lnum) {
     ptr = ml_get((linenr_T)lnum);
-
     llen = (int)STRLEN(ptr);
-
-    for ( i = 0; i < llen; i++) {
+    for (i = 0; i < llen; i++) {
       ptr[i] = toF_TyA(ptr[i]);
-
     }
   }
 
@@ -1759,12 +2354,11 @@ void conv_to_pstd(void)          {
  */
 static void lrswapbuf(char_u *buf, int len)
 {
-  char_u      *s, *e;
+  char_u *s, *e;
   int c;
 
   s = buf;
   e = buf + len - 1;
-
   while (e > s) {
     c = *s;
     *s = *e;
@@ -1777,32 +2371,34 @@ static void lrswapbuf(char_u *buf, int len)
 /*
  * swap all the characters in reverse direction
  */
-char_u *lrswap(char_u *ibuf)
+char_u* lrswap(char_u *ibuf)
 {
-  if (ibuf != NULL && *ibuf != NUL)
+  if ((ibuf != NULL) && (*ibuf != NUL)) {
     lrswapbuf(ibuf, (int)STRLEN(ibuf));
+  }
   return ibuf;
 }
 
 /*
  * swap all the Farsi characters in reverse direction
  */
-char_u *lrFswap(char_u *cmdbuf, int len)
+char_u* lrFswap(char_u *cmdbuf, int len)
 {
   int i, cnt;
-
-  if (cmdbuf == NULL)
+  if (cmdbuf == NULL) {
     return cmdbuf;
+  }
 
-  if (len == 0 && (len = (int)STRLEN(cmdbuf)) == 0)
+  if ((len == 0) && ((len = (int)STRLEN(cmdbuf)) == 0)) {
     return cmdbuf;
+  }
 
   for (i = 0; i < len; i++) {
-    for (cnt = 0; i + cnt < len
-         && (F_isalpha(cmdbuf[i + cnt])
-             || F_isdigit(cmdbuf[i + cnt])
-             || cmdbuf[i + cnt] == ' '); ++cnt)
-      ;
+    for (cnt = 0; i + cnt < len &&
+         (F_isalpha(cmdbuf[i + cnt]) ||
+          F_isdigit(cmdbuf[i + cnt]) ||
+          cmdbuf[i + cnt] == ' '); ++cnt) {
+    }
 
     lrswapbuf(cmdbuf + i, cnt);
     i += cnt;
@@ -1815,38 +2411,40 @@ char_u *lrFswap(char_u *cmdbuf, int len)
  * accordingly.
  * TODO: handle different separator characters.  Use skip_regexp().
  */
-char_u *lrF_sub(char_u *ibuf)
+char_u* lrF_sub(char_u *ibuf)
 {
-  char_u      *p, *ep;
+  char_u *p, *ep;
   int i, cnt;
 
   p = ibuf;
 
   /* Find the boundary of the search path */
-  while (((p = vim_strchr(p + 1, '/')) != NULL) && p[-1] == '\\')
-    ;
+  while (((p = vim_strchr(p + 1, '/')) != NULL) && p[-1] == '\\') {
+  }
 
-  if (p == NULL)
+  if (p == NULL) {
     return ibuf;
+  }
 
   /* Reverse the Farsi characters in the search path. */
-  lrFswap(ibuf, (int)(p-ibuf));
+  lrFswap(ibuf, (int)(p - ibuf));
 
   /* Now find the boundary of the substitute section */
-  if ((ep = (char_u *)strrchr((char *)++p, '/')) != NULL)
+  if ((ep = (char_u *)strrchr((char *)++p, '/')) != NULL) {
     cnt = (int)(ep - p);
-  else
+  } else {
     cnt = (int)STRLEN(p);
+  }
 
   /* Reverse the characters in the substitute section and take care of '\' */
-  for (i = 0; i < cnt-1; i++)
+  for (i = 0; i < cnt - 1; i++) {
     if (p[i] == '\\') {
-      p[i] = p[i+1];
+      p[i] = p[i + 1];
       p[++i] = '\\';
     }
+  }
 
   lrswapbuf(p, cnt);
-
   return ibuf;
 }
 
@@ -1858,246 +2456,426 @@ int cmdl_fkmap(int c)
   int tempc;
 
   switch (c) {
-  case '0':
-  case '1':
-  case '2':
-  case '3':
-  case '4':
-  case '5':
-  case '6':
-  case '7':
-  case '8':
-  case '9':
-  case '`':
-  case ' ':
-  case '.':
-  case '!':
-  case '"':
-  case '$':
-  case '%':
-  case '^':
-  case '&':
-  case '/':
-  case '(':
-  case ')':
-  case '=':
-  case '\\':
-  case '?':
-  case '+':
-  case '-':
-  case '_':
-  case '*':
-  case ':':
-  case '#':
-  case '~':
-  case '@':
-  case '<':
-  case '>':
-  case '{':
-  case '}':
-  case '|':
-  case 'B':
-  case 'E':
-  case 'F':
-  case 'H':
-  case 'I':
-  case 'K':
-  case 'L':
-  case 'M':
-  case 'O':
-  case 'P':
-  case 'Q':
-  case 'R':
-  case 'T':
-  case 'U':
-  case 'W':
-  case 'Y':
-  case  NL:
-  case  TAB:
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case '`':
+    case ' ':
+    case '.':
+    case '!':
+    case '"':
+    case '$':
+    case '%':
+    case '^':
+    case '&':
+    case '/':
+    case '(':
+    case ')':
+    case '=':
+    case '\\':
+    case '?':
+    case '+':
+    case '-':
+    case '_':
+    case '*':
+    case ':':
+    case '#':
+    case '~':
+    case '@':
+    case '<':
+    case '>':
+    case '{':
+    case '}':
+    case '|':
+    case 'B':
+    case 'E':
+    case 'F':
+    case 'H':
+    case 'I':
+    case 'K':
+    case 'L':
+    case 'M':
+    case 'O':
+    case 'P':
+    case 'Q':
+    case 'R':
+    case 'T':
+    case 'U':
+    case 'W':
+    case 'Y':
+    case  NL:
+    case  TAB:
+      switch ((tempc = cmd_gchar(AT_CURSOR))) {
+        case _BE:
+        case _PE:
+        case _TE:
+        case _SE:
+        case _JIM:
+        case _CHE:
+        case _HE_J:
+        case _XE:
+        case _SIN:
+        case _SHIN:
+        case _SAD:
+        case _ZAD:
+        case _AYN:
+        case _GHAYN:
+        case _FE:
+        case _GHAF:
+        case _KAF:
+        case _GAF:
+        case _LAM:
+        case _MIM:
+        case _NOON:
+        case _HE:
+        case _HE_:
+            cmd_pchar(toF_TyA(tempc), AT_CURSOR);
+          break;
 
-    switch ((tempc = cmd_gchar(AT_CURSOR))) {
-    case _BE:
-    case _PE:
-    case _TE:
-    case _SE:
-    case _JIM:
-    case _CHE:
-    case _HE_J:
-    case _XE:
-    case _SIN:
-    case _SHIN:
-    case _SAD:
-    case _ZAD:
-    case _AYN:
-    case _GHAYN:
-    case _FE:
-    case _GHAF:
-    case _KAF:
-    case _GAF:
-    case _LAM:
-    case _MIM:
-    case _NOON:
-    case _HE:
-    case _HE_:
-      cmd_pchar(toF_TyA(tempc), AT_CURSOR);
+        case _AYN_:
+            cmd_pchar(AYN_, AT_CURSOR);
+          break;
+
+        case _GHAYN_:
+            cmd_pchar(GHAYN_, AT_CURSOR);
+          break;
+
+        case _IE:
+          if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR + 1)) {
+            cmd_pchar(IE_, AT_CURSOR);
+          } else {
+            cmd_pchar(IE,  AT_CURSOR);
+          }
+          break;
+
+        case _YEE:
+          if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR + 1)) {
+            cmd_pchar(YEE_, AT_CURSOR);
+          } else {
+            cmd_pchar(YEE,  AT_CURSOR);
+          }
+          break;
+
+        case _YE:
+          if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR + 1)) {
+            cmd_pchar(YE_, AT_CURSOR);
+          } else {
+            cmd_pchar(YE,  AT_CURSOR);
+          }
+      }
+
+      switch (c) {
+        case '0':
+          return FARSI_0;
+
+        case '1':
+          return FARSI_1;
+
+        case '2':
+          return FARSI_2;
+
+        case '3':
+          return FARSI_3;
+
+        case '4':
+          return FARSI_4;
+
+        case '5':
+          return FARSI_5;
+
+        case '6':
+          return FARSI_6;
+
+        case '7':
+          return FARSI_7;
+
+        case '8':
+          return FARSI_8;
+
+        case '9':
+          return FARSI_9;
+
+        case 'B':
+          return F_PSP;
+
+        case 'E':
+          return JAZR_N;
+
+        case 'F':
+          return ALEF_D_H;
+
+        case 'H':
+          return ALEF_A;
+
+        case 'I':
+          return TASH;
+
+        case 'K':
+          return F_LQUOT;
+
+        case 'L':
+          return F_RQUOT;
+
+        case 'M':
+          return HAMZE;
+
+        case 'O':
+          return '[';
+
+        case 'P':
+          return ']';
+
+        case 'Q':
+          return OO;
+
+        case 'R':
+          return MAD_N;
+
+        case 'T':
+          return OW;
+
+        case 'U':
+          return MAD;
+
+        case 'W':
+          return OW_OW;
+
+        case 'Y':
+          return JAZR;
+
+        case '`':
+          return F_PCN;
+
+        case '!':
+          return F_EXCL;
+
+        case '@':
+          return F_COMMA;
+
+        case '#':
+          return F_DIVIDE;
+
+        case '$':
+          return F_CURRENCY;
+
+        case '%':
+          return F_PERCENT;
+
+        case '^':
+          return F_MUL;
+
+        case '&':
+          return F_BCOMMA;
+
+        case '*':
+          return F_STAR;
+
+        case '(':
+          return F_LPARENT;
+
+        case ')':
+          return F_RPARENT;
+
+        case '-':
+          return F_MINUS;
+
+        case '_':
+          return F_UNDERLINE;
+
+        case '=':
+          return F_EQUALS;
+
+        case '+':
+          return F_PLUS;
+
+        case '\\':
+          return F_BSLASH;
+
+        case '|':
+          return F_PIPE;
+
+        case ':':
+          return F_DCOLON;
+
+        case '"':
+          return F_SEMICOLON;
+
+        case '.':
+          return F_PERIOD;
+
+        case '/':
+          return F_SLASH;
+
+        case '<':
+          return F_LESS;
+
+        case '>':
+          return F_GREATER;
+
+        case '?':
+          return F_QUESTION;
+
+        case ' ':
+          return F_BLANK;
+      }
       break;
-    case _AYN_:
-      cmd_pchar(AYN_, AT_CURSOR);
-      break;
-    case _GHAYN_:
-      cmd_pchar(GHAYN_, AT_CURSOR);
-      break;
-    case _IE:
-      if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR+1))
-        cmd_pchar(IE_, AT_CURSOR);
-      else
-        cmd_pchar(IE, AT_CURSOR);
-      break;
-    case _YEE:
-      if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR+1))
-        cmd_pchar(YEE_, AT_CURSOR);
-      else
-        cmd_pchar(YEE, AT_CURSOR);
-      break;
-    case _YE:
-      if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR+1))
-        cmd_pchar(YE_, AT_CURSOR);
-      else
-        cmd_pchar(YE, AT_CURSOR);
-    }
 
-    switch (c) {
-    case '0':   return FARSI_0;
-    case '1':   return FARSI_1;
-    case '2':   return FARSI_2;
-    case '3':   return FARSI_3;
-    case '4':   return FARSI_4;
-    case '5':   return FARSI_5;
-    case '6':   return FARSI_6;
-    case '7':   return FARSI_7;
-    case '8':   return FARSI_8;
-    case '9':   return FARSI_9;
-    case 'B':   return F_PSP;
-    case 'E':   return JAZR_N;
-    case 'F':   return ALEF_D_H;
-    case 'H':   return ALEF_A;
-    case 'I':   return TASH;
-    case 'K':   return F_LQUOT;
-    case 'L':   return F_RQUOT;
-    case 'M':   return HAMZE;
-    case 'O':   return '[';
-    case 'P':   return ']';
-    case 'Q':   return OO;
-    case 'R':   return MAD_N;
-    case 'T':   return OW;
-    case 'U':   return MAD;
-    case 'W':   return OW_OW;
-    case 'Y':   return JAZR;
-    case '`':   return F_PCN;
-    case '!':   return F_EXCL;
-    case '@':   return F_COMMA;
-    case '#':   return F_DIVIDE;
-    case '$':   return F_CURRENCY;
-    case '%':   return F_PERCENT;
-    case '^':   return F_MUL;
-    case '&':   return F_BCOMMA;
-    case '*':   return F_STAR;
-    case '(':   return F_LPARENT;
-    case ')':   return F_RPARENT;
-    case '-':   return F_MINUS;
-    case '_':   return F_UNDERLINE;
-    case '=':   return F_EQUALS;
-    case '+':   return F_PLUS;
-    case '\\':  return F_BSLASH;
-    case '|':   return F_PIPE;
-    case ':':   return F_DCOLON;
-    case '"':   return F_SEMICOLON;
-    case '.':   return F_PERIOD;
-    case '/':   return F_SLASH;
-    case '<':   return F_LESS;
-    case '>':   return F_GREATER;
-    case '?':   return F_QUESTION;
-    case ' ':   return F_BLANK;
-    }
+    case 'a':
+      return _SHIN;
 
-    break;
+    case 'A':
+      return WAW_H;
 
-  case 'a':   return _SHIN;
-  case 'A':   return WAW_H;
-  case 'b':   return ZAL;
-  case 'c':   return ZE;
-  case 'C':   return JE;
-  case 'd':   return _YE;
-  case 'D':   return _YEE;
-  case 'e':   return _SE;
-  case 'f':   return _BE;
-  case 'g':   return _LAM;
-  case 'G':
-    if (cmd_gchar(AT_CURSOR) == _LAM ) {
-      cmd_pchar(LAM, AT_CURSOR);
-      return ALEF_U_H;
-    }
+    case 'b':
+      return ZAL;
 
-    if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR))
-      return ALEF_U_H_;
-    else
-      return ALEF_U_H;
-  case 'h':
-    if (cmd_gchar(AT_CURSOR) == _LAM ) {
-      cmd_pchar(LA, AT_CURSOR);
-      redrawcmdline();
-      return K_IGNORE;
-    }
+    case 'c':
+      return ZE;
 
-    if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR))
-      return ALEF_;
-    else
-      return ALEF;
-  case 'i':
-    if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR))
-      return _HE_;
-    else
-      return _HE;
-  case 'j':   return _TE;
-  case 'J':
-    if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR))
-      return TEE_;
-    else
-      return TEE;
-  case 'k':   return _NOON;
-  case 'l':   return _MIM;
-  case 'm':   return _PE;
-  case 'n':
-  case 'N':   return DAL;
-  case 'o':   return _XE;
-  case 'p':   return _HE_J;
-  case 'q':   return _ZAD;
-  case 'r':   return _GHAF;
-  case 's':   return _SIN;
-  case 'S':   return _IE;
-  case 't':   return _FE;
-  case 'u':
-    if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR))
-      return _AYN_;
-    else
-      return _AYN;
-  case 'v':
-  case 'V':   return RE;
-  case 'w':   return _SAD;
-  case 'x':
-  case 'X':   return _TA;
-  case 'y':
-    if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR))
-      return _GHAYN_;
-    else
-      return _GHAYN;
-  case 'z':
-  case 'Z':   return _ZA;
-  case ';':   return _KAF;
-  case '\'':  return _GAF;
-  case ',':   return WAW;
-  case '[':   return _JIM;
-  case ']':   return _CHE;
+    case 'C':
+      return JE;
+
+    case 'd':
+      return _YE;
+
+    case 'D':
+      return _YEE;
+
+    case 'e':
+      return _SE;
+
+    case 'f':
+      return _BE;
+
+    case 'g':
+      return _LAM;
+
+    case 'G':
+      if (cmd_gchar(AT_CURSOR) == _LAM) {
+        cmd_pchar(LAM, AT_CURSOR);
+        return ALEF_U_H;
+      }
+
+      if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR)) {
+        return ALEF_U_H_;
+      } else {
+        return ALEF_U_H;
+      }
+
+    case 'h':
+      if (cmd_gchar(AT_CURSOR) == _LAM) {
+        cmd_pchar(LA, AT_CURSOR);
+        redrawcmdline();
+        return K_IGNORE;
+      }
+
+      if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR)) {
+        return ALEF_;
+      } else {
+        return ALEF;
+      }
+
+    case 'i':
+      if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR)) {
+        return _HE_;
+      } else {
+        return _HE;
+      }
+
+    case 'j':
+      return _TE;
+
+    case 'J':
+      if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR)) {
+        return TEE_;
+      } else {
+        return TEE;
+      }
+
+    case 'k':
+      return _NOON;
+
+    case 'l':
+      return _MIM;
+
+    case 'm':
+      return _PE;
+
+    case 'n':
+    case 'N':
+      return DAL;
+
+    case 'o':
+      return _XE;
+
+    case 'p':
+      return _HE_J;
+
+    case 'q':
+      return _ZAD;
+
+    case 'r':
+      return _GHAF;
+
+    case 's':
+      return _SIN;
+
+    case 'S':
+      return _IE;
+
+    case 't':
+      return _FE;
+
+    case 'u':
+      if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR)) {
+        return _AYN_;
+      } else {
+        return _AYN;
+      }
+
+    case 'v':
+    case 'V':
+      return RE;
+
+    case 'w':
+      return _SAD;
+
+    case 'x':
+    case 'X':
+      return _TA;
+
+    case 'y':
+      if (F_is_TyB_TyC_TyD(SRC_CMD, AT_CURSOR)) {
+        return _GHAYN_;
+      } else {
+        return _GHAYN;
+      }
+
+    case 'z':
+    case 'Z':
+      return _ZA;
+
+    case ';':
+      return _KAF;
+
+    case '\'':
+      return _GAF;
+
+    case ',':
+      return WAW;
+
+    case '[':
+      return _JIM;
+
+    case ']':
+      return _CHE;
   }
 
   return c;
@@ -2108,9 +2886,9 @@ int cmdl_fkmap(int c)
  */
 int F_isalpha(int c)
 {
-  return ( c >= TEE_ && c <= _YE)
-         || (c >= ALEF_A && c <= YE)
-         || (c >= _IE && c <= YE_);
+  return (c >= TEE_ && c <= _YE) ||
+         (c >= ALEF_A && c <= YE) ||
+         (c >= _IE && c <= YE_);
 }
 
 /*
@@ -2139,7 +2917,7 @@ void farsi_fkey(cmdarg_T *cap)
         p_fkmap = 0;
         do_cmdline_cmd((char_u *)"set norl");
         MSG("");
-      } else   {
+      } else {
         p_fkmap = 1;
         do_cmdline_cmd((char_u *)"set rl");
         MSG("");
@@ -2152,10 +2930,11 @@ void farsi_fkey(cmdarg_T *cap)
   if (c == K_F9) {
     if (p_altkeymap && curwin->w_p_rl) {
       curwin->w_farsi = curwin->w_farsi ^ W_CONV;
-      if (curwin->w_farsi & W_CONV)
+      if (curwin->w_farsi & W_CONV) {
         conv_to_pvim();
-      else
+      } else {
         conv_to_pstd();
+      }
     }
   }
 }

--- a/src/farsi.h
+++ b/src/farsi.h
@@ -6,8 +6,8 @@
  * Do ":help credits" in Vim to see a list of people who contributed.
  */
 
-#ifndef NEOVIM_FARSI_H
-#define NEOVIM_FARSI_H
+#ifndef SRC_FARSI_H_
+#define SRC_FARSI_H_
 
 /*
  * Farsi characters are categorized into following types:
@@ -186,46 +186,49 @@
 #define W_CONV 0x1
 #define W_R_L  0x2
 
-
 /* special Farsi text messages */
 
-EXTERN char_u farsi_text_1[]
 #ifdef DO_INIT
-  = { YE_, _SIN, RE, ALEF_, _FE, ' ', 'V', 'I', 'M',
-      ' ', F_HE, _BE, ' ', SHIN, RE, _GAF, DAL,' ', NOON,
-      ALEF_, _YE, ALEF_, _PE, '\0'}
-
+EXTERN char_u farsi_text_1[] = {
+  YE_, _SIN, RE, ALEF_, _FE, ' ', 'V', 'I', 'M',
+  ' ', F_HE, _BE, ' ', SHIN, RE, _GAF, DAL, ' ', NOON,
+  ALEF_, _YE, ALEF_, _PE, '\0'
+};
+#else
+EXTERN char_u farsi_text_1[];
 #endif
-;
 
-EXTERN char_u farsi_text_2[]
 #ifdef DO_INIT
-  = { YE_, _SIN, RE, ALEF_, _FE, ' ', FARSI_3, FARSI_3,
-      FARSI_4, FARSI_2, ' ', DAL, RE, ALEF, DAL, _NOON,
-      ALEF_, _TE, _SIN, ALEF, ' ', F_HE, _BE, ' ', SHIN,
-      RE,  _GAF, DAL, ' ', NOON, ALEF_, _YE, ALEF_, _PE, '\0'}
-
+EXTERN char_u farsi_text_2[] = {
+  YE_, _SIN, RE, ALEF_, _FE, ' ', FARSI_3, FARSI_3,
+  FARSI_4, FARSI_2, ' ', DAL, RE, ALEF, DAL, _NOON,
+  ALEF_, _TE, _SIN, ALEF, ' ', F_HE, _BE, ' ', SHIN,
+  RE,  _GAF, DAL, ' ', NOON, ALEF_, _YE, ALEF_, _PE, '\0'
+};
+#else
+EXTERN char_u farsi_text_2[];
 #endif
-;
 
-EXTERN char_u farsi_text_3[]
 #ifdef DO_INIT
-  = { DAL, WAW, _SHIN, _YE, _MIM, _NOON, ' ', YE_, _NOON,
-      ALEF_,_BE, _YE, _TE, _SHIN, _PE, ' ', 'R','E','P','L',
-      'A','C','E', ' ', NOON, ALEF_, _MIM, RE, _FE, ZE, ALEF,
-      ' ', 'R', 'E', 'V', 'E', 'R', 'S', 'E', ' ', 'I', 'N',
-      'S', 'E', 'R', 'T', ' ', SHIN, WAW, RE, ' ', ALEF_, _BE,
-      ' ', YE_, _SIN, RE, ALEF_, _FE, ' ', RE, DAL, ' ', RE,
-      ALEF_, _KAF,' ', MIM, ALEF_, _GAF, _NOON, _HE, '\0'}
-
+EXTERN char_u farsi_text_3[] = {
+  DAL, WAW, _SHIN, _YE, _MIM, _NOON, ' ', YE_, _NOON,
+  ALEF_, _BE, _YE, _TE, _SHIN, _PE, ' ', 'R', 'E', 'P', 'L',
+  'A', 'C', 'E', ' ', NOON, ALEF_, _MIM, RE, _FE, ZE, ALEF,
+  ' ', 'R', 'E', 'V', 'E', 'R', 'S', 'E', ' ', 'I', 'N',
+  'S', 'E', 'R', 'T', ' ', SHIN, WAW, RE, ' ', ALEF_, _BE,
+  ' ', YE_, _SIN, RE, ALEF_, _FE, ' ', RE, DAL, ' ', RE,
+  ALEF_, _KAF, ' ', MIM, ALEF_, _GAF, _NOON, _HE, '\0'
+};
+#else
+EXTERN char_u farsi_text_3[];
 #endif
-;
 
-
-EXTERN char_u farsi_text_5[]
 #ifdef DO_INIT
-  = { ' ', YE_, _SIN, RE, ALEF_, _FE, '\0'}
+EXTERN char_u farsi_text_5[] = {
+  ' ', YE_, _SIN, RE, ALEF_, _FE, '\0'
+};
+#else
+EXTERN char_u farsi_text_5[];
 #endif
-;
 
-#endif /* NEOVIM_FARSI_H */
+#endif  // SRC_FARSI_H_

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -164,7 +164,7 @@ indent_switch_case                       = 0        # number
 
 # Spaces to shift the 'case' line, without affecting any other lines
 # Usually 0.
-indent_case_shift                        = 1        # number
+indent_case_shift                        = 0        # number
 
 # Spaces to indent '{' from 'case'.
 # By default, the brace will appear under the 'c' in case.
@@ -177,7 +177,7 @@ indent_col1_comment                      = true     # false/true
 # How to indent goto labels
 #  >0 : absolute column where 1 is the leftmost column
 #  <=0 : subtract from brace indent
-indent_label                             = 1        # number
+indent_label                             = 0        # number
 
 # Same as indent_label, but for access specifiers that are followed by a colon
 indent_access_spec                       = 1        # number
@@ -733,7 +733,7 @@ align_var_def_span                       = 0        # number
 #  0=Part of the type     'void *   foo;'
 #  1=Part of the variable 'void     *foo;'
 #  2=Dangling             'void    *foo;'
-align_var_def_star_style                 = 0        # number
+align_var_def_star_style                 = 1        # number
 
 # How to align the '&' in variable definitions.
 #  0=Part of the type
@@ -1222,7 +1222,7 @@ pos_arith                                = ignore   # ignore/join/lead/lead_brea
 pos_assign                               = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of boolean operators in wrapped expressions
-pos_bool                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_bool                                 = trail_break # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
 
 # The position of comparison operators in wrapped expressions
 pos_compare                              = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force


### PR DESCRIPTION
Starting #311 with the files with least churn.

Initial cleanup with uncrustify + manual changes for edge cases that uncrustify does not handle.

Ran the files with clint to check that style errors were fixed, then validated by building and running tests.
