### PR TITLE
[RDY] vim-patch:7.4.178

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -3528,6 +3528,11 @@ int do_join(long count, int insert_space, int save_undo, int use_formatoptions)
    */
   for (t = 0; t < count; ++t) {
     curr = curr_start = ml_get((linenr_T)(curwin->w_cursor.lnum + t));
+    if (t == 0) {
+      // Set the '[ mark.
+      curwin->w_buffer->b_op_start.lnum = curwin->w_cursor.lnum;
+      curwin->w_buffer->b_op_start.col = (colnr_T)STRLEN(curr);
+    }
     if (remove_comments) {
       /* We don't want to remove the comment leader if the
        * previous line is not a comment. */
@@ -3622,6 +3627,10 @@ int do_join(long count, int insert_space, int save_undo, int use_formatoptions)
     currsize = (int)STRLEN(curr);
   }
   ml_replace(curwin->w_cursor.lnum, newp, FALSE);
+
+  // Set the '] mark.
+  curwin->w_buffer->b_op_end.lnum = curwin->w_cursor.lnum;
+  curwin->w_buffer->b_op_end.col = (colnr_T)STRLEN(newp);
 
   /* Only report the change in the first line here, del_lines() will report
    * the deleted line. */

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,11 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  178,
+  //177,
+  //176,
+  //175,
+  //174,
   173,
   172,
   171,


### PR DESCRIPTION
Merging vim-patch:7.4.178

Problem:    The J command does not update '[ and '] marks. (William Gardner)
Solution:   Set the marks. (Christian Brabandt)

https://code.google.com/p/vim/source/detail?r=647e6bb15aa3f864eaf447fe77e3e3ae7e37b134
