### PR TITLE
[RDY] vim-patch:7.4.172

### DIFF
--- a/src/blowfish.h
+++ b/src/blowfish.h
@@ -2,7 +2,7 @@
 #define NEOVIM_BLOWFISH_H
 
 void bf_key_init(char_u *password, char_u *salt, int salt_len);
-void bf_ofb_init(char_u *iv, int iv_len);
+void bf_cfb_init(char_u *iv, int iv_len);
 void bf_crypt_encode(char_u *from, size_t len, char_u *to);
 void bf_crypt_decode(char_u *ptr, long len);
 void bf_crypt_init_keys(char_u *passwd);

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -2324,7 +2324,7 @@ check_for_cryptkey (
         crypt_init_keys(cryptkey);
       else {
         bf_key_init(cryptkey, ptr + CRYPT_MAGIC_LEN, salt_len);
-        bf_ofb_init(ptr + CRYPT_MAGIC_LEN + salt_len, seed_len);
+        bf_cfb_init(ptr + CRYPT_MAGIC_LEN + salt_len, seed_len);
       }
 
       /* Remove magic number from the text */
@@ -2373,7 +2373,7 @@ int prepare_crypt_read(FILE *fp)
     if (fread(buffer, salt_len + seed_len, 1, fp) != 1)
       return FAIL;
     bf_key_init(curbuf->b_p_key, buffer, salt_len);
-    bf_ofb_init(buffer + salt_len, seed_len);
+    bf_cfb_init(buffer + salt_len, seed_len);
   }
   return OK;
 }
@@ -2407,7 +2407,7 @@ char_u *prepare_crypt_write(buf_T *buf, int *lenp)
       seed = salt + salt_len;
       sha2_seed(salt, salt_len, seed, seed_len);
       bf_key_init(buf->b_p_key, salt, salt_len);
-      bf_ofb_init(seed, seed_len);
+      bf_cfb_init(seed, seed_len);
     }
   }
   *lenp = CRYPT_MAGIC_LEN + salt_len + seed_len;

--- a/src/memline.c
+++ b/src/memline.c
@@ -4284,7 +4284,7 @@ static void ml_crypt_prepare(memfile_T *mfp, off_t offset, int reading)
      * block for the salt. */
     vim_snprintf((char *)salt, sizeof(salt), "%ld", (long)offset);
     bf_key_init(key, salt, (int)STRLEN(salt));
-    bf_ofb_init(seed, MF_SEED_LEN);
+    bf_cfb_init(seed, MF_SEED_LEN);
   }
 }
 

--- a/src/version.c
+++ b/src/version.c
@@ -221,6 +221,8 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  172,
+  //171,
   170,
   169,
   //168,


### PR DESCRIPTION
Merging vim-patch:7.4.172

Problem:    The blowfish code mentions output feedback, but the code is
            actually doing cipher feedback.
Solution:   Adjust names and comments.

https://code.google.com/p/vim/source/detail?r=391e10afccf6879dcfab8b28cb1587a13eb835c0
