### PR TITLE
[RDY] refactor use of access() into `os/fs.c`

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -8881,7 +8881,8 @@ static void f_filereadable(typval_T *argvars, typval_T *rettv)
  */
 static void f_filewritable(typval_T *argvars, typval_T *rettv)
 {
-  rettv->vval.v_number = filewritable(get_tv_string(&argvars[0]));
+  char *filename = (char *)get_tv_string(&argvars[0]);
+  rettv->vval.v_number = os_file_is_writable(filename);
 }
 
 static void findfilendir(typval_T *argvars, typval_T *rettv,

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2496,15 +2496,11 @@ int not_writing(void)
  */
 static int check_readonly(int *forceit, buf_T *buf)
 {
-  struct stat st;
-
   /* Handle a file being readonly when the 'readonly' option is set or when
-   * the file exists and permissions are read-only.
-   * We will send 0777 to check_file_readonly(), as the "perm" variable is
-   * important for device checks but not here. */
+   * the file exists and permissions are read-only. */
   if (!*forceit && (buf->b_p_ro
-                    || (mch_stat((char *)buf->b_ffname, &st) >= 0
-                        && check_file_readonly(buf->b_ffname, 0777)))) {
+                    || (os_file_exists(buf->b_ffname)
+                        && os_file_is_readonly((char *)buf->b_ffname)))) {
     if ((p_confirm || cmdmod.confirm) && buf->b_fname != NULL) {
       char_u buff[DIALOG_MSG_SIZE];
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -472,16 +472,19 @@ readfile (
   }
 
   /*
-   * check readonly by trying to open the file for writing
+   * Check readonly by trying to open the file for writing.
+   * If this fails, we know that the file is readonly.
    */
   file_readonly = FALSE;
-  if (read_stdin) {
-  } else if (!read_buffer) {
-    if (!newfile
-        || readonlymode
-        || (fd = mch_open((char *)fname, O_RDWR | O_EXTRA, 0)) < 0) {
+  if (!read_buffer && !read_stdin) {
+    if (!newfile || readonlymode) {
       file_readonly = TRUE;
-      /* try to open ro */
+    } else if ((fd = mch_open((char *)fname, O_RDWR | O_EXTRA, 0)) < 0) {
+      // opening in readwrite mode failed => file is readonly
+      file_readonly = TRUE;
+    }
+    if (file_readonly == TRUE) {
+      // try to open readonly
       fd = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0);
     }
   }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -475,21 +475,11 @@ readfile (
   }
 
   /*
-   * for UNIX: check readonly with perm and mch_access()
-   * for MSDOS and Amiga: check readonly by trying to open the file for writing
+   * check readonly by trying to open the file for writing
    */
   file_readonly = FALSE;
   if (read_stdin) {
   } else if (!read_buffer) {
-#ifdef USE_MCH_ACCESS
-    if (
-# ifdef UNIX
-      !(perm & 0222) ||
-# endif
-      mch_access((char *)fname, W_OK))
-      file_readonly = TRUE;
-    fd = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0);
-#else
     if (!newfile
         || readonlymode
         || (fd = mch_open((char *)fname, O_RDWR | O_EXTRA, 0)) < 0) {
@@ -497,7 +487,6 @@ readfile (
       /* try to open ro */
       fd = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0);
     }
-#endif
   }
 
   if (fd < 0) {                     /* cannot open at all */

--- a/src/macros.h
+++ b/src/macros.h
@@ -120,7 +120,6 @@
  * On VMS file names are different and require a translation.
  * On the Mac open() has only two arguments.
  */
-#   define mch_access(n, p)     access((n), (p))
 #  define mch_fopen(n, p)       fopen((n), (p))
 # define mch_fstat(n, p)        fstat((n), (p))
 #  ifdef STAT_IGNORES_SLASH

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1686,33 +1686,6 @@ void sort_strings(char_u **files, int count)
 }
 
 /*
- * Return 0 for not writable, 1 for writable file, 2 for a dir which we have
- * rights to write into.
- */
-int filewritable(char_u *fname)
-{
-  int retval = 0;
-#if defined(UNIX) || defined(VMS)
-  int perm = 0;
-#endif
-
-#if defined(UNIX) || defined(VMS)
-  perm = os_getperm(fname);
-#endif
-  if (
-# if defined(UNIX) || defined(VMS)
-    (perm & 0222) &&
-#  endif
-    mch_access((char *)fname, W_OK) == 0
-    ) {
-    ++retval;
-    if (os_isdir(fname))
-      ++retval;
-  }
-  return retval;
-}
-
-/*
  * Print an error message with one or two "%s" and one or two string arguments.
  * This is not in message.c to avoid a warning for prototypes.
  */

--- a/src/misc2.h
+++ b/src/misc2.h
@@ -72,7 +72,6 @@ int vim_chdirfile(char_u *fname);
 int illegal_slash(char *name);
 int vim_chdir(char_u *new_dir);
 void sort_strings(char_u **files, int count);
-int filewritable(char_u *fname);
 int emsg3(char_u *s, char_u *a1, char_u *a2);
 int emsgn(char_u *s, long n);
 int get2c(FILE *fd);

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -281,7 +281,7 @@ int os_file_exists(const char_u *name)
 // return TRUE if a file appears to be read-only from the file permissions.
 int os_file_is_readonly(const char *name)
 {
-  if (mch_access(name, W_OK) == 0) {
+  if (access(name, W_OK) == 0) {
     return FALSE;
   } else {
     return TRUE;
@@ -292,7 +292,7 @@ int os_file_is_readonly(const char *name)
 // rights to write into.
 int os_file_is_writable(const char *name)
 {
-  if (mch_access(name, W_OK) == 0) {
+  if (access(name, W_OK) == 0) {
     if (os_isdir((char_u *)name)) {
       return 2;
     }

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -278,7 +278,6 @@ int os_file_exists(const char_u *name)
   }
 }
 
-// return TRUE if a file appears to be read-only from the file permissions.
 int os_file_is_readonly(const char *name)
 {
   if (access(name, W_OK) == 0) {
@@ -288,8 +287,6 @@ int os_file_is_readonly(const char *name)
   }
 }
 
-// return 0 for not writable, 1 for writable file, 2 for a dir which we have
-// rights to write into.
 int os_file_is_writable(const char *name)
 {
   if (access(name, W_OK) == 0) {

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -288,3 +288,16 @@ int os_file_is_readonly(const char *name)
   }
 }
 
+// return 0 for not writable, 1 for writable file, 2 for a dir which we have
+// rights to write into.
+int os_file_is_writable(const char *name)
+{
+  if (mch_access(name, W_OK) == 0) {
+    if (os_isdir((char_u *)name)) {
+      return 2;
+    }
+    return 1;
+  }
+  return 0;
+}
+

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -278,3 +278,13 @@ int os_file_exists(const char_u *name)
   }
 }
 
+// return TRUE if a file appears to be read-only from the file permissions.
+int os_file_is_readonly(const char *name)
+{
+  if (mch_access(name, W_OK) == 0) {
+    return FALSE;
+  } else {
+    return TRUE;
+  }
+}
+

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -60,6 +60,18 @@ int os_setperm(const char_u *name, int perm);
 /// @return `TRUE` if `name` exists.
 int os_file_exists(const char_u *name);
 
+/// Check if a file is readonly.
+///
+/// @return `True` if `name` is readonly.
+int os_file_is_readonly(const char *name);
+
+/// Check if a file is writable.
+///
+/// @return `0` if `name` is not writable,
+/// @return `1` if `name` is writable,
+/// @return `2` for a directory which we have rights to write into.
+int os_file_is_writable(const char *name);
+
 long_u os_total_mem(int special);
 const char *os_getenv(const char *name);
 int os_setenv(const char *name, const char *value, int overwrite);
@@ -68,7 +80,5 @@ int os_get_usernames(garray_T *usernames);
 int os_get_user_name(char *s, size_t len);
 int os_get_uname(uid_t uid, char *s, size_t len);
 char *os_get_user_directory(const char *name);
-int os_file_is_readonly(const char *name);
-int os_file_is_writable(const char *name);
 
 #endif  // NEOVIM_OS_OS_H

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -68,5 +68,6 @@ int os_get_usernames(garray_T *usernames);
 int os_get_user_name(char *s, size_t len);
 int os_get_uname(uid_t uid, char *s, size_t len);
 char *os_get_user_directory(const char *name);
+int os_file_is_readonly(const char *name);
 
 #endif  // NEOVIM_OS_OS_H

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -69,5 +69,6 @@ int os_get_user_name(char *s, size_t len);
 int os_get_uname(uid_t uid, char *s, size_t len);
 char *os_get_user_directory(const char *name);
 int os_file_is_readonly(const char *name);
+int os_file_is_writable(const char *name);
 
 #endif  // NEOVIM_OS_OS_H

--- a/src/os_unix_defs.h
+++ b/src/os_unix_defs.h
@@ -20,12 +20,6 @@
 # include <stdlib.h>
 #endif
 
-
-
-/* On AIX 4.2 there is a conflicting prototype for ioctl() in stropts.h and
- * unistd.h.  This hack should fix that (suggested by Jeff George).
- * But on AIX 4.3 it's alright (suggested by Jake Hamby). */
-
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif

--- a/src/spell.c
+++ b/src/spell.c
@@ -8587,7 +8587,7 @@ static void init_spellfile(void)
       else
         /* Copy the path from 'runtimepath' to buf[]. */
         copy_option_part(&rtp, buf, MAXPATHL, ",");
-      if (filewritable(buf) == 2) {
+      if (os_file_is_writable((char *)buf) == 2) {
         /* Use the first language name from 'spelllang' and the
          * encoding used in the first loaded .spl file. */
         if (aspath)
@@ -8597,7 +8597,7 @@ static void init_spellfile(void)
           /* Create the "spell" directory if it doesn't exist yet. */
           l = (int)STRLEN(buf);
           vim_snprintf((char *)buf + l, MAXPATHL - l, "/spell");
-          if (filewritable(buf) != 2)
+          if (os_file_is_writable((char *)buf) != 2)
             vim_mkdir(buf, 0755);
 
           l = (int)STRLEN(buf);

--- a/src/vim.h
+++ b/src/vim.h
@@ -1018,13 +1018,6 @@ typedef enum {
 # define O_NOFOLLOW 0
 #endif
 
-#ifndef W_OK
-# define W_OK 2         /* for systems that don't have W_OK in unistd.h */
-#endif
-#ifndef R_OK
-# define R_OK 4         /* for systems that don't have R_OK in unistd.h */
-#endif
-
 /*
  * defines to avoid typecasts from (char_u *) to (char *) and back
  * (vim_strchr() and vim_strrchr() are now in alloc.c)


### PR DESCRIPTION
It seems that there is no version of `access()` in `libuv`, so I use this function directly in `os/fs.c`. At least this function is not used anywhere outside the os abstraction layer.
