### PR TITLE
[RDY] Fix: Writing in possible invalid buffer in mch_dirname().

### DIFF
--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -33,10 +33,12 @@ int mch_chdir(char *path) {
  */
 int mch_dirname(char_u *buf, int len)
 {
+  assert(buf && len);
+
   int errno;
-  if ((errno = uv_cwd((char *) buf, len)) != 0) {
-      STRCPY(buf, uv_strerror(errno));
-      return FAIL;
+  if ((errno = uv_cwd((char *)buf, len)) != 0) {
+    vim_strncpy(buf, (char_u *)uv_strerror(errno), len - 1);
+    return FAIL;
   }
   return OK;
 }


### PR DESCRIPTION
uv_cwd() returns with error -EINVAL, in case no valid
buffer is used. Do not try to copy an error message into the buffer.

For all other errors copy only the first len characters of the error
message into the buffer.
