### PR TITLE
[RDY] test coverage reports with coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ before_install:
   - sudo ./scripts/travis-setup.sh 
 script:
   - ./scripts/travis.sh
+after_success:
+  - coveralls --encoding iso-8859-1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,15 @@ else()
   set(DEBUG 0)
 endif()
 
+option(USE_GCOV "Enable gcov support" OFF)
+
+if(USE_GCOV)
+  message(STATUS "Enabling gcov support")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+endif()
+
 # Modules used by platform auto-detection
 include(CheckLibraryExists)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/neovim/neovim.png?branch=master)](https://travis-ci.org/neovim/neovim)
 [![Stories in Ready](https://badge.waffle.io/neovim/neovim.png?label=ready)](https://waffle.io/neovim/neovim)
+[![Coverage Status](https://coveralls.io/repos/neovim/neovim/badge.png)](https://coveralls.io/r/neovim/neovim)
 
 Neovim is a project that seeks to aggressively refactor Vim in order to:
 

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -42,3 +42,5 @@ wget -q -O - http://llvm.org/releases/3.4/clang+llvm-3.4-x86_64-unknown-ubuntu12
 
 # [ -n "$USE_CLANG_34" ] &&
 # 	apt-get -qq -y --no-install-recommends install clang-3.4 lldb-3.4
+
+pip install cpp-coveralls --use-mirrors

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -60,7 +60,7 @@ if [ "$CC" = "clang" ]; then
 	export SKIP_UNITTEST=1
 	export UBSAN_OPTIONS="log_path=$tmpdir/ubsan" # not sure if this works
 
-	$MAKE_CMD cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$install_dir"
+	$MAKE_CMD cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$install_dir -DUSE_GCOV=ON"
 	$MAKE_CMD
 	if ! $MAKE_CMD test; then
 		reset
@@ -70,7 +70,7 @@ if [ "$CC" = "clang" ]; then
 	$MAKE_CMD install
 else
 	export SKIP_EXEC=1
-	$MAKE_CMD CMAKE_EXTRA_FLAGS="-DBUSTED_OUTPUT_TYPE=TAP"
-	$MAKE_CMD cmake
+	$MAKE_CMD CMAKE_EXTRA_FLAGS="-DBUSTED_OUTPUT_TYPE=TAP -DUSE_GCOV=ON"
+	$MAKE_CMD cmake CMAKE_EXTRA_FLAGS="-DUSE_GCOV=ON"
 	$MAKE_CMD unittest
 fi


### PR DESCRIPTION
Hopefully generating test coverage reports will make it easier for people to contribute tests, which is a Good Thing.

Currently blocked by:
- all the other stuff happening with the build system
- coveralls.io are doing maintenance ATM
