### PR TITLE
[RDY] Refactor ga_init()

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -422,7 +422,7 @@ char_u* str_foldcase(char_u *str, int orglen, char_u *buf, int buflen)
 
   // Copy "str" into "buf" or allocated memory, unmodified.
   if (buf == NULL) {
-    ga_init2(&ga, 1, 10);
+    ga_init(&ga, 1, 10);
 
     if (ga_grow(&ga, len + 1) == FAIL) {
       return NULL;

--- a/src/digraph.c
+++ b/src/digraph.c
@@ -2017,7 +2017,7 @@ void ex_loadkeymap(exarg_T *eap)
   keymap_unload();
 
   curbuf->b_kmap_state = 0;
-  ga_init2(&curbuf->b_kmap_ga, (int)sizeof(kmap_T), 20);
+  ga_init(&curbuf->b_kmap_ga, (int)sizeof(kmap_T), 20);
 
   // Set 'cpoptions' to "C" to avoid line continuation.
   p_cpo = (char_u *)"C";

--- a/src/eval.c
+++ b/src/eval.c
@@ -1045,7 +1045,7 @@ var_redir_start (
   }
 
   /* The output is stored in growarray "redir_ga" until redirection ends. */
-  ga_init2(&redir_ga, (int)sizeof(char), 500);
+  ga_init(&redir_ga, (int)sizeof(char), 500);
 
   /* Parse the variable name (can be a dict or list entry). */
   redir_endp = get_lval(redir_varname, NULL, redir_lval, FALSE, FALSE, 0,
@@ -1302,7 +1302,7 @@ char_u *eval_to_string(char_u *arg, char_u **nextcmd, int convert)
     retval = NULL;
   else {
     if (convert && tv.v_type == VAR_LIST) {
-      ga_init2(&ga, (int)sizeof(char), 80);
+      ga_init(&ga, (int)sizeof(char), 80);
       if (tv.vval.v_list != NULL) {
         list_join(&ga, tv.vval.v_list, (char_u *)"\n", TRUE, 0);
         if (tv.vval.v_list->lv_len > 0)
@@ -5759,7 +5759,7 @@ static char_u *list2string(typval_T *tv, int copyID)
 
   if (tv->vval.v_list == NULL)
     return NULL;
-  ga_init2(&ga, (int)sizeof(char), 80);
+  ga_init(&ga, (int)sizeof(char), 80);
   ga_append(&ga, '[');
   if (list_join(&ga, tv->vval.v_list, (char_u *)", ", FALSE, copyID) == FAIL) {
     vim_free(ga.ga_data);
@@ -5854,7 +5854,7 @@ static int list_join(garray_T *gap, list_T *l, char_u *sep, int echo_style, int 
   join_T      *p;
   int i;
 
-  ga_init2(&join_ga, (int)sizeof(join_T), l->lv_len);
+  ga_init(&join_ga, (int)sizeof(join_T), l->lv_len);
   retval = list_join_inner(gap, l, sep, echo_style, copyID, &join_ga);
 
   /* Dispose each item in join_ga. */
@@ -6450,7 +6450,7 @@ static char_u *dict2string(typval_T *tv, int copyID)
 
   if ((d = tv->vval.v_dict) == NULL)
     return NULL;
-  ga_init2(&ga, (int)sizeof(char), 80);
+  ga_init(&ga, (int)sizeof(char), 80);
   ga_append(&ga, '{');
 
   todo = (int)d->dv_hashtab.ht_used;
@@ -11044,7 +11044,7 @@ static void f_join(typval_T *argvars, typval_T *rettv)
   rettv->v_type = VAR_STRING;
 
   if (sep != NULL) {
-    ga_init2(&ga, (int)sizeof(char), 80);
+    ga_init(&ga, (int)sizeof(char), 80);
     list_join(&ga, argvars[0].vval.v_list, sep, TRUE, 0);
     ga_append(&ga, NUL);
     rettv->vval.v_string = (char_u *)ga.ga_data;
@@ -14859,7 +14859,7 @@ static void f_tr(typval_T *argvars, typval_T *rettv)
   rettv->vval.v_string = NULL;
   if (fromstr == NULL || tostr == NULL)
     return;                     /* type error; errmsg already given */
-  ga_init2(&ga, (int)sizeof(char), 80);
+  ga_init(&ga, (int)sizeof(char), 80);
 
   if (!has_mbyte)
     /* not multi-byte: fromstr and tostr must be the same length */
@@ -15132,7 +15132,7 @@ static void f_winrestcmd(typval_T *argvars, typval_T *rettv)
   garray_T ga;
   char_u buf[50];
 
-  ga_init2(&ga, (int)sizeof(char), 70);
+  ga_init(&ga, (int)sizeof(char), 70);
   for (wp = firstwin; wp != NULL; wp = wp->w_next) {
     sprintf((char *)buf, "%dresize %d|", winnr, wp->w_height);
     ga_concat(&ga, buf);
@@ -16994,7 +16994,7 @@ void ex_execute(exarg_T *eap)
   int len;
   int save_did_emsg;
 
-  ga_init2(&ga, 1, 80);
+  ga_init(&ga, 1, 80);
 
   if (eap->skip)
     ++emsg_skip;
@@ -17261,8 +17261,8 @@ void ex_function(exarg_T *eap)
   }
   p = skipwhite(p + 1);
 
-  ga_init2(&newargs, (int)sizeof(char_u *), 3);
-  ga_init2(&newlines, (int)sizeof(char_u *), 3);
+  ga_init(&newargs, (int)sizeof(char_u *), 3);
+  ga_init(&newlines, (int)sizeof(char_u *), 3);
 
   if (!eap->skip) {
     /* Check the name of the function.  Unless it's a dictionary function
@@ -19554,7 +19554,7 @@ char_u *do_string_sub(char_u *str, char_u *pat, char_u *sub, char_u *flags)
   save_cpo = p_cpo;
   p_cpo = empty_option;
 
-  ga_init2(&ga, 1, 200);
+  ga_init(&ga, 1, 200);
 
   do_all = (flags[0] == 'g');
 

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5409,7 +5409,7 @@ void ex_helptags(exarg_T *eap)
 
   /* Go over all files in the directory to find out what languages are
    * present. */
-  ga_init2(&ga, 1, 10);
+  ga_init(&ga, 1, 10);
   for (i = 0; i < filecount; ++i) {
     len = (int)STRLEN(files[i]);
     if (len > 4) {
@@ -5524,7 +5524,7 @@ helptags_one (
    * If using the "++t" argument or generating tags for "$VIMRUNTIME/doc"
    * add the "help-tags" tag.
    */
-  ga_init2(&ga, (int)sizeof(char_u *), 100);
+  ga_init(&ga, (int)sizeof(char_u *), 100);
   if (add_help_tags || fullpathcmp((char_u *)"$VIMRUNTIME/doc",
           dir, FALSE) == FPC_SAME) {
     if (ga_grow(&ga, 1) == FAIL)

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1053,7 +1053,7 @@ static void script_do_profile(scriptitem_T *si)
   profile_zero(&si->sn_pr_total);
   profile_zero(&si->sn_pr_self);
 
-  ga_init2(&si->sn_prl_ga, sizeof(sn_prl_T), 100);
+  ga_init(&si->sn_prl_ga, sizeof(sn_prl_T), 100);
   si->sn_prl_idx = -1;
   si->sn_prof_on = TRUE;
   si->sn_pr_nest = 0;
@@ -1542,7 +1542,7 @@ static char_u *do_one_arg(char_u *str)
  */
 int get_arglist(garray_T *gap, char_u *str)
 {
-  ga_init2(gap, (int)sizeof(char_u *), 20);
+  ga_init(gap, (int)sizeof(char_u *), 20);
   while (*str != NUL) {
     if (ga_grow(gap, 1) == FAIL) {
       ga_clear(gap);
@@ -2922,7 +2922,7 @@ char_u *getsourceline(int c, void *cookie, int indent)
     if (sp->nextline != NULL && *(p = skipwhite(sp->nextline)) == '\\') {
       garray_T ga;
 
-      ga_init2(&ga, (int)sizeof(char_u), 400);
+      ga_init(&ga, (int)sizeof(char_u), 400);
       ga_concat(&ga, line);
       ga_concat(&ga, p + 1);
       for (;; ) {
@@ -2986,7 +2986,7 @@ static char_u *get_one_sourceline(struct source_cookie *sp)
   int have_read = FALSE;
 
   /* use a growarray to store the sourced line */
-  ga_init2(&ga, 1, 250);
+  ga_init(&ga, 1, 250);
 
   /*
    * Loop until there is a finished line (or end-of-file).
@@ -3522,7 +3522,7 @@ static char_u **find_locales(void)
       NULL, kShellOptSilent);
   if (locale_a == NULL)
     return NULL;
-  ga_init2(&locales_ga, sizeof(char_u *), 20);
+  ga_init(&locales_ga, sizeof(char_u *), 20);
 
   /* Transform locale_a string where each locale is separated by "\n"
    * into an array of locale strings. */

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -555,7 +555,7 @@ int flags;
   cstack.cs_trylevel = 0;
   cstack.cs_emsg_silent_list = NULL;
   cstack.cs_lflags = 0;
-  ga_init2(&lines_ga, (int)sizeof(wcmd_T), 10);
+  ga_init(&lines_ga, (int)sizeof(wcmd_T), 10);
 
   real_cookie = getline_cookie(fgetline, cookie);
 
@@ -4358,7 +4358,7 @@ static int uc_add_command(char_u *name, size_t name_len, char_u *rep, long argt,
   if (flags & UC_BUFFER) {
     gap = &curbuf->b_ucmds;
     if (gap->ga_itemsize == 0)
-      ga_init2(gap, (int)sizeof(ucmd_T), 4);
+      ga_init(gap, (int)sizeof(ucmd_T), 4);
   } else
     gap = &ucmds;
 
@@ -5833,7 +5833,7 @@ void alist_clear(alist_T *al)
  */
 void alist_init(alist_T *al)
 {
-  ga_init2(&al->al_ga, (int)sizeof(aentry_T), 5);
+  ga_init(&al->al_ga, (int)sizeof(aentry_T), 5);
 }
 
 

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1778,7 +1778,7 @@ getexmodeline (
     startcol = msg_col;
   }
 
-  ga_init2(&line_ga, 1, 30);
+  ga_init(&line_ga, 1, 30);
 
   /* autoindent for :insert and :append is in the line itself */
   if (promptc <= 0) {
@@ -3970,7 +3970,7 @@ expand_shellcmd (
    * Go over all directories in $PATH.  Expand matches in that directory and
    * collect them in "ga".
    */
-  ga_init2(&ga, (int)sizeof(char *), 10);
+  ga_init(&ga, (int)sizeof(char *), 10);
   for (s = path; *s != NUL; s = e) {
     if (*s == ' ')
       ++s;              /* Skip space used for absolute path name. */
@@ -4087,7 +4087,7 @@ static int ExpandUserDefined(expand_T *xp, regmatch_T *regmatch, int *num_file, 
   if (retstr == NULL)
     return FAIL;
 
-  ga_init2(&ga, (int)sizeof(char *), 3);
+  ga_init(&ga, (int)sizeof(char *), 3);
   for (s = retstr; *s != NUL; s = e) {
     e = vim_strchr(s, '\n');
     if (e == NULL)
@@ -4131,7 +4131,7 @@ static int ExpandUserList(expand_T *xp, int *num_file, char_u ***file)
   if (retlist == NULL)
     return FAIL;
 
-  ga_init2(&ga, (int)sizeof(char *), 3);
+  ga_init(&ga, (int)sizeof(char *), 3);
   /* Loop over the items in the list. */
   for (li = retlist->lv_first; li != NULL; li = li->li_next) {
     if (li->li_tv.v_type != VAR_STRING || li->li_tv.vval.v_string == NULL)
@@ -4168,7 +4168,7 @@ static int ExpandRTDir(char_u *pat, int *num_file, char_u ***file, char *dirname
   *num_file = 0;
   *file = NULL;
   pat_len = (int)STRLEN(pat);
-  ga_init2(&ga, (int)sizeof(char *), 10);
+  ga_init(&ga, (int)sizeof(char *), 10);
 
   for (i = 0; dirnames[i] != NULL; ++i) {
     s = alloc((unsigned)(STRLEN(dirnames[i]) + pat_len + 7));
@@ -4238,7 +4238,7 @@ char_u *globpath(char_u *path, char_u *file, int expand_options)
   ExpandInit(&xpc);
   xpc.xp_context = EXPAND_FILES;
 
-  ga_init2(&ga, 1, 100);
+  ga_init(&ga, 1, 100);
 
   /* Loop over all entries in {path}. */
   while (*path != NUL) {
@@ -5452,7 +5452,7 @@ char_u *script_get(exarg_T *eap, char_u *cmd)
   if (cmd[0] != '<' || cmd[1] != '<' || eap->getline == NULL)
     return NULL;
 
-  ga_init2(&ga, 1, 0x400);
+  ga_init(&ga, 1, 0x400);
 
   if (cmd[2] != NUL)
     end_pattern = (char *)skipwhite(cmd + 2);

--- a/src/fold.c
+++ b/src/fold.c
@@ -607,7 +607,7 @@ void foldCreate(linenr_T start, linenr_T end)
   i = (int)(fp - (fold_T *)gap->ga_data);
   if (ga_grow(gap, 1) == OK) {
     fp = (fold_T *)gap->ga_data + i;
-    ga_init2(&fold_ga, (int)sizeof(fold_T), 10);
+    ga_init(&fold_ga, (int)sizeof(fold_T), 10);
 
     /* Count number of folds that will be contained in the new fold. */
     for (cont = 0; i + cont < gap->ga_len; ++cont)
@@ -931,7 +931,7 @@ foldMoveTo (
  */
 void foldInitWin(win_T *new_win)
 {
-  ga_init2(&new_win->w_folds, (int)sizeof(fold_T), 10);
+  ga_init(&new_win->w_folds, (int)sizeof(fold_T), 10);
 }
 
 /* find_wl_entry() {{{2 */
@@ -1009,7 +1009,7 @@ void cloneFoldGrowArray(garray_T *from, garray_T *to)
   fold_T      *from_p;
   fold_T      *to_p;
 
-  ga_init2(to, from->ga_itemsize, from->ga_growsize);
+  ga_init(to, from->ga_itemsize, from->ga_growsize);
   if (from->ga_len == 0 || ga_grow(to, from->ga_len) == FAIL)
     return;
 
@@ -2518,7 +2518,7 @@ static int foldInsert(garray_T *gap, int i)
   if (i < gap->ga_len)
     memmove(fp + 1, fp, sizeof(fold_T) * (gap->ga_len - i));
   ++gap->ga_len;
-  ga_init2(&fp->fd_nested, (int)sizeof(fold_T), 10);
+  ga_init(&fp->fd_nested, (int)sizeof(fold_T), 10);
   return OK;
 }
 

--- a/src/garray.c
+++ b/src/garray.c
@@ -17,7 +17,11 @@
 void ga_clear(garray_T *gap)
 {
   vim_free(gap->ga_data);
-  ga_init(gap);
+
+  // Initialize growing array without resetting itemsize or growsize
+  gap->ga_data = NULL;
+  gap->ga_maxlen = 0;
+  gap->ga_len = 0;
 }
 
 /// Clear a growing array that contains a list of strings.
@@ -32,17 +36,6 @@ void ga_clear_strings(garray_T *gap)
   ga_clear(gap);
 }
 
-/// Initialize a growing array.	Don't forget to set ga_itemsize and
-/// ga_growsize!  Or use ga_init2().
-///
-/// @param gap
-void ga_init(garray_T *gap)
-{
-  gap->ga_data = NULL;
-  gap->ga_maxlen = 0;
-  gap->ga_len = 0;
-}
-
 /// Initialize a growing array.
 ///
 /// @param gap
@@ -50,7 +43,9 @@ void ga_init(garray_T *gap)
 /// @param growsize
 void ga_init2(garray_T *gap, int itemsize, int growsize)
 {
-  ga_init(gap);
+  gap->ga_data = NULL;
+  gap->ga_maxlen = 0;
+  gap->ga_len = 0;
   gap->ga_itemsize = itemsize;
   gap->ga_growsize = growsize;
 }

--- a/src/garray.c
+++ b/src/garray.c
@@ -41,7 +41,7 @@ void ga_clear_strings(garray_T *gap)
 /// @param gap
 /// @param itemsize
 /// @param growsize
-void ga_init2(garray_T *gap, int itemsize, int growsize)
+void ga_init(garray_T *gap, int itemsize, int growsize)
 {
   gap->ga_data = NULL;
   gap->ga_maxlen = 0;

--- a/src/garray.h
+++ b/src/garray.h
@@ -16,7 +16,7 @@ typedef struct growarray {
 
 void ga_clear(garray_T *gap);
 void ga_clear_strings(garray_T *gap);
-void ga_init2(garray_T *gap, int itemsize, int growsize);
+void ga_init(garray_T *gap, int itemsize, int growsize);
 int ga_grow(garray_T *gap, int n);
 char_u *ga_concat_strings(garray_T *gap);
 void ga_remove_duplicate_strings(garray_T *gap);

--- a/src/garray.h
+++ b/src/garray.h
@@ -16,7 +16,6 @@ typedef struct growarray {
 
 void ga_clear(garray_T *gap);
 void ga_clear_strings(garray_T *gap);
-void ga_init(garray_T *gap);
 void ga_init2(garray_T *gap, int itemsize, int growsize);
 int ga_grow(garray_T *gap, int n);
 char_u *ga_concat_strings(garray_T *gap);

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -3208,7 +3208,7 @@ char_u *map_mode_to_chars(int mode)
 {
   garray_T mapmode;
 
-  ga_init2(&mapmode, 1, 7);
+  ga_init(&mapmode, 1, 7);
 
   if ((mode & (INSERT + CMDLINE)) == INSERT + CMDLINE)
     ga_append(&mapmode, '!');                           /* :map! */

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -1577,7 +1577,7 @@ static void prt_flush_buffer(void)
       prt_write_string("s\n");
 
     ga_clear(&prt_ps_buffer);
-    ga_init2(&prt_ps_buffer, (int)sizeof(char), prt_bufsiz);
+    ga_init(&prt_ps_buffer, (int)sizeof(char), prt_bufsiz);
   }
 }
 
@@ -2441,7 +2441,7 @@ int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
   prt_bufsiz = psettings->chars_per_line;
   if (prt_out_mbyte)
     prt_bufsiz *= 2;
-  ga_init2(&prt_ps_buffer, (int)sizeof(char), prt_bufsiz);
+  ga_init(&prt_ps_buffer, (int)sizeof(char), prt_bufsiz);
 
   prt_page_num = 0;
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -1490,7 +1490,7 @@ void ex_menutranslate(exarg_T *eap)
   char_u              *from, *from_noamp, *to;
 
   if (menutrans_ga.ga_itemsize == 0)
-    ga_init2(&menutrans_ga, (int)sizeof(menutrans_T), 5);
+    ga_init(&menutrans_ga, (int)sizeof(menutrans_T), 5);
 
   /*
    * ":menutrans clear": clear all translations.

--- a/src/message.c
+++ b/src/message.c
@@ -1311,7 +1311,7 @@ str2special_save (
   garray_T ga;
   char_u      *p = str;
 
-  ga_init2(&ga, 1, 40);
+  ga_init(&ga, 1, 40);
   while (*p != NUL)
     ga_concat(&ga, str2special(&p, is_lhs));
   ga_append(&ga, NUL);

--- a/src/option.c
+++ b/src/option.c
@@ -1990,7 +1990,7 @@ void set_init_1(void)
     garray_T ga;
     int mustfree;
 
-    ga_init2(&ga, 1, 100);
+    ga_init(&ga, 1, 100);
     for (n = 0; n < (long)(sizeof(names) / sizeof(char *)); ++n) {
       mustfree = FALSE;
 # ifdef UNIX
@@ -7711,7 +7711,7 @@ static void langmap_init(void)
 
   for (i = 0; i < 256; i++)
     langmap_mapchar[i] = i;      /* we init with a one-to-one map */
-  ga_init2(&langmap_mapga, sizeof(langmap_entry_T), 8);
+  ga_init(&langmap_mapga, sizeof(langmap_entry_T), 8);
 }
 
 /*

--- a/src/os/users.c
+++ b/src/os/users.c
@@ -16,7 +16,7 @@ int os_get_usernames(garray_T *users)
   if (users == NULL) {
     return FALSE;
   }
-  ga_init2(users, sizeof(char *), 20);
+  ga_init(users, sizeof(char *), 20);
 
 # if defined(HAVE_GETPWENT) && defined(HAVE_PWD_H)
   char *user;

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1959,7 +1959,7 @@ int mch_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
         }
 
         if (opts & kShellOptRead)
-          ga_init2(&ga, 1, BUFLEN);
+          ga_init(&ga, 1, BUFLEN);
 
         noread_cnt = 0;
 # if defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H)

--- a/src/path.c
+++ b/src/path.c
@@ -803,7 +803,7 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
   char_u      *short_name;
 
   ga_remove_duplicate_strings(gap);
-  ga_init2(&path_ga, (int)sizeof(char_u *), 1);
+  ga_init(&path_ga, (int)sizeof(char_u *), 1);
 
   /*
    * We need to prepend a '*' at the beginning of file_pattern so that the
@@ -957,7 +957,7 @@ expand_in_path (
     return 0;
   os_dirname(curdir, MAXPATHL);
 
-  ga_init2(&path_ga, (int)sizeof(char_u *), 1);
+  ga_init(&path_ga, (int)sizeof(char_u *), 1);
   expand_path_option(curdir, &path_ga);
   vim_free(curdir);
   if (path_ga.ga_len == 0)
@@ -1093,7 +1093,7 @@ gen_expand_wildcards (
   /*
    * The matching file names are stored in a growarray.  Init it empty.
    */
-  ga_init2(&ga, (int)sizeof(char_u *), 30);
+  ga_init(&ga, (int)sizeof(char_u *), 30);
 
   for (i = 0; i < num_pat; ++i) {
     add_pat = -1;

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -3411,13 +3411,13 @@ proftime_T  *tm;         /* timeout limit or NULL */
   if (regstack.ga_data == NULL) {
     /* Use an item size of 1 byte, since we push different things
      * onto the regstack. */
-    ga_init2(&regstack, 1, REGSTACK_INITIAL);
+    ga_init(&regstack, 1, REGSTACK_INITIAL);
     ga_grow(&regstack, REGSTACK_INITIAL);
     regstack.ga_growsize = REGSTACK_INITIAL * 8;
   }
 
   if (backpos.ga_data == NULL) {
-    ga_init2(&backpos, sizeof(backpos_T), BACKPOS_INITIAL);
+    ga_init(&backpos, sizeof(backpos_T), BACKPOS_INITIAL);
     ga_grow(&backpos, BACKPOS_INITIAL);
     backpos.ga_growsize = BACKPOS_INITIAL * 8;
   }

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -2363,7 +2363,7 @@ static void nfa_print_state(FILE *debugf, nfa_state_T *state)
 {
   garray_T indent;
 
-  ga_init2(&indent, 1, 64);
+  ga_init(&indent, 1, 64);
   ga_append(&indent, '\0');
   nfa_print_state2(debugf, state, &indent);
   ga_clear(&indent);

--- a/src/spell.c
+++ b/src/spell.c
@@ -2381,8 +2381,8 @@ static slang_T *slang_alloc(char_u *lang)
   if (lp != NULL) {
     if (lang != NULL)
       lp->sl_name = vim_strsave(lang);
-    ga_init2(&lp->sl_rep, sizeof(fromto_T), 10);
-    ga_init2(&lp->sl_repsal, sizeof(fromto_T), 10);
+    ga_init(&lp->sl_rep, sizeof(fromto_T), 10);
+    ga_init(&lp->sl_repsal, sizeof(fromto_T), 10);
     lp->sl_compmax = MAXWLEN;
     lp->sl_compsylmax = MAXWLEN;
     hash_init(&lp->sl_wordcount);
@@ -2980,7 +2980,7 @@ static int read_sal_section(FILE *fd, slang_T *slang)
     return SP_TRUNCERROR;
 
   gap = &slang->sl_sal;
-  ga_init2(gap, sizeof(salitem_T), 10);
+  ga_init(gap, sizeof(salitem_T), 10);
   if (ga_grow(gap, cnt + 1) == FAIL)
     return SP_OTHERERROR;
 
@@ -3283,7 +3283,7 @@ static int read_compound(FILE *fd, slang_T *slang, int len)
     gap = &slang->sl_comppat;
     c = get2c(fd);                                      /* <comppatcount> */
     todo -= 2;
-    ga_init2(gap, sizeof(char_u *), c);
+    ga_init(gap, sizeof(char_u *), c);
     if (ga_grow(gap, c) == OK)
       while (--c >= 0) {
         ((char_u **)(gap->ga_data))[gap->ga_len++] =
@@ -3440,7 +3440,7 @@ static int init_syl_tab(slang_T *slang)
   int l;
   syl_item_T  *syl;
 
-  ga_init2(&slang->sl_syl_items, sizeof(syl_item_T), 4);
+  ga_init(&slang->sl_syl_items, sizeof(syl_item_T), 4);
   p = vim_strchr(slang->sl_syllable, '/');
   while (p != NULL) {
     *p++ = NUL;
@@ -3536,7 +3536,7 @@ static int set_sofo(slang_T *lp, char_u *from, char_u *to)
      * The list contains from-to pairs with a terminating NUL.
      * sl_sal_first[] is used for latin1 "from" characters. */
     gap = &lp->sl_sal;
-    ga_init2(gap, sizeof(int *), 1);
+    ga_init(gap, sizeof(int *), 1);
     if (ga_grow(gap, 256) == FAIL)
       return SP_OTHERERROR;
     memset(gap->ga_data, 0, sizeof(int *) * 256);
@@ -3861,7 +3861,7 @@ char_u *did_set_spelllang(win_T *wp)
     return NULL;
   recursive = TRUE;
 
-  ga_init2(&ga, sizeof(langp_T), 2);
+  ga_init(&ga, sizeof(langp_T), 2);
   clear_midword(wp);
 
   /* Make a copy of 'spelllang', the SpellFileMissing autocommands may change
@@ -7875,7 +7875,7 @@ static int sug_maketable(spellinfo_T *spin)
 
   /* Use a buffer to store the line info, avoids allocating many small
    * pieces of memory. */
-  ga_init2(&ga, 1, 100);
+  ga_init(&ga, 1, 100);
 
   /* recursively go through the tree */
   if (sug_filltable(spin, spin->si_foldroot->wn_sibling, 0, &ga) == -1)
@@ -8175,12 +8175,12 @@ mkspell (
   spin.si_ascii = ascii;
   spin.si_followup = TRUE;
   spin.si_rem_accents = TRUE;
-  ga_init2(&spin.si_rep, (int)sizeof(fromto_T), 20);
-  ga_init2(&spin.si_repsal, (int)sizeof(fromto_T), 20);
-  ga_init2(&spin.si_sal, (int)sizeof(fromto_T), 20);
-  ga_init2(&spin.si_map, (int)sizeof(char_u), 100);
-  ga_init2(&spin.si_comppat, (int)sizeof(char_u *), 20);
-  ga_init2(&spin.si_prefcond, (int)sizeof(char_u *), 50);
+  ga_init(&spin.si_rep, (int)sizeof(fromto_T), 20);
+  ga_init(&spin.si_repsal, (int)sizeof(fromto_T), 20);
+  ga_init(&spin.si_sal, (int)sizeof(fromto_T), 20);
+  ga_init(&spin.si_map, (int)sizeof(char_u), 100);
+  ga_init(&spin.si_comppat, (int)sizeof(char_u *), 20);
+  ga_init(&spin.si_prefcond, (int)sizeof(char_u *), 50);
   hash_init(&spin.si_commonwords);
   spin.si_newcompID = 127;      /* start compound ID at first maximum */
 
@@ -9423,7 +9423,7 @@ spell_suggest_list (
   spell_find_suggest(word, 0, &sug, maxcount, FALSE, need_cap, interactive);
 
   /* Make room in "gap". */
-  ga_init2(gap, sizeof(char_u *), sug.su_ga.ga_len + 1);
+  ga_init(gap, sizeof(char_u *), sug.su_ga.ga_len + 1);
   if (ga_grow(gap, sug.su_ga.ga_len) == OK) {
     for (i = 0; i < sug.su_ga.ga_len; ++i) {
       stp = &SUG(sug.su_ga, i);
@@ -9475,8 +9475,8 @@ spell_find_suggest (
    * Set the info in "*su".
    */
   memset(su, 0, sizeof(suginfo_T));
-  ga_init2(&su->su_ga, (int)sizeof(suggest_T), 10);
-  ga_init2(&su->su_sga, (int)sizeof(suggest_T), 10);
+  ga_init(&su->su_ga, (int)sizeof(suggest_T), 10);
+  ga_init(&su->su_sga, (int)sizeof(suggest_T), 10);
   if (*badptr == NUL)
     return;
   hash_init(&su->su_banned);
@@ -9833,7 +9833,7 @@ someerror:
 
       /* Read all the wordnr lists into the buffer, one NUL terminated
        * list per line. */
-      ga_init2(&ga, 1, 100);
+      ga_init(&ga, 1, 100);
       for (wordnr = 0; wordnr < wcount; ++wordnr) {
         ga.ga_len = 0;
         for (;; ) {
@@ -11652,7 +11652,7 @@ static void score_combine(suginfo_T *su)
   check_suggestions(su, &su->su_sga);
   (void)cleanup_suggestions(&su->su_sga, su->su_maxscore, su->su_maxcount);
 
-  ga_init2(&ga, (int)sizeof(suginfo_T), 1);
+  ga_init(&ga, (int)sizeof(suginfo_T), 1);
   if (ga_grow(&ga, su->su_ga.ga_len + su->su_sga.ga_len) == FAIL)
     return;
 

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -1386,7 +1386,7 @@ static synstate_T *store_current_state(void)
     if (current_state.ga_len > SST_FIX_STATES) {
       /* Need to clear it, might be something remaining from when the
        * length was less than SST_FIX_STATES. */
-      ga_init2(&sp->sst_union.sst_ga, (int)sizeof(bufstate_T), 1);
+      ga_init(&sp->sst_union.sst_ga, (int)sizeof(bufstate_T), 1);
       if (ga_grow(&sp->sst_union.sst_ga, current_state.ga_len) == FAIL)
         sp->sst_stacksize = 0;
       else
@@ -1776,7 +1776,7 @@ syn_current_attr (
 
   /* Init the list of zero-width matches with a nextlist.  This is used to
    * avoid matching the same item in the same position twice. */
-  ga_init2(&zero_width_next_ga, (int)sizeof(int), 10);
+  ga_init(&zero_width_next_ga, (int)sizeof(int), 10);
 
   /*
    * Repeat matching keywords and patterns, to find contained items at the
@@ -5861,7 +5861,7 @@ static void syntime_report(void)
     return;
   }
 
-  ga_init2(&ga, sizeof(time_entry_T), 50);
+  ga_init(&ga, sizeof(time_entry_T), 50);
   profile_zero(&total_total);
   for (idx = 0; idx < curwin->w_s->b_syn_patterns.ga_len; ++idx) {
     spp = &(SYN_ITEMS(curwin->w_s)[idx]);

--- a/src/tag.c
+++ b/src/tag.c
@@ -1200,7 +1200,7 @@ find_tags (
   lbuf = alloc(lbuf_size);
   tag_fname = alloc(MAXPATHL + 1);
   for (mtt = 0; mtt < MT_COUNT; ++mtt)
-    ga_init2(&ga_match[mtt], (int)sizeof(struct match_found *), 100);
+    ga_init(&ga_match[mtt], (int)sizeof(struct match_found *), 100);
 
   /* check for out of memory situation */
   if (lbuf == NULL || tag_fname == NULL
@@ -2100,7 +2100,7 @@ get_tagfname (
      */
     if (first) {
       ga_clear_strings(&tag_fnames);
-      ga_init2(&tag_fnames, (int)sizeof(char_u *), 10);
+      ga_init(&tag_fnames, (int)sizeof(char_u *), 10);
       do_in_runtimepath((char_u *)
           "doc/tags doc/tags-??"
           , TRUE, found_tagfile_cb, NULL);

--- a/src/term.c
+++ b/src/term.c
@@ -4716,7 +4716,7 @@ translate_mapping (
   int cpo_special;
   int cpo_keycode;
 
-  ga_init2(&ga, 1, 40);
+  ga_init(&ga, 1, 40);
 
   cpo_bslash = (vim_strchr(p_cpo, CPO_BSLASH) != NULL);
   cpo_special = (vim_strchr(p_cpo, CPO_SPECI) != NULL);

--- a/src/term.c
+++ b/src/term.c
@@ -4716,9 +4716,7 @@ translate_mapping (
   int cpo_special;
   int cpo_keycode;
 
-  ga_init(&ga);
-  ga.ga_itemsize = 1;
-  ga.ga_growsize = 40;
+  ga_init2(&ga, 1, 40);
 
   cpo_bslash = (vim_strchr(p_cpo, CPO_BSLASH) != NULL);
   cpo_special = (vim_strchr(p_cpo, CPO_SPECI) != NULL);

--- a/src/undo.c
+++ b/src/undo.c
@@ -2418,7 +2418,7 @@ void ex_undolist(exarg_T *eap)
    */
   mark = ++lastmark;
   nomark = ++lastmark;
-  ga_init2(&ga, (int)sizeof(char *), 20);
+  ga_init(&ga, (int)sizeof(char *), 20);
 
   uhp = curbuf->b_u_oldhead;
   while (uhp != NULL) {

--- a/src/window.c
+++ b/src/window.c
@@ -3876,7 +3876,7 @@ void win_size_save(garray_T *gap)
 {
   win_T       *wp;
 
-  ga_init2(gap, (int)sizeof(int), 1);
+  ga_init(gap, (int)sizeof(int), 1);
   if (ga_grow(gap, win_count() * 2) == OK)
     for (wp = firstwin; wp != NULL; wp = wp->w_next) {
       ((int *)gap->ga_data)[gap->ga_len++] =


### PR DESCRIPTION
`garray.c` contains both `ga_init()` and `ga_init2()`. `ga_init()`  is used exactly once outside of `garray.c`. On the other hand, `ga_init2()` is used around 80 times throughout the code base. There is no need to have both of these functions, so this PR inlines `ga_init()` and renames `ga_init2()` to `ga_init()`.
