### PR TITLE
[RDY] Do not include farsi.c in main.c

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ file( GLOB NEOVIM_SOURCES *.c )
 
 foreach(sfile ${NEOVIM_SOURCES})
   get_filename_component(f ${sfile} NAME)
-  if(${f} MATCHES "^(regexp_nfa.c|farsi.c)$")
+  if(${f} MATCHES "^(regexp_nfa.c)$")
     list(APPEND to_remove ${sfile})
   endif()
 endforeach()

--- a/src/charset.c
+++ b/src/charset.c
@@ -4,6 +4,7 @@
 
 #include "vim.h"
 #include "charset.h"
+#include "farsi.h"
 #include "main.h"
 #include "mbyte.h"
 #include "memline.h"

--- a/src/edit.c
+++ b/src/edit.c
@@ -19,6 +19,7 @@
 #include "eval.h"
 #include "ex_docmd.h"
 #include "ex_getln.h"
+#include "farsi.h"
 #include "fileio.h"
 #include "fold.h"
 #include "getchar.h"

--- a/src/edit.h
+++ b/src/edit.h
@@ -1,6 +1,8 @@
 #ifndef NEOVIM_EDIT_H
 #define NEOVIM_EDIT_H
 
+#include "vim.h"
+
 /*
  * Array indexes used for cptext argument of ins_compl_add().
  */

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -24,6 +24,7 @@
 #include "ex_docmd.h"
 #include "ex_eval.h"
 #include "ex_getln.h"
+#include "farsi.h"
 #include "fileio.h"
 #include "fold.h"
 #include "getchar.h"

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -23,6 +23,7 @@
 #include "ex_cmds2.h"
 #include "ex_docmd.h"
 #include "ex_eval.h"
+#include "farsi.h"
 #include "fileio.h"
 #include "getchar.h"
 #include "if_cscope.h"

--- a/src/farsi.c
+++ b/src/farsi.c
@@ -2,17 +2,55 @@
 ///
 /// Functions for Farsi language
 ///
-/// Included by main.c, when FEAT_FKMAP is defined.
 
-#include "farsi.h"
+
 #include "edit.h"
+#include "ex_docmd.h"
+#include "ex_eval.h"
 #include "ex_getln.h"
+#include "farsi.h"
+#include "getchar.h"
+#include "memline.h"
+#include "message.h"
+#include "misc1.h"
+#include "misc2.h"
+#include "screen.h"
+#include "vim.h"
 
 
 #define SRC_EDT 0
 #define SRC_CMD 1
 
 #define AT_CURSOR 0
+
+// special Farsi text messages
+
+const char_u farsi_text_1[] = {
+  YE_, _SIN, RE, ALEF_, _FE, ' ', 'V', 'I', 'M',
+  ' ', F_HE, _BE, ' ', SHIN, RE, _GAF, DAL, ' ', NOON,
+  ALEF_, _YE, ALEF_, _PE, '\0'
+};
+
+const char_u farsi_text_2[] = {
+  YE_, _SIN, RE, ALEF_, _FE, ' ', FARSI_3, FARSI_3,
+  FARSI_4, FARSI_2, ' ', DAL, RE, ALEF, DAL, _NOON,
+  ALEF_, _TE, _SIN, ALEF, ' ', F_HE, _BE, ' ', SHIN,
+  RE,  _GAF, DAL, ' ', NOON, ALEF_, _YE, ALEF_, _PE, '\0'
+};
+
+const char_u farsi_text_3[] = {
+  DAL, WAW, _SHIN, _YE, _MIM, _NOON, ' ', YE_, _NOON,
+  ALEF_, _BE, _YE, _TE, _SHIN, _PE, ' ', 'R', 'E', 'P', 'L',
+  'A', 'C', 'E', ' ', NOON, ALEF_, _MIM, RE, _FE, ZE, ALEF,
+  ' ', 'R', 'E', 'V', 'E', 'R', 'S', 'E', ' ', 'I', 'N',
+  'S', 'E', 'R', 'T', ' ', SHIN, WAW, RE, ' ', ALEF_, _BE,
+  ' ', YE_, _SIN, RE, ALEF_, _FE, ' ', RE, DAL, ' ', RE,
+  ALEF_, _KAF, ' ', MIM, ALEF_, _GAF, _NOON, _HE, '\0'
+};
+
+const char_u farsi_text_5[] = {
+  ' ', YE_, _SIN, RE, ALEF_, _FE, '\0'
+};
 
 static int toF_Xor_X_(int c);
 static int F_is_TyE(int c);

--- a/src/farsi.c
+++ b/src/farsi.c
@@ -9,6 +9,11 @@
 #include "ex_getln.h"
 
 
+#define SRC_EDT 0
+#define SRC_CMD 1
+
+#define AT_CURSOR 0
+
 static int toF_Xor_X_(int c);
 static int F_is_TyE(int c);
 static int F_is_TyC_TyD(int c);

--- a/src/farsi.h
+++ b/src/farsi.h
@@ -11,6 +11,9 @@
 #ifndef NEOVIM_FARSI_H
 #define NEOVIM_FARSI_H
 
+#include "normal.h"
+#include "types.h"
+
 // Farsi character set definition
 
 // Begin of the non-standard part
@@ -159,48 +162,22 @@
 #define W_R_L  0x2
 
 // special Farsi text messages
+extern const char_u farsi_text_1[];
+extern const char_u farsi_text_2[];
+extern const char_u farsi_text_3[];
+extern const char_u farsi_text_5[];
 
-#ifdef DO_INIT
-EXTERN char_u farsi_text_1[] = {
-  YE_, _SIN, RE, ALEF_, _FE, ' ', 'V', 'I', 'M',
-  ' ', F_HE, _BE, ' ', SHIN, RE, _GAF, DAL, ' ', NOON,
-  ALEF_, _YE, ALEF_, _PE, '\0'
-};
-#else
-EXTERN char_u farsi_text_1[];
-#endif
-
-#ifdef DO_INIT
-EXTERN char_u farsi_text_2[] = {
-  YE_, _SIN, RE, ALEF_, _FE, ' ', FARSI_3, FARSI_3,
-  FARSI_4, FARSI_2, ' ', DAL, RE, ALEF, DAL, _NOON,
-  ALEF_, _TE, _SIN, ALEF, ' ', F_HE, _BE, ' ', SHIN,
-  RE,  _GAF, DAL, ' ', NOON, ALEF_, _YE, ALEF_, _PE, '\0'
-};
-#else
-EXTERN char_u farsi_text_2[];
-#endif
-
-#ifdef DO_INIT
-EXTERN char_u farsi_text_3[] = {
-  DAL, WAW, _SHIN, _YE, _MIM, _NOON, ' ', YE_, _NOON,
-  ALEF_, _BE, _YE, _TE, _SHIN, _PE, ' ', 'R', 'E', 'P', 'L',
-  'A', 'C', 'E', ' ', NOON, ALEF_, _MIM, RE, _FE, ZE, ALEF,
-  ' ', 'R', 'E', 'V', 'E', 'R', 'S', 'E', ' ', 'I', 'N',
-  'S', 'E', 'R', 'T', ' ', SHIN, WAW, RE, ' ', ALEF_, _BE,
-  ' ', YE_, _SIN, RE, ALEF_, _FE, ' ', RE, DAL, ' ', RE,
-  ALEF_, _KAF, ' ', MIM, ALEF_, _GAF, _NOON, _HE, '\0'
-};
-#else
-EXTERN char_u farsi_text_3[];
-#endif
-
-#ifdef DO_INIT
-EXTERN char_u farsi_text_5[] = {
-  ' ', YE_, _SIN, RE, ALEF_, _FE, '\0'
-};
-#else
-EXTERN char_u farsi_text_5[];
-#endif
+int toF_TyA(int c);
+int fkmap(int c);
+void conv_to_pvim(void);
+void conv_to_pstd(void);
+char_u *lrswap(char_u *ibuf);
+char_u *lrFswap(char_u *cmdbuf, int len);
+char_u *lrF_sub(char_u *ibuf);
+int cmdl_fkmap(int c);
+int F_isalpha(int c);
+int F_isdigit(int c);
+int F_ischar(int c);
+void farsi_fkey(cmdarg_T *cap);
 
 #endif  // NEOVIM_FARSI_H

--- a/src/farsi.h
+++ b/src/farsi.h
@@ -154,14 +154,6 @@
 #define WAW_H           0xf9
 #define ALEF_D_H        0xfa
 
-// global definitions
-// ==================
-
-#define SRC_EDT 0
-#define SRC_CMD 1
-
-#define AT_CURSOR 0
-
 // definitions for the window dependent functions (w_farsi).
 #define W_CONV 0x1
 #define W_R_L  0x2

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -23,6 +23,7 @@
 #include "eval.h"
 #include "ex_docmd.h"
 #include "ex_getln.h"
+#include "farsi.h"
 #include "main.h"
 #include "mbyte.h"
 #include "memline.h"

--- a/src/globals.h
+++ b/src/globals.h
@@ -1139,9 +1139,4 @@ EXTERN int curr_tmode INIT(= TMODE_COOK); /* contains current terminal mode */
 /* volatile because it is used in signal handler deathtrap(). */
 EXTERN volatile bool in_mch_delay INIT(= false);  /* sleeping in mch_delay() */
 
-/*
- * Optional Farsi support.  Include it here, so EXTERN and INIT are defined.
- */
-# include "farsi.h"
-
 #endif /* NEOVIM_GLOBALS_H */

--- a/src/main.c
+++ b/src/main.c
@@ -2392,10 +2392,3 @@ time_msg (
 }
 
 #endif
-
-
-
-/*
- * When FEAT_FKMAP is defined, also compile the Farsi source code.
- */
-# include "farsi.c"

--- a/src/main.h
+++ b/src/main.h
@@ -14,17 +14,5 @@ void time_msg(char *mesg, void *tv_start);
 void server_to_input_buf(char_u *str);
 char_u *eval_client_expr_to_string(char_u *expr);
 char_u *serverConvert(char_u *client_enc, char_u *data, char_u **tofree);
-int toF_TyA(int c);
-int fkmap(int c);
-void conv_to_pvim(void);
-void conv_to_pstd(void);
-char_u *lrswap(char_u *ibuf);
-char_u *lrFswap(char_u *cmdbuf, int len);
-char_u *lrF_sub(char_u *ibuf);
-int cmdl_fkmap(int c);
-int F_isalpha(int c);
-int F_isdigit(int c);
-int F_ischar(int c);
-void farsi_fkey(cmdarg_T *cap);
 /* vim: set ft=c : */
 #endif /* NEOVIM_MAIN_H */

--- a/src/normal.c
+++ b/src/normal.c
@@ -24,6 +24,7 @@
 #include "ex_cmds2.h"
 #include "ex_docmd.h"
 #include "ex_getln.h"
+#include "farsi.h"
 #include "fileio.h"
 #include "fold.h"
 #include "getchar.h"

--- a/src/screen.c
+++ b/src/screen.c
@@ -96,6 +96,7 @@
 #include "eval.h"
 #include "ex_cmds2.h"
 #include "ex_getln.h"
+#include "farsi.h"
 #include "fileio.h"
 #include "fold.h"
 #include "getchar.h"

--- a/src/search.c
+++ b/src/search.c
@@ -18,6 +18,7 @@
 #include "ex_cmds.h"
 #include "ex_cmds2.h"
 #include "ex_getln.h"
+#include "farsi.h"
 #include "fileio.h"
 #include "fold.h"
 #include "getchar.h"

--- a/src/window.c
+++ b/src/window.c
@@ -19,6 +19,7 @@
 #include "ex_docmd.h"
 #include "ex_eval.h"
 #include "ex_getln.h"
+#include "farsi.h"
 #include "fileio.h"
 #include "fold.h"
 #include "getchar.h"


### PR DESCRIPTION
- Move some #defines from farsi.h to farsi.c
- Change CMakeLists.txt to compile farsi.c normally
- Add const to global variables in farsi.h and define them in farsi.c (no need
  to include farsi.h with DO_INIT defined in globals.h)
- Include farsi.h where necessary
- Include all necessary headers in farsi.c
- Move farsi function declarations from main.h to farsi.h
