### PR TITLE
[RDY] Remove dead code related to memory handling and replace vim_realloc by realloc

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -12015,7 +12015,7 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
           /* Change "prev" buffer to be the right size.  This way
            * the bytes are only copied once, and very long lines are
            * allocated only once.  */
-          if ((s = vim_realloc(prev, prevlen + len + 1)) != NULL) {
+          if ((s = realloc(prev, prevlen + len + 1)) != NULL) {
             memmove(s + prevlen, start, len);
             s[prevlen + len] = NUL;
             prev = NULL;             /* the list will own the string */
@@ -12100,7 +12100,7 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
           prevsize = grow50pc > growmin ? grow50pc : growmin;
         }
         newprev = prev == NULL ? alloc(prevsize)
-                  : vim_realloc(prev, prevsize);
+                  : realloc(prev, prevsize);
         if (newprev == NULL) {
           do_outofmem_msg((long_u)prevsize);
           failed = TRUE;

--- a/src/file_search.c
+++ b/src/file_search.c
@@ -386,7 +386,7 @@ vim_findfile_init (
         void    *ptr;
 
         helper = walker;
-        ptr = vim_realloc(search_ctx->ffsc_stopdirs_v,
+        ptr = realloc(search_ctx->ffsc_stopdirs_v,
             (dircount + 1) * sizeof(char_u *));
         if (ptr)
           search_ctx->ffsc_stopdirs_v = ptr;

--- a/src/garray.c
+++ b/src/garray.c
@@ -73,7 +73,7 @@ int ga_grow(garray_T *gap, int n)
     new_len = gap->ga_itemsize * (gap->ga_len + n);
     pp = (gap->ga_data == NULL)
          ? alloc((unsigned)new_len)
-         : vim_realloc(gap->ga_data, new_len);
+         : realloc(gap->ga_data, new_len);
 
     if (pp == NULL) {
       return FAIL;

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1330,7 +1330,7 @@ static int cs_insert_filelist(char *fname, char *ppath, char *flags, struct stat
     } else {
       /* Reallocate space for more connections. */
       csinfo_size *= 2;
-      csinfo = vim_realloc(csinfo, sizeof(csinfo_T)*csinfo_size);
+      csinfo = realloc(csinfo, sizeof(csinfo_T)*csinfo_size);
     }
     if (csinfo == NULL)
       return -1;
@@ -1870,7 +1870,7 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
     /* hopefully 'num' (num of matches) will be less than 10^16 */
     newsize = (int)(strlen(csfmt_str) + 16 + strlen(lno));
     if (bufsize < newsize) {
-      buf = (char *)vim_realloc(buf, newsize);
+      buf = (char *)realloc(buf, newsize);
       if (buf == NULL)
         bufsize = 0;
       else
@@ -1891,7 +1891,7 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
     newsize = (int)(strlen(context) + strlen(cntxformat));
 
     if (bufsize < newsize) {
-      buf = (char *)vim_realloc(buf, newsize);
+      buf = (char *)realloc(buf, newsize);
       if (buf == NULL)
         bufsize = 0;
       else

--- a/src/memline.c
+++ b/src/memline.c
@@ -4371,7 +4371,7 @@ static void ml_updatechunk(buf_T *buf, linenr_T line, long len, int updtype)
     if (buf->b_ml.ml_usedchunks + 1 >= buf->b_ml.ml_numchunks) {
       buf->b_ml.ml_numchunks = buf->b_ml.ml_numchunks * 3 / 2;
       buf->b_ml.ml_chunksize = (chunksize_T *)
-                               vim_realloc(buf->b_ml.ml_chunksize,
+                               realloc(buf->b_ml.ml_chunksize,
           sizeof(chunksize_T) * buf->b_ml.ml_numchunks);
       if (buf->b_ml.ml_chunksize == NULL) {
         /* Hmmmm, Give up on offset for this buffer */

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2417,7 +2417,7 @@ int get_keystroke(void)
       /* Need some more space. This might happen when receiving a long
        * escape sequence. */
       buflen += 100;
-      buf = vim_realloc(buf, buflen);
+      buf = realloc(buf, buflen);
       maxlen = (buflen - 6 - len) / 3;
     }
     if (buf == NULL) {

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -694,13 +694,6 @@ void vim_mem_profile_dump(void)
 #endif /* MEM_PROFILE */
 
 /*
- * Some memory is reserved for error messages and for being able to
- * call mf_release_all(), which needs some memory for mf_trans_add().
- */
-# define KEEP_ROOM (2 * 8192L)
-#define KEEP_ROOM_KB (KEEP_ROOM / 1024L)
-
-/*
  * Note: if unsigned is 16 bits we can only allocate up to 64K with alloc().
  * Use lalloc for larger blocks.
  */
@@ -760,9 +753,6 @@ char_u *lalloc(long_u size, int message)
   char_u      *p;                   /* pointer to new storage space */
   static int releasing = FALSE;     /* don't do mf_release_all() recursive */
   int try_again;
-#if defined(HAVE_AVAIL_MEM) && !defined(SMALL_MEM)
-  static long_u allocated = 0;      /* allocated since last avail check */
-#endif
 
   /* Safety check for allocating zero bytes */
   if (size == 0) {
@@ -782,33 +772,9 @@ char_u *lalloc(long_u size, int message)
    * if some blocks are released call malloc again.
    */
   for (;; ) {
-    /*
-     * Handle three kind of systems:
-     * 1. No check for available memory: Just return.
-     * 2. Slow check for available memory: call mch_avail_mem() after
-     *    allocating KEEP_ROOM amount of memory.
-     * 3. Strict check for available memory: call mch_avail_mem()
-     */
     if ((p = (char_u *)malloc((size_t)size)) != NULL) {
-#ifndef HAVE_AVAIL_MEM
-      /* 1. No check for available memory: Just return. */
+      /* No check for available memory: Just return. */
       goto theend;
-#else
-# ifndef SMALL_MEM
-      /* 2. Slow check for available memory: call mch_avail_mem() after
-       *    allocating (KEEP_ROOM / 2) amount of memory. */
-      allocated += size;
-      if (allocated < KEEP_ROOM / 2)
-        goto theend;
-      allocated = 0;
-# endif
-      /* 3. check for available memory: call mch_avail_mem() */
-      if (mch_avail_mem(TRUE) < KEEP_ROOM_KB && !releasing) {
-        free((char *)p);                /* System is low... no go! */
-        p = NULL;
-      } else
-        goto theend;
-#endif
     }
     /*
      * Remember that mf_release_all() is being called to avoid an endless

--- a/src/normal.c
+++ b/src/normal.c
@@ -4496,7 +4496,7 @@ static void nv_ident(cmdarg_T *cap)
       vim_free(buf);
       return;
     }
-    newbuf = (char_u *)vim_realloc(buf, STRLEN(buf) + STRLEN(p) + 1);
+    newbuf = (char_u *)realloc(buf, STRLEN(buf) + STRLEN(p) + 1);
     if (newbuf == NULL) {
       vim_free(buf);
       vim_free(p);

--- a/src/option.c
+++ b/src/option.c
@@ -2024,25 +2024,20 @@ void set_init_1(void)
    */
   opt_idx = findoption((char_u *)"maxmemtot");
   if (opt_idx >= 0) {
-#if !defined(HAVE_AVAIL_MEM) && !defined(HAVE_TOTAL_MEM)
+#ifndef HAVE_TOTAL_MEM
     if (options[opt_idx].def_val[VI_DEFAULT] == (char_u *)0L)
 #endif
     {
-#ifdef HAVE_AVAIL_MEM
-      /* Use amount of memory available at this moment. */
-      n = (mch_avail_mem(FALSE) >> 1);
-#else
-# ifdef HAVE_TOTAL_MEM
+#ifdef HAVE_TOTAL_MEM
       /* Use amount of memory available to Vim. */
       n = (mch_total_mem(FALSE) >> 1);
-# else
+#else
       n = (0x7fffffff >> 11);
-# endif
 #endif
       options[opt_idx].def_val[VI_DEFAULT] = (char_u *)n;
       opt_idx = findoption((char_u *)"maxmem");
       if (opt_idx >= 0) {
-#if !defined(HAVE_AVAIL_MEM) && !defined(HAVE_TOTAL_MEM)
+#ifndef HAVE_TOTAL_MEM
         if ((long)options[opt_idx].def_val[VI_DEFAULT] > (long)n
             || (long)options[opt_idx].def_val[VI_DEFAULT] == 0L)
 #endif

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -3963,7 +3963,7 @@ skip_add:
         subs = &temp_subs;
       }
 
-      l->t = vim_realloc(l->t, newlen * sizeof(nfa_thread_T));
+      l->t = realloc(l->t, newlen * sizeof(nfa_thread_T));
       l->len = newlen;
     }
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -1387,13 +1387,6 @@ typedef int VimClipboard;       /* This is required for the prototypes. */
 /* stop using fastcall for Borland */
 
 
-/* Note: a NULL argument for vim_realloc() is not portable, don't use it. */
-#if defined(MEM_PROFILE)
-# define vim_realloc(ptr, size)  mem_realloc((ptr), (size))
-#else
-# define vim_realloc(ptr, size)  realloc((ptr), (size))
-#endif
-
 /*
  * The following macros stop display/event loop nesting at the wrong time.
  */


### PR DESCRIPTION
- `HAVE_AVAIL_MEM` is always undefined. Remove tests and dead code
  
  > Defining HAVE_AVAIL_MEM doesn't even build. The code tries to call
  > `mch_avail_mem` which is not defined.
- Use `realloc` instead of `vim_realloc`
