### PR TITLE
[RDY] Make `EventType` enum private to input.c

### DIFF
--- a/src/os/event.h
+++ b/src/os/event.h
@@ -2,15 +2,10 @@
 #define NEOVIM_OS_EVENT_H
 
 #include <stdint.h>
-
-typedef enum {
-  kEventNone,
-  kEventInput,
-  kEventEof
-} EventType;
+#include <stdbool.h>
 
 void event_init(void);
-EventType event_poll(int32_t ms);
+bool event_poll(int32_t ms);
 
 #endif
 

--- a/src/os/input.h
+++ b/src/os/input.h
@@ -4,11 +4,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "os/event.h"
 #include "types.h"
 
 void input_init(void);
-EventType input_check(void);
+bool input_ready(void);
 void input_start(void);
 void input_stop(void);
 uint32_t input_read(char *buf, uint32_t count);


### PR DESCRIPTION
This enum doesn't need to be public since `event_poll` is only interested in
user input(but other events may be handled by libuv callbacks).
