### PR TITLE
[RFC] Move signal handling to libuv event loop

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@
 #include "version.h"
 #include "window.h"
 #include "os/os.h"
+#include "os/signal.h"
 
 /* Maximum number of commands from + or -c arguments. */
 #define MAX_ARG_CMDS 10
@@ -2167,9 +2168,7 @@ mainerr (
     char_u *str       /* extra argument or NULL */
 )
 {
-#if defined(UNIX) || defined(__EMX__) || defined(VMS)
-  reset_signals();              /* kill us with CTRL-C here, if you like */
-#endif
+  signal_stop();              /* kill us with CTRL-C here, if you like */
 
   mch_errmsg(longVersion);
   mch_errmsg("\n");
@@ -2214,9 +2213,7 @@ static void usage(void)
     N_("-q [errorfile]  edit file with first error")
   };
 
-#if defined(UNIX) || defined(__EMX__) || defined(VMS)
-  reset_signals();              /* kill us with CTRL-C here, if you like */
-#endif
+  signal_stop();              /* kill us with CTRL-C here, if you like */
 
   mch_msg(longVersion);
   mch_msg(_("\n\nusage:"));

--- a/src/normal.c
+++ b/src/normal.c
@@ -7480,9 +7480,6 @@ static void nv_open(cmdarg_T *cap)
     n_opencmd(cap);
 }
 
-
-
-
 /*
  * Trigger CursorHold event.
  * When waiting for a character for 'updatetime' K_CURSORHOLD is put in the

--- a/src/os/event.c
+++ b/src/os/event.c
@@ -1,13 +1,26 @@
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 #include <uv.h>
 
 #include "os/event.h"
 #include "os/input.h"
+#include "os/signal.h"
+#include "vim.h"
+#include "misc2.h"
 
+typedef struct EventNode {
+  Event *event;
+  struct EventNode *next;
+} EventNode;
+
+static EventNode *head, *tail;
 static uv_timer_t timer;
 static uv_prepare_t timer_prepare;
+static bool poll_uv_loop(int ms);
+static void process_all_events(void);
+static bool has_pending_events(void);
 static void timer_cb(uv_timer_t *handle, int);
 static void timer_prepare_cb(uv_prepare_t *, int);
 
@@ -17,13 +30,93 @@ void event_init()
   input_init();
   // Timer to wake the event loop if a timeout argument is passed to
   // `event_poll`
+  // Signals
+  signal_init();
   uv_timer_init(uv_default_loop(), &timer);
   // This prepare handle that actually starts the timer
   uv_prepare_init(uv_default_loop(), &timer_prepare);
 }
 
-// Wait for some event
 bool event_poll(int32_t ms)
+{
+  int64_t remaining = ms;
+  uint64_t end;
+  bool result;
+
+  if (ms > 0) {
+    // Calculate end time in nanoseconds
+    end = uv_hrtime() + ms * 1e6;
+  }
+
+  for (;;) {
+    result = poll_uv_loop((int32_t)remaining);
+    // Process queued events
+    process_all_events();
+
+    if (ms > 0) {
+      // Calculate remaining time in milliseconds
+      remaining = (end - uv_hrtime()) / 1e6; 
+    }
+
+    if (input_ready() || got_int) {
+      // Bail out if we have pending input
+      return true;
+    }
+
+    if (!result || (ms >= 0 && remaining <= 0)) {
+      // Or if we timed out  
+      return false;
+    }
+  }
+}
+
+// Push an event to the queue
+void event_push(Event *event)
+{
+  EventNode *node = (EventNode *)xmalloc(sizeof(EventNode));
+  node->event = event;
+  node->next = NULL;
+
+  if (head == NULL) {
+    head = node;
+  } else {
+    tail->next = node;
+  }
+
+  tail = node;
+}
+
+// Runs the appropriate action for each queued event
+static void process_all_events()
+{
+  EventNode *next;
+  Event *event;
+
+  while (has_pending_events()) {
+    next = head->next;
+    event = head->event;
+    free(head);
+    head = next;
+
+    switch (event->type) {
+      case kEventSignal:
+        signal_handle(event);
+        break;
+      default:
+        abort();
+    }
+
+  }
+}
+
+// Checks if there are queued events
+bool has_pending_events()
+{
+  return head != NULL;
+}
+
+// Wait for some event
+static bool poll_uv_loop(int32_t ms)
 {
   bool timed_out;
   uv_run_mode run_mode = UV_RUN_ONCE;
@@ -55,9 +148,11 @@ bool event_poll(int32_t ms)
     uv_run(uv_default_loop(), run_mode);
   } while (
       // Continue running if ...
-      !input_ready()  // ... we have no input
-      && run_mode != UV_RUN_NOWAIT  // ... ms != 0
-      && !timed_out);  // ... we didn't get a timeout
+      !input_ready() && // we have no input
+      !has_pending_events() && // no events are waiting to be processed
+      run_mode != UV_RUN_NOWAIT && // ms != 0
+      !timed_out  // we didn't get a timeout
+      );
 
   input_stop();
 
@@ -66,7 +161,7 @@ bool event_poll(int32_t ms)
     uv_timer_stop(&timer);
   }
 
-  return input_ready();
+  return input_ready() || has_pending_events();
 }
 
 // Set a flag in the `event_poll` loop for signaling of a timeout

--- a/src/os/event.h
+++ b/src/os/event.h
@@ -4,8 +4,18 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+typedef enum {
+  kEventSignal
+} EventType;
+
+typedef struct {
+  EventType type;
+  void *data;
+} Event;
+
 void event_init(void);
 bool event_poll(int32_t ms);
+void event_push(Event *event);
 
 #endif  // NEOVIM_OS_EVENT_H
 

--- a/src/os/input.c
+++ b/src/os/input.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -58,7 +59,7 @@ void input_init()
   }
 }
 
-// Check if there's a pending input event
+// Check if there's pending input
 bool input_ready()
 {
   return rbuffer.rpos < rbuffer.wpos || eof;
@@ -126,11 +127,11 @@ int os_inchar(char_u *buf, int maxlen, int32_t ms, int tb_change_cnt)
   InbufPollResult result;
 
   if (ms >= 0) {
-    if ((result = inbuf_poll(ms)) != kInputAvail) {
+    if ((result = inbuf_poll(ms)) == kInputNone) {
       return 0;
     }
   } else {
-    if ((result = inbuf_poll(p_ut)) != kInputAvail) {
+    if ((result = inbuf_poll(p_ut)) == kInputNone) {
       if (trigger_cursorhold() && maxlen >= 3
           && !typebuf_changed(tb_change_cnt)) {
         buf[0] = K_SPECIAL;
@@ -177,9 +178,10 @@ static InbufPollResult inbuf_poll(int32_t ms)
     return kInputAvail;
 
   if (event_poll(ms)) {
-    if (rbuffer.rpos == rbuffer.wpos && eof) {
+    if (!got_int && rbuffer.rpos == rbuffer.wpos && eof) {
       return kInputEof;
     }
+
     return kInputAvail;
   }
 

--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -1,0 +1,155 @@
+#include <stdbool.h>
+
+#include <uv.h>
+
+#include "types.h"
+#include "vim.h"
+#include "globals.h"
+#include "memline.h"
+#include "eval.h"
+#include "term.h"
+#include "misc1.h"
+#include "misc2.h"
+#include "os/event.h"
+#include "os/signal.h"
+
+static uv_signal_t sint, spipe, shup, squit, sterm, swinch;
+#ifdef SIGPWR
+static uv_signal_t spwr;
+#endif
+
+static bool rejecting_deadly;
+static char * signal_name(int signum);
+static void deadly_signal(int signum);
+static void signal_cb(uv_signal_t *, int signum);
+
+void signal_init()
+{
+  uv_signal_init(uv_default_loop(), &sint);
+  uv_signal_init(uv_default_loop(), &spipe);
+  uv_signal_init(uv_default_loop(), &shup);
+  uv_signal_init(uv_default_loop(), &squit);
+  uv_signal_init(uv_default_loop(), &sterm);
+  uv_signal_init(uv_default_loop(), &swinch);
+  uv_signal_start(&sint, signal_cb, SIGINT);
+  uv_signal_start(&spipe, signal_cb, SIGPIPE);
+  uv_signal_start(&shup, signal_cb, SIGHUP);
+  uv_signal_start(&squit, signal_cb, SIGQUIT);
+  uv_signal_start(&sterm, signal_cb, SIGTERM);
+  uv_signal_start(&swinch, signal_cb, SIGWINCH);
+#ifdef SIGPWR
+  uv_signal_init(uv_default_loop(), &spwr);
+  uv_signal_start(&spwr, signal_cb, SIGPWR);
+#endif
+}
+
+void signal_stop()
+{
+  uv_signal_stop(&sint);
+  uv_signal_stop(&spipe);
+  uv_signal_stop(&shup);
+  uv_signal_stop(&squit);
+  uv_signal_stop(&sterm);
+  uv_signal_stop(&swinch);
+#ifdef SIGPWR
+  uv_signal_stop(&spwr);
+#endif
+}
+
+void signal_reject_deadly()
+{
+  rejecting_deadly = true;
+}
+
+void signal_accept_deadly()
+{
+  rejecting_deadly = false;
+}
+
+void signal_handle(Event *event)
+{
+  int signum = *(int *)event->data;
+
+  free(event->data);
+  free(event);
+
+  switch (signum) {
+    case SIGINT:
+      got_int = TRUE;
+      break;
+#ifdef SIGPWR
+    case SIGPWR:
+      // Signal of a power failure(eg batteries low), flush the swap files to
+      // be safe
+      ml_sync_all(FALSE, FALSE);
+      break;
+#endif
+    case SIGPIPE:
+      // Ignore
+      break;
+    case SIGWINCH:
+      shell_resized();
+      break;
+    case SIGTERM:
+    case SIGQUIT:
+    case SIGHUP:
+      if (!rejecting_deadly) {
+        deadly_signal(signum);
+      }
+      break;
+    default:
+      fprintf(stderr, "Invalid signal %d", signum);
+      break;
+  }
+}
+
+static char * signal_name(int signum)
+{
+  switch (signum) {
+    case SIGINT:
+      return "SIGINT";
+#ifdef SIGPWR
+    case SIGPWR:
+      return "SIGPWR";
+#endif
+    case SIGPIPE:
+      return "SIGPIPE";
+    case SIGWINCH:
+      return "SIGWINCH";
+    case SIGTERM:
+      return "SIGTERM";
+    case SIGQUIT:
+      return "SIGQUIT";
+    case SIGHUP:
+      return "SIGHUP";
+    default:
+      return "Unknown";
+  }
+}
+
+// This function handles deadly signals.
+// It tries to preserve any swap files and exit properly.
+// (partly from Elvis).
+// NOTE: Avoid unsafe functions, such as allocating memory, they can result in
+// a deadlock.
+static void deadly_signal(int signum)
+{
+  // Set the v:dying variable.
+  set_vim_var_nr(VV_DYING, 1);
+
+  sprintf((char *)IObuff, "Vim: Caught deadly signal '%s'\n",
+      signal_name(signum));
+
+  // Preserve files and exit.  This sets the really_exiting flag to prevent
+  // calling free().
+  preserve_exit();
+}
+
+static void signal_cb(uv_signal_t *handle, int signum)
+{
+  Event *event = (Event *)xmalloc(sizeof(Event));
+  event->type = kEventSignal;
+  event->data = xmalloc(sizeof(int));
+  *(int *)event->data = signum;
+  event_push(event);
+}

--- a/src/os/signal.h
+++ b/src/os/signal.h
@@ -1,0 +1,13 @@
+#ifndef NEOVIM_OS_SIGNAL_H
+#define NEOVIM_OS_SIGNAL_H
+
+#include "os/event.h"
+
+void signal_init(void);
+void signal_stop(void);
+void signal_accept_deadly(void);
+void signal_reject_deadly(void);
+void signal_handle(Event *event);
+
+#endif
+

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -5,9 +5,6 @@
 
 /* os_unix.c */
 void mch_write(char_u *s, int len);
-void mch_startjmp(void);
-void mch_endjmp(void);
-void mch_didjmp(void);
 void mch_suspend(void);
 void mch_init(void);
 void reset_signals(void);

--- a/src/ui.c
+++ b/src/ui.c
@@ -34,6 +34,7 @@
 #include "os_unix.h"
 #include "os/time.h"
 #include "os/input.h"
+#include "os/signal.h"
 #include "screen.h"
 #include "term.h"
 #include "window.h"
@@ -145,7 +146,7 @@ ui_inchar (
   /* If we are going to wait for some time or block... */
   if (wtime == -1 || wtime > 100L) {
     /* ... allow signals to kill us. */
-    (void)vim_handle_signal(SIGNAL_UNBLOCK);
+    signal_accept_deadly();
 
     /* ... there is no need for CTRL-C to interrupt something, don't let
      * it set got_int when it was mapped. */
@@ -161,7 +162,7 @@ ui_inchar (
 
   if (wtime == -1 || wtime > 100L)
     /* block SIGHUP et al. */
-    (void)vim_handle_signal(SIGNAL_BLOCK);
+    signal_reject_deadly();
 
   ctrl_c_interrupts = TRUE;
 


### PR DESCRIPTION
This removes all signal handling code from os_unix.c to os/signal.c, which
registers watchers on libuv default loop. Now signal handling will only happen
when Neovim transfers control to libuv, and SIG{HUP,TERM,QUIT} are the only
deadly signals intercepted.

I removed excessive signal handling code. For example, before it tried to handle SIGABRT which normally generates a core dump by exiting cleanly. Vim only generated core core dumps explicitly with `may_core_dump` function, and if the signal was received multiple times. This shouldn't happen with libuv since signals are delivered synchronously to `signal_cb` and only when libuv is polling for events. Signals such as SIGABRT normally mean program errors(eg: failed assertions) and should probably exit imediatelly. SIG{HUP,TERM,QUIT} are the only deadly signals we are handling because these are not related to bugs.

There may still be a resize problem with the `RealWaitForChar` in `mch_call_shell` since that still uses `select/poll` directly, but it should be fixed when `mch_call_shell` is reimplemented with libuv process facilities

@philix / @stefan991 Are the OS X redrawing problems fixed in this branch?
