### PR TITLE
[RFC] Remove code supporting interactive programs from vim

### DIFF
--- a/src/ex_cmds_defs.h
+++ b/src/ex_cmds_defs.h
@@ -843,8 +843,6 @@ enum CMD_index
       BANG|FILE1|RANGE|NOTADR|EDITCMD|ARGOPT|TRLBAR),
   EX(CMD_sfirst,          "sfirst",       ex_rewind,
       EXTRA|BANG|EDITCMD|ARGOPT|TRLBAR),
-  EX(CMD_shell,           "shell",        ex_shell,
-      TRLBAR|CMDWIN),
   EX(CMD_simalt,          "simalt",       ex_simalt,
       NEEDARG|WORD1|TRLBAR|CMDWIN),
   EX(CMD_sign,            "sign",         ex_sign,

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -155,7 +155,6 @@ static void ex_stop(exarg_T *eap);
 static void ex_exit(exarg_T *eap);
 static void ex_print(exarg_T *eap);
 static void ex_goto(exarg_T *eap);
-static void ex_shell(exarg_T *eap);
 static void ex_preserve(exarg_T *eap);
 static void ex_recover(exarg_T *eap);
 static void ex_mode(exarg_T *eap);
@@ -5720,14 +5719,6 @@ static void ex_print(exarg_T *eap)
 static void ex_goto(exarg_T *eap)
 {
   goto_byte(eap->line2);
-}
-
-/*
- * ":shell".
- */
-static void ex_shell(exarg_T *eap)
-{
-  do_shell(NULL, 0);
 }
 
 #if (defined(FEAT_WINDOWS) && defined(HAVE_DROP_FILE)) \

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1122,7 +1122,6 @@ int mch_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
   int retval = -1;
   char        **argv = NULL;
   int i;
-  char_u      *p;
   int fd_toshell[2];                    /* for pipes */
   int fd_fromshell[2];
   int pipe_error = FALSE;
@@ -1287,7 +1286,6 @@ int mch_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
         int len;
         int p_more_save;
         int old_State;
-        int c;
         int toshell_fd;
         int fromshell_fd;
         garray_T ga;
@@ -1431,44 +1429,6 @@ int mch_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
                 else
                   ga_append(&ga, buffer[i]);
               }
-            } else if (has_mbyte) {
-              int l;
-
-              len += buffer_off;
-              buffer[len] = NUL;
-
-              /* Check if the last character in buffer[] is
-               * incomplete, keep these bytes for the next
-               * round. */
-              for (p = buffer; p < buffer + len; p += l) {
-                l = mb_cptr2len(p);
-                if (l == 0)
-                  l = 1;                    /* NUL byte? */
-                else if (MB_BYTE2LEN(*p) != l)
-                  break;
-              }
-              if (p == buffer) {                /* no complete character */
-                /* avoid getting stuck at an illegal byte */
-                if (len >= 12)
-                  ++p;
-                else {
-                  buffer_off = len;
-                  continue;
-                }
-              }
-              c = *p;
-              *p = NUL;
-              msg_puts(buffer);
-              if (p < buffer + len) {
-                *p = c;
-                buffer_off = (buffer + len) - p;
-                memmove(buffer, p, buffer_off);
-                continue;
-              }
-              buffer_off = 0;
-            } else {
-              buffer[len] = NUL;
-              msg_puts(buffer);
             }
 
             windgoto(msg_row, msg_col);

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1123,7 +1123,6 @@ int mch_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
   char        **argv = NULL;
   int i;
   char_u      *p;
-  int pty_master_fd = -1;                   /* for pty's */
   int fd_toshell[2];                    /* for pipes */
   int fd_fromshell[2];
   int pipe_error = FALSE;
@@ -1389,128 +1388,7 @@ int mch_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
         gettimeofday(&start_tv, NULL);
 # endif
         for (;; ) {
-          /*
-           * Check if keys have been typed, write them to the child
-           * if there are any.
-           * Don't do this if we are expanding wild cards (would eat
-           * typeahead).
-           * Don't do this when filtering and terminal is in cooked
-           * mode, the shell command will handle the I/O.  Avoids
-           * that a typed password is echoed for ssh or gpg command.
-           * Don't get characters when the child has already
-           * finished (wait_pid == 0).
-           * Don't read characters unless we didn't get output for a
-           * while (noread_cnt > 4), avoids that ":r !ls" eats
-           * typeahead.
-           */
           len = 0;
-          if (!(opts & kShellOptExpand)
-              && ((opts &
-                   (kShellOptRead|kShellOptWrite|kShellOptCooked))
-                  != (kShellOptRead|kShellOptWrite|kShellOptCooked)
-                  )
-              && wait_pid == 0
-              && (ta_len > 0 || noread_cnt > 4)) {
-            if (ta_len == 0) {
-              /* Get extra characters when we don't have any.
-               * Reset the counter and timer. */
-              noread_cnt = 0;
-# if defined(HAVE_GETTIMEOFDAY) && defined(HAVE_SYS_TIME_H)
-              gettimeofday(&start_tv, NULL);
-# endif
-              len = ui_inchar(ta_buf, BUFLEN, 10L, 0);
-            }
-            if (ta_len > 0 || len > 0) {
-              /*
-               * For pipes:
-               * Check for CTRL-C: send interrupt signal to child.
-               * Check for CTRL-D: EOF, close pipe to child.
-               */
-              if (len == 1 && (pty_master_fd < 0 || cmd != NULL)) {
-# ifdef SIGINT
-                /*
-                 * Send SIGINT to the child's group or all
-                 * processes in our group.
-                 */
-                if (ta_buf[ta_len] == Ctrl_C
-                    || ta_buf[ta_len] == intr_char) {
-#  ifdef HAVE_SETSID
-                  kill(-pid, SIGINT);
-#  else
-                  kill(0, SIGINT);
-#  endif
-                  if (wpid > 0)
-                    kill(wpid, SIGINT);
-                }
-# endif
-                if (pty_master_fd < 0 && toshell_fd >= 0
-                    && ta_buf[ta_len] == Ctrl_D) {
-                  close(toshell_fd);
-                  toshell_fd = -1;
-                }
-              }
-
-              /* replace K_BS by <BS> and K_DEL by <DEL> */
-              for (i = ta_len; i < ta_len + len; ++i) {
-                if (ta_buf[i] == CSI && len - i > 2) {
-                  c = TERMCAP2KEY(ta_buf[i + 1], ta_buf[i + 2]);
-                  if (c == K_DEL || c == K_KDEL || c == K_BS) {
-                    memmove(ta_buf + i + 1, ta_buf + i + 3,
-                        (size_t)(len - i - 2));
-                    if (c == K_DEL || c == K_KDEL)
-                      ta_buf[i] = DEL;
-                    else
-                      ta_buf[i] = Ctrl_H;
-                    len -= 2;
-                  }
-                } else if (ta_buf[i] == '\r')
-                  ta_buf[i] = '\n';
-                if (has_mbyte)
-                  i += (*mb_ptr2len_len)(ta_buf + i,
-                                         ta_len + len - i) - 1;
-              }
-
-              /*
-               * For pipes: echo the typed characters.
-               * For a pty this does not seem to work.
-               */
-              if (pty_master_fd < 0) {
-                for (i = ta_len; i < ta_len + len; ++i) {
-                  if (ta_buf[i] == '\n' || ta_buf[i] == '\b')
-                    msg_putchar(ta_buf[i]);
-                  else if (has_mbyte) {
-                    int l = (*mb_ptr2len)(ta_buf + i);
-
-                    msg_outtrans_len(ta_buf + i, l);
-                    i += l - 1;
-                  } else
-                    msg_outtrans_len(ta_buf + i, 1);
-                }
-                windgoto(msg_row, msg_col);
-                out_flush();
-              }
-
-              ta_len += len;
-
-              /*
-               * Write the characters to the child, unless EOF has
-               * been typed for pipes.  Write one character at a
-               * time, to avoid losing too much typeahead.
-               * When writing buffer lines, drop the typed
-               * characters (only check for CTRL-C).
-               */
-              if (opts & kShellOptWrite)
-                ta_len = 0;
-              else if (toshell_fd >= 0) {
-                len = write(toshell_fd, (char *)ta_buf, (size_t)1);
-                if (len > 0) {
-                  ta_len -= len;
-                  memmove(ta_buf, ta_buf + len, ta_len);
-                }
-              }
-            }
-          }
-
           if (got_int) {
             /* CTRL-C sends a signal to the child, we ignore it
              * ourselves */

--- a/src/ui.c
+++ b/src/ui.c
@@ -209,23 +209,6 @@ void ui_suspend(void)
   mch_suspend();
 }
 
-#if !defined(UNIX) || !defined(SIGTSTP) || defined(PROTO) || defined(__BEOS__)
-/*
- * When the OS can't really suspend, call this function to start a shell.
- * This is never called in the GUI.
- */
-void suspend_shell(void)
-{
-  if (*p_sh == NUL)
-    EMSG(_(e_shellempty));
-  else {
-    MSG_PUTS(_("new shell started\n"));
-    do_shell(NULL, 0);
-  }
-}
-
-#endif
-
 /*
  * Try to get the current Vim shell size.  Put the result in Rows and Columns.
  * Use the new sizes as defaults for 'columns' and 'lines'.


### PR DESCRIPTION
I want to remove all code for emulating a terminal inside vim but before some feedback/opinions would be good. Here are my reasons:
- This code in the first commit was only needed for the old GUI. Right now the interactive program will only spawn when the terminal is in cooked mode so everything should just work.
- Even in the old GUI, running interactive shells was clumsly:
  - GUI doesnt seem to handle terminal colors
  - The documentation (:h gui-shell) says that support is incomplete
  - On windows it spawns a separate window(is that different than creating an ex command that does the same?)
- Terminal emulation is something that should be implemented as a plugin. For example, [conque shell](http://www.vim.org/scripts/script.php?script_id=2771) is much better than vim own terminal emulation, and it could be easily ported to run on the new extension architecture(most of it is implemented in python) making it work much better(async updates)
- Most plugins probably dont need it.(not sure about this)
- Even in terminal vim, the idiomatic way to use a shell is ctrl+z
- Leaving this code will complicate things when we externalize the UI

On top of that, vim itself seems to reject the idea(:h develop.txt):

"
- Vim is not a shell or an Operating System.  You will not be able to run a
  shell inside Vim or use it to control a debugger.  This should work the
  other way around: Use Vim as a component from a shell or in an IDE.
  A satirical way to say this: "Unlike Emacs, Vim does not attempt to include
  everything but the kitchen sink, but some people say that you can clean one
  with it.  ;-)"
  "

So I see no reason why this was implemented in the first place.

I thought about doing this while reading(in a lot of pain) mch_call_shell code for #444 but I guess this should be on a separate PR and not before I have some feedback
