### PR TITLE
[RDY] func-attr: fix non-existent function attributes for clang 3.5 + add nonnull attr

### DIFF
--- a/src/func_attr.h
+++ b/src/func_attr.h
@@ -29,8 +29,6 @@
   // (not definition), like so:
   // void myfunc(void) FUNC_ATTR_ALWAYS_INLINE;
   #define FUNC_ATTR_MALLOC __attribute__((malloc))
-  #define FUNC_ATTR_ALLOC_SIZE(x) __attribute__((alloc_size(x)))
-  #define FUNC_ATTR_ALLOC_SIZE_PROD(x,y) __attribute__((alloc_size(x,y)))
   #define FUNC_ATTR_ALLOC_ALIGN(x) __attribute__((alloc_align(x)))
   #define FUNC_ATTR_PURE __attribute__ ((pure))
   #define FUNC_ATTR_CONST __attribute__((const))
@@ -43,15 +41,43 @@
     // intel only
   #else
     // gcc only
+    #define FUNC_ATTR_ALLOC_SIZE(x) __attribute__((alloc_size(x)))
+    #define FUNC_ATTR_ALLOC_SIZE_PROD(x,y) __attribute__((alloc_size(x,y)))
   #endif
-#else
+#endif
+
+// define function attributes that haven't been defined for this specific
+// compiler.
+
+#ifndef FUNC_ATTR_MALLOC
   #define FUNC_ATTR_MALLOC
+#endif
+
+#ifndef FUNC_ATTR_ALLOC_SIZE
   #define FUNC_ATTR_ALLOC_SIZE(x)
+#endif
+
+#ifndef FUNC_ATTR_ALLOC_SIZE_PROD
   #define FUNC_ATTR_ALLOC_SIZE_PROD(x,y)
+#endif
+
+#ifndef FUNC_ATTR_ALLOC_ALIGN
   #define FUNC_ATTR_ALLOC_ALIGN(x)
+#endif
+
+#ifndef FUNC_ATTR_PURE
   #define FUNC_ATTR_PURE
+#endif
+
+#ifndef FUNC_ATTR_CONST
   #define FUNC_ATTR_CONST
+#endif
+
+#ifndef FUNC_ATTR_WARN_UNUSED_RESULT
   #define FUNC_ATTR_WARN_UNUSED_RESULT
+#endif
+
+#ifndef FUNC_ATTR_ALWAYS_INLINE
   #define FUNC_ATTR_ALWAYS_INLINE
 #endif
 

--- a/src/func_attr.h
+++ b/src/func_attr.h
@@ -40,9 +40,18 @@
   #elif defined(__INTEL_COMPILER)
     // intel only
   #else
+    #define GCC_VERSION \
+           (__GNUC__ * 10000 + \
+            __GNUC_MINOR__ * 100 + \
+            __GNUC_PATCHLEVEL__)
     // gcc only
     #define FUNC_ATTR_ALLOC_SIZE(x) __attribute__((alloc_size(x)))
     #define FUNC_ATTR_ALLOC_SIZE_PROD(x,y) __attribute__((alloc_size(x,y)))
+    #define FUNC_ATTR_NONNULL_ALL __attribute__((nonnull))
+    #define FUNC_ATTR_NONNULL_ARG(...) __attribute__((nonnull(__VA_ARGS__)))
+    #if GCC_VERSION >= 40900
+      #define FUNC_ATTR_NONNULL_RET __attribute__((returns_nonnull))
+    #endif
   #endif
 #endif
 
@@ -79,6 +88,18 @@
 
 #ifndef FUNC_ATTR_ALWAYS_INLINE
   #define FUNC_ATTR_ALWAYS_INLINE
+#endif
+
+#ifndef FUNC_ATTR_NONNULL_ALL
+  #define FUNC_ATTR_NONNULL_ALL
+#endif
+
+#ifndef FUNC_ATTR_NONNULL_ARG
+  #define FUNC_ATTR_NONNULL_ARG(...)
+#endif
+
+#ifndef FUNC_ATTR_NONNULL_RET
+  #define FUNC_ATTR_NONNULL_RET
 #endif
 
 #endif // NEOVIM_FUNC_ATTR_H

--- a/src/misc2.h
+++ b/src/misc2.h
@@ -29,9 +29,10 @@ char_u *alloc_clear(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 char_u *alloc_check(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 char_u *lalloc_clear(long_u size, int message) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 void try_to_free_memory();
-void *xmalloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
+void *xmalloc(size_t size)
+  FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1) FUNC_ATTR_NONNULL_RET;
 void *xrealloc(void *ptr, size_t size)
-  FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALLOC_SIZE(2);
+  FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET;
 char_u *lalloc(long_u size, int message) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 void do_outofmem_msg(long_u size);
 void free_all_mem(void);


### PR DESCRIPTION
@oni-link does this solve your clang 3.5 issue? I tried compiling llvm 3.5 with homebrew but it failed at some point.

@philix I took the liberty of adding another attribute that should save a lot of null-checks the compiler will try to do under the hood since your xmalloc/xrealloc can't return null.
