### PR TITLE
[RDY] Implement `mch_delay` on top of libuv

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -9,6 +9,8 @@
 #ifndef NEOVIM_GLOBALS_H
 #define NEOVIM_GLOBALS_H
 
+#include <stdbool.h>
+
 #include "ex_eval.h"
 #include "mbyte.h"
 #include "menu.h"
@@ -1130,6 +1132,12 @@ EXTERN FILE *time_fd INIT(= NULL);  /* where to write startup timing */
  */
 EXTERN int ignored;
 EXTERN char *ignoredp;
+
+/* Temporarily moved these static variables to assist in migrating from
+ * os_unix.c */
+EXTERN int curr_tmode INIT(= TMODE_COOK); /* contains current terminal mode */
+/* volatile because it is used in signal handler deathtrap(). */
+EXTERN volatile bool in_mch_delay INIT(= false);  /* sleeping in mch_delay() */
 
 /*
  * Optional Farsi support.  Include it here, so EXTERN and INIT are defined.

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -17,7 +17,7 @@
 #include "message.h"
 #include "misc1.h"
 #include "misc2.h"
-#include "os_unix.h"
+#include "os/time.h"
 #include "quickfix.h"
 #include "tag.h"
 #include "ui.h"

--- a/src/os/time.c
+++ b/src/os/time.c
@@ -1,0 +1,58 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <uv.h>
+
+#include "vim.h"
+#include "term.h"
+
+static uv_mutex_t delay_mutex;
+static uv_cond_t delay_cond;
+
+static void delay(uint64_t ms);
+
+void time_init()
+{
+  uv_mutex_init(&delay_mutex);
+  uv_cond_init(&delay_cond);
+}
+
+void mch_delay(uint64_t ms, bool ignoreinput)
+{
+  int old_tmode;
+
+  if (ignoreinput) {
+    /* Go to cooked mode without echo, to allow SIGINT interrupting us
+     * here.  But we don't want QUIT to kill us (CTRL-\ used in a
+     * shell may produce SIGQUIT). */
+    in_mch_delay = true;
+    old_tmode = curr_tmode;
+
+    if (curr_tmode == TMODE_RAW)
+      settmode(TMODE_SLEEP);
+
+    delay(ms);
+
+    settmode(old_tmode);
+    in_mch_delay = false;
+  } else {
+    delay(ms);
+  }
+}
+
+static void delay(uint64_t ms)
+{
+  uint64_t hrtime;
+  int64_t ns = ms * 1000000; /* convert to nanoseconds */
+
+  uv_mutex_lock(&delay_mutex);
+
+  while (ns > 0) {
+    hrtime =  uv_hrtime();
+    if (uv_cond_timedwait(&delay_cond, &delay_mutex, ns) == UV_ETIMEDOUT)
+      break;
+    ns -= uv_hrtime() - hrtime;
+  }
+
+  uv_mutex_unlock(&delay_mutex);
+}

--- a/src/os/time.h
+++ b/src/os/time.h
@@ -1,0 +1,11 @@
+#ifndef NEOVIM_OS_TIME_H
+#define NEOVIM_OS_TIME_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+void time_init(void);
+void mch_delay(uint64_t ms, bool ignoreinput);
+
+#endif
+

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -4,7 +4,6 @@
 void mch_write(char_u *s, int len);
 int mch_inchar(char_u *buf, int maxlen, long wtime, int tb_change_cnt);
 int mch_char_avail(void);
-void mch_delay(long msec, int ignoreinput);
 void mch_startjmp(void);
 void mch_endjmp(void);
 void mch_didjmp(void);

--- a/src/term.c
+++ b/src/term.c
@@ -46,6 +46,7 @@
 #include "ui.h"
 #include "window.h"
 #include "os/os.h"
+#include "os/time.h"
 
 #ifdef HAVE_TGETENT
 # ifdef HAVE_TERMIOS_H

--- a/src/ui.c
+++ b/src/ui.c
@@ -30,6 +30,7 @@
 #include "normal.h"
 #include "option.h"
 #include "os_unix.h"
+#include "os/time.h"
 #include "screen.h"
 #include "term.h"
 #include "window.h"

--- a/test/unit/os/time.moon
+++ b/test/unit/os/time.moon
@@ -1,0 +1,15 @@
+{time: lua_time} = require 'os'
+{:cimport, :eq} = require 'test.unit.helpers'
+
+time = cimport './src/os/time.h'
+
+describe 'time function', ->
+  describe 'mch_delay', ->
+    mch_delay = (ms) ->
+      time.mch_delay ms, false
+
+    it 'sleeps at least the number of requested milliseconds', ->
+      curtime = lua_time!
+      mch_delay 1000
+      ellapsed = lua_time! - curtime
+      eq true, ellapsed >= 1 and ellapsed <=2


### PR DESCRIPTION
Needed to temporarily move two static variables from os_unix.c to 'globals.h'
as those are shared by other functions still in os_unix.

This was extracted from #289
