### PR TITLE
Move `*arg_T` from `structs.h` to `normal.h`

### DIFF
--- a/src/ex_cmds_defs.h
+++ b/src/ex_cmds_defs.h
@@ -6,6 +6,8 @@
  * Do ":help credits" in Vim to see a list of people who contributed.
  */
 
+#include "normal.h"
+
 /*
  * This file defines the Ex commands.
  * When DO_DECLARE_EXCMD is defined, the table with ex command names and

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -34,6 +34,7 @@
 #include "crypt.h"
 #include "garray.h"
 #include "move.h"
+#include "normal.h"
 #include "option.h"
 #include "os_unix.h"
 #include "quickfix.h"

--- a/src/main.h
+++ b/src/main.h
@@ -1,6 +1,8 @@
 #ifndef NEOVIM_MAIN_H
 #define NEOVIM_MAIN_H
-/* main.c */
+
+#include "normal.h"
+
 void main_loop(int cmdwin, int noexmode);
 void getout_preserve_modified(int exitval);
 void getout(int exitval);

--- a/src/mark.c
+++ b/src/mark.c
@@ -25,6 +25,7 @@
 #include "message.h"
 #include "misc1.h"
 #include "misc2.h"
+#include "normal.h"
 #include "option.h"
 #include "quickfix.h"
 #include "search.h"

--- a/src/message.c
+++ b/src/message.c
@@ -27,6 +27,7 @@
 #include "garray.h"
 #include "ops.h"
 #include "option.h"
+#include "normal.h"
 #include "screen.h"
 #include "term.h"
 #include "ui.h"

--- a/src/normal.h
+++ b/src/normal.h
@@ -1,6 +1,61 @@
 #ifndef NEOVIM_NORMAL_H
 #define NEOVIM_NORMAL_H
-/* normal.c */
+
+#include "pos.h"
+
+/*
+ * Arguments for operators.
+ */
+typedef struct oparg_S {
+  int op_type;                  /* current pending operator type */
+  int regname;                  /* register to use for the operator */
+  int motion_type;              /* type of the current cursor motion */
+  int motion_force;             /* force motion type: 'v', 'V' or CTRL-V */
+  int use_reg_one;              /* TRUE if delete uses reg 1 even when not
+                                   linewise */
+  int inclusive;                /* TRUE if char motion is inclusive (only
+                                   valid when motion_type is MCHAR */
+  int end_adjusted;             /* backuped b_op_end one char (only used by
+                                   do_format()) */
+  pos_T start;                  /* start of the operator */
+  pos_T end;                    /* end of the operator */
+  pos_T cursor_start;           /* cursor position before motion for "gw" */
+
+  long line_count;              /* number of lines from op_start to op_end
+                                   (inclusive) */
+  int empty;                    /* op_start and op_end the same (only used by
+                                   do_change()) */
+  int is_VIsual;                /* operator on Visual area */
+  int block_mode;               /* current operator is Visual block mode */
+  colnr_T start_vcol;           /* start col for block mode operator */
+  colnr_T end_vcol;             /* end col for block mode operator */
+  long prev_opcount;            /* ca.opcount saved for K_CURSORHOLD */
+  long prev_count0;             /* ca.count0 saved for K_CURSORHOLD */
+} oparg_T;
+
+/*
+ * Arguments for Normal mode commands.
+ */
+typedef struct cmdarg_S {
+  oparg_T     *oap;             /* Operator arguments */
+  int prechar;                  /* prefix character (optional, always 'g') */
+  int cmdchar;                  /* command character */
+  int nchar;                    /* next command character (optional) */
+  int ncharC1;                  /* first composing character (optional) */
+  int ncharC2;                  /* second composing character (optional) */
+  int extra_char;               /* yet another character (optional) */
+  long opcount;                 /* count before an operator */
+  long count0;                  /* count before command, default 0 */
+  long count1;                  /* count before command, default 1 */
+  int arg;                      /* extra argument from nv_cmds[] */
+  int retval;                   /* return: CA_* values */
+  char_u      *searchbuf;       /* return: pointer to search pattern or NULL */
+} cmdarg_T;
+
+/* values for retval: */
+#define CA_COMMAND_BUSY     1   /* skip restarting edit() once */
+#define CA_NO_ADJ_OP_END    2   /* don't adjust operator end */
+
 void init_normal_cmds(void);
 void normal_cmd(oparg_T *oap, int toplevel);
 void do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank);

--- a/src/pos.h
+++ b/src/pos.h
@@ -1,0 +1,23 @@
+#ifndef NEOVIM_POS_H
+#define NEOVIM_POS_H
+
+/*
+ * position in file or buffer
+ */
+typedef struct {
+  linenr_T lnum;        /* line number */
+  colnr_T col;          /* column number */
+  colnr_T coladd;
+} pos_T;
+
+# define INIT_POS_T(l, c, ca) {l, c, ca}
+
+/*
+ * Same, but without coladd.
+ */
+typedef struct {
+  linenr_T lnum;        /* line number */
+  colnr_T col;          /* column number */
+} lpos_T;
+
+#endif /* NEOVIM_POS_H */

--- a/src/regexp_defs.h
+++ b/src/regexp_defs.h
@@ -13,6 +13,8 @@
 #ifndef _REGEXP_H
 #define _REGEXP_H
 
+#include "pos.h"
+
 /*
  * The number of sub-matches is limited to 10.
  * The first one (index 0) is the whole match, referenced with "\0".

--- a/src/structs.h
+++ b/src/structs.h
@@ -8,29 +8,12 @@
 
 // for garray_T
 #include "garray.h"
+// for pos_T and lpos_T
+#include "pos.h"
 
 /*
  * This file contains various definitions of structures that are used by Vim
  */
-
-/*
- * position in file or buffer
- */
-typedef struct {
-  linenr_T lnum;        /* line number */
-  colnr_T col;          /* column number */
-  colnr_T coladd;
-} pos_T;
-
-# define INIT_POS_T(l, c, ca) {l, c, ca}
-
-/*
- * Same, but without coladd.
- */
-typedef struct {
-  linenr_T lnum;        /* line number */
-  colnr_T col;          /* column number */
-} lpos_T;
 
 typedef struct window_S win_T;
 typedef struct wininfo_S wininfo_T;
@@ -39,7 +22,7 @@ typedef int scid_T;                             /* script ID */
 typedef struct file_buffer buf_T;       /* forward declaration */
 
 /*
- * This is here because regexp_defs.h needs pos_T and below regprog_T is used.
+ * This is here because regexp_defs.h needs win_T and regprog_T is used below.
  */
 #include "regexp_defs.h"
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -1722,67 +1722,7 @@ struct window_S {
    * In a non-location list window, w_llist_ref is NULL.
    */
   qf_info_T   *w_llist_ref;
-
-
-
-
-
-
-
 };
-
-/*
- * Arguments for operators.
- */
-typedef struct oparg_S {
-  int op_type;                  /* current pending operator type */
-  int regname;                  /* register to use for the operator */
-  int motion_type;              /* type of the current cursor motion */
-  int motion_force;             /* force motion type: 'v', 'V' or CTRL-V */
-  int use_reg_one;              /* TRUE if delete uses reg 1 even when not
-                                   linewise */
-  int inclusive;                /* TRUE if char motion is inclusive (only
-                                   valid when motion_type is MCHAR */
-  int end_adjusted;             /* backuped b_op_end one char (only used by
-                                   do_format()) */
-  pos_T start;                  /* start of the operator */
-  pos_T end;                    /* end of the operator */
-  pos_T cursor_start;           /* cursor position before motion for "gw" */
-
-  long line_count;              /* number of lines from op_start to op_end
-                                   (inclusive) */
-  int empty;                    /* op_start and op_end the same (only used by
-                                   do_change()) */
-  int is_VIsual;                /* operator on Visual area */
-  int block_mode;               /* current operator is Visual block mode */
-  colnr_T start_vcol;           /* start col for block mode operator */
-  colnr_T end_vcol;             /* end col for block mode operator */
-  long prev_opcount;            /* ca.opcount saved for K_CURSORHOLD */
-  long prev_count0;             /* ca.count0 saved for K_CURSORHOLD */
-} oparg_T;
-
-/*
- * Arguments for Normal mode commands.
- */
-typedef struct cmdarg_S {
-  oparg_T     *oap;             /* Operator arguments */
-  int prechar;                  /* prefix character (optional, always 'g') */
-  int cmdchar;                  /* command character */
-  int nchar;                    /* next command character (optional) */
-  int ncharC1;                  /* first composing character (optional) */
-  int ncharC2;                  /* second composing character (optional) */
-  int extra_char;               /* yet another character (optional) */
-  long opcount;                 /* count before an operator */
-  long count0;                  /* count before command, default 0 */
-  long count1;                  /* count before command, default 1 */
-  int arg;                      /* extra argument from nv_cmds[] */
-  int retval;                   /* return: CA_* values */
-  char_u      *searchbuf;       /* return: pointer to search pattern or NULL */
-} cmdarg_T;
-
-/* values for retval: */
-#define CA_COMMAND_BUSY     1   /* skip restarting edit() once */
-#define CA_NO_ADJ_OP_END    2   /* don't adjust operator end */
 
 #ifdef CURSOR_SHAPE
 /*


### PR DESCRIPTION
I had to move the `pos_T` and `lpos_T` to a new `pos.h` file to be able to move types that rely on `pos_T` from `structs.h`. `pos_T` is very small and in the future, with a simpler codebase will be able to put it into another header.
