### PR TITLE
[WIP] Remove BACKSLASH_IN_FILENAME

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2399,24 +2399,6 @@ int buflist_add(char_u *fname, int flags)
   return 0;
 }
 
-#if defined(BACKSLASH_IN_FILENAME) || defined(PROTO)
-/*
- * Adjust slashes in file names.  Called after 'shellslash' was set.
- */
-void buflist_slash_adjust(void)
-{
-  buf_T       *bp;
-
-  for (bp = firstbuf; bp != NULL; bp = bp->b_next) {
-    if (bp->b_ffname != NULL)
-      slash_adjust(bp->b_ffname);
-    if (bp->b_sfname != NULL)
-      slash_adjust(bp->b_sfname);
-  }
-}
-
-#endif
-
 /*
  * Set alternate cursor position for the current buffer and window "win".
  * Also save the local window option values.
@@ -2707,11 +2689,6 @@ void maketitle(void)
         buf[off++] = '(';
         home_replace(curbuf, curbuf->b_ffname,
             buf + off, SPACE_FOR_DIR - off, TRUE);
-#ifdef BACKSLASH_IN_FILENAME
-        /* avoid "c:/name" to be reduced to "c" */
-        if (isalpha(buf[off]) && buf[off + 1] == ':')
-          off += 2;
-#endif
         /* remove the file name */
         p = path_tail_with_sep(buf + off);
         if (p == buf + off)

--- a/src/charset.c
+++ b/src/charset.c
@@ -1885,18 +1885,7 @@ int hexhex2nr(char_u *p)
 /// @return TRUE if `str` starts with a backslash that should be removed.
 int rem_backslash(char_u *str)
 {
-#ifdef BACKSLASH_IN_FILENAME
-  return str[0] == '\\'
-         && str[1] < 0x80
-         && (str[1] == ' '
-             || (str[1] != NUL
-                 && str[1] != '*'
-                 && str[1] != '?'
-                 && !vim_isfilec(str[1])));
-
-#else  // ifdef BACKSLASH_IN_FILENAME
   return str[0] == '\\' && str[1] != NUL;
-#endif  // ifdef BACKSLASH_IN_FILENAME
 }
 
 /// Halve the number of backslashes in a file name argument.

--- a/src/eval.c
+++ b/src/eval.c
@@ -9662,10 +9662,6 @@ static void f_getcwd(typval_T *argvars, typval_T *rettv)
   if (cwd != NULL) {
     if (os_dirname(cwd, MAXPATHL) != FAIL) {
       rettv->vval.v_string = vim_strsave(cwd);
-#ifdef BACKSLASH_IN_FILENAME
-      if (rettv->vval.v_string != NULL)
-        slash_adjust(rettv->vval.v_string);
-#endif
     }
     vim_free(cwd);
   }
@@ -19305,9 +19301,6 @@ repeat:
     if ((*fnamep)[0] == '~'
 #if !defined(UNIX) && !(defined(VMS) && defined(USER_HOME))
         && ((*fnamep)[1] == '/'
-# ifdef BACKSLASH_IN_FILENAME
-            || (*fnamep)[1] == '\\'
-# endif
             || (*fnamep)[1] == NUL)
 
 #endif

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -2776,21 +2776,6 @@ void ex_scriptnames(exarg_T *eap)
     }
 }
 
-# if defined(BACKSLASH_IN_FILENAME) || defined(PROTO)
-/*
- * Fix slashes in the list of script names for 'shellslash'.
- */
-void scriptnames_slash_adjust(void)
-{
-  int i;
-
-  for (i = 1; i <= script_items.ga_len; ++i)
-    if (SCRIPT_ITEM(i).sn_name != NULL)
-      slash_adjust(SCRIPT_ITEM(i).sn_name);
-}
-
-# endif
-
 /*
  * Get a pointer to a script name.  Used for ":verbose set".
  */

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -264,9 +264,6 @@ getcmdline (
   }
   xpc.xp_context = EXPAND_NOTHING;
   xpc.xp_backslash = XP_BS_NONE;
-#ifndef BACKSLASH_IN_FILENAME
-  xpc.xp_shell = FALSE;
-#endif
 
   if (ccline.input_fn) {
     xpc.xp_context = ccline.xp_context;
@@ -531,12 +528,7 @@ getcmdline (
         while (--j > i) {
           if (has_mbyte)
             j -= (*mb_head_off)(ccline.cmdbuff, ccline.cmdbuff + j);
-          if (vim_ispathsep(ccline.cmdbuff[j])
-#ifdef BACKSLASH_IN_FILENAME
-              && vim_strchr(" *?[{`$%#", ccline.cmdbuff[j + 1])
-              == NULL
-#endif
-              ) {
+          if (vim_ispathsep(ccline.cmdbuff[j])) {
             if (found) {
               i = j + 1;
               break;
@@ -2978,9 +2970,6 @@ void ExpandInit(expand_T *xp)
   xp->xp_pattern = NULL;
   xp->xp_pattern_len = 0;
   xp->xp_backslash = XP_BS_NONE;
-#ifndef BACKSLASH_IN_FILENAME
-  xp->xp_shell = FALSE;
-#endif
   xp->xp_numfiles = -1;
   xp->xp_files = NULL;
   xp->xp_arg = NULL;
@@ -3026,20 +3015,9 @@ void ExpandEscape(expand_T *xp, char_u *str, int numfiles, char_u **files, int o
           if (p != NULL) {
             vim_free(files[i]);
             files[i] = p;
-#if defined(BACKSLASH_IN_FILENAME)
-            p = vim_strsave_escaped(files[i], (char_u *)" ");
-            if (p != NULL) {
-              vim_free(files[i]);
-              files[i] = p;
-            }
-#endif
           }
         }
-#ifdef BACKSLASH_IN_FILENAME
-        p = vim_strsave_fnameescape(files[i], FALSE);
-#else
         p = vim_strsave_fnameescape(files[i], xp->xp_shell);
-#endif
         if (p != NULL) {
           vim_free(files[i]);
           files[i] = p;
@@ -3080,17 +3058,6 @@ void ExpandEscape(expand_T *xp, char_u *str, int numfiles, char_u **files, int o
 char_u *vim_strsave_fnameescape(char_u *fname, int shell)
 {
   char_u      *p;
-#ifdef BACKSLASH_IN_FILENAME
-  char_u buf[20];
-  int j = 0;
-
-  /* Don't escape '[', '{' and '!' if they are in 'isfname'. */
-  for (p = PATH_ESC_CHARS; *p != NUL; ++p)
-    if ((*p != '[' && *p != '{' && *p != '!') || !vim_isfilec(*p))
-      buf[j++] = *p;
-  buf[j] = NUL;
-  p = vim_strsave_escaped(fname, buf);
-#else
   p = vim_strsave_escaped(fname, shell ? SHELL_ESC_CHARS : PATH_ESC_CHARS);
   if (shell && csh_like_shell() && p != NULL) {
     char_u      *s;
@@ -3101,7 +3068,6 @@ char_u *vim_strsave_fnameescape(char_u *fname, int shell)
     vim_free(p);
     p = s;
   }
-#endif
 
   /* '>' and '+' are special at the start of some commands, e.g. ":edit" and
    * ":write".  "cd -" has a special meaning. */
@@ -3313,11 +3279,7 @@ char_u *sm_gettail(char_u *s)
   int had_sep = FALSE;
 
   for (p = s; *p != NUL; ) {
-    if (vim_ispathsep(*p)
-#ifdef BACKSLASH_IN_FILENAME
-        && !rem_backslash(p)
-#endif
-        )
+    if (vim_ispathsep(*p))
       had_sep = TRUE;
     else if (had_sep) {
       t = p;
@@ -3463,13 +3425,11 @@ addstar (
        */
       tail = path_tail(retval);
       ends_in_star = (len > 0 && retval[len - 1] == '*');
-#ifndef BACKSLASH_IN_FILENAME
       for (i = len - 2; i >= 0; --i) {
         if (retval[i] != '\\')
           break;
         ends_in_star = !ends_in_star;
       }
-#endif
       if ((*retval != '~' || tail != retval)
           && !ends_in_star
           && vim_strchr(tail, '$') == NULL


### PR DESCRIPTION
According to @Hinidu [here](https://github.com/neovim/neovim/pull/447#discussion_r11269484):

> It ignores slash/backslash differences only if BACKSLASH_IN_FILENAME defined. In vim it is defined only in src/os_os2_cfg.h and src/os_dos.h. So it is not needed in modern neovim.

This will simplify much of the code in `path.c` and in other places.
