### PR TITLE
[RDY] vim-patch:7.4.173

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -1614,6 +1614,7 @@ void scroll_cursor_halfway(int atend)
   int used;
   lineoff_T loff;
   lineoff_T boff;
+  linenr_T old_topline = curwin->w_topline;
 
   loff.lnum = boff.lnum = curwin->w_cursor.lnum;
   (void)hasFolding(loff.lnum, &loff.lnum, &boff.lnum);
@@ -1652,6 +1653,8 @@ void scroll_cursor_halfway(int atend)
   if (!hasFolding(topline, &curwin->w_topline, NULL))
     curwin->w_topline = topline;
   curwin->w_topfill = topfill;
+  if (old_topline > curwin->w_topline + curwin->w_height)
+    curwin->w_botfill = FALSE;
   check_topfill(curwin, FALSE);
   curwin->w_valid &= ~(VALID_WROW|VALID_CROW|VALID_BOTLINE|VALID_BOTLINE_AP);
   curwin->w_valid |= VALID_TOPLINE;

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,7 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  173,
   172,
   171,
   170,


### PR DESCRIPTION
Merging vim-patch:7.4.173

Problem:    When using scrollbind the cursor can end up below the last line.
            (mvxxc)
Solution:   Reset w_botfill when scrolling up. (Christian Brabandt)

https://code.google.com/p/vim/source/detail?r=233ad7b960d0fbeb224b383918113b25c74ebe35
