### PR TITLE
[RDY] Include <stdint.h> in types.h and libuv's <stdint-msvc2008.h> for old MSVC

### DIFF
--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -461,14 +461,6 @@ static int bf_self_test(void)                {
   int i, bn;
   int err = 0;
   block8 bk;
-  uint32_t ui = 0xffffffffUL;
-
-  /* We can't simply use sizeof(uint32_t), it would generate a compiler
-   * warning. */
-  if (ui != 0xffffffffUL || ui + 1 != 0) {
-    err++;
-    EMSG(_("E820: sizeof(uint32_t) != 4"));
-  }
 
   if (!bf_check_tables(ipa, sbi, 0x6ffa520a))
     err++;

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -23,20 +23,20 @@
 #define BF_OFB_LEN  (8*(BF_BLOCK))
 
 typedef union {
-  UINT32_T ul[2];
+  uint32_t ul[2];
   char_u uc[8];
 } block8;
 
 
-static void bf_e_block(UINT32_T *p_xl, UINT32_T *p_xr);
+static void bf_e_block(uint32_t *p_xl, uint32_t *p_xr);
 static void bf_e_cblock(char_u *block);
-static int bf_check_tables(UINT32_T a_ipa[18], UINT32_T a_sbi[4][256],
-                           UINT32_T val);
+static int bf_check_tables(uint32_t a_ipa[18], uint32_t a_sbi[4][256],
+                           uint32_t val);
 static int bf_self_test(void);
 
 /* Blowfish code */
-static UINT32_T pax[18];
-static UINT32_T ipa[18] = {
+static uint32_t pax[18];
+static uint32_t ipa[18] = {
   0x243f6a88u, 0x85a308d3u, 0x13198a2eu,
   0x03707344u, 0xa4093822u, 0x299f31d0u,
   0x082efa98u, 0xec4e6c89u, 0x452821e6u,
@@ -45,8 +45,8 @@ static UINT32_T ipa[18] = {
   0xb5470917u, 0x9216d5d9u, 0x8979fb1bu
 };
 
-static UINT32_T sbx[4][256];
-static UINT32_T sbi[4][256] = {
+static uint32_t sbx[4][256];
+static uint32_t sbi[4][256] = {
   {0xd1310ba6u, 0x98dfb5acu, 0x2ffd72dbu, 0xd01adfb7u,
    0xb8e1afedu, 0x6a267e96u, 0xba7c9045u, 0xf12c7f99u,
    0x24a19947u, 0xb3916cf7u, 0x0801f2e2u, 0x858efc16u,
@@ -321,9 +321,9 @@ static UINT32_T sbi[4][256] = {
         sbx[3][xr & 0xFF];
 
 
-static void bf_e_block(UINT32_T *p_xl, UINT32_T *p_xr)
+static void bf_e_block(uint32_t *p_xl, uint32_t *p_xr)
 {
-  UINT32_T temp, xl = *p_xl, xr = *p_xr;
+  uint32_t temp, xl = *p_xl, xr = *p_xr;
 
   F1(0) F2(1) F1(2) F2(3) F1(4) F2(5) F1(6) F2(7)
   F1(8) F2(9) F1(10) F2(11) F1(12) F2(13) F1(14) F2(15)
@@ -368,7 +368,7 @@ void bf_key_init(char_u *password, char_u *salt, int salt_len)
 {
   int i, j, keypos = 0;
   unsigned u;
-  UINT32_T val, data_l, data_r;
+  uint32_t val, data_l, data_r;
   char_u   *key;
   int keylen;
 
@@ -417,10 +417,10 @@ void bf_key_init(char_u *password, char_u *salt, int salt_len)
 /*
  * BF Self test for corrupted tables or instructions
  */
-static int bf_check_tables(UINT32_T a_ipa[18], UINT32_T a_sbi[4][256], UINT32_T val)
+static int bf_check_tables(uint32_t a_ipa[18], uint32_t a_sbi[4][256], uint32_t val)
 {
   int i, j;
-  UINT32_T c = 0;
+  uint32_t c = 0;
 
   for (i = 0; i < 18; i++)
     c ^= a_ipa[i];
@@ -436,7 +436,7 @@ typedef struct {
   char_u plaintxt[9];
   char_u cryptxt[9];
   char_u badcryptxt[9];     /* cryptxt when big/little endian is wrong */
-  UINT32_T keysum;
+  uint32_t keysum;
 } struct_bf_test_data;
 
 /*
@@ -461,9 +461,9 @@ static int bf_self_test(void)                {
   int i, bn;
   int err = 0;
   block8 bk;
-  UINT32_T ui = 0xffffffffUL;
+  uint32_t ui = 0xffffffffUL;
 
-  /* We can't simply use sizeof(UINT32_T), it would generate a compiler
+  /* We can't simply use sizeof(uint32_t), it would generate a compiler
    * warning. */
   if (ui != 0xffffffffUL || ui + 1 != 0) {
     err++;
@@ -580,8 +580,8 @@ bf_crypt_init_keys (
 static int save_randbyte_offset;
 static int save_update_offset;
 static char_u save_ofb_buffer[BF_OFB_LEN];
-static UINT32_T save_pax[18];
-static UINT32_T save_sbx[4][256];
+static uint32_t save_pax[18];
+static uint32_t save_sbx[4][256];
 
 /*
  * Save the current crypt state.  Can only be used once before

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3652,7 +3652,7 @@ restore_backup:
      */
     ptr = ml_get_buf(buf, lnum, FALSE) - 1;
     if (write_undo_file)
-      sha256_update(&sha_ctx, ptr + 1, (UINT32_T)(STRLEN(ptr + 1) + 1));
+      sha256_update(&sha_ctx, ptr + 1, (uint32_t)(STRLEN(ptr + 1) + 1));
     while ((c = *++ptr) != NUL) {
       if (c == NL)
         *s = NUL;                       /* replace newlines with NULs */

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -27,10 +27,10 @@ static void sha256_process(context_sha256_T *ctx, char_u data[64]);
 
 #define GET_UINT32(n, b, i)                 \
   {                                           \
-    (n) = ( (UINT32_T)(b)[(i)    ] << 24)   \
-          | ( (UINT32_T)(b)[(i) + 1] << 16)   \
-          | ( (UINT32_T)(b)[(i) + 2] <<  8)   \
-          | ( (UINT32_T)(b)[(i) + 3]      );  \
+    (n) = ( (uint32_t)(b)[(i)    ] << 24)   \
+          | ( (uint32_t)(b)[(i) + 1] << 16)   \
+          | ( (uint32_t)(b)[(i) + 2] <<  8)   \
+          | ( (uint32_t)(b)[(i) + 3]      );  \
   }
 
 #define PUT_UINT32(n,b,i)                 \
@@ -58,8 +58,8 @@ void sha256_start(context_sha256_T *ctx)
 
 static void sha256_process(context_sha256_T *ctx, char_u data[64])
 {
-  UINT32_T temp1, temp2, W[64];
-  UINT32_T A, B, C, D, E, F, G, H;
+  uint32_t temp1, temp2, W[64];
+  uint32_t A, B, C, D, E, F, G, H;
 
   GET_UINT32(W[0],  data,  0);
   GET_UINT32(W[1],  data,  4);
@@ -187,9 +187,9 @@ static void sha256_process(context_sha256_T *ctx, char_u data[64])
   ctx->state[7] += H;
 }
 
-void sha256_update(context_sha256_T *ctx, char_u *input, UINT32_T length)
+void sha256_update(context_sha256_T *ctx, char_u *input, uint32_t length)
 {
-  UINT32_T left, fill;
+  uint32_t left, fill;
 
   if (length == 0)
     return;
@@ -230,8 +230,8 @@ static char_u sha256_padding[64] = {
 
 void sha256_finish(context_sha256_T *ctx, char_u digest[32])
 {
-  UINT32_T last, padn;
-  UINT32_T high, low;
+  uint32_t last, padn;
+  uint32_t high, low;
   char_u msglen[8];
 
   high = (ctx->total[0] >> 29) | (ctx->total[1] <<  3);

--- a/src/sha256.h
+++ b/src/sha256.h
@@ -2,14 +2,14 @@
 #define NEOVIM_SHA256_H
 
 typedef struct {
-  UINT32_T total[2];
-  UINT32_T state[8];
+  uint32_t total[2];
+  uint32_t state[8];
   char_u buffer[64];
 } context_sha256_T;
 
 void sha256_start(context_sha256_T *ctx);
 void sha256_update(context_sha256_T *ctx, char_u *input,
-                   UINT32_T length);
+                   uint32_t length);
 void sha256_finish(context_sha256_T *ctx, char_u digest[32]);
 char_u *sha256_bytes(char_u *buf, int buf_len, char_u *salt,
                      int salt_len);

--- a/src/types.h
+++ b/src/types.h
@@ -9,6 +9,8 @@
 #ifndef NEOVIM_TYPES_H
 #define NEOVIM_TYPES_H
 
+#include <stdint.h>
+
 /*
  * Shorthand for unsigned variables. Many systems, but not all, have u_char
  * already defined, so we use char_u to avoid trouble.

--- a/src/undo.c
+++ b/src/undo.c
@@ -666,7 +666,7 @@ void u_compute_hash(char_u *hash)
   sha256_start(&ctx);
   for (lnum = 1; lnum <= curbuf->b_ml.ml_line_count; ++lnum) {
     p = ml_get(lnum);
-    sha256_update(&ctx, p, (UINT32_T)(STRLEN(p) + 1));
+    sha256_update(&ctx, p, (uint32_t)(STRLEN(p) + 1));
   }
   sha256_finish(&ctx, hash);
 }

--- a/src/vim.h
+++ b/src/vim.h
@@ -149,9 +149,6 @@ typedef unsigned long u8char_T;     /* long should be 32 bits or more */
 
 #include <assert.h>
 
-#ifdef HAVE_STDINT_H
-# include <stdint.h>
-#endif
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>
 #endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -41,19 +41,6 @@ Error: configure did not run properly.Check auto/config.log.
  * doesn't work well and avoiding it keeps the binary backward compatible.
  */
 
-/* We may need to define the uint32_t on non-Unix system, but using the same
- * identifier causes conflicts.  Therefore use UINT32_T. */
-# define UINT32_TYPEDEF uint32_t
-#endif
-
-#if !defined(UINT32_TYPEDEF)
-# if defined(uint32_t)  /* this doesn't catch typedefs, unfortunately */
-#  define UINT32_TYPEDEF uint32_t
-# else
-/* Fall back to assuming unsigned int is 32 bit.  If this is wrong then the
- * test in blowfish.c will fail. */
-#  define UINT32_TYPEDEF unsigned int
-# endif
 #endif
 
 /* user ID of root is usually zero, but not for everybody */
@@ -936,10 +923,6 @@ typedef enum {
 #endif
 
 #define MAYBE   2           /* sometimes used for a variant on TRUE */
-
-#ifndef UINT32_T
-typedef UINT32_TYPEDEF UINT32_T;
-#endif
 
 /*
  * Operator IDs; The order must correspond to opchars[] in ops.c!


### PR DESCRIPTION
In short, this is PR #296 , but much less aggressive. I didn't redefine `long_u`, `long_i`... This would require changing many `printf`-style function calls to deal with the fact that long is 32-bits on Windows.

I replaced `UINT32_T` by `uint32_t`and deleted `UINT32_T` related code.

See my last comments there https://github.com/neovim/neovim/pull/296#issuecomment-37474283
