### PR TITLE
[RFC] replace python by python2 in clint.py

### DIFF
--- a/clint.py
+++ b/clint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
python2 is the portable name according to PEP 394.

http://legacy.python.org/dev/peps/pep-0394/
