### PR TITLE
Remove unused define

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -250,7 +250,6 @@ readfile (
   context_sha256_T sha_ctx;
   int read_undo_file = FALSE;
   int split = 0;                        /* number of split lines */
-#define UNKNOWN  0x0fffffff             /* file size is unknown */
   linenr_T linecnt;
   int error = FALSE;                    /* errors encountered */
   int ff_error = EOL_UNKNOWN;           /* file format with errors */


### PR DESCRIPTION
This #define is used nowhere, so it should be safe to remove it.
