### PR TITLE
[RFC] Rearrange fields in struct vimvar (to fix issue #223)

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -311,7 +311,7 @@ typedef struct {
 #define VV_RO           2       /* read-only */
 #define VV_RO_SBX       4       /* read-only in the sandbox */
 
-#define VV_NAME(s, t)   s, {{t, 0, {0}}, 0, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}}
+#define VV_NAME(s, t)   s, {{t, 0, {0}}, 0, {0}}
 
 static struct vimvar {
   char        *vv_name;         /* name of variable, without v: */

--- a/src/eval.c
+++ b/src/eval.c
@@ -311,12 +311,11 @@ typedef struct {
 #define VV_RO           2       /* read-only */
 #define VV_RO_SBX       4       /* read-only in the sandbox */
 
-#define VV_NAME(s, t)   s, {{t, 0, {0}}, 0, {0}}, {0}
+#define VV_NAME(s, t)   s, {{t, 0, {0}}, 0, {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}}
 
 static struct vimvar {
   char        *vv_name;         /* name of variable, without v: */
   dictitem_T vv_di;             /* value and name for key */
-  char vv_filler[16];           /* space for LONGEST name below!!! */
   char vv_flags;                /* VV_COMPAT, VV_RO, VV_RO_SBX */
 } vimvars[VV_LEN] =
 {

--- a/src/structs.h
+++ b/src/structs.h
@@ -907,12 +907,11 @@ struct listvar_S {
 /*
  * Structure to hold an item of a Dictionary.
  * Also used for a variable.
- * The key is copied into "di_key" to avoid an extra alloc/free for it.
  */
 struct dictitem_S {
   typval_T di_tv;               /* type and value of the variable */
   char_u di_flags;              /* flags (only used for variable) */
-  char_u di_key[1];             /* key (actually longer!) */
+  char_u di_key[17];             /* key */
 };
 
 typedef struct dictitem_S dictitem_T;


### PR DESCRIPTION
As far as I can tell these changes should fix issue #223.

Since the vv_filler field is never accessed directly removing it should not have any negative impact.

I searched the code base for any issues that could arise from this change but since the memory layout should stay the same, nothing stood out to me. If I missed a critical case feel free to close this pull request.
