### PR TITLE
[WIP/IGNORE] Make it easy to disable the use of clang 3.4.

### DIFF
--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -1,6 +1,17 @@
 #!/bin/sh -e
 
-[ "$CC" != "clang" ] && exit
+# [ "$CC" != "clang" ] && exit
+
+env
+
+echo "Downloading clang 3.4..."
+mkdir /usr/local/clang-3.4
+wget -q -O - http://llvm.org/releases/3.4/clang+llvm-3.4-x86_64-unknown-ubuntu12.04.tar.xz |
+	unxz -c | tar xvf - --strip-components=1 -C /usr/local/clang-3.4
+
+
+# The section below is still around, in case we want to try the llvm.org/apt/
+# repository again.
 
 # Set to true to enable using the clang stable builds hosted at
 # http://llvm.org/apt/.
@@ -10,24 +21,24 @@
 # to remove them from the .list file), to the toolchain being packaged
 # incorrectly (most likely due to a change in version number--3.4.0 -> 3.4.1).
 # Use with care.
-USE_CLANG_34=
+# USE_CLANG_34=true
 
-if [ -n "$USE_CLANG_34" ]; then
-	add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
-	wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
+# if [ -n "$USE_CLANG_34" ]; then
+# 	add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
+# 	wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
 
-	cat > /etc/apt/sources.list.d/clang.list << "EOF"
-# deb http://llvm.org/apt/precise/ llvm-toolchain-precise main
-# deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise main
-# 3.4
-deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main
-# deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main
-# Common
-deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main
-EOF
-fi
+# 	cat > /etc/apt/sources.list.d/clang.list << "EOF"
+# # deb http://llvm.org/apt/precise/ llvm-toolchain-precise main
+# # deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise main
+# # 3.4
+# deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main
+# # deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main
+# # Common
+# deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main
+# EOF
+# fi
 
-apt-get -qq update
+# apt-get -qq update
 
-[ -n "$USE_CLANG_34" ] &&
-	apt-get -qq -y --no-install-recommends install clang-3.4 lldb-3.4
+# [ -n "$USE_CLANG_34" ] &&
+# 	apt-get -qq -y --no-install-recommends install clang-3.4 lldb-3.4

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -1,12 +1,23 @@
 #!/bin/sh -e
 
-# [ "$CC" != "clang" ] && exit
+[ "$CC" != "clang" ] && exit
 
-add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
-wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
+# Set to true to enable using the clang stable builds hosted at
+# http://llvm.org/apt/.
+#
+# Note: there have been issues with this repository.  Several days in a row
+# there have been problems running from broken a source repository (causing us
+# to remove them from the .list file), to the toolchain being packaged
+# incorrectly (most likely due to a change in version number--3.4.0 -> 3.4.1).
+# Use with care.
+USE_CLANG_34=
 
-cat > /etc/apt/sources.list.d/clang.list << "EOF"
-deb http://llvm.org/apt/precise/ llvm-toolchain-precise main
+if [ -n "$USE_CLANG_34" ]; then
+	add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
+	wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
+
+	cat > /etc/apt/sources.list.d/clang.list << "EOF"
+# deb http://llvm.org/apt/precise/ llvm-toolchain-precise main
 # deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise main
 # 3.4
 deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main
@@ -14,6 +25,9 @@ deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main
 # Common
 deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main
 EOF
+fi
 
 apt-get -qq update
-apt-get -qq -y --no-install-recommends install clang-3.4 lldb-3.4
+
+[ -n "$USE_CLANG_34" ] &&
+	apt-get -qq -y --no-install-recommends install clang-3.4 lldb-3.4

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -25,9 +25,13 @@ check_and_report() {
 # for more information.
 MAKE_CMD="make -j2"
 
+if dpkg -s clang-3.4 > /dev/null 2>&1; then
+	USE_CLANG_34=true
+fi
+
 if [ "$CC" = "clang" ]; then
-	# force using the version installed by 'travis-setup.sh'
-	export CC=/usr/bin/clang
+	# force using the version installed by 'travis-setup.sh', if enabled
+	test -f /usr/bin/clang && export CC=/usr/bin/clang
 
 	install_dir="$(pwd)/dist"
 	# temporary directory for writing sanitizer logs
@@ -36,13 +40,19 @@ if [ "$CC" = "clang" ]; then
 	mkdir -p "$tmpdir"
 
 	# need the symbolizer path for stack traces with source information
-	symbolizer=/usr/bin/llvm-symbolizer-3.4
+	if [ -n "$USE_CLANG_34" ]; then
+		symbolizer=/usr/bin/llvm-symbolizer-3.4
+		export ASAN_OPTIONS="detect_leaks=1:"
+	else
+		symbolizer=/usr/local/clang-3.3/bin/llvm-symbolizer
+        fi
 
-	export SKIP_UNITTEST=1
 	export SANITIZE=1
 	export ASAN_SYMBOLIZER_PATH=$symbolizer
-	export ASAN_OPTIONS="detect_leaks=1:log_path=$tmpdir/asan"
+	export ASAN_OPTIONS="${ASAN_OPTIONS}log_path=$tmpdir/asan"
 	export TSAN_OPTIONS="external_symbolizer_path=$symbolizer:log_path=$tmpdir/tsan"
+
+	export SKIP_UNITTEST=1
 	export UBSAN_OPTIONS="log_path=$tmpdir/ubsan" # not sure if this works
 
 	$MAKE_CMD cmake CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$install_dir"


### PR DESCRIPTION
It appears the llvm.org/apt repository isn't always reliable.  So let's
make using it conditional, just in case they're failing for some reason.

Note: disabling the use of 3.4 means that we don't get leak detection.
But, we get a more stable build platform.

**Ignore this for now while I test a few things with Travis CI**
