### PR TITLE
[RFC] remove pointless cruft from src/macros.h

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -424,7 +424,7 @@ aucmd_abort:
     return;
 
   /* Change directories when the 'acd' option is set. */
-  DO_AUTOCHDIR
+  do_autochdir();
 
   /*
    * Remove the buffer from the list.
@@ -1254,7 +1254,7 @@ void enter_buffer(buf_T *buf)
 
 
   /* Change directories when the 'acd' option is set. */
-  DO_AUTOCHDIR
+  do_autochdir();
 
   if (curbuf->b_kmap_state & KEYMAP_INIT)
     (void)keymap_init();
@@ -1271,8 +1271,11 @@ void enter_buffer(buf_T *buf)
  */
 void do_autochdir(void)
 {
-  if (curbuf->b_ffname != NULL && vim_chdirfile(curbuf->b_ffname) == OK)
-    shorten_fnames(TRUE);
+  if (p_acd) {
+    if (curbuf->b_ffname != NULL && vim_chdirfile(curbuf->b_ffname) == OK) {
+      shorten_fnames(TRUE);
+    }
+  }
 }
 
 /*

--- a/src/charset.c
+++ b/src/charset.c
@@ -223,8 +223,8 @@ int buf_init_chartab(buf_T *buf, int global)
         // work properly when 'encoding' is "latin1" and the locale is
         // "C".
         if (!do_isalpha
-            || MB_ISLOWER(c)
-            || MB_ISUPPER(c)
+            || vim_islower(c)
+            || vim_isupper(c)
             || (p_altkeymap && (F_isalpha(c) || F_isdigit(c)))) {
           if (i == 0) {
             // (re)set ID flag

--- a/src/edit.c
+++ b/src/edit.c
@@ -2001,12 +2001,12 @@ int ins_compl_add_infercase(char_u *str, int len, int icase, char_u *fname, int 
           c = mb_ptr2char_adv(&p);
         else
           c = *(p++);
-        if (MB_ISLOWER(c)) {
+        if (vim_islower(c)) {
           has_lower = TRUE;
-          if (MB_ISUPPER(wca[i])) {
+          if (vim_isupper(wca[i])) {
             /* Rule 1 is satisfied. */
             for (i = actual_compl_length; i < actual_len; ++i)
-              wca[i] = MB_TOLOWER(wca[i]);
+              wca[i] = vim_tolower(wca[i]);
             break;
           }
         }
@@ -2023,13 +2023,13 @@ int ins_compl_add_infercase(char_u *str, int len, int icase, char_u *fname, int 
             c = mb_ptr2char_adv(&p);
           else
             c = *(p++);
-          if (was_letter && MB_ISUPPER(c) && MB_ISLOWER(wca[i])) {
+          if (was_letter && vim_isupper(c) && vim_islower(wca[i])) {
             /* Rule 2 is satisfied. */
             for (i = actual_compl_length; i < actual_len; ++i)
-              wca[i] = MB_TOUPPER(wca[i]);
+              wca[i] = vim_toupper(wca[i]);
             break;
           }
-          was_letter = MB_ISLOWER(c) || MB_ISUPPER(c);
+          was_letter = vim_islower(c) || vim_isupper(c);
         }
       }
 
@@ -2040,10 +2040,10 @@ int ins_compl_add_infercase(char_u *str, int len, int icase, char_u *fname, int 
           c = mb_ptr2char_adv(&p);
         else
           c = *(p++);
-        if (MB_ISLOWER(c))
-          wca[i] = MB_TOLOWER(wca[i]);
-        else if (MB_ISUPPER(c))
-          wca[i] = MB_TOUPPER(wca[i]);
+        if (vim_islower(c))
+          wca[i] = vim_tolower(wca[i]);
+        else if (vim_isupper(c))
+          wca[i] = vim_toupper(wca[i]);
       }
 
       /*
@@ -2230,7 +2230,7 @@ static void ins_compl_longest_match(compl_T *match)
         c1 = *p;
         c2 = *s;
       }
-      if (match->cp_icase ? (MB_TOLOWER(c1) != MB_TOLOWER(c2))
+      if (match->cp_icase ? (vim_tolower(c1) != vim_tolower(c2))
           : (c1 != c2))
         break;
       if (has_mbyte) {

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2105,7 +2105,7 @@ int rename_buffer(char_u *new_fname)
   vim_free(sfname);
   apply_autocmds(EVENT_BUFFILEPOST, NULL, NULL, FALSE, curbuf);
   /* Change directories when the 'acd' option is set. */
-  DO_AUTOCHDIR
+  do_autochdir();
   return OK;
 }
 
@@ -2302,7 +2302,7 @@ int do_write(exarg_T *eap)
         redraw_tabline = TRUE;
       }
       /* Change directories when the 'acd' option is set. */
-      DO_AUTOCHDIR
+      do_autochdir();
     }
   }
 
@@ -3049,7 +3049,7 @@ do_ecmd (
     }
 
     /* Change directories when the 'acd' option is set. */
-    DO_AUTOCHDIR
+    do_autochdir();
 
     /*
      * Careful: open_buffer() and apply_autocmds() may change the current
@@ -3188,7 +3188,7 @@ do_ecmd (
     need_start_insertmode = TRUE;
 
   /* Change directories when the 'acd' option is set. */
-  DO_AUTOCHDIR
+  do_autochdir();
 
 
 theend:

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1145,7 +1145,7 @@ getcmdline (
            * command line has no uppercase characters, convert
            * the character to lowercase */
           if (p_ic && p_scs && !pat_has_uppercase(ccline.cmdbuff))
-            c = MB_TOLOWER(c);
+            c = vim_tolower(c);
           if (c != NUL) {
             if (c == firstc || vim_strchr((char_u *)(
                       p_magic ? "\\^$.*[" : "\\^$"), c)

--- a/src/file_search.c
+++ b/src/file_search.c
@@ -1122,7 +1122,7 @@ static int ff_wc_equal(char_u *s1, char_u *s2)
     int c1 = PTR2CHAR(s1 + i);
     int c2 = PTR2CHAR(s2 + i);
 
-    if ((p_fic ? MB_TOLOWER(c1) != MB_TOLOWER(c2) : c1 != c2)
+    if ((p_fic ? vim_tolower(c1) != vim_tolower(c2) : c1 != c2)
         && (prev1 != '*' || prev2 != '*'))
       return FAIL;
     prev2 = prev1;

--- a/src/macros.h
+++ b/src/macros.h
@@ -11,11 +11,6 @@
  */
 
 /*
- * pchar(lp, c) - put character 'c' at position 'lp'
- */
-#define pchar(lp, c) (*(ml_get_buf(curbuf, (lp).lnum, TRUE) + (lp).col) = (c))
-
-/*
  * Position comparisons
  */
 # define lt(a, b) (((a).lnum != (b).lnum) \

--- a/src/macros.h
+++ b/src/macros.h
@@ -42,20 +42,13 @@
 
 /*
  * toupper() and tolower() that use the current locale.
- * On some systems toupper()/tolower() only work on lower/uppercase
- * characters, first use islower() or isupper() then.
  * Careful: Only call TOUPPER_LOC() and TOLOWER_LOC() with a character in the
  * range 0 - 255.  toupper()/tolower() on some systems can't handle others.
  * Note: It is often better to use vim_tolower() and vim_toupper(), because many
  * toupper() and tolower() implementations only work for ASCII.
  */
-# ifdef BROKEN_TOUPPER
-#  define TOUPPER_LOC(c)        (islower(c) ? toupper(c) : (c))
-#  define TOLOWER_LOC(c)        (isupper(c) ? tolower(c) : (c))
-# else
-#  define TOUPPER_LOC           toupper
-#  define TOLOWER_LOC           tolower
-# endif
+#define TOUPPER_LOC toupper
+#define TOLOWER_LOC tolower
 
 /* toupper() and tolower() for ASCII only and ignore the current locale. */
 # define TOUPPER_ASC(c) (((c) < 'a' || (c) > 'z') ? (c) : (c) - ('a' - 'A'))

--- a/src/macros.h
+++ b/src/macros.h
@@ -51,7 +51,7 @@
  * characters, first use islower() or isupper() then.
  * Careful: Only call TOUPPER_LOC() and TOLOWER_LOC() with a character in the
  * range 0 - 255.  toupper()/tolower() on some systems can't handle others.
- * Note: It is often better to use MB_TOLOWER() and MB_TOUPPER(), because many
+ * Note: It is often better to use vim_tolower() and vim_toupper(), because many
  * toupper() and tolower() implementations only work for ASCII.
  */
 # ifdef BROKEN_TOUPPER
@@ -65,15 +65,6 @@
 /* toupper() and tolower() for ASCII only and ignore the current locale. */
 # define TOUPPER_ASC(c) (((c) < 'a' || (c) > 'z') ? (c) : (c) - ('a' - 'A'))
 # define TOLOWER_ASC(c) (((c) < 'A' || (c) > 'Z') ? (c) : (c) + ('a' - 'A'))
-
-/*
- * MB_ISLOWER() and MB_ISUPPER() are to be used on multi-byte characters.  But
- * don't use them for negative values!
- */
-# define MB_ISLOWER(c)  vim_islower(c)
-# define MB_ISUPPER(c)  vim_isupper(c)
-# define MB_TOLOWER(c)  vim_tolower(c)
-# define MB_TOUPPER(c)  vim_toupper(c)
 
 /* Use our own isdigit() replacement, because on MS-Windows isdigit() returns
  * non-zero for superscript 1.  Also avoids that isdigit() crashes for numbers

--- a/src/macros.h
+++ b/src/macros.h
@@ -185,6 +185,4 @@
 # define MB_CHAR2LEN(c)     (has_mbyte ? mb_char2len(c) : 1)
 # define PTR2CHAR(p)        (has_mbyte ? mb_ptr2char(p) : (int)*(p))
 
-# define DO_AUTOCHDIR if (p_acd) do_autochdir();
-
 # define RESET_BINDING(wp)  (wp)->w_p_scb = FALSE; (wp)->w_p_crb = FALSE

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -2875,7 +2875,7 @@ int mb_strnicmp(char_u *s1, char_u *s2, size_t nn)
       if (l <= 1) {
         /* Single byte: first check normally, then with ignore case. */
         if (s1[i] != s2[i]) {
-          cdiff = MB_TOLOWER(s1[i]) - MB_TOLOWER(s2[i]);
+          cdiff = vim_tolower(s1[i]) - vim_tolower(s2[i]);
           if (cdiff != 0)
             return cdiff;
         }

--- a/src/message.c
+++ b/src/message.c
@@ -2771,7 +2771,7 @@ do_dialog (
         }
 
         /* Make the character lowercase, as chars in "hotkeys" are. */
-        c = MB_TOLOWER(c);
+        c = vim_tolower(c);
         retval = 1;
         for (i = 0; hotkeys[i]; ++i) {
           if (has_mbyte) {
@@ -2819,7 +2819,7 @@ copy_char (
 
   if (has_mbyte) {
     if (lowercase) {
-      c = MB_TOLOWER((*mb_ptr2char)(from));
+      c = vim_tolower((*mb_ptr2char)(from));
       return (*mb_char2bytes)(c, to);
     } else {
       len = (*mb_ptr2len)(from);

--- a/src/ops.c
+++ b/src/ops.c
@@ -1698,6 +1698,14 @@ static void mb_adjust_opend(oparg_T *oap)
 }
 
 /*
+ * Put character 'c' at position 'lp'
+ */
+static inline void pchar(pos_T lp, int c)
+{
+    *(ml_get_buf(curbuf, lp.lnum, TRUE) + lp.col) = c;;
+}
+
+/*
  * Replace a whole area with one character.
  */
 int op_replace(oparg_T *oap, int c)

--- a/src/ops.c
+++ b/src/ops.c
@@ -2031,16 +2031,16 @@ int swapchar(int op_type, pos_T *pos)
   if (enc_dbcs != 0 && c >= 0x100)      /* No lower/uppercase letter */
     return FALSE;
   nc = c;
-  if (MB_ISLOWER(c)) {
+  if (vim_islower(c)) {
     if (op_type == OP_ROT13)
       nc = ROT13(c, 'a');
     else if (op_type != OP_LOWER)
-      nc = MB_TOUPPER(c);
-  } else if (MB_ISUPPER(c)) {
+      nc = vim_toupper(c);
+  } else if (vim_isupper(c)) {
     if (op_type == OP_ROT13)
       nc = ROT13(c, 'A');
     else if (op_type != OP_UPPER)
-      nc = MB_TOLOWER(c);
+      nc = vim_tolower(c);
   }
   if (nc != c) {
     if (enc_utf8 && (c >= 0x80 || nc >= 0x80)) {
@@ -3288,7 +3288,7 @@ void ex_display(exarg_T *eap)
     } else
       yb = &(y_regs[i]);
 
-    if (name == MB_TOLOWER(redir_reg)
+    if (name == vim_tolower(redir_reg)
         || (redir_reg == '"' && yb == y_previous))
       continue;             /* do not list register being written to, the
                              * pointer can be freed */

--- a/src/option.c
+++ b/src/option.c
@@ -5354,7 +5354,7 @@ set_bool_option (
     p_wiv = (*T_XS != NUL);
   } else if ((int *)varp == &p_acd) {
     /* Change directories when the 'acd' option is set now. */
-    DO_AUTOCHDIR
+    do_autochdir();
   }
   /* 'diff' */
   else if ((int *)varp == &curwin->w_p_diff) {

--- a/src/path.c
+++ b/src/path.c
@@ -327,7 +327,7 @@ int vim_fnamencmp(char_u *x, char_u *y, size_t len)
     cx = PTR2CHAR(px);
     cy = PTR2CHAR(py);
     if (cx == NUL || cy == NUL
-        || ((p_fic ? MB_TOLOWER(cx) != MB_TOLOWER(cy) : cx != cy)
+        || ((p_fic ? vim_tolower(cx) != vim_tolower(cy) : cx != cy)
             && !(cx == '/' && cy == '\\')
             && !(cx == '\\' && cy == '/')))
       break;
@@ -1728,7 +1728,7 @@ int pathcmp(const char *p, const char *q, int maxlen)
       break;
     }
 
-    if ((p_fic ? MB_TOUPPER(c1) != MB_TOUPPER(c2) : c1 != c2)
+    if ((p_fic ? vim_toupper(c1) != vim_toupper(c2) : c1 != c2)
 #ifdef BACKSLASH_IN_FILENAME
         /* consider '/' and '\\' to be equal */
         && !((c1 == '/' && c2 == '\\')
@@ -1739,7 +1739,7 @@ int pathcmp(const char *p, const char *q, int maxlen)
         return -1;
       if (vim_ispathsep(c2))
         return 1;
-      return p_fic ? MB_TOUPPER(c1) - MB_TOUPPER(c2)
+      return p_fic ? vim_toupper(c1) - vim_toupper(c2)
              : c1 - c2;         /* no match */
     }
   }

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -2288,7 +2288,7 @@ collection:
               break;
             case CLASS_LOWER:
               for (cu = 1; cu <= 255; cu++)
-                if (MB_ISLOWER(cu))
+                if (vim_islower(cu))
                   regc(cu);
               break;
             case CLASS_PRINT:
@@ -2308,7 +2308,7 @@ collection:
               break;
             case CLASS_UPPER:
               for (cu = 1; cu <= 255; cu++)
-                if (MB_ISUPPER(cu))
+                if (vim_isupper(cu))
                   regc(cu);
               break;
             case CLASS_XDIGIT:
@@ -3512,7 +3512,7 @@ proftime_T  *tm;         /* timeout limit or NULL */
         || (ireg_ic && ((
                           (enc_utf8 && utf_fold(prog->regstart) == utf_fold(c)))
                         || (c < 255 && prog->regstart < 255 &&
-                            MB_TOLOWER(prog->regstart) == MB_TOLOWER(c)))))
+                            vim_tolower(prog->regstart) == vim_tolower(c)))))
       retval = regtry(prog, col);
     else
       retval = 0;
@@ -4185,7 +4185,7 @@ regmatch (
           if (*opnd != *reginput
               && (!ireg_ic || (
                     !enc_utf8 &&
-                    MB_TOLOWER(*opnd) != MB_TOLOWER(*reginput))))
+                    vim_tolower(*opnd) != vim_tolower(*reginput))))
             status = RA_NOMATCH;
           else if (*opnd == NUL) {
             /* match empty string always works; happens when "~" is
@@ -4597,10 +4597,10 @@ regmatch (
           if (OP(next) == EXACTLY) {
             rst.nextb = *OPERAND(next);
             if (ireg_ic) {
-              if (MB_ISUPPER(rst.nextb))
-                rst.nextb_ic = MB_TOLOWER(rst.nextb);
+              if (vim_isupper(rst.nextb))
+                rst.nextb_ic = vim_tolower(rst.nextb);
               else
-                rst.nextb_ic = MB_TOUPPER(rst.nextb);
+                rst.nextb_ic = vim_toupper(rst.nextb);
             } else
               rst.nextb_ic = rst.nextb;
           } else {
@@ -5366,8 +5366,8 @@ do_class:
      * would have been used for it.  It does handle single-byte
      * characters, such as latin1. */
     if (ireg_ic) {
-      cu = MB_TOUPPER(*opnd);
-      cl = MB_TOLOWER(*opnd);
+      cu = vim_toupper(*opnd);
+      cl = vim_tolower(*opnd);
       while (count < maxcount && (*scan == cu || *scan == cl)) {
         count++;
         scan++;
@@ -6341,10 +6341,10 @@ static char_u *cstrchr(char_u *s, int c)
    * For UTF-8 need to use folded case. */
   if (enc_utf8 && c > 0x80)
     cc = utf_fold(c);
-  else if (MB_ISUPPER(c))
-    cc = MB_TOLOWER(c);
-  else if (MB_ISLOWER(c))
-    cc = MB_TOUPPER(c);
+  else if (vim_isupper(c))
+    cc = vim_tolower(c);
+  else if (vim_islower(c))
+    cc = vim_toupper(c);
   else
     return vim_strchr(s, c);
 
@@ -6392,7 +6392,7 @@ static fptr_T do_upper(d, c)
 int         *d;
 int c;
 {
-  *d = MB_TOUPPER(c);
+  *d = vim_toupper(c);
 
   return (fptr_T)NULL;
 }
@@ -6401,7 +6401,7 @@ static fptr_T do_Upper(d, c)
 int         *d;
 int c;
 {
-  *d = MB_TOUPPER(c);
+  *d = vim_toupper(c);
 
   return (fptr_T)do_Upper;
 }
@@ -6410,7 +6410,7 @@ static fptr_T do_lower(d, c)
 int         *d;
 int c;
 {
-  *d = MB_TOLOWER(c);
+  *d = vim_tolower(c);
 
   return (fptr_T)NULL;
 }
@@ -6419,7 +6419,7 @@ static fptr_T do_Lower(d, c)
 int         *d;
 int c;
 {
-  *d = MB_TOLOWER(c);
+  *d = vim_tolower(c);
 
   return (fptr_T)do_Lower;
 }

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -4278,7 +4278,7 @@ static int check_char_class(int class, int c)
       return OK;
     break;
   case NFA_CLASS_LOWER:
-    if (MB_ISLOWER(c))
+    if (vim_islower(c))
       return OK;
     break;
   case NFA_CLASS_PRINT:
@@ -4294,7 +4294,7 @@ static int check_char_class(int class, int c)
       return OK;
     break;
   case NFA_CLASS_UPPER:
-    if (MB_ISUPPER(c))
+    if (vim_isupper(c))
       return OK;
     break;
   case NFA_CLASS_XDIGIT:
@@ -4803,7 +4803,7 @@ static long find_match_text(colnr_T startcol, int regstart, char_u *match_text)
     for (len1 = 0; match_text[len1] != NUL; len1 += MB_CHAR2LEN(c1)) {
       c1 = PTR2CHAR(match_text + len1);
       c2 = PTR2CHAR(regline + col + len2);
-      if (c1 != c2 && (!ireg_ic || MB_TOLOWER(c1) != MB_TOLOWER(c2))) {
+      if (c1 != c2 && (!ireg_ic || vim_tolower(c1) != vim_tolower(c2))) {
         match = FALSE;
         break;
       }
@@ -5462,11 +5462,11 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
               break;
             }
             if (ireg_ic) {
-              int curc_low = MB_TOLOWER(curc);
+              int curc_low = vim_tolower(curc);
               int done = FALSE;
 
               for (; c1 <= c2; ++c1)
-                if (MB_TOLOWER(c1) == curc_low) {
+                if (vim_tolower(c1) == curc_low) {
                   result = result_if_matched;
                   done = TRUE;
                   break;
@@ -5476,8 +5476,8 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
             }
           } else if (state->c < 0 ? check_char_class(state->c, curc)
                      : (curc == state->c
-                        || (ireg_ic && MB_TOLOWER(curc)
-                            == MB_TOLOWER(state->c)))) {
+                        || (ireg_ic && vim_tolower(curc)
+                            == vim_tolower(state->c)))) {
             result = result_if_matched;
             break;
           }
@@ -5838,7 +5838,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
         result = (c == curc);
 
         if (!result && ireg_ic)
-          result = MB_TOLOWER(c) == MB_TOLOWER(curc);
+          result = vim_tolower(c) == vim_tolower(curc);
         /* If there is a composing character which is not being
          * ignored there can be no match. Match with composing
          * character uses NFA_COMPOSING above. */
@@ -5985,8 +5985,8 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
             /* Checking if the required start character matches is
              * cheaper than adding a state that won't match. */
             c = PTR2CHAR(reginput + clen);
-            if (c != prog->regstart && (!ireg_ic || MB_TOLOWER(c)
-                                        != MB_TOLOWER(prog->regstart))) {
+            if (c != prog->regstart && (!ireg_ic || vim_tolower(c)
+                                        != vim_tolower(prog->regstart))) {
 #ifdef ENABLE_LOG
               fprintf(log_fd,
                   "  Skipping start state, regstart does not match\n");

--- a/src/search.c
+++ b/src/search.c
@@ -364,7 +364,7 @@ int pat_has_uppercase(char_u *pat)
         p += 2;
       else
         p += 1;
-    } else if (MB_ISUPPER(*p))
+    } else if (vim_isupper(*p))
       return TRUE;
     else
       ++p;

--- a/src/spell.c
+++ b/src/spell.c
@@ -8686,13 +8686,13 @@ void init_spell_chartab(void)
   } else {
     /* Rough guess: use locale-dependent library functions. */
     for (i = 128; i < 256; ++i) {
-      if (MB_ISUPPER(i)) {
+      if (vim_isupper(i)) {
         spelltab.st_isw[i] = TRUE;
         spelltab.st_isu[i] = TRUE;
-        spelltab.st_fold[i] = MB_TOLOWER(i);
-      } else if (MB_ISLOWER(i))   {
+        spelltab.st_fold[i] = vim_tolower(i);
+      } else if (vim_islower(i))   {
         spelltab.st_isw[i] = TRUE;
-        spelltab.st_upper[i] = MB_TOUPPER(i);
+        spelltab.st_upper[i] = vim_toupper(i);
       }
     }
   }

--- a/src/window.c
+++ b/src/window.c
@@ -3535,7 +3535,7 @@ static void win_enter_ext(win_T *wp, int undo_sync, int curwin_invalid, int trig
   setmouse();                   /* in case jumped to/from help buffer */
 
   /* Change directories when the 'acd' option is set. */
-  DO_AUTOCHDIR
+  do_autochdir();
 }
 
 


### PR DESCRIPTION
I think most of them are vestiges of the `#ifdef` spaghetti
