### PR TITLE
[RFC] use more verbose output type for unittests on travis

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 
 export VALGRIND_CHECK=1
+export BUSTED_OUTPUT_TYPE="TAP"
 make cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$PWD/dist"
 make
 make unittest

--- a/scripts/unittest.sh
+++ b/scripts/unittest.sh
@@ -3,4 +3,7 @@
 (cd "$pkgroot/build" && make) || exit 1
 eval "$(luarocks path)"
 
-busted --pattern=.moon ./test
+if [ -z "$BUSTED_OUTPUT_TYPE" ]; then
+    export BUSTED_OUTPUT_TYPE="utf_terminal"
+fi
+busted --pattern=.moon -o $BUSTED_OUTPUT_TYPE ./test


### PR DESCRIPTION
This should make debugging unittests which cause segfaults on Travis easier.
With the green bubbles it is not clear which test caused the segfault.
On my pull request #313 I had 2 segfaults, but I didn't know if it was the segfault from #306 or if i produced them myself :)
