### PR TITLE
[RDY] Merging vim-patch:7.4.171

### DIFF
--- a/src/buffer_defs.h
+++ b/src/buffer_defs.h
@@ -51,22 +51,25 @@ typedef struct taggy {
   int cur_fnum;                 /* buffer number used for cur_match */
 } taggy_T;
 
+typedef struct buffblock buffblock_T;
+typedef struct buffheader buffheader_T;
+
 /*
  * structure used to store one block of the stuff/redo/recording buffers
  */
 struct buffblock {
-  struct buffblock    *b_next;          /* pointer to next buffblock */
-  char_u b_str[1];                      /* contents (actually longer) */
+  buffblock_T *b_next;  // pointer to next buffblock
+  char_u b_str[1];      // contents (actually longer)
 };
 
 /*
  * header used for the stuff buffer and the redo buffer
  */
 struct buffheader {
-  struct buffblock bh_first;            /* first (dummy) block of list */
-  struct buffblock    *bh_curr;         /* buffblock for appending */
-  int bh_index;                         /* index for reading */
-  int bh_space;                         /* space in bh_curr for appending */
+  buffblock_T bh_first;  // first (dummy) block of list
+  buffblock_T *bh_curr;  // buffblock for appending
+  int bh_index;          // index for reading
+  int bh_space;          // space in bh_curr for appending
 };
 
 /*
@@ -245,7 +248,8 @@ typedef struct {
   int typebuf_valid;                        /* TRUE when save_typebuf valid */
   int old_char;
   int old_mod_mask;
-  struct buffheader save_stuffbuff;
+  buffheader_T save_readbuf1;
+  buffheader_T save_readbuf2;
 #ifdef USE_INPUT_BUF
   char_u              *save_inputbuf;
 #endif

--- a/src/getchar.h
+++ b/src/getchar.h
@@ -1,10 +1,11 @@
 #ifndef NEOVIM_GETCHAR_H
 #define NEOVIM_GETCHAR_H
 /* getchar.c */
-void free_buff(struct buffheader *buf);
+void free_buff(buffheader_T *buf);
 char_u *get_recorded(void);
 char_u *get_inserted(void);
 int stuff_empty(void);
+int readbuf1_empty(void);
 void typeahead_noflush(int c);
 void flush_buffers(int flush_typeahead);
 void ResetRedobuff(void);

--- a/src/globals.h
+++ b/src/globals.h
@@ -753,11 +753,6 @@ EXTERN int RedrawingDisabled INIT(= 0);
 EXTERN int readonlymode INIT(= FALSE);      /* Set to TRUE for "view" */
 EXTERN int recoverymode INIT(= FALSE);      /* Set to TRUE for "-r" option */
 
-EXTERN struct buffheader stuffbuff      /* stuff buffer */
-#ifdef DO_INIT
-  = {{NULL, {NUL}}, NULL, 0, 0}
-#endif
-;
 EXTERN typebuf_T typebuf                /* typeahead buffer */
 #ifdef DO_INIT
   = {NULL, NULL, 0, 0, 0, 0, 0, 0, 0}

--- a/src/normal.c
+++ b/src/normal.c
@@ -572,8 +572,8 @@ normal_cmd (
 
   /* Set v:count here, when called from main() and not a stuffed
    * command, so that v:count can be used in an expression mapping
-   * when there is no count. */
-  if (toplevel && stuff_empty())
+   * when there is no count. Do set it for redo. */
+  if (toplevel && readbuf1_empty())
     set_vcount_ca(&ca, &set_prevcount);
 
   /*
@@ -637,8 +637,8 @@ getcount:
         ca.count0 = 999999999L;
       /* Set v:count here, when called from main() and not a stuffed
        * command, so that v:count can be used in an expression mapping
-       * right after the count. */
-      if (toplevel && stuff_empty())
+       * right after the count. Do set it for redo. */
+      if (toplevel && readbuf1_empty())
         set_vcount_ca(&ca, &set_prevcount);
       if (ctrl_w) {
         ++no_mapping;
@@ -705,8 +705,9 @@ getcount:
 
   /*
    * Only set v:count when called from main() and not a stuffed command.
+   * Do set it for redo.
    */
-  if (toplevel && stuff_empty())
+  if (toplevel && readbuf1_empty())
     set_vcount(ca.count0, ca.count1, set_prevcount);
 
   /*

--- a/src/version.c
+++ b/src/version.c
@@ -203,7 +203,7 @@ static char *(features[]) = {
 static int included_patches[] = {
   // Add new patch number below this line
   172,
-  //171,
+  171,
   170,
   169,
   //168,


### PR DESCRIPTION
Merging vim-patch:7.4.171

Problem:    Redo does not set v:count and v:count1.
Solution:   Use a separate buffer for redo, so that we can set the counts when
                   performing redo.

https://code.google.com/p/vim/source/detail?r=beb037a6c2708f539d50840637f70eed0811d93c
