### PR TITLE
[RFC] Fix luajit cimport method

### DIFF
--- a/src/os_unix_defs.h
+++ b/src/os_unix_defs.h
@@ -89,13 +89,8 @@
 # endif
 #endif
 
-#if !defined(HAVE_SYS_TIME_H) || defined(TIME_WITH_SYS_TIME)
-# include <time.h>          /* on some systems time.h should not be
-                               included together with sys/time.h */
-#endif
-#ifdef HAVE_SYS_TIME_H
-# include <sys/time.h>
-#endif
+#include <time.h>
+#include <sys/time.h>
 
 #include <signal.h>
 

--- a/test/unit/helpers.moon
+++ b/test/unit/helpers.moon
@@ -10,17 +10,16 @@ cimport = (...) ->
 
   for path in *paths
     new_cdefs = {}
-    header_file = io.popen "/usr/bin/env cc -E #{path}"
+    header_file = io.popen "/usr/bin/env cc -P -E #{path}"
 
     if not header_file
       error "cannot find #{path}"
 
     for line in header_file\lines! do
-      if not line\match '^#[^\n]*$'
-        -- find if line has already been cdef'ed
-        defined = [buffer_line for buffer_line in *cdef_buffer when line == buffer_line]
-        if next(defined) == nil
-          table.insert(new_cdefs, line)
+      -- find if line has already been cdef'ed
+      defined = [buffer_line for buffer_line in *cdef_buffer when line == buffer_line]
+      if next(defined) == nil
+        table.insert(new_cdefs, line)
 
     header_file.close!
 

--- a/test/unit/helpers.moon
+++ b/test/unit/helpers.moon
@@ -1,46 +1,56 @@
-ffi = require 'ffi'
+-- cdef_buffer keeps a list of all the lines that have been defined.
+-- cdef_buffer is global because anything defined by ffi.cdef is permanent to the process
 
--- load neovim shared library
-libnvim = ffi.load './build/src/libnvim-test.so'
+export cdef_buffer = {}
 
--- Luajit ffi parser doesn't understand preprocessor directives, so
--- this helper function removes common directives before passing it the to ffi.
--- It will return a pointer to the library table, emulating 'requires'
-cimport = (path) ->
-  header_file = io.open path, 'rb'
+cimport = (...) ->
+  paths = {...}
+  ffi = require 'ffi'
+  libnvim = ffi.load './build/src/libnvim-test.so'
 
-  if not header_file
-    error "cannot find #{path}"
+  for path in *paths
+    new_cdefs = {}
+    header_file = io.popen "/usr/bin/env cc -E #{path}"
 
-  header = header_file\read '*a'
-  header_file.close!
-  header = string.gsub header, '#include[^\n]*\n', ''
-  header = string.gsub header, '#ifndef[^\n]*\n', ''
-  header = string.gsub header, '#define[^\n]*\n', ''
-  header = string.gsub header, '#endif[^\n]*\n', ''
-  ffi.cdef header
+    if not header_file
+      error "cannot find #{path}"
 
-  return libnvim
+    for line in header_file\lines! do
+      if not line\match '^#[^\n]*$'
+        -- find if line has already been cdef'ed
+        defined = [buffer_line for buffer_line in *cdef_buffer when line == buffer_line]
+        if next(defined) == nil
+          table.insert(new_cdefs, line)
 
-cimport './src/types.h'
+    header_file.close!
 
--- take a pointer to a C-allocated string and return an interned
--- version while also freeing the memory
-internalize = (cdata) ->
-  ffi.gc cdata, ffi.C.free
-  return ffi.string cdata
+    -- add the lines to the buffer
+    for line in *new_cdefs
+      table.insert(cdef_buffer, line)
 
-cstr = ffi.typeof 'char[?]'
+    ffi.cdef table.concat(new_cdefs, "\n")
 
-to_cstr = (string) ->
-  cstr (string.len string) + 1, string
+  -- take a pointer to a C-allocated string and return an interned
+  -- version while also freeing the memory
+  internalize = (cdata) ->
+    ffi.gc cdata, ffi.C.free
+    return ffi.string cdata
+
+  cstr = ffi.typeof 'char[?]'
+
+  to_cstr = (string) ->
+    cstr (string.len string) + 1, string
+
+  return {
+    ffi: ffi
+    lib: libnvim
+    cstr: cstr
+    to_cstr: to_cstr
+    internalize: internalize
+  }
+
 
 return {
   cimport: cimport
-  internalize: internalize
   eq: (expected, actual) -> assert.are.same expected, actual
-  ffi: ffi
-  lib: libnvim
-  cstr: cstr
-  to_cstr: to_cstr
 }

--- a/test/unit/misc1.moon
+++ b/test/unit/misc1.moon
@@ -1,18 +1,16 @@
-{:cimport, :internalize, :eq, :ffi, :lib, :cstr, :to_cstr} = require 'test.unit.helpers'
+import cimport, eq from require 'test.unit.helpers'
+import lib, ffi, cstr, to_cstr, internalize from cimport './src/types.h', './src/vim.h', './src/misc1.h'
 
---misc1 = cimport './src/misc1.h'
-
--- remove these statements once 'cimport' is working properly for misc1.h
 misc1 = lib
+
 ffi.cdef [[
 enum FPC {
   FPC_SAME = 1, FPC_DIFF = 2, FPC_NOTX = 4, FPC_DIFFX = 6, FPC_SAMEX = 7
 };
-int fullpathcmp(char_u *s1, char_u *s2, int checkname);
 ]]
 
 -- import constants parsed by ffi
-{:FPC_SAME, :FPC_DIFF, :FPC_NOTX, :FPC_DIFFX, :FPC_SAMEX} = lib
+{:FPC_SAME, :FPC_DIFF, :FPC_NOTX, :FPC_DIFFX, :FPC_SAMEX} = misc1
 
 describe 'misc1 function', ->
   describe 'fullpathcmp', ->

--- a/test/unit/os/env.moon
+++ b/test/unit/os/env.moon
@@ -1,14 +1,8 @@
-{:cimport, :internalize, :eq, :ffi, :lib, :cstr, :to_cstr} = require 'test.unit.helpers'
+import cimport, eq from require 'test.unit.helpers'
+import lib, ffi, cstr, to_cstr, internalize from cimport './src/types.h', './src/os/os.h'
 require 'lfs'
 
--- fs = cimport './src/os/os.h'
--- remove these statements once 'cimport' is working properly for misc1.h
 env = lib
-ffi.cdef [[
-const char *mch_getenv(const char *name);
-int mch_setenv(const char *name, const char *value, int override);
-char *mch_getenvname_at_index(size_t index);
-]]
 
 NULL = ffi.cast 'void*', 0
 

--- a/test/unit/os/fs.moon
+++ b/test/unit/os/fs.moon
@@ -1,9 +1,10 @@
-{:cimport, :internalize, :eq, :ffi, :lib, :cstr, :to_cstr} = require 'test.unit.helpers'
+import cimport, eq from require 'test.unit.helpers'
+import lib, ffi, cstr, to_cstr, internalize from cimport './src/types.h', './src/os/os.h'
+
+fs = lib
+
 require 'lfs'
 
--- fs = cimport './src/os/os.h'
--- remove these statements once 'cimport' is working properly for misc1.h
-fs = lib
 ffi.cdef [[
 enum OKFAIL {
   OK = 1, FAIL = 0
@@ -11,10 +12,6 @@ enum OKFAIL {
 enum BOOLEAN {
   TRUE = 1, FALSE = 0
 };
-int mch_dirname(char_u *buf, int len);
-int mch_isdir(char_u * name);
-int is_executable(char_u *name);
-int mch_can_exe(char_u *name);
 ]]
 
 -- import constants parsed by ffi

--- a/test/unit/os/users.moon
+++ b/test/unit/os/users.moon
@@ -1,5 +1,5 @@
 import cimport, eq from require 'test.unit.helpers'
-import lib, ffi, cstr, to_cstr, internalize from cimport './src/types.h', './src/vim.h', './src/misc1.h'
+import lib, ffi, cstr, to_cstr, internalize from cimport './src/types.h', './src/os/os.h'
 
 users = lib
 

--- a/test/unit/os/users.moon
+++ b/test/unit/os/users.moon
@@ -1,20 +1,9 @@
-{:cimport, :internalize, :eq, :ffi, :lib, :cstr} = require 'test.unit.helpers'
+import cimport, eq from require 'test.unit.helpers'
+import lib, ffi, cstr, to_cstr, internalize from cimport './src/types.h', './src/vim.h', './src/misc1.h'
 
--- fs = cimport './src/os/os.h'
--- remove these statements once 'cimport' is working properly for misc1.h
 users = lib
+
 ffi.cdef [[
-typedef struct growarray {
-  int ga_len;
-  int ga_maxlen;
-  int ga_itemsize;
-  int ga_growsize;
-  void    *ga_data;
-} garray_T;
-int mch_get_usernames(garray_T *usernames);
-int mch_get_user_name(char *s, size_t len);
-int mch_get_uname(int uid, char *s, size_t len);
-char *mch_get_user_directory(const char *name);
 int getuid(void);
 ]]
 


### PR DESCRIPTION
This PR removes method declarations from `ffi.cdef` in each test, making it easier to begin writing tests for existing functionality. Any `#define` are still required to be cdef'ed as enums for now.

The one thing I am unsure about is the change I had to make to `src/os_unix_defs.h` which was needed to define the `timeval` struct.

I have only tested this on Mac OS X.
