### PR TITLE
[RDY] Merging vim-patch:7.4.170

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4979,14 +4979,18 @@ int find_help_tags(char_u *arg, int *num_matches, char_u ***matches, int keep_la
                              "?", ":?", "?<CR>", "g?", "g?g?", "g??", "z?",
                              "/\\?", "/\\z(\\)", "\\=", ":s\\=",
                              "[count]", "[quotex]", "[range]",
-                             "[pattern]", "\\|", "\\%$"};
+                             "[pattern]", "\\|", "\\%$",
+                             "s/\\~", "s/\\U", "s/\\L",
+                             "s/\\1", "s/\\2", "s/\\3", "s/\\9"};
   static char *(rtable[]) = {"star", "gstar", "[star", "]star", ":star",
                              "/star", "/\\\\star", "quotestar", "starstar",
                              "cpo-star", "/\\\\(\\\\)", "/\\\\%(\\\\)",
                              "?", ":?", "?<CR>", "g?", "g?g?", "g??", "z?",
                              "/\\\\?", "/\\\\z(\\\\)", "\\\\=", ":s\\\\=",
                              "\\[count]", "\\[quotex]", "\\[range]",
-                             "\\[pattern]", "\\\\bar", "/\\\\%\\$"};
+                             "\\[pattern]", "\\\\bar", "/\\\\%\\$",
+                             "s/\\\\\\~", "s/\\\\U", "s/\\\\L",
+                             "s/\\\\1", "s/\\\\2", "s/\\\\3", "s/\\\\9"};
   int flags;
 
   d = IObuff;               /* assume IObuff is long enough! */
@@ -5020,7 +5024,7 @@ int find_help_tags(char_u *arg, int *num_matches, char_u ***matches, int keep_la
       /* Replace:
        * "[:...:]" with "\[:...:]"
        * "[++...]" with "\[++...]"
-       * "\{" with "\\{"
+       * "\{" with "\\{"               -- matching "} \}"
        */
       if ((arg[0] == '[' && (arg[1] == ':'
                              || (arg[1] == '+' && arg[2] == '+')))

--- a/src/version.c
+++ b/src/version.c
@@ -221,6 +221,7 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  170,
   169,
   //168,
   //167,


### PR DESCRIPTION
Merging vim-patch:7.4.170

Problem:    Some help tags don't work with ":help". (Tim Chase)
Solution:   Add exceptions.

https://code.google.com/p/vim/source/detail?r=8122eab8fcdbbdaac62dfbf7c6458cb3e6f46b04
