### PR TITLE
[RDY] Include local.mk at the end of Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
--include local.mk
-
 CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=.deps/usr
 
 BUILD_TYPE ?= $(shell (type ninja > /dev/null 2>&1 && echo "Ninja") || \
@@ -67,3 +65,5 @@ install: | nvim
 	+$(BUILD_TOOL) -C build install
 
 .PHONY: test unittest clean distclean nvim cmake deps install
+
+-include local.mk


### PR DESCRIPTION
As proposed by @jszakmeister, include `local.mk` at the end of `Makefile` in order to avoid the quirks reported in #436.
