### PR TITLE
[RFC] Add better way to install travis dependencies

### DIFF
--- a/scripts/travis-deps.sh
+++ b/scripts/travis-deps.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+. scripts/common.sh
+
+deps_ver=87ed1667957410341686ec50f0f8c9d2ca4abffd
+deps_repo=tarruda/deps
+deps_sha1=2e36cf7f01009207ec649941536f3e60740e0f7c
+deps_dir=/opt/neovim-deps
+
+github_download "$deps_repo" "$deps_ver" "$deps_dir" "$deps_sha1"


### PR DESCRIPTION
All dependencies for building/testing are built into an external github
repository. This script will install everything into /opt/neovim-deps, and by
having github as single point of failure, travis builds are now very reliable.

From my POV this is a good thing, because we can rest assured that travis builds won't fail due to broken external servers. It will also speed up travis builds.

@jszakmeister what are your thoughts? Since you are handling build-related issues I leave this to your decision. If you like this solution, feel free to bundle it with #348
