### PR TITLE
[RDY] Adapt os module to the style guide

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2425,7 +2425,7 @@ void buflist_altfpos(win_T *win)
 
 /*
  * Return TRUE if 'ffname' is not the same file as current file.
- * Fname must have a full path (expanded by mch_get_absolute_path()).
+ * Fname must have a full path (expanded by os_get_absolute_path()).
  */
 int otherfile(char_u *ffname)
 {

--- a/src/diff.c
+++ b/src/diff.c
@@ -824,7 +824,7 @@ static void diff_file(char_u *tmp_orig, char_u *tmp_new, char_u *tmp_diff)
 
     if (cmd != NULL) {
       /* We don't want $DIFF_OPTIONS to get in the way. */
-      if (mch_getenv("DIFF_OPTIONS")) {
+      if (os_getenv("DIFF_OPTIONS")) {
         vim_setenv((char_u *)"DIFF_OPTIONS", (char_u *)"");
       }
 
@@ -906,18 +906,18 @@ void ex_diffpatch(exarg_T *eap)
   // have our own temp dir use that instead, it will be cleaned up when we
   // exit (any .rej files created).  Don't change directory if we can't
   // return to the current.
-  if ((mch_dirname(dirbuf, MAXPATHL) != OK)
-      || (mch_chdir((char *)dirbuf) != 0)) {
+  if ((os_dirname(dirbuf, MAXPATHL) != OK)
+      || (os_chdir((char *)dirbuf) != 0)) {
     dirbuf[0] = NUL;
   } else {
 # ifdef TEMPDIRNAMES
     if (vim_tempdir != NULL) {
-      ignored = mch_chdir((char *)vim_tempdir);
+      ignored = os_chdir((char *)vim_tempdir);
     } else {
-      ignored = mch_chdir("/tmp");
+      ignored = os_chdir("/tmp");
     }
 # else
-    ignored = mch_chdir("/tmp");
+    ignored = os_chdir("/tmp");
 # endif  // ifdef TEMPDIRNAMES
     shorten_fnames(TRUE);
   }
@@ -948,7 +948,7 @@ void ex_diffpatch(exarg_T *eap)
 
 #ifdef UNIX
   if (dirbuf[0] != NUL) {
-    if (mch_chdir((char *)dirbuf) != 0) {
+    if (os_chdir((char *)dirbuf) != 0) {
       EMSG(_(e_prev_dir));
     }
     shorten_fnames(TRUE);

--- a/src/eval.c
+++ b/src/eval.c
@@ -8549,7 +8549,7 @@ static void f_eventhandler(typval_T *argvars, typval_T *rettv)
  */
 static void f_executable(typval_T *argvars, typval_T *rettv)
 {
-  rettv->vval.v_number = mch_can_exe(get_tv_string(&argvars[0]));
+  rettv->vval.v_number = os_can_exe(get_tv_string(&argvars[0]));
 }
 
 /*
@@ -8565,7 +8565,7 @@ static void f_exists(typval_T *argvars, typval_T *rettv)
   p = get_tv_string(&argvars[0]);
   if (*p == '$') {                      /* environment variable */
     /* first try "normal" environment variables (fast) */
-    if (mch_getenv((char *)(p + 1)) != NULL)
+    if (os_getenv((char *)(p + 1)) != NULL)
       n = TRUE;
     else {
       /* try expanding things like $VIM and ${HOME} */
@@ -8862,7 +8862,7 @@ static void f_filereadable(typval_T *argvars, typval_T *rettv)
 # define O_NONBLOCK 0
 #endif
   p = get_tv_string(&argvars[0]);
-  if (*p && !mch_isdir(p) && (fd = mch_open((char *)p,
+  if (*p && !os_isdir(p) && (fd = mch_open((char *)p,
                                   O_RDONLY | O_NONBLOCK, 0)) >= 0) {
     n = TRUE;
     close(fd);
@@ -9660,7 +9660,7 @@ static void f_getcwd(typval_T *argvars, typval_T *rettv)
   rettv->vval.v_string = NULL;
   cwd = alloc(MAXPATHL);
   if (cwd != NULL) {
-    if (mch_dirname(cwd, MAXPATHL) != FAIL) {
+    if (os_dirname(cwd, MAXPATHL) != FAIL) {
       rettv->vval.v_string = vim_strsave(cwd);
 #ifdef BACKSLASH_IN_FILENAME
       if (rettv->vval.v_string != NULL)
@@ -9719,7 +9719,7 @@ static void f_getfsize(typval_T *argvars, typval_T *rettv)
   rettv->v_type = VAR_NUMBER;
 
   if (mch_stat((char *)fname, &st) >= 0) {
-    if (mch_isdir(fname))
+    if (os_isdir(fname))
       rettv->vval.v_number = 0;
     else {
       rettv->vval.v_number = (varnumber_T)st.st_size;
@@ -9812,7 +9812,7 @@ static void f_getftype(typval_T *argvars, typval_T *rettv)
     default: t = "other";
     }
 # else
-    if (mch_isdir(fname))
+    if (os_isdir(fname))
       t = "dir";
     else
       t = "file";
@@ -10886,7 +10886,7 @@ static void f_invert(typval_T *argvars, typval_T *rettv)
  */
 static void f_isdirectory(typval_T *argvars, typval_T *rettv)
 {
-  rettv->vval.v_number = mch_isdir(get_tv_string(&argvars[0]));
+  rettv->vval.v_number = os_isdir(get_tv_string(&argvars[0]));
 }
 
 /*
@@ -11664,7 +11664,7 @@ static int mkdir_recurse(char_u *dir, int prot)
   updir = vim_strnsave(dir, (int)(p - dir));
   if (updir == NULL)
     return FAIL;
-  if (mch_isdir(updir))
+  if (os_isdir(updir))
     r = OK;
   else if (mkdir_recurse(updir, prot) == OK)
     r = vim_mkdir_emsg(updir, prot);
@@ -12479,7 +12479,7 @@ static void f_resolve(typval_T *argvars, typval_T *rettv)
           q[-1] = NUL;
           q = gettail(p);
         }
-        if (q > p && !mch_is_absolute_path(buf)) {
+        if (q > p && !os_is_absolute_path(buf)) {
           /* symlink is relative to directory of argument */
           cpy = alloc((unsigned)(STRLEN(p) + STRLEN(buf) + 1));
           if (cpy != NULL) {
@@ -19345,7 +19345,7 @@ repeat:
     }
 
     /* Append a path separator to a directory. */
-    if (mch_isdir(*fnamep)) {
+    if (os_isdir(*fnamep)) {
       /* Make room for one or two extra characters. */
       *fnamep = vim_strnsave(*fnamep, (int)STRLEN(*fnamep) + 2);
       vim_free(*bufp);          /* free any allocated file name */
@@ -19379,7 +19379,7 @@ repeat:
 
     if (p != NULL) {
       if (c == '.') {
-        mch_dirname(dirname, MAXPATHL);
+        os_dirname(dirname, MAXPATHL);
         s = shorten_fname(p, dirname);
         if (s != NULL) {
           *fnamep = s;

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1730,7 +1730,7 @@ static char_u *viminfo_filename(char_u *file)
     else if ((file = find_viminfo_parameter('n')) == NULL || *file == NUL) {
 #ifdef VIMINFO_FILE2
       /* don't use $HOME when not defined (turned into "c:/"!). */
-      if (mch_getenv((char_u *)"HOME") == NULL) {
+      if (os_getenv((char_u *)"HOME") == NULL) {
         /* don't use $VIM when not available. */
         expand_env((char_u *)"$VIM", NameBuff, MAXPATHL);
         if (STRCMP("$VIM", NameBuff) != 0)          /* $VIM was expanded */
@@ -2335,7 +2335,7 @@ check_overwrite (
     if (!eap->forceit && !eap->append) {
 #ifdef UNIX
       /* with UNIX it is possible to open a directory */
-      if (mch_isdir(ffname)) {
+      if (os_isdir(ffname)) {
         EMSG2(_(e_isadir2), ffname);
         return FAIL;
       }
@@ -5384,7 +5384,7 @@ void ex_helptags(exarg_T *eap)
   xpc.xp_context = EXPAND_DIRECTORIES;
   dirname = ExpandOne(&xpc, eap->arg, NULL,
       WILD_LIST_NOTFOUND|WILD_SILENT, WILD_EXPAND_FREE);
-  if (dirname == NULL || !mch_isdir(dirname)) {
+  if (dirname == NULL || !os_isdir(dirname)) {
     EMSG2(_("E150: Not a directory: %s"), eap->arg);
     return;
   }

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -2493,7 +2493,7 @@ do_source (
   vim_free(p);
   if (fname_exp == NULL)
     return retval;
-  if (mch_isdir(fname_exp)) {
+  if (os_isdir(fname_exp)) {
     smsg((char_u *)_("Cannot source a directory: \"%s\""), fname);
     goto theend;
   }
@@ -3317,11 +3317,11 @@ char_u *get_mess_lang(void)
   p = (char_u *)get_locale_val(LC_COLLATE);
 #  endif
 # else
-  p = mch_getenv((char_u *)"LC_ALL");
+  p = os_getenv((char_u *)"LC_ALL");
   if (p == NULL || *p == NUL) {
-    p = mch_getenv((char_u *)"LC_MESSAGES");
+    p = os_getenv((char_u *)"LC_MESSAGES");
     if (p == NULL || *p == NUL)
-      p = mch_getenv((char_u *)"LANG");
+      p = os_getenv((char_u *)"LANG");
   }
 # endif
   return p;
@@ -3338,11 +3338,11 @@ static char_u *get_mess_env(void)
 {
   char_u      *p;
 
-  p = (char_u *)mch_getenv("LC_ALL");
+  p = (char_u *)os_getenv("LC_ALL");
   if (p == NULL || *p == NUL) {
-    p = (char_u *)mch_getenv("LC_MESSAGES");
+    p = (char_u *)os_getenv("LC_MESSAGES");
     if (p == NULL || *p == NUL) {
-      p = (char_u *)mch_getenv("LANG");
+      p = (char_u *)os_getenv("LANG");
       if (p != NULL && VIM_ISDIGIT(*p))
         p = NULL;                       /* ignore something like "1043" */
 # ifdef HAVE_GET_LOCALE_VAL

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6607,7 +6607,7 @@ void post_chdir(int local)
     if (globaldir == NULL && prev_dir != NULL)
       globaldir = vim_strsave(prev_dir);
     /* Remember this local directory for the window. */
-    if (mch_dirname(NameBuff, MAXPATHL) == OK)
+    if (os_dirname(NameBuff, MAXPATHL) == OK)
       curwin->w_localdir = vim_strsave(NameBuff);
   } else {
     /* We are now in the global directory, no need to remember its
@@ -6656,7 +6656,7 @@ void ex_cd(exarg_T *eap)
 
     /* Save current directory for next ":cd -" */
     tofree = prev_dir;
-    if (mch_dirname(NameBuff, MAXPATHL) == OK)
+    if (os_dirname(NameBuff, MAXPATHL) == OK)
       prev_dir = vim_strsave(NameBuff);
     else
       prev_dir = NULL;
@@ -6687,7 +6687,7 @@ void ex_cd(exarg_T *eap)
  */
 static void ex_pwd(exarg_T *eap)
 {
-  if (mch_dirname(NameBuff, MAXPATHL) == OK) {
+  if (os_dirname(NameBuff, MAXPATHL) == OK) {
 #ifdef BACKSLASH_IN_FILENAME
     slash_adjust(NameBuff);
 #endif
@@ -7281,7 +7281,7 @@ static void ex_mkrc(exarg_T *eap)
 
 #if defined(FEAT_SESSION) && defined(vim_mkdir)
   /* When using 'viewdir' may have to create the directory. */
-  if (using_vdir && !mch_isdir(p_vdir))
+  if (using_vdir && !os_isdir(p_vdir))
     vim_mkdir_emsg(p_vdir, 0755);
 #endif
 
@@ -7337,15 +7337,15 @@ static void ex_mkrc(exarg_T *eap)
           /*
            * Change to session file's dir.
            */
-          if (mch_dirname(dirnow, MAXPATHL) == FAIL
-              || mch_chdir((char *)dirnow) != 0)
+          if (os_dirname(dirnow, MAXPATHL) == FAIL
+              || os_chdir((char *)dirnow) != 0)
             *dirnow = NUL;
           if (*dirnow != NUL && (ssop_flags & SSOP_SESDIR)) {
             if (vim_chdirfile(fname) == OK)
               shorten_fnames(TRUE);
           } else if (*dirnow != NUL
                      && (ssop_flags & SSOP_CURDIR) && globaldir != NULL) {
-            if (mch_chdir((char *)globaldir) == 0)
+            if (os_chdir((char *)globaldir) == 0)
               shorten_fnames(TRUE);
           }
 
@@ -7355,7 +7355,7 @@ static void ex_mkrc(exarg_T *eap)
           if (*dirnow != NUL && ((ssop_flags & SSOP_SESDIR)
                                  || ((ssop_flags & SSOP_CURDIR) && globaldir !=
                                      NULL))) {
-            if (mch_chdir((char *)dirnow) != 0)
+            if (os_chdir((char *)dirnow) != 0)
               EMSG(_(e_prev_dir));
             shorten_fnames(TRUE);
           }
@@ -7428,7 +7428,7 @@ open_exfile (
 
 #ifdef UNIX
   /* with Unix it is possible to open a directory */
-  if (mch_isdir(fname)) {
+  if (os_isdir(fname)) {
     EMSG2(_(e_isadir2), fname);
     return NULL;
   }

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -3256,13 +3256,13 @@ static int showmatches(expand_T *xp, int wildmenu)
             exp_path = expand_env_save_opt(files_found[k], TRUE);
             halved_slash = backslash_halve_save(
                 exp_path != NULL ? exp_path : files_found[k]);
-            j = mch_isdir(halved_slash != NULL ? halved_slash
+            j = os_isdir(halved_slash != NULL ? halved_slash
                 : files_found[k]);
             vim_free(exp_path);
             vim_free(halved_slash);
           } else
             /* Expansion was done here, file names are literal. */
-            j = mch_isdir(files_found[k]);
+            j = os_isdir(files_found[k]);
           if (showtail)
             p = L_SHOWFILE(k);
           else {
@@ -3954,7 +3954,7 @@ expand_shellcmd (
   flags |= EW_FILE | EW_EXEC;
 
   /* For an absolute name we don't use $PATH. */
-  if (mch_is_absolute_path(pat))
+  if (os_is_absolute_path(pat))
     path = (char_u *)" ";
   else if ((pat[0] == '.' && (vim_ispathsep(pat[1])
                               || (pat[1] == '.' && vim_ispathsep(pat[2])))))

--- a/src/file_search.c
+++ b/src/file_search.c
@@ -343,7 +343,7 @@ vim_findfile_init (
       path += 2;
     } else
 #endif
-    if (mch_dirname(ff_expand_buffer, MAXPATHL) == FAIL)
+    if (os_dirname(ff_expand_buffer, MAXPATHL) == FAIL)
       goto error_return;
 
     search_ctx->ffsc_start_dir = vim_strsave(ff_expand_buffer);
@@ -498,7 +498,7 @@ vim_findfile_init (
 
     STRCPY(buf, ff_expand_buffer);
     STRCPY(buf + eb_len, search_ctx->ffsc_fix_path);
-    if (mch_isdir(buf)) {
+    if (os_isdir(buf)) {
       STRCAT(ff_expand_buffer, search_ctx->ffsc_fix_path);
       add_pathsep(ff_expand_buffer);
     } else {
@@ -818,7 +818,7 @@ char_u *vim_findfile(void *search_ctx_arg)
           for (i = stackp->ffs_filearray_cur;
                i < stackp->ffs_filearray_size; ++i) {
             if (!path_with_url(stackp->ffs_filearray[i])
-                && !mch_isdir(stackp->ffs_filearray[i]))
+                && !os_isdir(stackp->ffs_filearray[i]))
               continue;                 /* not a directory */
 
             /* prepare the filename to be checked for existence
@@ -844,7 +844,7 @@ char_u *vim_findfile(void *search_ctx_arg)
                            == FINDFILE_BOTH
                            || ((search_ctx->ffsc_find_what
                                 == FINDFILE_DIR)
-                               == mch_isdir(file_path)))))
+                               == os_isdir(file_path)))))
 #ifndef FF_VERBOSE
                   && (ff_check_visited(
                           &search_ctx->ffsc_visited_list->ffvl_visited_list,
@@ -877,7 +877,7 @@ char_u *vim_findfile(void *search_ctx_arg)
 
                 if (!path_with_url(file_path))
                   simplify_filename(file_path);
-                if (mch_dirname(ff_expand_buffer, MAXPATHL)
+                if (os_dirname(ff_expand_buffer, MAXPATHL)
                     == OK) {
                   p = shorten_fname(file_path,
                       ff_expand_buffer);
@@ -910,7 +910,7 @@ char_u *vim_findfile(void *search_ctx_arg)
            */
           for (i = stackp->ffs_filearray_cur;
                i < stackp->ffs_filearray_size; ++i) {
-            if (!mch_isdir(stackp->ffs_filearray[i]))
+            if (!os_isdir(stackp->ffs_filearray[i]))
               continue;                 /* not a directory */
 
             ff_push(search_ctx,
@@ -934,7 +934,7 @@ char_u *vim_findfile(void *search_ctx_arg)
           if (fnamecmp(stackp->ffs_filearray[i],
                   stackp->ffs_fix_path) == 0)
             continue;             /* don't repush same directory */
-          if (!mch_isdir(stackp->ffs_filearray[i]))
+          if (!os_isdir(stackp->ffs_filearray[i]))
             continue;               /* not a directory */
           ff_push(search_ctx,
               ff_create_stack_element(stackp->ffs_filearray[i],
@@ -1519,7 +1519,7 @@ find_file_in_path_option (
             (os_file_exists(NameBuff)
              && (find_what == FINDFILE_BOTH
                  || ((find_what == FINDFILE_DIR)
-                     == mch_isdir(NameBuff))))) {
+                     == os_isdir(NameBuff))))) {
             file_name = vim_strsave(NameBuff);
             goto theend;
           }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -405,7 +405,7 @@ readfile (
      * On Unix it is possible to read a directory, so we have to
      * check for it before the mch_open().
      */
-    perm = mch_getperm(fname);
+    perm = os_getperm(fname);
     if (perm >= 0 && !S_ISREG(perm)                 /* not a regular file ... */
 # ifdef S_ISFIFO
         && !S_ISFIFO(perm)                          /* ... or fifo */
@@ -508,8 +508,8 @@ readfile (
     /*
      * On MSDOS and Amiga we can't open a directory, check here.
      */
-    isdir_f = (mch_isdir(fname));
-    perm = mch_getperm(fname);      /* check if the file exists */
+    isdir_f = (os_isdir(fname));
+    perm = os_getperm(fname);      /* check if the file exists */
     if (isdir_f) {
       filemess(curbuf, sfname, (char_u *)_("is a directory"), 0);
       curbuf->b_p_ro = TRUE;            /* must use "w!" now */
@@ -613,7 +613,7 @@ readfile (
     /* Set swap file protection bits after creating it. */
     if (swap_mode > 0 && curbuf->b_ml.ml_mfp != NULL
         && curbuf->b_ml.ml_mfp->mf_fname != NULL)
-      (void)mch_setperm(curbuf->b_ml.ml_mfp->mf_fname, (long)swap_mode);
+      (void)os_setperm(curbuf->b_ml.ml_mfp->mf_fname, (long)swap_mode);
 #endif
   }
 
@@ -2879,10 +2879,10 @@ buf_write (
     newfile = TRUE;
     perm = -1;
   } else {
-    perm = mch_getperm(fname);
+    perm = os_getperm(fname);
     if (perm < 0)
       newfile = TRUE;
-    else if (mch_isdir(fname)) {
+    else if (os_isdir(fname)) {
       errnum = (char_u *)"E502: ";
       errmsg = (char_u *)_("is a directory");
       goto fail;
@@ -3201,7 +3201,7 @@ buf_write (
           } else {
             /* set file protection same as original file, but
              * strip s-bit */
-            (void)mch_setperm(backup, perm & 0777);
+            (void)os_setperm(backup, perm & 0777);
 
 #ifdef UNIX
             /*
@@ -3215,7 +3215,7 @@ buf_write (
                 && fchown(bfd, (uid_t)-1, st_old.st_gid) != 0
 # endif
                 )
-              mch_setperm(backup,
+              os_setperm(backup,
                   (perm & 0707) | ((perm & 07) << 3));
 # ifdef HAVE_SELINUX
             mch_copy_sec(fname, backup);
@@ -3371,7 +3371,7 @@ nobackup:
   if (forceit && perm >= 0 && !(perm & 0200) && st_old.st_uid == getuid()
       && vim_strchr(p_cpo, CPO_FWRITE) == NULL) {
     perm |= 0200;
-    (void)mch_setperm(fname, perm);
+    (void)os_setperm(fname, perm);
     made_writable = TRUE;
   }
 #endif
@@ -3760,7 +3760,7 @@ restore_backup:
         || st.st_gid != st_old.st_gid) {
       ignored = fchown(fd, st_old.st_uid, st_old.st_gid);
       if (perm >= 0)            /* set permission again, may have changed */
-        (void)mch_setperm(wfname, perm);
+        (void)os_setperm(wfname, perm);
     }
 # endif
     buf_setino(buf);
@@ -3779,7 +3779,7 @@ restore_backup:
     perm &= ~0200;              /* reset 'w' bit for security reasons */
 #endif
   if (perm >= 0)                /* set perm. of new file same as old file */
-    (void)mch_setperm(wfname, perm);
+    (void)os_setperm(wfname, perm);
 #ifdef HAVE_ACL
   /* Probably need to set the ACL before changing the user (can't set the
    * ACL on a file the user doesn't own). */
@@ -3996,7 +3996,7 @@ restore_backup:
         close(empty_fd);
     }
     if (org != NULL) {
-      mch_setperm((char_u *)org, mch_getperm(fname) & 0777);
+      os_setperm((char_u *)org, os_getperm(fname) & 0777);
       vim_free(org);
     }
   }
@@ -4716,7 +4716,7 @@ char_u *shorten_fname1(char_u *full_path)
   dirname = alloc(MAXPATHL);
   if (dirname == NULL)
     return full_path;
-  if (mch_dirname(dirname, MAXPATHL) == OK) {
+  if (os_dirname(dirname, MAXPATHL) == OK) {
     p = shorten_fname(full_path, dirname);
     if (p == NULL || *p == NUL)
       p = full_path;
@@ -4768,14 +4768,14 @@ void shorten_fnames(int force)
   buf_T       *buf;
   char_u      *p;
 
-  mch_dirname(dirname, MAXPATHL);
+  os_dirname(dirname, MAXPATHL);
   for (buf = firstbuf; buf != NULL; buf = buf->b_next) {
     if (buf->b_fname != NULL
         && !bt_nofile(buf)
         && !path_with_url(buf->b_fname)
         && (force
             || buf->b_sfname == NULL
-            || mch_is_absolute_path(buf->b_sfname))) {
+            || os_is_absolute_path(buf->b_sfname))) {
       vim_free(buf->b_sfname);
       buf->b_sfname = NULL;
       p = shorten_fname(buf->b_ffname, dirname);
@@ -4810,7 +4810,7 @@ void shorten_filenames(char_u **fnames, int count)
 
   if (fnames == NULL || count < 1)
     return;
-  mch_dirname(dirname, sizeof(dirname));
+  os_dirname(dirname, sizeof(dirname));
   for (i = 0; i < count; ++i) {
     if ((p = shorten_fname(fnames[i], dirname)) != NULL) {
       /* shorten_fname() returns pointer in given "fnames[i]".  If free
@@ -4875,7 +4875,7 @@ buf_modname (
     retval = alloc((unsigned)(MAXPATHL + extlen + 3));
     if (retval == NULL)
       return NULL;
-    if (mch_dirname(retval, MAXPATHL) == FAIL ||
+    if (os_dirname(retval, MAXPATHL) == FAIL ||
         (fnamelen = (int)STRLEN(retval)) == 0) {
       vim_free(retval);
       return NULL;
@@ -5185,7 +5185,7 @@ int vim_rename(char_u *from, char_u *to)
   /*
    * Rename() failed, try copying the file.
    */
-  perm = mch_getperm(from);
+  perm = os_getperm(from);
 #ifdef HAVE_ACL
   /* For systems that support ACL: get the ACL from the original file. */
   acl = mch_get_acl(from);
@@ -5234,7 +5234,7 @@ int vim_rename(char_u *from, char_u *to)
     to = from;
   }
 #ifndef UNIX        /* for Unix mch_open() already set the permission */
-  mch_setperm(to, perm);
+  os_setperm(to, perm);
 #endif
 #ifdef HAVE_ACL
   mch_set_acl(to, acl);
@@ -5405,7 +5405,7 @@ buf_check_timestamp (
 #ifdef HAVE_ST_MODE
                  || (int)st.st_mode != buf->b_orig_mode
 #else
-                 || mch_getperm(buf->b_ffname) != buf->b_orig_mode
+                 || os_getperm(buf->b_ffname) != buf->b_orig_mode
 #endif
                  )) {
     retval = 1;
@@ -5421,7 +5421,7 @@ buf_check_timestamp (
 
     /* Don't do anything for a directory.  Might contain the file
      * explorer. */
-    if (mch_isdir(buf->b_fname))
+    if (os_isdir(buf->b_fname))
       ;
 
     /*
@@ -5725,7 +5725,7 @@ void buf_store_time(buf_T *buf, struct stat *st, char_u *fname)
 #ifdef HAVE_ST_MODE
   buf->b_orig_mode = (int)st->st_mode;
 #else
-  buf->b_orig_mode = mch_getperm(fname);
+  buf->b_orig_mode = os_getperm(fname);
 #endif
 }
 
@@ -5836,7 +5836,7 @@ vim_tempname (
 
       /* expand $TMP, leave room for "/v1100000/999999999" */
       expand_env((char_u *)tempdirs[i], itmp, TEMPNAMELEN - 20);
-      if (mch_isdir(itmp)) {                    /* directory exists */
+      if (os_isdir(itmp)) {                    /* directory exists */
         add_pathsep(itmp);
 
 # ifdef HAVE_MKDTEMP

--- a/src/globals.h
+++ b/src/globals.h
@@ -1137,6 +1137,6 @@ EXTERN char *ignoredp;
  * os_unix.c */
 EXTERN int curr_tmode INIT(= TMODE_COOK); /* contains current terminal mode */
 /* volatile because it is used in signal handler deathtrap(). */
-EXTERN volatile bool in_mch_delay INIT(= false);  /* sleeping in mch_delay() */
+EXTERN volatile bool in_os_delay INIT(= false);  /* sleeping in os_delay() */
 
 #endif /* NEOVIM_GLOBALS_H */

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -2534,7 +2534,7 @@ int mch_print_begin(prt_settings_T *psettings)
    */
   prt_dsc_start();
   prt_dsc_textline("Title", (char *)psettings->jobname);
-  if (mch_get_user_name(buffer, 256) == FAIL) {
+  if (os_get_user_name(buffer, 256) == FAIL) {
     STRCPY(buffer, "Unknown");
   }
   prt_dsc_textline("For", buffer);

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -2073,7 +2073,7 @@ static void cs_release_csp(int i, int freefnpp)
       waitpid_errno = errno;
       if (pid != 0)
         break;          /* break unless the process is still running */
-      mch_delay(50L, FALSE);       /* sleep 50 ms */
+      os_delay(50L, FALSE);       /* sleep 50 ms */
     }
 # endif
     /*
@@ -2104,7 +2104,7 @@ static void cs_release_csp(int i, int freefnpp)
             alive = FALSE;             /* cscope process no longer exists */
             break;
           }
-          mch_delay(50L, FALSE);           /* sleep 50ms */
+          os_delay(50L, FALSE);           /* sleep 50ms */
         }
       }
       if (alive)

--- a/src/main.c
+++ b/src/main.c
@@ -1434,8 +1434,8 @@ scripterror:
       if (ga_grow(&global_alist.al_ga, 1) == FAIL
           || (p = vim_strsave((char_u *)argv[0])) == NULL)
         mch_exit(2);
-      if (parmp->diff_mode && mch_isdir(p) && GARGCOUNT > 0
-          && !mch_isdir(alist_name(&GARGLIST[0]))) {
+      if (parmp->diff_mode && os_isdir(p) && GARGCOUNT > 0
+          && !os_isdir(alist_name(&GARGLIST[0]))) {
         char_u      *r;
 
         r = concat_fnames(p, gettail(alist_name(&GARGLIST[0])), TRUE);
@@ -2115,7 +2115,7 @@ process_env (
   linenr_T save_sourcing_lnum;
   scid_T save_sid;
 
-  initstr = (char_u *)mch_getenv((char *)env);
+  initstr = (char_u *)os_getenv((char *)env);
   if (initstr != NULL && *initstr != NUL) {
     if (is_viminit)
       vimrc_found(NULL, NULL);

--- a/src/mark.c
+++ b/src/mark.c
@@ -480,7 +480,7 @@ static void fname2fnum(xfmark_T *fm)
       vim_strncpy(NameBuff, fm->fname, MAXPATHL - 1);
 
     /* Try to shorten the file name. */
-    mch_dirname(IObuff, IOSIZE);
+    os_dirname(IObuff, IOSIZE);
     p = shorten_fname(NameBuff, IObuff);
 
     /* buflist_new() will call fmarks_check_names() */

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -3463,9 +3463,9 @@ char_u * enc_locale()
 #  if defined(HAVE_LOCALE_H) || defined(X_LOCALE)
     if ((s = setlocale(LC_CTYPE, NULL)) == NULL || *s == NUL)
 #  endif
-      if ((s = (char *)mch_getenv("LC_ALL")) == NULL || *s == NUL)
-        if ((s = (char *)mch_getenv("LC_CTYPE")) == NULL || *s == NUL)
-          s = (char *)mch_getenv("LANG");
+      if ((s = (char *)os_getenv("LC_ALL")) == NULL || *s == NUL)
+        if ((s = (char *)os_getenv("LC_CTYPE")) == NULL || *s == NUL)
+          s = (char *)os_getenv("LANG");
 
   if (s == NULL || *s == NUL)
     return FAIL;

--- a/src/memline.c
+++ b/src/memline.c
@@ -345,7 +345,7 @@ int ml_open(buf_T *buf)
     b0p->b0_dirty = buf->b_changed ? B0_DIRTY : 0;
     b0p->b0_flags = get_fileformat(buf) + 1;
     set_b0_fname(b0p, buf);
-    (void)mch_get_user_name((char *)b0p->b0_uname, B0_UNAME_SIZE);
+    (void)os_get_user_name((char *)b0p->b0_uname, B0_UNAME_SIZE);
     b0p->b0_uname[B0_UNAME_SIZE - 1] = NUL;
     mch_get_host_name(b0p->b0_hname, B0_HNAME_SIZE);
     b0p->b0_hname[B0_HNAME_SIZE - 1] = NUL;
@@ -850,7 +850,7 @@ static void set_b0_fname(ZERO_BL *b0p, buf_T *buf)
         B0_FNAME_SIZE_CRYPT, TRUE);
     if (b0p->b0_fname[0] == '~') {
       /* If there is no user name or it is too long, don't use "~/" */
-      int retval = mch_get_user_name(uname, B0_UNAME_SIZE);
+      int retval = os_get_user_name(uname, B0_UNAME_SIZE);
       size_t ulen = STRLEN(uname);
       size_t flen = STRLEN(b0p->b0_fname);
       if (retval == FAIL || ulen + flen > B0_FNAME_SIZE_CRYPT - 1) {
@@ -1751,7 +1751,7 @@ static time_t swapfile_info(char_u *fname)
   if (mch_stat((char *)fname, &st) != -1) {
 #ifdef UNIX
     /* print name of owner of the file */
-    if (mch_get_uname(st.st_uid, uname, B0_UNAME_SIZE) == OK) {
+    if (os_get_uname(st.st_uid, uname, B0_UNAME_SIZE) == OK) {
       MSG_PUTS(_("          owned by: "));
       msg_outtrans((char_u *)uname);
       MSG_PUTS(_("   dated: "));
@@ -3392,7 +3392,7 @@ int resolve_symlink(char_u *fname, char_u *buf)
      * portion of the filename (if any) and the path the symlink
      * points to.
      */
-    if (mch_is_absolute_path(buf))
+    if (os_is_absolute_path(buf))
       STRCPY(tmp, buf);
     else {
       char_u *tail;
@@ -3798,7 +3798,7 @@ findswapname (
        */
       if (!(buf->b_p_sn || buf->b_shortname)) {         /* not tried yet */
         fname[n - 1] = 'x';
-        r = mch_getperm(fname);                 /* try "file.swx" */
+        r = os_getperm(fname);                 /* try "file.swx" */
         fname[n - 1] = 'p';
         if (r >= 0) {                       /* "file.swx" seems to exist */
           buf->b_shortname = TRUE;

--- a/src/message.c
+++ b/src/message.c
@@ -752,7 +752,7 @@ void ex_messages(exarg_T *eap)
 
   msg_hist_off = TRUE;
 
-  s = mch_getenv("LANG");
+  s = os_getenv("LANG");
   if (s != NULL && *s != NUL)
     msg_attr((char_u *)
         _("Messages maintainer: Bram Moolenaar <Bram@vim.org>"),

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2669,7 +2669,7 @@ void vim_beep(void)
  * - get value of $HOME
  * For Unix:
  *  - go to that directory
- *  - do mch_dirname() to get the real name of that directory.
+ *  - do os_dirname() to get the real name of that directory.
  *  This also works with mounts and links.
  *  Don't do this for MS-DOS, it will change the "current dir" for a drive.
  */
@@ -2683,7 +2683,7 @@ void init_homedir(void)
   vim_free(homedir);
   homedir = NULL;
 
-  var = (char_u *)mch_getenv("HOME");
+  var = (char_u *)os_getenv("HOME");
 
   if (var != NULL && *var == NUL)       /* empty is same as not set */
     var = NULL;
@@ -2695,11 +2695,11 @@ void init_homedir(void)
      * Change to the directory and get the actual path.  This resolves
      * links.  Don't do it when we can't return.
      */
-    if (mch_dirname(NameBuff, MAXPATHL) == OK
-        && mch_chdir((char *)NameBuff) == 0) {
-      if (!mch_chdir((char *)var) && mch_dirname(IObuff, IOSIZE) == OK)
+    if (os_dirname(NameBuff, MAXPATHL) == OK
+        && os_chdir((char *)NameBuff) == 0) {
+      if (!os_chdir((char *)var) && os_dirname(IObuff, IOSIZE) == OK)
         var = IObuff;
-      if (mch_chdir((char *)NameBuff) != 0)
+      if (os_chdir((char *)NameBuff) != 0)
         EMSG(_(e_prev_dir));
     }
 #endif
@@ -2858,12 +2858,12 @@ expand_env_esc (
         *var = NUL;
 # ifdef UNIX
         /*
-         * Use mch_get_user_directory() to get the user directory.
+         * Use os_get_user_directory() to get the user directory.
          * If this function fails, the shell is used to
          * expand ~user. This is slower and may fail if the shell
          * does not support ~user (old versions of /bin/sh).
          */
-        var = (char_u *)mch_get_user_directory((char *)dst + 1);
+        var = (char_u *)os_get_user_directory((char *)dst + 1);
         mustfree = TRUE;
         if (var == NULL)
         {
@@ -2999,7 +2999,7 @@ char_u *vim_getenv(char_u *name, int *mustfree)
   int vimruntime;
 
 
-  p = (char_u *)mch_getenv((char *)name);
+  p = (char_u *)os_getenv((char *)name);
   if (p != NULL && *p == NUL)       /* empty is the same as not set */
     p = NULL;
 
@@ -3020,7 +3020,7 @@ char_u *vim_getenv(char_u *name, int *mustfree)
       && *default_vimruntime_dir == NUL
 #endif
       ) {
-    p = (char_u *)mch_getenv("VIM");
+    p = (char_u *)os_getenv("VIM");
     if (p != NULL && *p == NUL)             /* empty is the same as not set */
       p = NULL;
     if (p != NULL) {
@@ -3028,7 +3028,7 @@ char_u *vim_getenv(char_u *name, int *mustfree)
       if (p != NULL)
         *mustfree = TRUE;
       else
-        p = (char_u *)mch_getenv("VIM");
+        p = (char_u *)os_getenv("VIM");
 
     }
   }
@@ -3077,7 +3077,7 @@ char_u *vim_getenv(char_u *name, int *mustfree)
       /* check that the result is a directory name */
       p = vim_strnsave(p, (int)(pend - p));
 
-      if (p != NULL && !mch_isdir(p)) {
+      if (p != NULL && !os_isdir(p)) {
         vim_free(p);
         p = NULL;
       } else {
@@ -3139,11 +3139,11 @@ static char_u *vim_version_dir(char_u *vimdir)
   if (vimdir == NULL || *vimdir == NUL)
     return NULL;
   p = concat_fnames(vimdir, (char_u *)VIM_VERSION_NODOT, TRUE);
-  if (p != NULL && mch_isdir(p))
+  if (p != NULL && os_isdir(p))
     return p;
   vim_free(p);
   p = concat_fnames(vimdir, (char_u *)RUNTIME_DIRNAME, TRUE);
-  if (p != NULL && mch_isdir(p))
+  if (p != NULL && os_isdir(p))
     return p;
   vim_free(p);
   return NULL;
@@ -3170,7 +3170,7 @@ static char_u *remove_tail(char_u *p, char_u *pend, char_u *name)
  */
 void vim_setenv(char_u *name, char_u *val)
 {
-  mch_setenv((char *)name, (char *)val, 1);
+  os_setenv((char *)name, (char *)val, 1);
   /*
    * When setting $VIMRUNTIME adjust the directory to find message
    * translations to $VIMRUNTIME/lang.
@@ -3194,7 +3194,7 @@ char_u *get_env_name(expand_T *xp, int idx)
 # define ENVNAMELEN 100
   // this static buffer is needed to avoid a memory leak in ExpandGeneric
   static char_u name[ENVNAMELEN];
-  char *envname = mch_getenvname_at_index(idx);
+  char *envname = os_getenvname_at_index(idx);
   if (envname) {
     vim_strncpy(name, (char_u *)envname, ENVNAMELEN - 1);
     vim_free(envname);
@@ -3218,7 +3218,7 @@ static void init_users(void)
 
   lazy_init_done = TRUE;
   
-  mch_get_usernames(&ga_users);
+  os_get_usernames(&ga_users);
 }
 
 /*
@@ -3294,7 +3294,7 @@ home_replace (
   if (homedir != NULL)
     dirlen = STRLEN(homedir);
 
-  homedir_env_orig = homedir_env = (char_u *)mch_getenv("HOME");
+  homedir_env_orig = homedir_env = (char_u *)os_getenv("HOME");
   /* Empty is the same as not set. */
   if (homedir_env != NULL && *homedir_env == NUL)
     homedir_env = NULL;
@@ -3656,7 +3656,7 @@ int dir_of_file_exists(char_u *fname)
     return TRUE;
   c = *p;
   *p = NUL;
-  retval = mch_isdir(fname);
+  retval = os_isdir(fname);
   *p = c;
   return retval;
 }
@@ -4332,7 +4332,7 @@ static void expand_path_option(char_u *curdir, garray_T *gap)
     else if (path_with_url(buf))
       /* URL can't be used here */
       continue;
-    else if (!mch_is_absolute_path(buf)) {
+    else if (!os_is_absolute_path(buf)) {
       /* Expand relative path to their full path equivalent */
       len = (int)STRLEN(curdir);
       if (len + (int)STRLEN(buf) + 3 > MAXPATHL)
@@ -4438,7 +4438,7 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
 
   if ((curdir = alloc((int)(MAXPATHL))) == NULL)
     goto theend;
-  mch_dirname(curdir, MAXPATHL);
+  os_dirname(curdir, MAXPATHL);
   expand_path_option(curdir, &path_ga);
 
   in_curdir = (char_u **)alloc_clear(gap->ga_len * sizeof(char_u *));
@@ -4473,7 +4473,7 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
         break;
       }
 
-    if (mch_is_absolute_path(path)) {
+    if (os_is_absolute_path(path)) {
       /*
        * Last resort: shorten relative to curdir if possible.
        * 'possible' means:
@@ -4563,7 +4563,7 @@ expand_in_path (
 
   if ((curdir = alloc((unsigned)MAXPATHL)) == NULL)
     return 0;
-  mch_dirname(curdir, MAXPATHL);
+  os_dirname(curdir, MAXPATHL);
 
   ga_init2(&path_ga, (int)sizeof(char_u *), 1);
   expand_path_option(curdir, &path_ga);
@@ -4762,7 +4762,7 @@ gen_expand_wildcards (
        */
       if (mch_has_exp_wildcard(p)) {
         if ((flags & EW_PATH)
-            && !mch_is_absolute_path(p)
+            && !os_is_absolute_path(p)
             && !(p[0] == '.'
                  && (vim_ispathsep(p[1])
                      || (p[1] == '.' && vim_ispathsep(p[2]))))
@@ -4896,12 +4896,12 @@ addfile (
     return;
 #endif
 
-  isdir = mch_isdir(f);
+  isdir = os_isdir(f);
   if ((isdir && !(flags & EW_DIR)) || (!isdir && !(flags & EW_FILE)))
     return;
 
   /* If the file isn't executable, may not add it.  Do accept directories. */
-  if (!isdir && (flags & EW_EXEC) && !mch_can_exe(f))
+  if (!isdir && (flags & EW_EXEC) && !os_can_exe(f))
     return;
 
   /* Make room for another item in the file list. */

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1628,7 +1628,7 @@ int vim_chdirfile(char_u *fname)
 
   vim_strncpy(dir, fname, MAXPATHL - 1);
   *gettail_sep(dir) = NUL;
-  return mch_chdir((char *)dir) == 0 ? OK : FAIL;
+  return os_chdir((char *)dir) == 0 ? OK : FAIL;
 }
 #endif
 
@@ -1644,7 +1644,7 @@ int illegal_slash(char *name)
     return FALSE;           /* no file name is not illegal */
   if (name[strlen(name) - 1] != '/')
     return FALSE;           /* no trailing slash */
-  if (mch_isdir((char_u *)name))
+  if (os_isdir((char_u *)name))
     return FALSE;           /* trailing slash for a directory */
   return TRUE;
 }
@@ -1652,7 +1652,7 @@ int illegal_slash(char *name)
 
 /*
  * Change directory to "new_dir".  If FEAT_SEARCHPATH is defined, search
- * 'cdpath' for relative directory names, otherwise just mch_chdir().
+ * 'cdpath' for relative directory names, otherwise just os_chdir().
  */
 int vim_chdir(char_u *new_dir)
 {
@@ -1663,7 +1663,7 @@ int vim_chdir(char_u *new_dir)
       FNAME_MESS, curbuf->b_ffname);
   if (dir_name == NULL)
     return -1;
-  r = mch_chdir((char *)dir_name);
+  r = os_chdir((char *)dir_name);
   vim_free(dir_name);
   return r;
 }
@@ -1802,7 +1802,7 @@ int filewritable(char_u *fname)
 #endif
 
 #if defined(UNIX) || defined(VMS)
-  perm = mch_getperm(fname);
+  perm = os_getperm(fname);
 #endif
   if (
 # if defined(UNIX) || defined(VMS)
@@ -1811,7 +1811,7 @@ int filewritable(char_u *fname)
     mch_access((char *)fname, W_OK) == 0
     ) {
     ++retval;
-    if (mch_isdir(fname))
+    if (os_isdir(fname))
       ++retval;
   }
   return retval;

--- a/src/option.c
+++ b/src/option.c
@@ -1962,7 +1962,7 @@ void set_init_1(void)
   p_cp = TRUE;
 
   /* Use POSIX compatibility when $VIM_POSIX is set. */
-  if (mch_getenv("VIM_POSIX") != NULL) {
+  if (os_getenv("VIM_POSIX") != NULL) {
     set_string_default("cpo", (char_u *)CPO_ALL);
     set_string_default("shm", (char_u *)"A");
   }
@@ -1971,7 +1971,7 @@ void set_init_1(void)
    * Find default value for 'shell' option.
    * Don't use it if it is empty.
    */
-  if (((p = (char_u *)mch_getenv("SHELL")) != NULL && *p != NUL)
+  if (((p = (char_u *)os_getenv("SHELL")) != NULL && *p != NUL)
       )
     set_string_default("sh", p);
 
@@ -2030,7 +2030,7 @@ void set_init_1(void)
     {
 #ifdef HAVE_TOTAL_MEM
       /* Use amount of memory available to Vim. */
-      n = (mch_total_mem(FALSE) >> 1);
+      n = (os_total_mem(FALSE) >> 1);
 #else
       n = (0x7fffffff >> 11);
 #endif
@@ -2166,7 +2166,7 @@ void set_init_1(void)
    * NOTE: mlterm's author is being asked to 'set' a variable
    *       instead of an environment variable due to inheritance.
    */
-  if (mch_getenv("MLTERM") != NULL)
+  if (os_getenv("MLTERM") != NULL)
     set_option_value((char_u *)"tbidi", 1L, NULL, 0);
 
   /* Parse default for 'fillchars'. */
@@ -2444,7 +2444,7 @@ static char_u *term_bg_default(void)
       || STRCMP(T_NAME, "screen.linux") == 0
       || STRCMP(T_NAME, "cygwin") == 0
       || STRCMP(T_NAME, "putty") == 0
-      || ((p = (char_u *)mch_getenv("COLORFGBG")) != NULL
+      || ((p = (char_u *)os_getenv("COLORFGBG")) != NULL
           && (p = vim_strrchr(p, ';')) != NULL
           && ((p[1] >= '0' && p[1] <= '6') || p[1] == '8')
           && p[2] == NUL))

--- a/src/os/env.c
+++ b/src/os/env.c
@@ -1,15 +1,4 @@
-/* vi:set ts=2 sts=2 sw=2:
- *
- * VIM - Vi IMproved	by Bram Moolenaar
- *
- * Do ":help uganda"  in Vim to read copying and usage conditions.
- * Do ":help credits" in Vim to see a list of people who contributed.
- * See README.txt for an overview of the Vim source code.
- */
-
-/*
- * env.c -- environment variable access
- */
+// env.c -- environment variable access
 
 #include <uv.h>
 
@@ -33,15 +22,13 @@ int os_setenv(const char *name, const char *value, int overwrite)
 char *os_getenvname_at_index(size_t index)
 {
 # if defined(AMIGA) || defined(__MRC__) || defined(__SC__)
-  /*
-   * No environ[] on the Amiga and on the Mac (using MPW).
-   */
+  // No environ[] on the Amiga and on the Mac (using MPW).
   return NULL;
 # else
 # if defined(HAVE__NSGETENVIRON)
   char **environ = *_NSGetEnviron();
 # elif !defined(__WIN32__)
-  /* Borland C++ 5.2 has this in a header file. */
+  // Borland C++ 5.2 has this in a header file.
   extern char         **environ;
 # endif
   // check if index is inside the environ array

--- a/src/os/env.c
+++ b/src/os/env.c
@@ -20,17 +20,17 @@
 #include <crt_externs.h>
 #endif
 
-const char *mch_getenv(const char *name)
+const char *os_getenv(const char *name)
 {
   return getenv(name);
 }
 
-int mch_setenv(const char *name, const char *value, int overwrite)
+int os_setenv(const char *name, const char *value, int overwrite)
 {
   return setenv(name, value, overwrite);
 }
 
-char *mch_getenvname_at_index(size_t index)
+char *os_getenvname_at_index(size_t index)
 {
 # if defined(AMIGA) || defined(__MRC__) || defined(__SC__)
   /*

--- a/src/os/event.c
+++ b/src/os/event.c
@@ -13,23 +13,23 @@ static void timer_prepare_cb(uv_prepare_t *, int);
 
 void event_init()
 {
-  /* Initialize input events */
+  // Initialize input events
   input_init();
-  /* Timer to wake the event loop if a timeout argument is passed to
-   * `event_poll` */
+  // Timer to wake the event loop if a timeout argument is passed to
+  // `event_poll`
   uv_timer_init(uv_default_loop(), &timer);
-  /* This prepare handle that actually starts the timer */
+  // This prepare handle that actually starts the timer
   uv_prepare_init(uv_default_loop(), &timer_prepare);
 }
 
-/* Wait for some event */
+// Wait for some event
 bool event_poll(int32_t ms)
 {
   bool timed_out;
   uv_run_mode run_mode = UV_RUN_ONCE;
 
   if (input_ready()) {
-    /* If there's a pending input event to be consumed, do it now */
+    // If there's a pending input event to be consumed, do it now
     return true;
   }
 
@@ -37,42 +37,39 @@ bool event_poll(int32_t ms)
   timed_out = false;
 
   if (ms > 0) {
-    /* Timeout passed as argument to the timer */
+    // Timeout passed as argument to the timer
     timer.data = &timed_out;
-    /* We only start the timer after the loop is running, for that we
-     * use an prepare handle(pass the interval as data to it) */
+    // We only start the timer after the loop is running, for that we
+    // use an prepare handle(pass the interval as data to it)
     timer_prepare.data = &ms;
     uv_prepare_start(&timer_prepare, timer_prepare_cb);
   } else if (ms == 0) {
-    /* 
-     * For ms == 0, we need to do a non-blocking event poll by
-     * setting the run mode to UV_RUN_NOWAIT.
-     */
+    // For ms == 0, we need to do a non-blocking event poll by
+    // setting the run mode to UV_RUN_NOWAIT.
     run_mode = UV_RUN_NOWAIT;
   }
 
   do {
-    /* Run one event loop iteration, blocking for events if run_mode is
-     * UV_RUN_ONCE */
+    // Run one event loop iteration, blocking for events if run_mode is
+    // UV_RUN_ONCE
     uv_run(uv_default_loop(), run_mode);
   } while (
-      /* Continue running if ... */
-      !input_ready() && /* ... we have no input */
-      run_mode != UV_RUN_NOWAIT && /* ... ms != 0 */
-      !timed_out  /* ... we didn't get a timeout */
-      );
+      // Continue running if ...
+      !input_ready()  // ... we have no input
+      && run_mode != UV_RUN_NOWAIT  // ... ms != 0
+      && !timed_out);  // ... we didn't get a timeout
 
   input_stop();
 
   if (ms > 0) {
-    /* Stop the timer */
+    // Stop the timer
     uv_timer_stop(&timer);
   }
 
   return input_ready();
 }
 
-/* Set a flag in the `event_poll` loop for signaling of a timeout */
+// Set a flag in the `event_poll` loop for signaling of a timeout
 static void timer_cb(uv_timer_t *handle, int status)
 {
   *((bool *)handle->data) = true;

--- a/src/os/event.h
+++ b/src/os/event.h
@@ -7,5 +7,5 @@
 void event_init(void);
 bool event_poll(int32_t ms);
 
-#endif
+#endif  // NEOVIM_OS_EVENT_H
 

--- a/src/os/input.c
+++ b/src/os/input.c
@@ -122,7 +122,7 @@ uint32_t input_read(char *buf, uint32_t count)
 
 
 /* Low level input function. */
-int mch_inchar(char_u *buf, int maxlen, long ms, int tb_change_cnt)
+int os_inchar(char_u *buf, int maxlen, long ms, int tb_change_cnt)
 {
   InbufPollResult result;
 
@@ -158,7 +158,7 @@ int mch_inchar(char_u *buf, int maxlen, long ms, int tb_change_cnt)
 }
 
 /* Check if a character is available for reading */
-bool mch_char_avail()
+bool os_char_avail()
 {
   return inbuf_poll(0) == kInputAvail;
 }
@@ -167,7 +167,7 @@ bool mch_char_avail()
  * Check for CTRL-C typed by reading all available characters.
  * In cooked mode we should get SIGINT, no need to check.
  */
-void mch_breakcheck()
+void os_breakcheck()
 {
   if (curr_tmode == TMODE_RAW && event_poll(0))
     fill_input_buf(FALSE);

--- a/src/os/input.h
+++ b/src/os/input.h
@@ -11,9 +11,8 @@ bool input_ready(void);
 void input_start(void);
 void input_stop(void);
 uint32_t input_read(char *buf, uint32_t count);
-int os_inchar(char_u *, int, long, int);
+int os_inchar(char_u *, int, int32_t, int);
 bool os_char_avail(void);
 void os_breakcheck(void);
 
-#endif
-
+#endif  // NEOVIM_OS_INPUT_H

--- a/src/os/input.h
+++ b/src/os/input.h
@@ -11,9 +11,9 @@ bool input_ready(void);
 void input_start(void);
 void input_stop(void);
 uint32_t input_read(char *buf, uint32_t count);
-int mch_inchar(char_u *, int, long, int);
-bool mch_char_avail(void);
-void mch_breakcheck(void);
+int os_inchar(char_u *, int, long, int);
+bool os_char_avail(void);
+void os_breakcheck(void);
 
 #endif
 

--- a/src/os/mem.c
+++ b/src/os/mem.c
@@ -1,26 +1,13 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
- * VIM - Vi IMproved	by Bram Moolenaar
- *
- * Do ":help uganda"  in Vim to read copying and usage conditions.
- * Do ":help credits" in Vim to see a list of people who contributed.
- * See README.txt for an overview of the Vim source code.
- */
-
-/*
- * os.c -- OS-level calls to query hardware, etc.
- */
+// os.c -- OS-level calls to query hardware, etc.
 
 #include <uv.h>
 
 #include "os/os.h"
 
-/*
- * Return total amount of memory available in Kbyte.
- * Doesn't change when memory has been allocated.
- */
+// Return total amount of memory available in Kbyte.
+// Doesn't change when memory has been allocated.
 long_u os_total_mem(int special) {
-  /* We need to return memory in *Kbytes* but uv_get_total_memory() returns the
-   * number of bytes of total memory. */
+  // We need to return memory in *Kbytes* but uv_get_total_memory() returns the
+  // number of bytes of total memory.
   return uv_get_total_memory() >> 10;
 }

--- a/src/os/mem.c
+++ b/src/os/mem.c
@@ -19,7 +19,7 @@
  * Return total amount of memory available in Kbyte.
  * Doesn't change when memory has been allocated.
  */
-long_u mch_total_mem(int special) {
+long_u os_total_mem(int special) {
   /* We need to return memory in *Kbytes* but uv_get_total_memory() returns the
    * number of bytes of total memory. */
   return uv_get_total_memory() >> 10;

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -3,22 +3,22 @@
 
 #include "vim.h"
 
-long_u mch_total_mem(int special);
-int mch_chdir(char *path);
-int mch_dirname(char_u *buf, size_t len);
-int mch_get_absolute_path(char_u *fname, char_u *buf, int len, int force);
-int mch_is_absolute_path(const char_u *fname);
-int mch_isdir(const char_u *name);
-int mch_can_exe(const char_u *name);
-const char *mch_getenv(const char *name);
-int mch_setenv(const char *name, const char *value, int overwrite);
-char *mch_getenvname_at_index(size_t index);
-int mch_get_usernames(garray_T *usernames);
-int mch_get_user_name(char *s, size_t len);
-int mch_get_uname(uid_t uid, char *s, size_t len);
-char *mch_get_user_directory(const char *name);
-long mch_getperm(const char_u *name);
-int mch_setperm(const char_u *name, int perm);
+long_u os_total_mem(int special);
+int os_chdir(char *path);
+int os_dirname(char_u *buf, size_t len);
+int os_get_absolute_path(char_u *fname, char_u *buf, int len, int force);
+int os_is_absolute_path(const char_u *fname);
+int os_isdir(const char_u *name);
+int os_can_exe(const char_u *name);
+const char *os_getenv(const char *name);
+int os_setenv(const char *name, const char *value, int overwrite);
+char *os_getenvname_at_index(size_t index);
+int os_get_usernames(garray_T *usernames);
+int os_get_user_name(char *s, size_t len);
+int os_get_uname(uid_t uid, char *s, size_t len);
+char *os_get_user_directory(const char *name);
+long os_getperm(const char_u *name);
+int os_setperm(const char_u *name, int perm);
 int os_file_exists(char_u *name);
 
 #endif

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -4,7 +4,7 @@
 #include "vim.h"
 
 long_u os_total_mem(int special);
-int os_chdir(char *path);
+int os_chdir(const char *path);
 int os_dirname(char_u *buf, size_t len);
 int os_get_absolute_path(char_u *fname, char_u *buf, int len, int force);
 int os_is_absolute_path(const char_u *fname);
@@ -17,8 +17,8 @@ int os_get_usernames(garray_T *usernames);
 int os_get_user_name(char *s, size_t len);
 int os_get_uname(uid_t uid, char *s, size_t len);
 char *os_get_user_directory(const char *name);
-long os_getperm(const char_u *name);
+int32_t os_getperm(const char_u *name);
 int os_setperm(const char_u *name, int perm);
-int os_file_exists(char_u *name);
+int os_file_exists(const char_u *name);
 
-#endif
+#endif  // NEOVIM_OS_OS_H

--- a/src/os/time.c
+++ b/src/os/time.c
@@ -17,7 +17,7 @@ void time_init()
   uv_cond_init(&delay_cond);
 }
 
-void mch_delay(uint64_t ms, bool ignoreinput)
+void os_delay(uint64_t ms, bool ignoreinput)
 {
   int old_tmode;
 
@@ -25,7 +25,7 @@ void mch_delay(uint64_t ms, bool ignoreinput)
     /* Go to cooked mode without echo, to allow SIGINT interrupting us
      * here.  But we don't want QUIT to kill us (CTRL-\ used in a
      * shell may produce SIGQUIT). */
-    in_mch_delay = true;
+    in_os_delay = true;
     old_tmode = curr_tmode;
 
     if (curr_tmode == TMODE_RAW)
@@ -34,7 +34,7 @@ void mch_delay(uint64_t ms, bool ignoreinput)
     delay(ms);
 
     settmode(old_tmode);
-    in_mch_delay = false;
+    in_os_delay = false;
   } else {
     delay(ms);
   }

--- a/src/os/time.c
+++ b/src/os/time.c
@@ -22,9 +22,9 @@ void os_delay(uint64_t ms, bool ignoreinput)
   int old_tmode;
 
   if (ignoreinput) {
-    /* Go to cooked mode without echo, to allow SIGINT interrupting us
-     * here.  But we don't want QUIT to kill us (CTRL-\ used in a
-     * shell may produce SIGQUIT). */
+    // Go to cooked mode without echo, to allow SIGINT interrupting us
+    // here.  But we don't want QUIT to kill us (CTRL-\ used in a
+    // shell may produce SIGQUIT).
     in_os_delay = true;
     old_tmode = curr_tmode;
 
@@ -43,7 +43,7 @@ void os_delay(uint64_t ms, bool ignoreinput)
 static void delay(uint64_t ms)
 {
   uint64_t hrtime;
-  int64_t ns = ms * 1000000; /* convert to nanoseconds */
+  int64_t ns = ms * 1000000;  // convert to nanoseconds
 
   uv_mutex_lock(&delay_mutex);
 

--- a/src/os/time.h
+++ b/src/os/time.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 
 void time_init(void);
-void mch_delay(uint64_t ms, bool ignoreinput);
+void os_delay(uint64_t ms, bool ignoreinput);
 
 #endif
 

--- a/src/os/time.h
+++ b/src/os/time.h
@@ -7,5 +7,4 @@
 void time_init(void);
 void os_delay(uint64_t ms, bool ignoreinput);
 
-#endif
-
+#endif  // NEOVIM_OS_TIME_H

--- a/src/os/users.c
+++ b/src/os/users.c
@@ -24,7 +24,7 @@
  * Initialize users garray and fill it with os usernames.
  * Return Ok for success, FAIL for failure.
  */
-int mch_get_usernames(garray_T *users)
+int os_get_usernames(garray_T *users)
 {
   if (users == NULL) {
     return FALSE;
@@ -59,9 +59,9 @@ int mch_get_usernames(garray_T *users)
  * Insert user name in s[len].
  * Return OK if a name found.
  */
-int mch_get_user_name(char *s, size_t len)
+int os_get_user_name(char *s, size_t len)
 {
-  return mch_get_uname(getuid(), s, len);
+  return os_get_uname(getuid(), s, len);
 }
 
 /*
@@ -69,7 +69,7 @@ int mch_get_user_name(char *s, size_t len)
  * Return OK if a name found.
  * If the name is not found, write the uid into s[len] and return FAIL.
  */
-int mch_get_uname(uid_t uid, char *s, size_t len)
+int os_get_uname(uid_t uid, char *s, size_t len)
 {
 #if defined(HAVE_PWD_H) && defined(HAVE_GETPWUID)
   struct passwd *pw;
@@ -89,7 +89,7 @@ int mch_get_uname(uid_t uid, char *s, size_t len)
  * The caller has to free() the returned string.
  * If the username is not found, NULL is returned.
  */
-char *mch_get_user_directory(const char *name)
+char *os_get_user_directory(const char *name)
 {
 #if defined(HAVE_GETPWNAM) && defined(HAVE_PWD_H)
   struct passwd *pw;

--- a/src/os/users.c
+++ b/src/os/users.c
@@ -1,15 +1,4 @@
-/* vi:set ts=2 sts=2 sw=2:
- *
- * VIM - Vi IMproved	by Bram Moolenaar
- *
- * Do ":help uganda"  in Vim to read copying and usage conditions.
- * Do ":help credits" in Vim to see a list of people who contributed.
- * See README.txt for an overview of the Vim source code.
- */
-
-/*
- * users.c -- operating system user information
- */
+// users.c -- operating system user information
 
 #include <uv.h>
 
@@ -20,10 +9,8 @@
 # include <pwd.h>
 #endif
 
-/*
- * Initialize users garray and fill it with os usernames.
- * Return Ok for success, FAIL for failure.
- */
+// Initialize users garray and fill it with os usernames.
+// Return Ok for success, FAIL for failure.
 int os_get_usernames(garray_T *users)
 {
   if (users == NULL) {
@@ -37,7 +24,7 @@ int os_get_usernames(garray_T *users)
 
   setpwent();
   while ((pw = getpwent()) != NULL) {
-    /* pw->pw_name shouldn't be NULL but just in case... */
+    // pw->pw_name shouldn't be NULL but just in case...
     if (pw->pw_name != NULL) {
       if (ga_grow(users, 1) == FAIL) {
         return FAIL;
@@ -55,20 +42,16 @@ int os_get_usernames(garray_T *users)
   return OK;
 }
 
-/*
- * Insert user name in s[len].
- * Return OK if a name found.
- */
+// Insert user name in s[len].
+// Return OK if a name found.
 int os_get_user_name(char *s, size_t len)
 {
   return os_get_uname(getuid(), s, len);
 }
 
-/*
- * Insert user name for "uid" in s[len].
- * Return OK if a name found.
- * If the name is not found, write the uid into s[len] and return FAIL.
- */
+// Insert user name for "uid" in s[len].
+// Return OK if a name found.
+// If the name is not found, write the uid into s[len] and return FAIL.
 int os_get_uname(uid_t uid, char *s, size_t len)
 {
 #if defined(HAVE_PWD_H) && defined(HAVE_GETPWUID)
@@ -81,14 +64,12 @@ int os_get_uname(uid_t uid, char *s, size_t len)
   }
 #endif
   snprintf(s, len, "%d", (int)uid);
-  return FAIL; // a number is not a name
+  return FAIL;  // a number is not a name
 }
 
-/*
- * Returns the user directory for the given username.
- * The caller has to free() the returned string.
- * If the username is not found, NULL is returned.
- */
+// Returns the user directory for the given username.
+// The caller has to free() the returned string.
+// If the username is not found, NULL is returned.
 char *os_get_user_directory(const char *name)
 {
 #if defined(HAVE_GETPWNAM) && defined(HAVE_PWD_H)

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -419,10 +419,10 @@ deathtrap SIGDEFARG(sigarg) {
 
 #ifdef SIGHASARG
 # ifdef SIGQUIT
-  /* While in mch_delay() we go to cooked mode to allow a CTRL-C to
+  /* While in os_delay() we go to cooked mode to allow a CTRL-C to
    * interrupt us.  But in cooked mode we may also get SIGQUIT, e.g., when
    * pressing CTRL-\, but we don't want Vim to exit then. */
-  if (in_mch_delay && sigarg == SIGQUIT)
+  if (in_os_delay && sigarg == SIGQUIT)
     SIGRETURN;
 # endif
 
@@ -568,7 +568,7 @@ void mch_suspend()
     long wait_time;
     for (wait_time = 0; !sigcont_received && wait_time <= 3L; wait_time++)
       /* Loop is not entered most of the time */
-      mch_delay(wait_time, FALSE);
+      os_delay(wait_time, FALSE);
   }
 # endif
 
@@ -1594,9 +1594,9 @@ int mch_get_shellsize()
    *    the ioctl() values!
    */
   if (columns == 0 || rows == 0 || vim_strchr(p_cpo, CPO_TSIZE) != NULL) {
-    if ((p = (char_u *)mch_getenv("LINES")))
+    if ((p = (char_u *)os_getenv("LINES")))
       rows = atoi((char *)p);
-    if ((p = (char_u *)mch_getenv("COLUMNS")))
+    if ((p = (char_u *)os_getenv("COLUMNS")))
       columns = atoi((char *)p);
   }
 
@@ -1667,7 +1667,7 @@ waitstatus  *status;
 # endif
     if (wait_pid == 0) {
       /* Wait for 10 msec before trying again. */
-      mch_delay(10L, TRUE);
+      os_delay(10L, TRUE);
       continue;
     }
     if (wait_pid <= 0
@@ -1879,13 +1879,13 @@ int options;                    /* SHELL_*, see vim.h */
         }
 # endif
         /* Simulate to have a dumb terminal (for now) */
-        mch_setenv("TERM", "dumb", 1);
+        os_setenv("TERM", "dumb", 1);
         sprintf((char *)envbuf, "%ld", Rows);
-        mch_setenv("ROWS", (char *)envbuf, 1);
+        os_setenv("ROWS", (char *)envbuf, 1);
         sprintf((char *)envbuf, "%ld", Rows);
-        mch_setenv("LINES", (char *)envbuf, 1);
+        os_setenv("LINES", (char *)envbuf, 1);
         sprintf((char *)envbuf, "%ld", Columns);
-        mch_setenv("COLUMNS", (char *)envbuf, 1);
+        os_setenv("COLUMNS", (char *)envbuf, 1);
 
         /*
          * stderr is only redirected when using the GUI, so that a
@@ -2180,7 +2180,7 @@ int options;                    /* SHELL_*, see vim.h */
            * Check if the child has any characters to be printed.
            * Read them and write them to our window.	Repeat this as
            * long as there is something to do, avoid the 10ms wait
-           * for mch_inchar(), or sending typeahead characters to
+           * for os_inchar(), or sending typeahead characters to
            * the external process.
            * TODO: This should handle escape sequences, compatible
            * to some terminal (vt52?).
@@ -2739,7 +2739,7 @@ int flags;                      /* EW_* flags */
   /* When running in the background, give it some time to create the temp
    * file, but don't wait for it to finish. */
   if (ampersent)
-    mch_delay(10L, TRUE);
+    os_delay(10L, TRUE);
 
   extra_shell_arg = NULL;               /* cleanup */
   show_shell_mess = TRUE;
@@ -2915,12 +2915,12 @@ int flags;                      /* EW_* flags */
       continue;
 
     /* check if this entry should be included */
-    dir = (mch_isdir((*file)[i]));
+    dir = (os_isdir((*file)[i]));
     if ((dir && !(flags & EW_DIR)) || (!dir && !(flags & EW_FILE)))
       continue;
 
     /* Skip files that are not executable if we check for that. */
-    if (!dir && (flags & EW_EXEC) && !mch_can_exe((*file)[i]))
+    if (!dir && (flags & EW_EXEC) && !os_can_exe((*file)[i]))
       continue;
 
     p = alloc((unsigned)(STRLEN((*file)[i]) + 1 + dir));

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1184,7 +1184,7 @@ static char_u *qf_push_dir(char_u *dirbuf, struct dir_stack_T **stackptr)
       vim_free((*stackptr)->dirname);
       (*stackptr)->dirname = concat_fnames(ds_new->dirname, dirbuf,
           TRUE);
-      if (mch_isdir((*stackptr)->dirname) == TRUE)
+      if (os_isdir((*stackptr)->dirname) == TRUE)
         break;
 
       ds_new = ds_new->next;
@@ -2866,7 +2866,7 @@ void ex_vimgrep(exarg_T *eap)
 
   /* Remember the current directory, because a BufRead autocommand that does
    * ":lcd %:p:h" changes the meaning of short path names. */
-  mch_dirname(dirname_start, MAXPATHL);
+  os_dirname(dirname_start, MAXPATHL);
 
   /* Remember the value of qf_start, so that we can check for autocommands
    * changing the current quickfix list. */
@@ -3133,7 +3133,7 @@ static void restore_start_dir(char_u *dirname_start)
   char_u *dirname_now = alloc(MAXPATHL);
 
   if (NULL != dirname_now) {
-    mch_dirname(dirname_now, MAXPATHL);
+    os_dirname(dirname_now, MAXPATHL);
     if (STRCMP(dirname_start, dirname_now) != 0) {
       /* If the directory has changed, change it back by building up an
        * appropriate ex command and executing it. */
@@ -3221,7 +3221,7 @@ load_dummy_buffer (
    * Let the caller know what the resulting dir was first, in case it is
    * important.
    */
-  mch_dirname(resulting_dir, MAXPATHL);
+  os_dirname(resulting_dir, MAXPATHL);
   restore_start_dir(dirname_start);
 
   if (!buf_valid(newbuf))

--- a/src/spell.c
+++ b/src/spell.c
@@ -8235,7 +8235,7 @@ mkspell (
       EMSG(_(e_exists));
       goto theend;
     }
-    if (mch_isdir(wfname)) {
+    if (os_isdir(wfname)) {
       EMSG2(_(e_isadir2), wfname);
       goto theend;
     }

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -4205,7 +4205,7 @@ static void syn_cmd_include(exarg_T *eap, int syncing)
    */
   eap->argt |= (XFILE | NOSPC);
   separate_nextcmd(eap);
-  if (*eap->arg == '<' || *eap->arg == '$' || mch_is_absolute_path(eap->arg)) {
+  if (*eap->arg == '<' || *eap->arg == '$' || os_is_absolute_path(eap->arg)) {
     /* For an absolute path, "$VIM/..." or "<sfile>.." we ":source" the
      * file.  Need to expand the file name first.  In other cases
      * ":runtime!" is used. */

--- a/src/term.c
+++ b/src/term.c
@@ -379,7 +379,7 @@ static struct builtin_term builtin_termcaps[] =
   /*
    * These codes are valid when nansi.sys or equivalent has been installed.
    * Function keys on a PC are preceded with a NUL. These are converted into
-   * K_NUL '\316' in mch_inchar(), because we cannot handle NULs in key codes.
+   * K_NUL '\316' in os_inchar(), because we cannot handle NULs in key codes.
    * CTRL-arrow is used instead of SHIFT-arrow.
    */
   {(int)KS_NAME,      "pcansi"},
@@ -2025,7 +2025,7 @@ void termcapinit(char_u *name)
   term = name;
 
   if (term == NULL)
-    term = (char_u *)mch_getenv("TERM");
+    term = (char_u *)os_getenv("TERM");
   if (term == NULL || *term == NUL)
     term = DEFAULT_TERM;
   set_string_option_direct((char_u *)"term", -1, term, OPT_FREE, 0);
@@ -2035,7 +2035,7 @@ void termcapinit(char_u *name)
   set_string_default("ttytype", term);
 
   /*
-   * Avoid using "term" here, because the next mch_getenv() may overwrite it.
+   * Avoid using "term" here, because the next os_getenv() may overwrite it.
    */
   set_termname(T_NAME != NULL ? T_NAME : term);
 }
@@ -2674,7 +2674,7 @@ void stoptermcap(void)
       if (crv_status == CRV_SENT || u7_status == U7_SENT) {
 # ifdef UNIX
         /* Give the terminal a chance to respond. */
-        mch_delay(100L, FALSE);
+        os_delay(100L, FALSE);
 # endif
 # ifdef TCIFLUSH
         /* Discard data received but not read. */

--- a/src/ui.c
+++ b/src/ui.c
@@ -129,7 +129,7 @@ ui_inchar (
     static int count = 0;
 
 # ifndef NO_CONSOLE
-    retval = mch_inchar(buf, maxlen, (wtime >= 0 && wtime < 10)
+    retval = os_inchar(buf, maxlen, (wtime >= 0 && wtime < 10)
         ? 10L : wtime, tb_change_cnt);
     if (retval > 0 || typebuf_changed(tb_change_cnt) || wtime >= 0)
       goto theend;
@@ -155,7 +155,7 @@ ui_inchar (
 
 #ifndef NO_CONSOLE
   {
-    retval = mch_inchar(buf, maxlen, wtime, tb_change_cnt);
+    retval = os_inchar(buf, maxlen, wtime, tb_change_cnt);
   }
 #endif
 
@@ -183,7 +183,7 @@ int ui_char_avail(void)
   if (no_console_input())
     return 0;
 # endif
-  return mch_char_avail();
+  return os_char_avail();
 #else
   return 0;
 #endif
@@ -195,7 +195,7 @@ int ui_char_avail(void)
  */
 void ui_delay(long msec, int ignoreinput)
 {
-  mch_delay(msec, ignoreinput);
+  os_delay(msec, ignoreinput);
 }
 
 /*
@@ -272,7 +272,7 @@ void ui_new_shellsize(void)
 
 void ui_breakcheck(void)
 {
-  mch_breakcheck();
+  os_breakcheck();
 }
 
 /*****************************************************************************

--- a/src/undo.c
+++ b/src/undo.c
@@ -724,7 +724,7 @@ char_u *u_get_undo_file_name(char_u *buf_ffname, int reading)
       STRCAT(p, ".un~");
     } else {
       dir_name[dir_len] = NUL;
-      if (mch_isdir(dir_name)) {
+      if (os_isdir(dir_name)) {
         if (munged_name == NULL) {
           munged_name = vim_strsave(ffname);
           if (munged_name == NULL)
@@ -1167,7 +1167,7 @@ void u_write_undo(char_u *name, int forceit, buf_T *buf, char_u *hash)
       st_old_valid = TRUE;
     }
 #else
-    perm = mch_getperm(buf->b_ffname);
+    perm = os_getperm(buf->b_ffname);
     if (perm < 0)
       perm = 0600;
 #endif
@@ -1231,7 +1231,7 @@ void u_write_undo(char_u *name, int forceit, buf_T *buf, char_u *hash)
     EMSG2(_(e_not_open), file_name);
     goto theend;
   }
-  (void)mch_setperm(file_name, perm);
+  (void)os_setperm(file_name, perm);
   if (p_verbose > 0) {
     verbose_enter();
     smsg((char_u *)_("Writing undo file: %s"), file_name);
@@ -1256,7 +1256,7 @@ void u_write_undo(char_u *name, int forceit, buf_T *buf, char_u *hash)
       && fchown(fd, (uid_t)-1, st_old.st_gid) != 0
 # endif
       )
-    mch_setperm(file_name, (perm & 0707) | ((perm & 07) << 3));
+    os_setperm(file_name, (perm & 0707) | ((perm & 07) << 3));
 # ifdef HAVE_SELINUX
   if (buf->b_ffname != NULL)
     mch_copy_sec(buf->b_ffname, file_name);

--- a/src/vim.h
+++ b/src/vim.h
@@ -499,7 +499,7 @@ enum {
 #define SHELL_WRITE     64      /* write lines from buffer */
 
 /* Values returned by mch_nodetype() */
-#define NODE_NORMAL     0       /* file or directory, check with mch_isdir()*/
+#define NODE_NORMAL     0       /* file or directory, check with os_isdir()*/
 #define NODE_WRITABLE   1       /* something we can write to (character
                                    device, fifo, socket, ..) */
 #define NODE_OTHER      2       /* non-writable thing (e.g., block device) */

--- a/src/window.c
+++ b/src/window.c
@@ -3499,15 +3499,15 @@ static void win_enter_ext(win_T *wp, int undo_sync, int curwin_invalid, int trig
     if (globaldir == NULL) {
       char_u cwd[MAXPATHL];
 
-      if (mch_dirname(cwd, MAXPATHL) == OK)
+      if (os_dirname(cwd, MAXPATHL) == OK)
         globaldir = vim_strsave(cwd);
     }
-    if (mch_chdir((char *)curwin->w_localdir) == 0)
+    if (os_chdir((char *)curwin->w_localdir) == 0)
       shorten_fnames(TRUE);
   } else if (globaldir != NULL) {
     /* Window doesn't have a local directory and we are not in the global
      * directory: Change to the global directory. */
-    ignored = mch_chdir((char *)globaldir);
+    ignored = os_chdir((char *)globaldir);
     vim_free(globaldir);
     globaldir = NULL;
     shorten_fnames(TRUE);
@@ -5084,7 +5084,7 @@ int path_with_url(char_u *fname)
  */
 int vim_isAbsName(char_u *name)
 {
-  return path_with_url(name) != 0 || mch_is_absolute_path(name);
+  return path_with_url(name) != 0 || os_is_absolute_path(name);
 }
 
 /*
@@ -5109,7 +5109,7 @@ vim_FullName (
 
   url = path_with_url(fname);
   if (!url)
-    retval = mch_get_absolute_path(fname, buf, len, force);
+    retval = os_get_absolute_path(fname, buf, len, force);
   if (url || retval == FAIL) {
     /* something failed; use the file name (truncate when too long) */
     vim_strncpy(buf, fname, len - 1);

--- a/test/unit/os/env.moon
+++ b/test/unit/os/env.moon
@@ -5,26 +5,26 @@ require 'lfs'
 -- remove these statements once 'cimport' is working properly for misc1.h
 env = lib
 ffi.cdef [[
-const char *mch_getenv(const char *name);
-int mch_setenv(const char *name, const char *value, int override);
-char *mch_getenvname_at_index(size_t index);
+const char *os_getenv(const char *name);
+int os_setenv(const char *name, const char *value, int override);
+char *os_getenvname_at_index(size_t index);
 ]]
 
 NULL = ffi.cast 'void*', 0
 
 describe 'env function', ->
 
-  mch_setenv = (name, value, override) ->
-    env.mch_setenv (to_cstr name), (to_cstr value), override
+  os_setenv = (name, value, override) ->
+    env.os_setenv (to_cstr name), (to_cstr value), override
 
-  mch_getenv = (name) ->
-    rval = env.mch_getenv (to_cstr name)
+  os_getenv = (name) ->
+    rval = env.os_getenv (to_cstr name)
     if rval != NULL
       ffi.string rval
     else
       NULL
 
-  describe 'mch_setenv', ->
+  describe 'os_setenv', ->
 
     OK = 0
 
@@ -32,48 +32,48 @@ describe 'env function', ->
       name = 'NEOVIM_UNIT_TEST_SETENV_1N'
       value = 'NEOVIM_UNIT_TEST_SETENV_1V'
       eq nil, os.getenv name
-      eq OK, (mch_setenv name, value, 1)
+      eq OK, (os_setenv name, value, 1)
       eq value, os.getenv name
 
     it "dosn't overwrite an env variable if overwrite is 0", ->
       name = 'NEOVIM_UNIT_TEST_SETENV_2N'
       value = 'NEOVIM_UNIT_TEST_SETENV_2V'
       value_updated = 'NEOVIM_UNIT_TEST_SETENV_2V_UPDATED'
-      eq OK, (mch_setenv name, value, 0)
+      eq OK, (os_setenv name, value, 0)
       eq value, os.getenv name
-      eq OK, (mch_setenv name, value_updated, 0)
+      eq OK, (os_setenv name, value_updated, 0)
       eq value, os.getenv name
 
-  describe 'mch_getenv', ->
+  describe 'os_getenv', ->
 
     it 'reads an env variable', ->
       name = 'NEOVIM_UNIT_TEST_GETENV_1N'
       value =  'NEOVIM_UNIT_TEST_GETENV_1V'
-      eq NULL, mch_getenv name
-      -- need to use mch_setenv, because lua dosn't have a setenv function
-      mch_setenv name, value, 1
-      eq value, mch_getenv name
+      eq NULL, os_getenv name
+      -- need to use os_setenv, because lua dosn't have a setenv function
+      os_setenv name, value, 1
+      eq value, os_getenv name
 
     it 'returns NULL if the env variable is not found', ->
       name = 'NEOVIM_UNIT_TEST_GETENV_NOTFOUND'
-      eq NULL, mch_getenv name
+      eq NULL, os_getenv name
 
-  describe 'mch_getenvname_at_index', ->
+  describe 'os_getenvname_at_index', ->
 
     it 'returns names of environment variables', ->
       test_name = 'NEOVIM_UNIT_TEST_GETENVNAME_AT_INDEX_1N'
       test_value =  'NEOVIM_UNIT_TEST_GETENVNAME_AT_INDEX_1V'
-      mch_setenv test_name, test_value, 1
+      os_setenv test_name, test_value, 1
       i = 0
       names = {}
       found_name = false
-      name = env.mch_getenvname_at_index i
+      name = env.os_getenvname_at_index i
       while name != NULL
         table.insert names, ffi.string name
         if (ffi.string name) == test_name
           found_name = true
         i += 1
-        name = env.mch_getenvname_at_index i
+        name = env.os_getenvname_at_index i
 
       eq true, (table.getn names) > 0
       eq true, found_name
@@ -81,12 +81,12 @@ describe 'env function', ->
     it 'returns NULL if the index is out of bounds', ->
       huge = ffi.new 'size_t', 10000
       maxuint32 = ffi.new 'size_t', 4294967295
-      eq NULL, env.mch_getenvname_at_index huge
-      eq NULL, env.mch_getenvname_at_index maxuint32
+      eq NULL, env.os_getenvname_at_index huge
+      eq NULL, env.os_getenvname_at_index maxuint32
       if ffi.abi '64bit'
         -- couldn't use a bigger number because it gets converted to 
         -- double somewere, should be big enough anyway
         -- maxuint64 = ffi.new 'size_t', 18446744073709551615
         maxuint64 = ffi.new 'size_t', 18446744073709000000
-        eq NULL, env.mch_getenvname_at_index maxuint64
+        eq NULL, env.os_getenvname_at_index maxuint64
 

--- a/test/unit/os/fs.moon
+++ b/test/unit/os/fs.moon
@@ -16,7 +16,7 @@ int os_dirname(char_u *buf, int len);
 int os_isdir(char_u * name);
 int is_executable(char_u *name);
 int os_can_exe(char_u *name);
-long os_getperm(char_u *name);
+int32_t os_getperm(char_u *name);
 int os_setperm(char_u *name, long perm);
 int os_file_exists(const char_u *name);
 ]]

--- a/test/unit/os/time.moon
+++ b/test/unit/os/time.moon
@@ -7,12 +7,12 @@ describe 'time function', ->
   setup ->
     time.time_init!
 
-  describe 'mch_delay', ->
-    mch_delay = (ms) ->
-      time.mch_delay ms, false
+  describe 'os_delay', ->
+    os_delay = (ms) ->
+      time.os_delay ms, false
 
     it 'sleeps at least the number of requested milliseconds', ->
       curtime = lua_time!
-      mch_delay 1000
+      os_delay 1000
       ellapsed = lua_time! - curtime
       eq true, ellapsed >= 1 and ellapsed <=2

--- a/test/unit/os/users.moon
+++ b/test/unit/os/users.moon
@@ -11,10 +11,10 @@ typedef struct growarray {
   int ga_growsize;
   void    *ga_data;
 } garray_T;
-int mch_get_usernames(garray_T *usernames);
-int mch_get_user_name(char *s, size_t len);
-int mch_get_uname(int uid, char *s, size_t len);
-char *mch_get_user_directory(const char *name);
+int os_get_usernames(garray_T *usernames);
+int os_get_user_name(char *s, size_t len);
+int os_get_uname(int uid, char *s, size_t len);
+char *os_get_user_directory(const char *name);
 int getuid(void);
 ]]
 
@@ -37,14 +37,14 @@ describe 'users function', ->
   -- will probably not work on windows
   current_username = os.getenv 'USER'
 
-  describe 'mch_get_usernames', ->
+  describe 'os_get_usernames', ->
 
     it 'returns FAIL if called with NULL', ->
-      eq FAIL, users.mch_get_usernames NULL
+      eq FAIL, users.os_get_usernames NULL
 
     it 'fills the names garray with os usernames and returns OK', ->
       ga_users = garray_new!
-      eq OK, users.mch_get_usernames ga_users
+      eq OK, users.os_get_usernames ga_users
       user_count = garray_get_len ga_users
       assert.is_true user_count > 0
       current_username_found = false
@@ -54,37 +54,37 @@ describe 'users function', ->
           current_username_found = true
       assert.is_true current_username_found
 
-  describe 'mch_get_user_name', ->
+  describe 'os_get_user_name', ->
 
     it 'should write the username into the buffer and return OK', ->
       name_out = ffi.new 'char[100]'
-      eq OK, users.mch_get_user_name(name_out, 100)
+      eq OK, users.os_get_user_name(name_out, 100)
       eq current_username, ffi.string name_out
 
-  describe 'mch_get_uname', ->
+  describe 'os_get_uname', ->
 
     it 'should write the username into the buffer and return OK', ->
       name_out = ffi.new 'char[100]'
       user_id = lib.getuid!
-      eq OK, users.mch_get_uname(user_id, name_out, 100)
+      eq OK, users.os_get_uname(user_id, name_out, 100)
       eq current_username, ffi.string name_out
 
     it 'should FAIL if the userid is not found', ->
       name_out = ffi.new 'char[100]'
       -- hoping nobody has this uid
       user_id = 2342
-      eq FAIL, users.mch_get_uname(user_id, name_out, 100)
+      eq FAIL, users.os_get_uname(user_id, name_out, 100)
       eq '2342', ffi.string name_out
 
-  describe 'mch_get_user_directory', ->
+  describe 'os_get_user_directory', ->
 
     it 'should return NULL if called with NULL', ->
-      eq NULL, users.mch_get_user_directory NULL
+      eq NULL, users.os_get_user_directory NULL
 
     it 'should return $HOME for the current user', ->
       home = os.getenv('HOME')
-      eq home, ffi.string (users.mch_get_user_directory current_username)
+      eq home, ffi.string (users.os_get_user_directory current_username)
 
     it 'should return NULL if the user is not found', ->
-      eq NULL, users.mch_get_user_directory 'neovim_user_not_found_test'
+      eq NULL, users.os_get_user_directory 'neovim_user_not_found_test'
 


### PR DESCRIPTION
This PR tries to fix the style of the os module.
What is done so far:
- `mch_*` functions are renamed to `os_*`
- `/*...*/` are replaced with `//...` comments
- copyright messages are deleted
- some other clint warnings are fixed (like too long lines, wrong parentheses, etc.)

Remaining `clint.py` errors:

```
$ python clint.py src/os/*
src/os/env.c:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Done processing src/os/env.c
src/os/event.c:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Done processing src/os/event.c
src/os/event.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
src/os/event.h:1:  #ifndef header guard has wrong style, please use: SRC_OS_EVENT_H_  [build/header_guard] [5]
src/os/event.h:15:  #endif line should be "#endif  // SRC_OS_EVENT_H_"  [build/header_guard] [5]
Done processing src/os/event.h
src/os/fs.c:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
src/os/fs.c:124:  Do not use variable-length arrays.  Use an appropriately named ('k' followed by CamelCase) compile-time constant for the size.  [runtime/arrays] [1]
Done processing src/os/fs.c
src/os/input.c:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Done processing src/os/input.c
src/os/input.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
src/os/input.h:1:  #ifndef header guard has wrong style, please use: SRC_OS_INPUT_H_  [build/header_guard] [5]
src/os/input.h:19:  #endif line should be "#endif  // SRC_OS_INPUT_H_"  [build/header_guard] [5]
Done processing src/os/input.h
src/os/mem.c:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Done processing src/os/mem.c
src/os/os.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
src/os/os.h:1:  #ifndef header guard has wrong style, please use: SRC_OS_OS_H_  [build/header_guard] [5]
src/os/os.h:24:  #endif line should be "#endif  // SRC_OS_OS_H_"  [build/header_guard] [5]
Done processing src/os/os.h
src/os/time.c:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Done processing src/os/time.c
src/os/time.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
src/os/time.h:1:  #ifndef header guard has wrong style, please use: SRC_OS_TIME_H_  [build/header_guard] [5]
src/os/time.h:10:  #endif line should be "#endif  // SRC_OS_TIME_H_"  [build/header_guard] [5]
Done processing src/os/time.h
src/os/users.c:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
src/os/users.c:60:  Consider using getpwuid_r(...) instead of getpwuid(...) for improved thread safety.  [runtime/threadsafe_fn] [2]
src/os/users.c:80:  Consider using getpwnam_r(...) instead of getpwnam(...) for improved thread safety.  [runtime/threadsafe_fn] [2]
Done processing src/os/users.c
Total errors found: 22
```

Most of the errors are wrong (header guards and copyright warnings). These are fixed by ~~#409~~ #302.
Any thoughts on the last two errors (use `getpw[uid|nam]_r` instead of `getpw[uid|nam]`) are appreciated.
Also feel free to be pedantic with this PR. Surely there are lots of style issues which can be solved in this module.
