### PR TITLE
[RDY] Remove simpler cases of OOM error handling (after *alloc calls)

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1369,10 +1369,6 @@ buflist_new (
   }
   if (buf != curbuf || curbuf == NULL) {
     buf = (buf_T *)alloc_clear((unsigned)sizeof(buf_T));
-    if (buf == NULL) {
-      vim_free(ffname);
-      return NULL;
-    }
     /* init b: variables */
     buf->b_vars = dict_alloc();
     if (buf->b_vars == NULL) {
@@ -1391,8 +1387,7 @@ buflist_new (
   clear_wininfo(buf);
   buf->b_wininfo = (wininfo_T *)alloc_clear((unsigned)sizeof(wininfo_T));
 
-  if ((ffname != NULL && (buf->b_ffname == NULL || buf->b_sfname == NULL))
-      || buf->b_wininfo == NULL) {
+  if (ffname != NULL && (buf->b_ffname == NULL || buf->b_sfname == NULL)) {
     vim_free(buf->b_ffname);
     buf->b_ffname = NULL;
     vim_free(buf->b_sfname);
@@ -1837,8 +1832,6 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
   /* Make a copy of "pat" and change "^" to "\(^\|[\/]\)". */
   if (*pat == '^') {
     patc = alloc((unsigned)STRLEN(pat) + 11);
-    if (patc == NULL)
-      return FAIL;
     STRCPY(patc, "\\(^\\|[\\/]\\)");
     STRCPY(patc + 11, pat + 1);
   } else
@@ -2001,8 +1994,6 @@ static void buflist_setfpos(buf_T *buf, win_T *win, linenr_T lnum, colnr_T col, 
   if (wip == NULL) {
     /* allocate a new entry */
     wip = (wininfo_T *)alloc_clear((unsigned)sizeof(wininfo_T));
-    if (wip == NULL)
-      return;
     wip->wi_win = win;
     if (lnum == 0)              /* set lnum even when it's 0 */
       lnum = 1;
@@ -2523,8 +2514,6 @@ fileinfo (
   size_t len;
 
   buffer = alloc(IOSIZE);
-  if (buffer == NULL)
-    return;
 
   if (fullname > 1) {       /* 2 CTRL-G: include buffer number */
     vim_snprintf((char *)buffer, IOSIZE, "buf %d: ", curbuf->b_fnum);
@@ -3700,8 +3689,6 @@ do_arg_all (
 
   opened_len = ARGCOUNT;
   opened = alloc_clear((unsigned)opened_len);
-  if (opened == NULL)
-    return;
 
   /* Autocommands may do anything to the argument list.  Make sure it's not
    * freed while we are working here by "locking" it.  We still have to
@@ -4292,8 +4279,6 @@ void write_viminfo_bufferlist(FILE *fp)
   /* Allocate room for the file name, lnum and col. */
 #define LINE_BUF_LEN (MAXPATHL + 40)
   line = alloc(LINE_BUF_LEN);
-  if (line == NULL)
-    return;
 
   FOR_ALL_TAB_WINDOWS(tp, win)
   set_last_cursor(win);
@@ -4380,26 +4365,24 @@ static void insert_sign(
     signlist_T	*newsign;
 
     newsign = (signlist_T *)lalloc((long_u)sizeof(signlist_T), FALSE);
-    if (newsign != NULL) {
-        newsign->id = id;
-        newsign->lnum = lnum;
-        newsign->typenr = typenr;
-        newsign->next = next;
+    newsign->id = id;
+    newsign->lnum = lnum;
+    newsign->typenr = typenr;
+    newsign->next = next;
 
-        if (prev == NULL) {
-            /* When adding first sign need to redraw the windows to create the
-             * column for signs. */
-            if (buf->b_signlist == NULL) {
-                redraw_buf_later(buf, NOT_VALID);
-                changed_cline_bef_curs();
-            }
+    if (prev == NULL) {
+        /* When adding first sign need to redraw the windows to create the
+         * column for signs. */
+        if (buf->b_signlist == NULL) {
+            redraw_buf_later(buf, NOT_VALID);
+            changed_cline_bef_curs();
+        }
 
-            /* first sign in signlist */
-            buf->b_signlist = newsign;
-        }
-        else {
-            prev->next = newsign;
-        }
+        /* first sign in signlist */
+        buf->b_signlist = newsign;
+    }
+    else {
+        prev->next = newsign;
     }
 }
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -825,31 +825,29 @@ static void diff_file(char_u *tmp_orig, char_u *tmp_new, char_u *tmp_diff)
         + STRLEN(p_srr) + 27;
     char_u *cmd = alloc((unsigned)len);
 
-    if (cmd != NULL) {
-      /* We don't want $DIFF_OPTIONS to get in the way. */
-      if (os_getenv("DIFF_OPTIONS")) {
-        vim_setenv((char_u *)"DIFF_OPTIONS", (char_u *)"");
-      }
-
-      /* Build the diff command and execute it.  Always use -a, binary
-       * differences are of no use.  Ignore errors, diff returns
-       * non-zero when differences have been found. */
-      vim_snprintf((char *)cmd, len, "diff %s%s%s%s%s %s",
-                   diff_a_works == FALSE ? "" : "-a ",
-                   "",
-                   (diff_flags & DIFF_IWHITE) ? "-b " : "",
-                   (diff_flags & DIFF_ICASE) ? "-i " : "",
-                   tmp_orig, tmp_new);
-      append_redir(cmd, (int)len, p_srr, tmp_diff);
-      block_autocmds(); /* Avoid ShellCmdPost stuff */
-      (void)call_shell(
-          cmd,
-          kShellOptFilter | kShellOptSilent | kShellOptDoOut,
-          NULL
-          );
-      unblock_autocmds();
-      vim_free(cmd);
+    /* We don't want $DIFF_OPTIONS to get in the way. */
+    if (os_getenv("DIFF_OPTIONS")) {
+      vim_setenv((char_u *)"DIFF_OPTIONS", (char_u *)"");
     }
+
+    /* Build the diff command and execute it.  Always use -a, binary
+     * differences are of no use.  Ignore errors, diff returns
+     * non-zero when differences have been found. */
+    vim_snprintf((char *)cmd, len, "diff %s%s%s%s%s %s",
+                 diff_a_works == FALSE ? "" : "-a ",
+                 "",
+                 (diff_flags & DIFF_IWHITE) ? "-b " : "",
+                 (diff_flags & DIFF_ICASE) ? "-i " : "",
+                 tmp_orig, tmp_new);
+    append_redir(cmd, (int)len, p_srr, tmp_diff);
+    block_autocmds(); /* Avoid ShellCmdPost stuff */
+    (void)call_shell(
+        cmd,
+        kShellOptFilter | kShellOptSilent | kShellOptDoOut,
+        NULL
+        );
+    unblock_autocmds();
+    vim_free(cmd);
   }
 }
 
@@ -902,9 +900,6 @@ void ex_diffpatch(exarg_T *eap)
 #endif  // ifdef UNIX
 
   buf = alloc((unsigned)buflen);
-  if (buf == NULL) {
-    goto theend;
-  }
 
 #ifdef UNIX
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -1643,14 +1643,12 @@ change_indent (
       curwin->w_cursor.col = (colnr_T)new_cursor_col;
       i = (int)curwin->w_virtcol - vcol;
       ptr = alloc((unsigned)(i + 1));
-      if (ptr != NULL) {
-        new_cursor_col += i;
-        ptr[i] = NUL;
-        while (--i >= 0)
-          ptr[i] = ' ';
-        ins_str(ptr);
-        vim_free(ptr);
-      }
+      new_cursor_col += i;
+      ptr[i] = NUL;
+      while (--i >= 0)
+        ptr[i] = ' ';
+      ins_str(ptr);
+      vim_free(ptr);
     }
 
     /*
@@ -1987,83 +1985,81 @@ int ins_compl_add_infercase(char_u *str, int len, int icase, char_u *fname, int 
 
     /* Allocate wide character array for the completion and fill it. */
     wca = (int *)alloc((unsigned)(actual_len * sizeof(int)));
-    if (wca != NULL) {
-      p = str;
-      for (i = 0; i < actual_len; ++i)
-        if (has_mbyte)
-          wca[i] = mb_ptr2char_adv(&p);
-        else
-          wca[i] = *(p++);
+    p = str;
+    for (i = 0; i < actual_len; ++i)
+      if (has_mbyte)
+        wca[i] = mb_ptr2char_adv(&p);
+      else
+        wca[i] = *(p++);
 
-      /* Rule 1: Were any chars converted to lower? */
-      p = compl_orig_text;
-      for (i = 0; i < min_len; ++i) {
-        if (has_mbyte)
-          c = mb_ptr2char_adv(&p);
-        else
-          c = *(p++);
-        if (vim_islower(c)) {
-          has_lower = TRUE;
-          if (vim_isupper(wca[i])) {
-            /* Rule 1 is satisfied. */
-            for (i = actual_compl_length; i < actual_len; ++i)
-              wca[i] = vim_tolower(wca[i]);
-            break;
-          }
+    /* Rule 1: Were any chars converted to lower? */
+    p = compl_orig_text;
+    for (i = 0; i < min_len; ++i) {
+      if (has_mbyte)
+        c = mb_ptr2char_adv(&p);
+      else
+        c = *(p++);
+      if (vim_islower(c)) {
+        has_lower = TRUE;
+        if (vim_isupper(wca[i])) {
+          /* Rule 1 is satisfied. */
+          for (i = actual_compl_length; i < actual_len; ++i)
+            wca[i] = vim_tolower(wca[i]);
+          break;
         }
       }
-
-      /*
-       * Rule 2: No lower case, 2nd consecutive letter converted to
-       * upper case.
-       */
-      if (!has_lower) {
-        p = compl_orig_text;
-        for (i = 0; i < min_len; ++i) {
-          if (has_mbyte)
-            c = mb_ptr2char_adv(&p);
-          else
-            c = *(p++);
-          if (was_letter && vim_isupper(c) && vim_islower(wca[i])) {
-            /* Rule 2 is satisfied. */
-            for (i = actual_compl_length; i < actual_len; ++i)
-              wca[i] = vim_toupper(wca[i]);
-            break;
-          }
-          was_letter = vim_islower(c) || vim_isupper(c);
-        }
-      }
-
-      /* Copy the original case of the part we typed. */
-      p = compl_orig_text;
-      for (i = 0; i < min_len; ++i) {
-        if (has_mbyte)
-          c = mb_ptr2char_adv(&p);
-        else
-          c = *(p++);
-        if (vim_islower(c))
-          wca[i] = vim_tolower(wca[i]);
-        else if (vim_isupper(c))
-          wca[i] = vim_toupper(wca[i]);
-      }
-
-      /*
-       * Generate encoding specific output from wide character array.
-       * Multi-byte characters can occupy up to five bytes more than
-       * ASCII characters, and we also need one byte for NUL, so stay
-       * six bytes away from the edge of IObuff.
-       */
-      p = IObuff;
-      i = 0;
-      while (i < actual_len && (p - IObuff + 6) < IOSIZE)
-        if (has_mbyte)
-          p += (*mb_char2bytes)(wca[i++], p);
-        else
-          *(p++) = wca[i++];
-      *p = NUL;
-
-      vim_free(wca);
     }
+
+    /*
+     * Rule 2: No lower case, 2nd consecutive letter converted to
+     * upper case.
+     */
+    if (!has_lower) {
+      p = compl_orig_text;
+      for (i = 0; i < min_len; ++i) {
+        if (has_mbyte)
+          c = mb_ptr2char_adv(&p);
+        else
+          c = *(p++);
+        if (was_letter && vim_isupper(c) && vim_islower(wca[i])) {
+          /* Rule 2 is satisfied. */
+          for (i = actual_compl_length; i < actual_len; ++i)
+            wca[i] = vim_toupper(wca[i]);
+          break;
+        }
+        was_letter = vim_islower(c) || vim_isupper(c);
+      }
+    }
+
+    /* Copy the original case of the part we typed. */
+    p = compl_orig_text;
+    for (i = 0; i < min_len; ++i) {
+      if (has_mbyte)
+        c = mb_ptr2char_adv(&p);
+      else
+        c = *(p++);
+      if (vim_islower(c))
+        wca[i] = vim_tolower(wca[i]);
+      else if (vim_isupper(c))
+        wca[i] = vim_toupper(wca[i]);
+    }
+
+    /*
+     * Generate encoding specific output from wide character array.
+     * Multi-byte characters can occupy up to five bytes more than
+     * ASCII characters, and we also need one byte for NUL, so stay
+     * six bytes away from the edge of IObuff.
+     */
+    p = IObuff;
+    i = 0;
+    while (i < actual_len && (p - IObuff + 6) < IOSIZE)
+      if (has_mbyte)
+        p += (*mb_char2bytes)(wca[i++], p);
+      else
+        *(p++) = wca[i++];
+    *p = NUL;
+
+    vim_free(wca);
 
     return ins_compl_add(IObuff, len, icase, fname, NULL, dir,
         flags, FALSE);
@@ -2120,8 +2116,6 @@ ins_compl_add (
    * Copy the values to the new match structure.
    */
   match = (compl_T *)alloc_clear((unsigned)sizeof(compl_T));
-  if (match == NULL)
-    return FAIL;
   match->cp_number = -1;
   if (flags & ORIGINAL_TEXT)
     match->cp_number = 0;
@@ -2459,67 +2453,65 @@ void ins_compl_show_pum(void)
     compl_match_array = (pumitem_T *)alloc_clear(
         (unsigned)(sizeof(pumitem_T)
                    * compl_match_arraysize));
-    if (compl_match_array != NULL) {
-      /* If the current match is the original text don't find the first
-       * match after it, don't highlight anything. */
-      if (compl_shown_match->cp_flags & ORIGINAL_TEXT)
-        shown_match_ok = TRUE;
+    /* If the current match is the original text don't find the first
+     * match after it, don't highlight anything. */
+    if (compl_shown_match->cp_flags & ORIGINAL_TEXT)
+      shown_match_ok = TRUE;
 
-      i = 0;
-      compl = compl_first_match;
-      do {
-        if ((compl->cp_flags & ORIGINAL_TEXT) == 0
-            && (compl_leader == NULL
-                || ins_compl_equal(compl, compl_leader, lead_len))) {
-          if (!shown_match_ok) {
-            if (compl == compl_shown_match || did_find_shown_match) {
-              /* This item is the shown match or this is the
-               * first displayed item after the shown match. */
-              compl_shown_match = compl;
-              did_find_shown_match = TRUE;
-              shown_match_ok = TRUE;
-            } else
-              /* Remember this displayed match for when the
-               * shown match is just below it. */
-              shown_compl = compl;
-            cur = i;
-          }
-
-          if (compl->cp_text[CPT_ABBR] != NULL)
-            compl_match_array[i].pum_text =
-              compl->cp_text[CPT_ABBR];
-          else
-            compl_match_array[i].pum_text = compl->cp_str;
-          compl_match_array[i].pum_kind = compl->cp_text[CPT_KIND];
-          compl_match_array[i].pum_info = compl->cp_text[CPT_INFO];
-          if (compl->cp_text[CPT_MENU] != NULL)
-            compl_match_array[i++].pum_extra =
-              compl->cp_text[CPT_MENU];
-          else
-            compl_match_array[i++].pum_extra = compl->cp_fname;
+    i = 0;
+    compl = compl_first_match;
+    do {
+      if ((compl->cp_flags & ORIGINAL_TEXT) == 0
+          && (compl_leader == NULL
+              || ins_compl_equal(compl, compl_leader, lead_len))) {
+        if (!shown_match_ok) {
+          if (compl == compl_shown_match || did_find_shown_match) {
+            /* This item is the shown match or this is the
+             * first displayed item after the shown match. */
+            compl_shown_match = compl;
+            did_find_shown_match = TRUE;
+            shown_match_ok = TRUE;
+          } else
+            /* Remember this displayed match for when the
+             * shown match is just below it. */
+            shown_compl = compl;
+          cur = i;
         }
 
-        if (compl == compl_shown_match) {
-          did_find_shown_match = TRUE;
+        if (compl->cp_text[CPT_ABBR] != NULL)
+          compl_match_array[i].pum_text =
+            compl->cp_text[CPT_ABBR];
+        else
+          compl_match_array[i].pum_text = compl->cp_str;
+        compl_match_array[i].pum_kind = compl->cp_text[CPT_KIND];
+        compl_match_array[i].pum_info = compl->cp_text[CPT_INFO];
+        if (compl->cp_text[CPT_MENU] != NULL)
+          compl_match_array[i++].pum_extra =
+            compl->cp_text[CPT_MENU];
+        else
+          compl_match_array[i++].pum_extra = compl->cp_fname;
+      }
 
-          /* When the original text is the shown match don't set
-           * compl_shown_match. */
-          if (compl->cp_flags & ORIGINAL_TEXT)
-            shown_match_ok = TRUE;
+      if (compl == compl_shown_match) {
+        did_find_shown_match = TRUE;
 
-          if (!shown_match_ok && shown_compl != NULL) {
-            /* The shown match isn't displayed, set it to the
-             * previously displayed match. */
-            compl_shown_match = shown_compl;
-            shown_match_ok = TRUE;
-          }
+        /* When the original text is the shown match don't set
+         * compl_shown_match. */
+        if (compl->cp_flags & ORIGINAL_TEXT)
+          shown_match_ok = TRUE;
+
+        if (!shown_match_ok && shown_compl != NULL) {
+          /* The shown match isn't displayed, set it to the
+           * previously displayed match. */
+          compl_shown_match = shown_compl;
+          shown_match_ok = TRUE;
         }
-        compl = compl->cp_next;
-      } while (compl != NULL && compl != compl_first_match);
+      }
+      compl = compl->cp_next;
+    } while (compl != NULL && compl != compl_first_match);
 
-      if (!shown_match_ok)          /* no displayed match at all */
-        cur = -1;
-    }
+    if (!shown_match_ok)          /* no displayed match at all */
+      cur = -1;
   } else {
     /* popup menu already exists, only need to find the current item.*/
     for (i = 0; i < compl_match_arraysize; ++i)
@@ -2575,8 +2567,6 @@ ins_compl_dictionaries (
   }
 
   buf = alloc(LSIZE);
-  if (buf == NULL)
-    return;
   regmatch.regprog = NULL;      /* so that we can goto theend */
 
   /* If 'infercase' is set, don't use 'smartcase' here */
@@ -2595,10 +2585,6 @@ ins_compl_dictionaries (
       goto theend;
     len = STRLEN(pat_esc) + 10;
     ptr = alloc((unsigned)len);
-    if (ptr == NULL) {
-      vim_free(pat_esc);
-      goto theend;
-    }
     vim_snprintf((char *)ptr, len, "^\\s*\\zs\\V%s", pat_esc);
     regmatch.regprog = vim_regcomp(ptr, RE_MAGIC);
     vim_free(pat_esc);
@@ -5885,16 +5871,14 @@ void set_last_insert(int c)
 
   vim_free(last_insert);
   last_insert = alloc(MB_MAXBYTES * 3 + 5);
-  if (last_insert != NULL) {
-    s = last_insert;
-    /* Use the CTRL-V only when entering a special char */
-    if (c < ' ' || c == DEL)
-      *s++ = Ctrl_V;
-    s = add_char2buf(c, s);
-    *s++ = ESC;
-    *s++ = NUL;
-    last_insert_skip = 0;
-  }
+  s = last_insert;
+  /* Use the CTRL-V only when entering a special char */
+  if (c < ' ' || c == DEL)
+    *s++ = Ctrl_V;
+  s = add_char2buf(c, s);
+  *s++ = ESC;
+  *s++ = NUL;
+  last_insert_skip = 0;
 }
 
 #if defined(EXITFREE) || defined(PROTO)
@@ -6300,10 +6284,6 @@ replace_push (
   if (replace_stack_len <= replace_stack_nr) {
     replace_stack_len += 50;
     p = lalloc(sizeof(char_u) * replace_stack_len, TRUE);
-    if (p == NULL) {        /* out of memory */
-      replace_stack_len -= 50;
-      return;
-    }
     if (replace_stack != NULL) {
       memmove(p, replace_stack,
           (size_t)(replace_stack_nr * sizeof(char_u)));

--- a/src/file_search.c
+++ b/src/file_search.c
@@ -390,11 +390,7 @@ vim_findfile_init (
         helper = walker;
         ptr = xrealloc(search_ctx->ffsc_stopdirs_v,
             (dircount + 1) * sizeof(char_u *));
-        if (ptr)
-          search_ctx->ffsc_stopdirs_v = ptr;
-        else
-          /* ignore, keep what we have and continue */
-          break;
+        search_ctx->ffsc_stopdirs_v = ptr;
         walker = vim_strchr(walker, ';');
         if (walker) {
           search_ctx->ffsc_stopdirs_v[dircount-1] =
@@ -789,9 +785,7 @@ char_u *vim_findfile(void *search_ctx_arg)
         if (path_with_url(dirptrs[0])) {
           stackp->ffs_filearray = (char_u **)
                                   alloc((unsigned)sizeof(char *));
-          if (stackp->ffs_filearray != NULL
-              && (stackp->ffs_filearray[0]
-                    = vim_strsave(dirptrs[0])) != NULL)
+          if ((stackp->ffs_filearray[0] = vim_strsave(dirptrs[0])) != NULL)
             stackp->ffs_filearray_size = 1;
           else
             stackp->ffs_filearray_size = 0;
@@ -1136,10 +1130,6 @@ static int ff_wc_equal(char_u *s1, char_u *s2)
  * maintains the list of already visited files and dirs
  * returns FAIL if the given file/dir is already in the list
  * returns OK if it is newly added
- *
- * TODO: What to do on memory allocation problems?
- *	 -> return TRUE - Better the file is found several times instead of
- *	    never.
  */
 static int ff_check_visited(ff_visited_T **visited_list, char_u *fname, char_u *wc_path)
 {
@@ -1189,29 +1179,27 @@ static int ff_check_visited(ff_visited_T **visited_list, char_u *fname, char_u *
   vp = (ff_visited_T *)alloc((unsigned)(sizeof(ff_visited_T)
                                         + STRLEN(ff_expand_buffer)));
 
-  if (vp != NULL) {
 #ifdef UNIX
-    if (!url) {
-      vp->ffv_dev_valid = TRUE;
-      vp->ffv_ino = st.st_ino;
-      vp->ffv_dev = st.st_dev;
-      vp->ffv_fname[0] = NUL;
-    } else {
-      vp->ffv_dev_valid = FALSE;
-      STRCPY(vp->ffv_fname, ff_expand_buffer);
-    }
-#else
+  if (!url) {
+    vp->ffv_dev_valid = TRUE;
+    vp->ffv_ino = st.st_ino;
+    vp->ffv_dev = st.st_dev;
+    vp->ffv_fname[0] = NUL;
+  } else {
+    vp->ffv_dev_valid = FALSE;
     STRCPY(vp->ffv_fname, ff_expand_buffer);
+  }
+#else
+  STRCPY(vp->ffv_fname, ff_expand_buffer);
 #endif
 
-    if (wc_path != NULL)
-      vp->ffv_wc_path = vim_strsave(wc_path);
-    else
-      vp->ffv_wc_path = NULL;
+  if (wc_path != NULL)
+    vp->ffv_wc_path = vim_strsave(wc_path);
+  else
+    vp->ffv_wc_path = NULL;
 
-    vp->ffv_next = *visited_list;
-    *visited_list = vp;
-  }
+  vp->ffv_next = *visited_list;
+  *visited_list = vp;
 
   return OK;
 }
@@ -1563,8 +1551,7 @@ find_file_in_path_option (
           break;
         }
 
-        if ((buf = alloc((int)(MAXPATHL))) == NULL)
-          break;
+        buf = alloc((int)(MAXPATHL));
 
         /* copy next path */
         buf[0] = 0;

--- a/src/file_search.c
+++ b/src/file_search.c
@@ -1198,11 +1198,12 @@ static int ff_check_visited(ff_visited_T **visited_list, char_u *fname, char_u *
       vp->ffv_fname[0] = NUL;
     } else {
       vp->ffv_dev_valid = FALSE;
-#endif
+      STRCPY(vp->ffv_fname, ff_expand_buffer);
+    }
+#else
     STRCPY(vp->ffv_fname, ff_expand_buffer);
-#ifdef UNIX
-  }
 #endif
+
     if (wc_path != NULL)
       vp->ffv_wc_path = vim_strsave(wc_path);
     else

--- a/src/fold.c
+++ b/src/fold.c
@@ -1606,8 +1606,6 @@ static void foldAddMarker(linenr_T lnum, char_u *marker, int markerlen)
 
   if (u_save(lnum - 1, lnum + 1) == OK) {
     newline = alloc((unsigned)(line_len + markerlen + STRLEN(cms) + 1));
-    if (newline == NULL)
-      return;
     STRCPY(newline, line);
     if (p == NULL)
       vim_strncpy(newline + line_len, marker, markerlen);
@@ -1679,11 +1677,9 @@ static void foldDelMarker(linenr_T lnum, char_u *marker, int markerlen)
       if (u_save(lnum - 1, lnum + 1) == OK) {
         /* Make new line: text-before-marker + text-after-marker */
         newline = alloc((unsigned)(STRLEN(line) - len + 1));
-        if (newline != NULL) {
-          STRNCPY(newline, line, p - line);
-          STRCPY(newline + (p - line), p + len);
-          ml_replace(lnum, newline, FALSE);
-        }
+        STRNCPY(newline, line, p - line);
+        STRCPY(newline + (p - line), p + len);
+        ml_replace(lnum, newline, FALSE);
       }
       break;
     }

--- a/src/garray.c
+++ b/src/garray.c
@@ -121,16 +121,14 @@ char_u* ga_concat_strings(garray_T *gap)
 
   s = alloc(len + 1);
 
-  if (s != NULL) {
-    *s = NUL;
-
-    for (i = 0; i < gap->ga_len; ++i) {
-      if (*s != NUL) {
-        STRCAT(s, ",");
-      }
-      STRCAT(s, ((char_u **)(gap->ga_data))[i]);
+  *s = NUL;
+  for (i = 0; i < gap->ga_len; ++i) {
+    if (*s != NUL) {
+      STRCAT(s, ",");
     }
+    STRCAT(s, ((char_u **)(gap->ga_data))[i]);
   }
+
   return s;
 }
 

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -441,8 +441,6 @@ static void prt_header(prt_settings_T *psettings, int pagenum, linenr_T lnum)
     width += PRINT_NUMBER_WIDTH;
 
   tbuf = alloc(width + IOSIZE);
-  if (tbuf == NULL)
-    return;
 
   if (*p_header != NUL) {
     linenr_T tmp_lnum, tmp_topline, tmp_botline;
@@ -2526,10 +2524,6 @@ int mch_print_begin(prt_settings_T *psettings)
                 alloc(sizeof(struct prt_ps_resource_S));
   res_cmap = (struct prt_ps_resource_S *)
              alloc(sizeof(struct prt_ps_resource_S));
-  if (res_prolog == NULL || res_encoding == NULL
-      || res_cidfont == NULL || res_cmap == NULL
-      )
-    goto theend;
 
   /*
    * PS DSC Header comments - no PS code!
@@ -2863,7 +2857,6 @@ int mch_print_begin(prt_settings_T *psettings)
   /* Fail if any problems writing out to the PS file */
   retval = !prt_file_error;
 
-theend:
   vim_free(res_prolog);
   vim_free(res_encoding);
   vim_free(res_cidfont);

--- a/src/indent.c
+++ b/src/indent.c
@@ -182,10 +182,6 @@ int set_indent(int size, int flags)
   // after the if (!curbuf->b_p_et) below.
   if (orig_char_len != -1) {
     newline = alloc(orig_char_len + size - ind_done + line_len);
-
-    if (newline == NULL) {
-      return FALSE;
-    }
     todo = size - ind_done;
 
     // Set total length of indent in characters, which may have been
@@ -207,10 +203,6 @@ int set_indent(int size, int flags)
   } else {
     todo = size;
     newline = alloc(ind_len + line_len);
-
-    if (newline == NULL) {
-      return FALSE;
-    }
     s = newline;
   }
 
@@ -376,10 +368,6 @@ int copy_indent(int size, char_u *src)
       // and the rest of the line.
       line_len = (int)STRLEN(ml_get_curline()) + 1;
       line = alloc(ind_len + line_len);
-
-      if (line == NULL) {
-        return FALSE;
-      }
       p = line;
     }
   }

--- a/src/indent_c.c
+++ b/src/indent_c.c
@@ -122,18 +122,17 @@ int cin_is_cinword(char_u *line)
 
   cinw_len = (int)STRLEN(curbuf->b_p_cinw) + 1;
   cinw_buf = alloc((unsigned)cinw_len);
-  if (cinw_buf != NULL) {
-    line = skipwhite(line);
-    for (cinw = curbuf->b_p_cinw; *cinw; ) {
-      len = copy_option_part(&cinw, cinw_buf, cinw_len, ",");
-      if (STRNCMP(line, cinw_buf, len) == 0
-          && (!vim_iswordc(line[len]) || !vim_iswordc(line[len - 1]))) {
-        retval = TRUE;
-        break;
-      }
+  line = skipwhite(line);
+  for (cinw = curbuf->b_p_cinw; *cinw; ) {
+    len = copy_option_part(&cinw, cinw_buf, cinw_len, ",");
+    if (STRNCMP(line, cinw_buf, len) == 0
+        && (!vim_iswordc(line[len]) || !vim_iswordc(line[len - 1]))) {
+      retval = TRUE;
+      break;
     }
-    vim_free(cinw_buf);
   }
+  vim_free(cinw_buf);
+
   return retval;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1318,8 +1318,6 @@ static void command_line_scan(mparm_T *parmp)
               } else
                 a = argv[0];
               p = alloc((unsigned)(STRLEN(a) + 4));
-              if (p == NULL)
-                mch_exit(2);
               sprintf((char *)p, "so %s", a);
               parmp->cmds_tofree[parmp->n_commands] = TRUE;
               parmp->commands[parmp->n_commands++] = p;
@@ -1473,11 +1471,9 @@ scripterror:
    * one. */
   if (parmp->n_commands > 0) {
     p = alloc((unsigned)STRLEN(parmp->commands[0]) + 3);
-    if (p != NULL) {
-      sprintf((char *)p, ":%s\r", parmp->commands[0]);
-      set_vim_var_string(VV_SWAPCOMMAND, p, -1);
-      vim_free(p);
-    }
+    sprintf((char *)p, ":%s\r", parmp->commands[0]);
+    set_vim_var_string(VV_SWAPCOMMAND, p, -1);
+    vim_free(p);
   }
   TIME_MSG("parsing arguments");
 }
@@ -1520,9 +1516,8 @@ static void init_startuptime(mparm_T *paramp)
  */
 static void allocate_generic_buffers(void)
 {
-  if ((IObuff = alloc(IOSIZE)) == NULL
-      || (NameBuff = alloc(MAXPATHL)) == NULL)
-    mch_exit(0);
+  IObuff = alloc(IOSIZE);
+  NameBuff = alloc(MAXPATHL);
   TIME_MSG("Allocated generic buffers");
 }
 

--- a/src/mark.c
+++ b/src/mark.c
@@ -1417,8 +1417,7 @@ void copy_viminfo_marks(vir_T *virp, FILE *fp_out, int count, int eof, int flags
   pos_T pos;
   list_T      *list = NULL;
 
-  if ((name_buf = alloc(LSIZE)) == NULL)
-    return;
+  name_buf = alloc(LSIZE);
   *name_buf = NUL;
 
   if (fp_out == NULL && (flags & (VIF_GET_OLDFILES | VIF_FORCEIT))) {

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -3334,49 +3334,47 @@ char_u * enc_canonize(char_u *enc)
 
   /* copy "enc" to allocated memory, with room for two '-' */
   r = alloc((unsigned)(STRLEN(enc) + 3));
-  if (r != NULL) {
-    /* Make it all lower case and replace '_' with '-'. */
-    p = r;
-    for (s = enc; *s != NUL; ++s) {
-      if (*s == '_')
-        *p++ = '-';
-      else
-        *p++ = TOLOWER_ASC(*s);
-    }
-    *p = NUL;
+  /* Make it all lower case and replace '_' with '-'. */
+  p = r;
+  for (s = enc; *s != NUL; ++s) {
+    if (*s == '_')
+      *p++ = '-';
+    else
+      *p++ = TOLOWER_ASC(*s);
+  }
+  *p = NUL;
 
-    /* Skip "2byte-" and "8bit-". */
-    p = enc_skip(r);
+  /* Skip "2byte-" and "8bit-". */
+  p = enc_skip(r);
 
-    /* Change "microsoft-cp" to "cp".  Used in some spell files. */
-    if (STRNCMP(p, "microsoft-cp", 12) == 0)
-      STRMOVE(p, p + 10);
+  /* Change "microsoft-cp" to "cp".  Used in some spell files. */
+  if (STRNCMP(p, "microsoft-cp", 12) == 0)
+    STRMOVE(p, p + 10);
 
-    /* "iso8859" -> "iso-8859" */
-    if (STRNCMP(p, "iso8859", 7) == 0) {
-      STRMOVE(p + 4, p + 3);
-      p[3] = '-';
-    }
+  /* "iso8859" -> "iso-8859" */
+  if (STRNCMP(p, "iso8859", 7) == 0) {
+    STRMOVE(p + 4, p + 3);
+    p[3] = '-';
+  }
 
-    /* "iso-8859n" -> "iso-8859-n" */
-    if (STRNCMP(p, "iso-8859", 8) == 0 && p[8] != '-') {
-      STRMOVE(p + 9, p + 8);
-      p[8] = '-';
-    }
+  /* "iso-8859n" -> "iso-8859-n" */
+  if (STRNCMP(p, "iso-8859", 8) == 0 && p[8] != '-') {
+    STRMOVE(p + 9, p + 8);
+    p[8] = '-';
+  }
 
-    /* "latin-N" -> "latinN" */
-    if (STRNCMP(p, "latin-", 6) == 0)
-      STRMOVE(p + 5, p + 6);
+  /* "latin-N" -> "latinN" */
+  if (STRNCMP(p, "latin-", 6) == 0)
+    STRMOVE(p + 5, p + 6);
 
-    if (enc_canon_search(p) >= 0) {
-      /* canonical name can be used unmodified */
-      if (p != r)
-        STRMOVE(r, p);
-    } else if ((i = enc_alias_search(p)) >= 0) {
-      /* alias recognized, get canonical name */
-      vim_free(r);
-      r = vim_strsave((char_u *)enc_canon_table[i].name);
-    }
+  if (enc_canon_search(p) >= 0) {
+    /* canonical name can be used unmodified */
+    if (p != r)
+      STRMOVE(r, p);
+  } else if ((i = enc_alias_search(p)) >= 0) {
+    /* alias recognized, get canonical name */
+    vim_free(r);
+    r = vim_strsave((char_u *)enc_canon_table[i].name);
   }
   return r;
 }
@@ -3537,7 +3535,7 @@ static char_u * iconv_string(vimconv_T *vcp, char_u *str, int slen, int *unconvl
        * increase the buffer size. */
       len = len + fromlen * 2 + 40;
       p = alloc((unsigned)len);
-      if (p != NULL && done > 0)
+      if (done > 0)
         memmove(p, result, done);
       vim_free(result);
       result = p;
@@ -3856,8 +3854,7 @@ int convert_input_safe(ptr, len, maxlen, restp, restlenp)
       if (unconvertlen > 0) {
         /* Move the unconverted characters to allocated memory. */
         *restp = alloc(unconvertlen);
-        if (*restp != NULL)
-          memmove(*restp, ptr + len - unconvertlen, unconvertlen);
+        memmove(*restp, ptr + len - unconvertlen, unconvertlen);
         *restlenp = unconvertlen;
       }
       memmove(ptr, d, dlen);
@@ -3913,8 +3910,6 @@ char_u * string_convert_ext(vcp, ptr, lenp, unconvlenp)
   switch (vcp->vc_type) {
     case CONV_TO_UTF8:            /* latin1 to utf-8 conversion */
       retval = alloc(len * 2 + 1);
-      if (retval == NULL)
-        break;
       d = retval;
       for (i = 0; i < len; ++i) {
         c = ptr[i];
@@ -3932,8 +3927,6 @@ char_u * string_convert_ext(vcp, ptr, lenp, unconvlenp)
 
     case CONV_9_TO_UTF8:          /* latin9 to utf-8 conversion */
       retval = alloc(len * 3 + 1);
-      if (retval == NULL)
-        break;
       d = retval;
       for (i = 0; i < len; ++i) {
         c = ptr[i];
@@ -3957,8 +3950,6 @@ char_u * string_convert_ext(vcp, ptr, lenp, unconvlenp)
     case CONV_TO_LATIN1:          /* utf-8 to latin1 conversion */
     case CONV_TO_LATIN9:          /* utf-8 to latin9 conversion */
       retval = alloc(len + 1);
-      if (retval == NULL)
-        break;
       d = retval;
       for (i = 0; i < len; ++i) {
         l = utf_ptr2len_len(ptr + i, len - i);

--- a/src/memory.c
+++ b/src/memory.c
@@ -71,8 +71,7 @@ char_u *alloc_clear(unsigned size)
   char_u *p;
 
   p = lalloc((long_u)size, TRUE);
-  if (p != NULL)
-    (void)memset(p, 0, (size_t)size);
+  (void)memset(p, 0, (size_t)size);
   return p;
 }
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -375,8 +375,6 @@ add_menu_path (
 
       /* Not already there, so lets add it */
       menu = (vimmenu_T *)alloc_clear((unsigned)sizeof(vimmenu_T));
-      if (menu == NULL)
-        goto erret;
 
       menu->modes = modes;
       menu->enabled = MENU_ALL_MODES;
@@ -467,22 +465,20 @@ add_menu_path (
 
         if (c != 0) {
           menu->strings[i] = alloc((unsigned)(STRLEN(call_data) + 5 ));
-          if (menu->strings[i] != NULL) {
-            menu->strings[i][0] = c;
-            if (d == 0)
-              STRCPY(menu->strings[i] + 1, call_data);
-            else {
-              menu->strings[i][1] = d;
-              STRCPY(menu->strings[i] + 2, call_data);
-            }
-            if (c == Ctrl_C) {
-              int len = (int)STRLEN(menu->strings[i]);
+          menu->strings[i][0] = c;
+          if (d == 0)
+            STRCPY(menu->strings[i] + 1, call_data);
+          else {
+            menu->strings[i][1] = d;
+            STRCPY(menu->strings[i] + 2, call_data);
+          }
+          if (c == Ctrl_C) {
+            int len = (int)STRLEN(menu->strings[i]);
 
-              /* Append CTRL-\ CTRL-G to obey 'insertmode'. */
-              menu->strings[i][len] = Ctrl_BSL;
-              menu->strings[i][len + 1] = Ctrl_G;
-              menu->strings[i][len + 2] = NUL;
-            }
+            /* Append CTRL-\ CTRL-G to obey 'insertmode'. */
+            menu->strings[i][len] = Ctrl_BSL;
+            menu->strings[i][len + 1] = Ctrl_G;
+            menu->strings[i][len + 2] = NUL;
           }
         } else
           menu->strings[i] = p;

--- a/src/message.c
+++ b/src/message.c
@@ -239,8 +239,7 @@ msg_strtrunc (
       else
         len = room + 2;
       buf = alloc(len);
-      if (buf != NULL)
-        trunc_string(s, buf, room, len);
+      trunc_string(s, buf, room, len);
     }
   }
   return buf;
@@ -394,8 +393,7 @@ static char_u *get_emsg_source(void)
   if (sourcing_name != NULL && other_sourcing_name()) {
     p = (char_u *)_("Error detected while processing %s:");
     Buf = alloc((unsigned)(STRLEN(sourcing_name) + STRLEN(p)));
-    if (Buf != NULL)
-      sprintf((char *)Buf, (char *)p, sourcing_name);
+    sprintf((char *)Buf, (char *)p, sourcing_name);
     return Buf;
   }
   return NULL;
@@ -417,8 +415,7 @@ static char_u *get_emsg_lnum(void)
       && sourcing_lnum != 0) {
     p = (char_u *)_("line %4ld:");
     Buf = alloc((unsigned)(STRLEN(p) + 20));
-    if (Buf != NULL)
-      sprintf((char *)Buf, (char *)p, (long)sourcing_lnum);
+    sprintf((char *)Buf, (char *)p, (long)sourcing_lnum);
     return Buf;
   }
   return NULL;
@@ -665,26 +662,24 @@ add_msg_hist (
 
   /* allocate an entry and add the message at the end of the history */
   p = (struct msg_hist *)alloc((int)sizeof(struct msg_hist));
-  if (p != NULL) {
-    if (len < 0)
-      len = (int)STRLEN(s);
-    /* remove leading and trailing newlines */
-    while (len > 0 && *s == '\n') {
-      ++s;
-      --len;
-    }
-    while (len > 0 && s[len - 1] == '\n')
-      --len;
-    p->msg = vim_strnsave(s, len);
-    p->next = NULL;
-    p->attr = attr;
-    if (last_msg_hist != NULL)
-      last_msg_hist->next = p;
-    last_msg_hist = p;
-    if (first_msg_hist == NULL)
-      first_msg_hist = last_msg_hist;
-    ++msg_hist_len;
+  if (len < 0)
+    len = (int)STRLEN(s);
+  /* remove leading and trailing newlines */
+  while (len > 0 && *s == '\n') {
+    ++s;
+    --len;
   }
+  while (len > 0 && s[len - 1] == '\n')
+    --len;
+  p->msg = vim_strnsave(s, len);
+  p->next = NULL;
+  p->attr = attr;
+  if (last_msg_hist != NULL)
+    last_msg_hist->next = p;
+  last_msg_hist = p;
+  if (first_msg_hist == NULL)
+    first_msg_hist = last_msg_hist;
+  ++msg_hist_len;
 }
 
 /*
@@ -1818,11 +1813,9 @@ static void inc_msg_scrolled(void)
     else {
       len = (int)STRLEN(p) + 40;
       tofree = alloc(len);
-      if (tofree != NULL) {
-        vim_snprintf((char *)tofree, len, _("%s line %ld"),
-            p, (long)sourcing_lnum);
-        p = tofree;
-      }
+      vim_snprintf((char *)tofree, len, _("%s line %ld"),
+          p, (long)sourcing_lnum);
+      p = tofree;
     }
     set_vim_var_string(VV_SCROLLSTART, p, -1);
     vim_free(tofree);
@@ -1872,22 +1865,20 @@ store_sb_text (
 
   if (s > *sb_str) {
     mp = (msgchunk_T *)alloc((int)(sizeof(msgchunk_T) + (s - *sb_str)));
-    if (mp != NULL) {
-      mp->sb_eol = finish;
-      mp->sb_msg_col = *sb_col;
-      mp->sb_attr = attr;
-      vim_strncpy(mp->sb_text, *sb_str, s - *sb_str);
+    mp->sb_eol = finish;
+    mp->sb_msg_col = *sb_col;
+    mp->sb_attr = attr;
+    vim_strncpy(mp->sb_text, *sb_str, s - *sb_str);
 
-      if (last_msgchunk == NULL) {
-        last_msgchunk = mp;
-        mp->sb_prev = NULL;
-      } else {
-        mp->sb_prev = last_msgchunk;
-        last_msgchunk->sb_next = mp;
-        last_msgchunk = mp;
-      }
-      mp->sb_next = NULL;
+    if (last_msgchunk == NULL) {
+      last_msgchunk = mp;
+      mp->sb_prev = NULL;
+    } else {
+      mp->sb_prev = last_msgchunk;
+      last_msgchunk->sb_next = mp;
+      last_msgchunk = mp;
     }
+    mp->sb_next = NULL;
   } else if (finish && last_msgchunk != NULL)
     last_msgchunk->sb_eol = TRUE;
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -3434,8 +3434,7 @@ find_decl (
   int retval = OK;
   int incll;
 
-  if ((pat = alloc(len + 7)) == NULL)
-    return FAIL;
+  pat = alloc(len + 7);
 
   /* Put "\V" before the pattern to avoid that the special meaning of "."
    * and "~" causes trouble. */
@@ -4410,8 +4409,6 @@ static void nv_ident(cmdarg_T *cap)
   kp_help = (*kp == NUL || STRCMP(kp, ":he") == 0
              || STRCMP(kp, ":help") == 0);
   buf = alloc((unsigned)(n * 2 + 30 + STRLEN(kp)));
-  if (buf == NULL)
-    return;
   buf[0] = NUL;
 
   switch (cmdchar) {
@@ -4500,11 +4497,6 @@ static void nv_ident(cmdarg_T *cap)
       return;
     }
     newbuf = (char_u *)xrealloc(buf, STRLEN(buf) + STRLEN(p) + 1);
-    if (newbuf == NULL) {
-      vim_free(buf);
-      vim_free(p);
-      return;
-    }
     buf = newbuf;
     STRCAT(buf, p);
     vim_free(p);

--- a/src/option.c
+++ b/src/option.c
@@ -3128,8 +3128,6 @@ do_set (
               if (adding || prepending || removing)
                 newlen += (unsigned)STRLEN(origval) + 1;
               newval = alloc(newlen);
-              if (newval == NULL)                /* out of mem, don't change */
-                break;
               s = newval;
 
               /*
@@ -3176,8 +3174,6 @@ do_set (
                   if (adding || prepending || removing)
                     newlen += (unsigned)STRLEN(origval) + 1;
                   newval = alloc(newlen);
-                  if (newval == NULL)
-                    break;
                   STRCPY(newval, s);
                 }
               }
@@ -4890,17 +4886,15 @@ skip:
     wp->w_p_cc_cols = NULL;
   else {
     wp->w_p_cc_cols = (int *)alloc((unsigned)sizeof(int) * (count + 1));
-    if (wp->w_p_cc_cols != NULL) {
-      /* sort the columns for faster usage on screen redraw inside
-       * win_line() */
-      qsort(color_cols, count, sizeof(int), int_cmp);
+    /* sort the columns for faster usage on screen redraw inside
+     * win_line() */
+    qsort(color_cols, count, sizeof(int), int_cmp);
 
-      for (i = 0; i < count; ++i)
-        /* skip duplicates */
-        if (j == 0 || wp->w_p_cc_cols[j - 1] != color_cols[i])
-          wp->w_p_cc_cols[j++] = color_cols[i];
-      wp->w_p_cc_cols[j] = -1;        /* end marker */
-    }
+    for (i = 0; i < count; ++i)
+      /* skip duplicates */
+      if (j == 0 || wp->w_p_cc_cols[j - 1] != color_cols[i])
+        wp->w_p_cc_cols[j++] = color_cols[i];
+    wp->w_p_cc_cols[j] = -1;        /* end marker */
   }
 
   return NULL;    /* no error */
@@ -6172,8 +6166,6 @@ showoptions (
 
   items = (struct vimoption **)alloc((unsigned)(sizeof(struct vimoption *) *
                                                 PARAM_COUNT));
-  if (items == NULL)
-    return;
 
   /* Highlight title */
   if (all == 2)
@@ -6465,8 +6457,6 @@ static int put_setstring(FILE *fd, char *cmd, char *name, char_u **valuep, int e
           return FAIL;
     } else if (expand) {
       buf = alloc(MAXPATHL);
-      if (buf == NULL)
-        return FAIL;
       home_replace(NULL, *valuep, buf, MAXPATHL, FALSE);
       if (put_escstr(fd, buf, 2) == FAIL) {
         vim_free(buf);
@@ -7515,8 +7505,6 @@ int ExpandOldSetting(int *num_file, char_u ***file)
 
   *num_file = 0;
   *file = (char_u **)alloc((unsigned)sizeof(char_u *));
-  if (*file == NULL)
-    return FAIL;
 
   /*
    * For a terminal key code expand_option_idx is < 0.

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -200,9 +200,6 @@ static int is_executable_in_path(const char_u *name)
 
   int buf_len = STRLEN(name) + STRLEN(path) + 2;
   char_u *buf = alloc((unsigned)(buf_len));
-  if (buf == NULL) {
-    return FALSE;
-  }
 
   // Walk through all entries in $PATH to check if "name" exists there and
   // is an executable file.

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1143,11 +1143,6 @@ int flags;                      /* EW_* flags */
     }
   }
   command = alloc(len);
-  if (command == NULL) {
-    /* out of memory */
-    vim_free(tempname);
-    return FAIL;
-  }
 
   /*
    * Build the shell command:
@@ -1297,13 +1292,6 @@ int flags;                      /* EW_* flags */
   len = ftell(fd);                      /* get size of temp file */
   fseek(fd, 0L, SEEK_SET);
   buffer = alloc(len + 1);
-  if (buffer == NULL) {
-    /* out of memory */
-    mch_remove(tempname);
-    vim_free(tempname);
-    fclose(fd);
-    return FAIL;
-  }
   i = fread((char *)buffer, 1, len, fd);
   fclose(fd);
   mch_remove(tempname);
@@ -1388,11 +1376,6 @@ int flags;                      /* EW_* flags */
   }
   *num_file = i;
   *file = (char_u **)alloc(sizeof(char_u *) * i);
-  if (*file == NULL) {
-    /* out of memory */
-    vim_free(buffer);
-    return FAIL;
-  }
 
   /*
    * Isolate the individual file names.
@@ -1437,12 +1420,10 @@ int flags;                      /* EW_* flags */
       continue;
 
     p = alloc((unsigned)(STRLEN((*file)[i]) + 1 + dir));
-    if (p) {
-      STRCPY(p, (*file)[i]);
-      if (dir)
-        add_pathsep(p);             /* add '/' to a directory name */
-      (*file)[j++] = p;
-    }
+    STRCPY(p, (*file)[i]);
+    if (dir)
+      add_pathsep(p);             /* add '/' to a directory name */
+    (*file)[j++] = p;
   }
   vim_free(buffer);
   *num_file = j;

--- a/src/path.c
+++ b/src/path.c
@@ -397,8 +397,6 @@ unix_expandpath (
 
   /* make room for file name */
   buf = alloc((int)STRLEN(path) + BASENAMELEN + 5);
-  if (buf == NULL)
-    return 0;
 
   /*
    * Find the first part in the path name that contains a wildcard.
@@ -627,8 +625,7 @@ static void expand_path_option(char_u *curdir, garray_T *gap)
   char_u      *p;
   int len;
 
-  if ((buf = alloc((int)MAXPATHL)) == NULL)
-    return;
+  buf = alloc((int)MAXPATHL);
 
   while (*path_option != NUL) {
     copy_option_part(&path_option, buf, MAXPATHL, " ,");
@@ -745,8 +742,6 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
    */
   len = (int)STRLEN(pattern);
   file_pattern = alloc(len + 2);
-  if (file_pattern == NULL)
-    return;
   file_pattern[0] = '*';
   file_pattern[1] = NUL;
   STRCAT(file_pattern, pattern);
@@ -761,14 +756,11 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
   if (regmatch.regprog == NULL)
     return;
 
-  if ((curdir = alloc((int)(MAXPATHL))) == NULL)
-    goto theend;
+  curdir = alloc((int)(MAXPATHL));
   os_dirname(curdir, MAXPATHL);
   expand_path_option(curdir, &path_ga);
 
   in_curdir = (char_u **)alloc_clear(gap->ga_len * sizeof(char_u *));
-  if (in_curdir == NULL)
-    goto theend;
 
   for (i = 0; i < gap->ga_len && !got_int; i++) {
     char_u      *path = fnames[i];
@@ -841,8 +833,6 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
     }
 
     rel_path = alloc((int)(STRLEN(short_name) + STRLEN(PATHSEPSTR) + 2));
-    if (rel_path == NULL)
-      goto theend;
     STRCPY(rel_path, ".");
     add_pathsep(rel_path);
     STRCAT(rel_path, short_name);
@@ -853,7 +843,6 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
     ui_breakcheck();
   }
 
-theend:
   vim_free(curdir);
   if (in_curdir != NULL) {
     for (i = 0; i < gap->ga_len; i++)
@@ -916,8 +905,7 @@ expand_in_path (
   char_u      *e;       /* end */
   char_u      *paths = NULL;
 
-  if ((curdir = alloc((unsigned)MAXPATHL)) == NULL)
-    return 0;
+  curdir = alloc((unsigned)MAXPATHL);
   os_dirname(curdir, MAXPATHL);
 
   ga_init(&path_ga, (int)sizeof(char_u *), 1);
@@ -1245,8 +1233,6 @@ addfile (
     return;
 
   p = alloc((unsigned)(STRLEN(f) + 1 + isdir));
-  if (p == NULL)
-    return;
 
   STRCPY(p, f);
 #ifdef BACKSLASH_IN_FILENAME
@@ -1745,8 +1731,6 @@ char_u *shorten_fname1(char_u *full_path)
   char_u      *p = full_path;
 
   dirname = alloc(MAXPATHL);
-  if (dirname == NULL)
-    return full_path;
   if (os_dirname(dirname, MAXPATHL) == OK) {
     p = shorten_fname(full_path, dirname);
     if (p == NULL || *p == NUL)

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -288,8 +288,6 @@ qf_init_ext (
   namebuf = alloc(CMDBUFFSIZE + 1);
   errmsg = alloc(CMDBUFFSIZE + 1);
   pattern = alloc(CMDBUFFSIZE + 1);
-  if (namebuf == NULL || errmsg == NULL || pattern == NULL)
-    goto qf_init_end;
 
   if (efile != NULL && (fd = mch_fopen((char *)efile, "r")) == NULL) {
     EMSG2(_(e_openerrf), efile);
@@ -325,16 +323,13 @@ qf_init_ext (
 #else
   i += 2;   /* "%f" can become two chars longer */
 #endif
-  if ((fmtstr = alloc(i)) == NULL)
-    goto error2;
+  fmtstr = alloc(i);
 
   while (efm[0] != NUL) {
     /*
      * Allocate a new eformat structure and put it at the end of the list
      */
     fmt_ptr = (efm_T *)alloc_clear((unsigned)sizeof(efm_T));
-    if (fmt_ptr == NULL)
-      goto error2;
     if (fmt_first == NULL)          /* first one */
       fmt_first = fmt_ptr;
     else
@@ -725,9 +720,7 @@ restofline:
           goto error2;
         if (*errmsg && !multiignore) {
           len = (int)STRLEN(qfprev->qf_text);
-          if ((ptr = alloc((unsigned)(len + STRLEN(errmsg) + 2)))
-              == NULL)
-            goto error2;
+          ptr = alloc((unsigned)(len + STRLEN(errmsg) + 2));
           STRCPY(ptr, qfprev->qf_text);
           vim_free(qfprev->qf_text);
           qfprev->qf_text = ptr;
@@ -866,8 +859,7 @@ static void qf_new_list(qf_info_T *qi, char_u *qf_title)
     char_u *p = alloc((int)STRLEN(qf_title) + 2);
 
     qi->qf_lists[qi->qf_curlist].qf_title = p;
-    if (p != NULL)
-      sprintf((char *)p, ":%s", (char *)qf_title);
+    sprintf((char *)p, ":%s", (char *)qf_title);
   }
 }
 
@@ -931,8 +923,8 @@ qf_add_entry (
 {
   qfline_T    *qfp;
 
-  if ((qfp = (qfline_T *)alloc((unsigned)sizeof(qfline_T))) == NULL)
-    return FAIL;
+  qfp = (qfline_T *)alloc((unsigned)sizeof(qfline_T));
+
   if (bufnum != 0)
     qfp->qf_fnum = bufnum;
   else
@@ -987,10 +979,8 @@ static qf_info_T *ll_new_list(void)
   qf_info_T *qi;
 
   qi = (qf_info_T *)alloc((unsigned)sizeof(qf_info_T));
-  if (qi != NULL) {
-    memset(qi, 0, (size_t)(sizeof(qf_info_T)));
-    qi->qf_refcount++;
-  }
+  memset(qi, 0, (size_t)(sizeof(qf_info_T)));
+  qi->qf_refcount++;
 
   return qi;
 }
@@ -1164,8 +1154,6 @@ static char_u *qf_push_dir(char_u *dirbuf, struct dir_stack_T **stackptr)
 
   /* allocate new stack element and hook it in */
   ds_new = (struct dir_stack_T *)alloc((unsigned)sizeof(struct dir_stack_T));
-  if (ds_new == NULL)
-    return NULL;
 
   ds_new->next = *stackptr;
   *stackptr = ds_new;
@@ -2530,8 +2518,6 @@ void ex_make(exarg_T *eap)
   if (*p_sp != NUL)
     len += (unsigned)STRLEN(p_sp) + (unsigned)STRLEN(fname) + 3;
   cmd = alloc(len);
-  if (cmd == NULL)
-    return;
   sprintf((char *)cmd, "%s%s%s", (char *)p_shq, (char *)eap->arg,
       (char *)p_shq);
   if (*p_sp != NUL)
@@ -2610,8 +2596,6 @@ static char_u *get_mef_name(void)
       off += 19;
 
     name = alloc((unsigned)STRLEN(p_mef) + 30);
-    if (name == NULL)
-      break;
     STRCPY(name, p_mef);
     sprintf((char *)name + (p - p_mef), "%d%d", start, off);
     STRCAT(name, p + 2);
@@ -2863,8 +2847,6 @@ void ex_vimgrep(exarg_T *eap)
 
   dirname_start = alloc(MAXPATHL);
   dirname_now = alloc(MAXPATHL);
-  if (dirname_start == NULL || dirname_now == NULL)
-    goto theend;
 
   /* Remember the current directory, because a BufRead autocommand that does
    * ":lcd %:p:h" changes the meaning of short path names. */
@@ -3134,19 +3116,17 @@ static void restore_start_dir(char_u *dirname_start)
 {
   char_u *dirname_now = alloc(MAXPATHL);
 
-  if (NULL != dirname_now) {
-    os_dirname(dirname_now, MAXPATHL);
-    if (STRCMP(dirname_start, dirname_now) != 0) {
-      /* If the directory has changed, change it back by building up an
-       * appropriate ex command and executing it. */
-      exarg_T ea;
+  os_dirname(dirname_now, MAXPATHL);
+  if (STRCMP(dirname_start, dirname_now) != 0) {
+    /* If the directory has changed, change it back by building up an
+     * appropriate ex command and executing it. */
+    exarg_T ea;
 
-      ea.arg = dirname_start;
-      ea.cmdidx = (curwin->w_localdir == NULL) ? CMD_cd : CMD_lcd;
-      ex_cd(&ea);
-    }
-    vim_free(dirname_now);
+    ea.arg = dirname_start;
+    ea.cmdidx = (curwin->w_localdir == NULL) ? CMD_cd : CMD_lcd;
+    ex_cd(&ea);
   }
+  vim_free(dirname_now);
 }
 
 /*

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -1222,8 +1222,6 @@ static regprog_T *bt_regcomp(char_u *expr, int re_flags)
 
   /* Allocate space. */
   r = (bt_regprog_T *)lalloc(sizeof(bt_regprog_T) + regsize, TRUE);
-  if (r == NULL)
-    return NULL;
 
   /*
    * Second pass: emit code.
@@ -3592,8 +3590,7 @@ static reg_extmatch_T *make_extmatch(void)
   reg_extmatch_T      *em;
 
   em = (reg_extmatch_T *)alloc_clear((unsigned)sizeof(reg_extmatch_T));
-  if (em != NULL)
-    em->refcnt = 1;
+  em->refcnt = 1;
   return em;
 }
 
@@ -5699,8 +5696,6 @@ static int match_with_backref(linenr_T start_lnum, colnr_T start_col, linenr_T e
         len += 50;              /* get some extra */
         vim_free(reg_tofree);
         reg_tofree = alloc(len);
-        if (reg_tofree == NULL)
-          return RA_FAIL;           /* out of memory!*/
         reg_tofreelen = len;
       }
       STRCPY(reg_tofree, regline);
@@ -6451,22 +6446,20 @@ char_u *regtilde(char_u *source, int magic)
         /* length = len(newsub) - 1 + len(prev_sub) + 1 */
         prevlen = (int)STRLEN(reg_prev_sub);
         tmpsub = alloc((unsigned)(STRLEN(newsub) + prevlen));
-        if (tmpsub != NULL) {
-          /* copy prefix */
-          len = (int)(p - newsub);              /* not including ~ */
-          memmove(tmpsub, newsub, (size_t)len);
-          /* interpret tilde */
-          memmove(tmpsub + len, reg_prev_sub, (size_t)prevlen);
-          /* copy postfix */
-          if (!magic)
-            ++p;                                /* back off \ */
-          STRCPY(tmpsub + len + prevlen, p + 1);
+        /* copy prefix */
+        len = (int)(p - newsub);              /* not including ~ */
+        memmove(tmpsub, newsub, (size_t)len);
+        /* interpret tilde */
+        memmove(tmpsub + len, reg_prev_sub, (size_t)prevlen);
+        /* copy postfix */
+        if (!magic)
+          ++p;                                /* back off \ */
+        STRCPY(tmpsub + len + prevlen, p + 1);
 
-          if (newsub != source)                 /* already allocated newsub */
-            vim_free(newsub);
-          newsub = tmpsub;
-          p = newsub + len + prevlen;
-        }
+        if (newsub != source)                 /* already allocated newsub */
+          vim_free(newsub);
+        newsub = tmpsub;
+        p = newsub + len + prevlen;
       } else if (magic)
         STRMOVE(p, p + 1);              /* remove '~' */
       else
@@ -6926,8 +6919,6 @@ char_u *reg_submatch(int no)
 
       if (retval == NULL) {
         retval = lalloc((long_u)len, TRUE);
-        if (retval == NULL)
-          return NULL;
       }
     }
   } else {

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -523,18 +523,17 @@ static char_u *nfa_get_match_text(nfa_state_T *start)
     return NULL;
 
   ret = alloc(len);
-  if (ret != NULL) {
-    p = start->out->out;     /* skip first char, it goes into regstart */
-    s = ret;
-    while (p->c > 0) {
-      if (has_mbyte)
-        s += (*mb_char2bytes)(p->c, s);
-      else
-        *s++ = p->c;
-      p = p->out;
-    }
-    *s = NUL;
+  p = start->out->out;     /* skip first char, it goes into regstart */
+  s = ret;
+  while (p->c > 0) {
+    if (has_mbyte)
+      s += (*mb_char2bytes)(p->c, s);
+    else
+      *s++ = p->c;
+    p = p->out;
   }
+  *s = NUL;
+
   return ret;
 }
 
@@ -4219,8 +4218,6 @@ addstate_here (
 
       l->len = l->len * 3 / 2 + 50;
       newl = (nfa_thread_T *)alloc(l->len * sizeof(nfa_thread_T));
-      if (newl == NULL)
-        return;
       memmove(&(newl[0]),
           &(l->t[0]),
           sizeof(nfa_thread_T) * listidx);
@@ -4550,10 +4547,6 @@ static int recursive_regmatch(nfa_state_T *state, nfa_pim_T *pim, nfa_regprog_T 
      * values and clear them. */
     if (*listids == NULL) {
       *listids = (int *)lalloc(sizeof(int) * nstate, TRUE);
-      if (*listids == NULL) {
-        EMSG(_("E878: (NFA) Could not allocate memory for branch traversal!"));
-        return 0;
-      }
     }
     nfa_save_listids(prog, *listids);
     need_restore = TRUE;
@@ -4885,8 +4878,6 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
   list[0].len = nstate + 1;
   list[1].t = (nfa_thread_T *)lalloc(size, TRUE);
   list[1].len = nstate + 1;
-  if (list[0].t == NULL || list[1].t == NULL)
-    goto theend;
 
 #ifdef ENABLE_LOG
   log_fd = fopen(NFA_REGEXP_RUN_LOG, "a");
@@ -6037,7 +6028,6 @@ nextchar:
   log_fd = NULL;
 #endif
 
-theend:
   /* Free memory */
   vim_free(list[0].t);
   vim_free(list[1].t);
@@ -6314,8 +6304,6 @@ static regprog_T *nfa_regcomp(char_u *expr, int re_flags)
   /* allocate the regprog with space for the compiled regexp */
   prog_size = sizeof(nfa_regprog_T) + sizeof(nfa_state_T) * (nstate - 1);
   prog = (nfa_regprog_T *)lalloc(prog_size, TRUE);
-  if (prog == NULL)
-    goto fail;
   state_ptr = prog->state;
 
   /*

--- a/src/search.c
+++ b/src/search.c
@@ -4199,22 +4199,20 @@ find_pattern_in_path (
         if (depth + 1 == old_files) {
           bigger = (SearchedFile *)lalloc((long_u)(
                 max_path_depth * 2 * sizeof(SearchedFile)), TRUE);
-          if (bigger != NULL) {
-            for (i = 0; i <= depth; i++)
-              bigger[i] = files[i];
-            for (i = depth + 1; i < old_files + max_path_depth; i++) {
-              bigger[i].fp = NULL;
-              bigger[i].name = NULL;
-              bigger[i].lnum = 0;
-              bigger[i].matched = FALSE;
-            }
-            for (i = old_files; i < max_path_depth; i++)
-              bigger[i + max_path_depth] = files[i];
-            old_files += max_path_depth;
-            max_path_depth *= 2;
-            vim_free(files);
-            files = bigger;
+          for (i = 0; i <= depth; i++)
+            bigger[i] = files[i];
+          for (i = depth + 1; i < old_files + max_path_depth; i++) {
+            bigger[i].fp = NULL;
+            bigger[i].name = NULL;
+            bigger[i].lnum = 0;
+            bigger[i].matched = FALSE;
           }
+          for (i = old_files; i < max_path_depth; i++)
+            bigger[i + max_path_depth] = files[i];
+          old_files += max_path_depth;
+          max_path_depth *= 2;
+          vim_free(files);
+          files = bigger;
         }
         if ((files[depth + 1].fp = mch_fopen((char *)new_fname, "r"))
             == NULL)

--- a/src/spell.c
+++ b/src/spell.c
@@ -2078,8 +2078,6 @@ spell_move_to (
       vim_free(buf);
       buflen = len + MAXWLEN + 2;
       buf = alloc(buflen);
-      if (buf == NULL)
-        break;
     }
 
     /* In first line check first word for Capital. */
@@ -2363,15 +2361,13 @@ static slang_T *slang_alloc(char_u *lang)
   slang_T *lp;
 
   lp = (slang_T *)alloc_clear(sizeof(slang_T));
-  if (lp != NULL) {
-    if (lang != NULL)
-      lp->sl_name = vim_strsave(lang);
-    ga_init(&lp->sl_rep, sizeof(fromto_T), 10);
-    ga_init(&lp->sl_repsal, sizeof(fromto_T), 10);
-    lp->sl_compmax = MAXWLEN;
-    lp->sl_compsylmax = MAXWLEN;
-    hash_init(&lp->sl_wordcount);
-  }
+  if (lang != NULL)
+    lp->sl_name = vim_strsave(lang);
+  ga_init(&lp->sl_rep, sizeof(fromto_T), 10);
+  ga_init(&lp->sl_repsal, sizeof(fromto_T), 10);
+  lp->sl_compmax = MAXWLEN;
+  lp->sl_compsylmax = MAXWLEN;
+  hash_init(&lp->sl_wordcount);
 
   return lp;
 }
@@ -2867,8 +2863,6 @@ static int read_prefcond_section(FILE *fd, slang_T *lp)
 
   lp->sl_prefprog = (regprog_T **)alloc_clear(
       (unsigned)sizeof(regprog_T *) * cnt);
-  if (lp->sl_prefprog == NULL)
-    return SP_OTHERERROR;
   lp->sl_prefixcnt = cnt;
 
   for (i = 0; i < cnt; ++i) {
@@ -2975,8 +2969,7 @@ static int read_sal_section(FILE *fd, slang_T *slang)
     ccnt = getc(fd);                            /* <salfromlen> */
     if (ccnt < 0)
       return SP_TRUNCERROR;
-    if ((p = alloc(ccnt + 2)) == NULL)
-      return SP_OTHERERROR;
+    p = alloc(ccnt + 2);
     smp->sm_lead = p;
 
     /* Read up to the first special char into sm_lead. */
@@ -3049,8 +3042,7 @@ static int read_sal_section(FILE *fd, slang_T *slang)
     /* Add one extra entry to mark the end with an empty sm_lead.  Avoids
      * that we need to check the index every time. */
     smp = &((salitem_T *)gap->ga_data)[gap->ga_len];
-    if ((p = alloc(1)) == NULL)
-      return SP_OTHERERROR;
+    p = alloc(1);
     p[0] = NUL;
     smp->sm_lead = p;
     smp->sm_leadlen = 0;
@@ -3132,8 +3124,6 @@ count_common_word (
   hi = hash_lookup(&lp->sl_wordcount, p, hash);
   if (HASHITEM_EMPTY(hi)) {
     wc = (wordcount_T *)alloc((unsigned)(sizeof(wordcount_T) + STRLEN(p)));
-    if (wc == NULL)
-      return;
     STRCPY(wc->wc_word, p);
     wc->wc_count = count;
     hash_add_item(&lp->sl_wordcount, hi, wc->wc_word, hash);
@@ -3290,24 +3280,14 @@ static int read_compound(FILE *fd, slang_T *slang, int len)
   if (enc_utf8)
     c += todo * 2;
   pat = alloc((unsigned)c);
-  if (pat == NULL)
-    return SP_OTHERERROR;
 
   /* We also need a list of all flags that can appear at the start and one
    * for all flags. */
   cp = alloc(todo + 1);
-  if (cp == NULL) {
-    vim_free(pat);
-    return SP_OTHERERROR;
-  }
   slang->sl_compstartflags = cp;
   *cp = NUL;
 
   ap = alloc(todo + 1);
-  if (ap == NULL) {
-    vim_free(pat);
-    return SP_OTHERERROR;
-  }
   slang->sl_compallflags = ap;
   *ap = NUL;
 
@@ -3542,8 +3522,6 @@ static int set_sofo(slang_T *lp, char_u *from, char_u *to)
     for (i = 0; i < 256; ++i)
       if (lp->sl_sal_first[i] > 0) {
         p = alloc(sizeof(int) * (lp->sl_sal_first[i] * 2 + 1));
-        if (p == NULL)
-          return SP_OTHERERROR;
         ((int **)gap->ga_data)[i] = (int *)p;
         *(int *)p = 0;
       }
@@ -3681,14 +3659,10 @@ spell_read_tree (
   if (len > 0) {
     /* Allocate the byte array. */
     bp = lalloc((long_u)len, TRUE);
-    if (bp == NULL)
-      return SP_OTHERERROR;
     *bytsp = bp;
 
     /* Allocate the index array. */
     ip = (idx_T *)lalloc_clear((long_u)(len * sizeof(int)), TRUE);
-    if (ip == NULL)
-      return SP_OTHERERROR;
     *idxsp = ip;
 
     /* Recursively read the tree and store it in the array. */
@@ -7731,8 +7705,6 @@ static void spell_make_sugfile(spellinfo_T *spin, char_u *wfname)
    * Make the file name by changing ".spl" to ".sug".
    */
   fname = alloc(MAXPATHL);
-  if (fname == NULL)
-    goto theend;
   vim_strncpy(fname, wfname, MAXPATHL - 1);
   len = (int)STRLEN(fname);
   fname[len - 2] = 'u';
@@ -8174,8 +8146,6 @@ mkspell (
   incount = fcount - 1;
 
   wfname = alloc(MAXPATHL);
-  if (wfname == NULL)
-    return;
 
   if (fcount >= 1) {
     len = (int)STRLEN(fnames[0]);
@@ -8227,8 +8197,6 @@ mkspell (
     }
 
     fname = alloc(MAXPATHL);
-    if (fname == NULL)
-      goto theend;
 
     /*
      * Init the aff and dic pointers.
@@ -8439,8 +8407,6 @@ spell_add_word (
       return;
     }
     fnamebuf = alloc(MAXPATHL);
-    if (fnamebuf == NULL)
-      return;
 
     for (spf = curwin->w_s->b_p_spf, i = 1; *spf != NUL; ++i) {
       copy_option_part(&spf, fnamebuf, MAXPATHL, ",");
@@ -8562,8 +8528,6 @@ static void init_spellfile(void)
 
   if (*curwin->w_s->b_p_spl != NUL && curwin->w_s->b_langp.ga_len > 0) {
     buf = alloc(MAXPATHL);
-    if (buf == NULL)
-      return;
 
     /* Find the end of the language name.  Exclude the region.  If there
      * is a path separator remember the start of the tail. */
@@ -9235,24 +9199,22 @@ void spell_suggest(int count)
     /* Replace the word. */
     p = alloc((unsigned)STRLEN(line) - stp->st_orglen
         + stp->st_wordlen + 1);
-    if (p != NULL) {
-      c = (int)(sug.su_badptr - line);
-      memmove(p, line, c);
-      STRCPY(p + c, stp->st_word);
-      STRCAT(p, sug.su_badptr + stp->st_orglen);
-      ml_replace(curwin->w_cursor.lnum, p, FALSE);
-      curwin->w_cursor.col = c;
+    c = (int)(sug.su_badptr - line);
+    memmove(p, line, c);
+    STRCPY(p + c, stp->st_word);
+    STRCAT(p, sug.su_badptr + stp->st_orglen);
+    ml_replace(curwin->w_cursor.lnum, p, FALSE);
+    curwin->w_cursor.col = c;
 
-      /* For redo we use a change-word command. */
-      ResetRedobuff();
-      AppendToRedobuff((char_u *)"ciw");
-      AppendToRedobuffLit(p + c,
-          stp->st_wordlen + sug.su_badlen - stp->st_orglen);
-      AppendCharToRedobuff(ESC);
+    /* For redo we use a change-word command. */
+    ResetRedobuff();
+    AppendToRedobuff((char_u *)"ciw");
+    AppendToRedobuffLit(p + c,
+        stp->st_wordlen + sug.su_badlen - stp->st_orglen);
+    AppendCharToRedobuff(ESC);
 
-      /* After this "p" may be invalid. */
-      changed_bytes(curwin->w_cursor.lnum, c);
-    }
+    /* After this "p" may be invalid. */
+    changed_bytes(curwin->w_cursor.lnum, c);
   } else
     curwin->w_cursor = prev_cursor;
 
@@ -9341,8 +9303,6 @@ void ex_spellrepall(exarg_T *eap)
   addlen = (int)(STRLEN(repl_to) - STRLEN(repl_from));
 
   frompat = alloc((unsigned)STRLEN(repl_from) + 7);
-  if (frompat == NULL)
-    return;
   sprintf((char *)frompat, "\\V\\<%s\\>", repl_from);
   p_ws = FALSE;
 
@@ -9360,8 +9320,6 @@ void ex_spellrepall(exarg_T *eap)
     if (addlen <= 0 || STRNCMP(line + curwin->w_cursor.col,
             repl_to, STRLEN(repl_to)) != 0) {
       p = alloc((unsigned)STRLEN(line) + addlen + 1);
-      if (p == NULL)
-        break;
       memmove(p, line, curwin->w_cursor.col);
       STRCPY(p + curwin->w_cursor.col, repl_to);
       STRCAT(p, line + curwin->w_cursor.col + STRLEN(repl_from));
@@ -9417,8 +9375,6 @@ spell_suggest_list (
        * replaced part. */
       wcopy = alloc(stp->st_wordlen
           + (unsigned)STRLEN(sug.su_badptr + stp->st_orglen) + 1);
-      if (wcopy == NULL)
-        break;
       STRCPY(wcopy, stp->st_word);
       STRCPY(wcopy + stp->st_wordlen, sug.su_badptr + stp->st_orglen);
       ((char_u **)gap->ga_data)[gap->ga_len++] = wcopy;
@@ -11864,11 +11820,9 @@ add_sound_suggest (
   if (HASHITEM_EMPTY(hi)) {
     sft = (sftword_T *)alloc((unsigned)(sizeof(sftword_T)
                                         + STRLEN(goodword)));
-    if (sft != NULL) {
-      sft->sft_score = score;
-      STRCPY(sft->sft_word, goodword);
-      hash_add_item(&slang->sl_sounddone, hi, sft->sft_word, hash);
-    }
+    sft->sft_score = score;
+    STRCPY(sft->sft_word, goodword);
+    hash_add_item(&slang->sl_sounddone, hi, sft->sft_word, hash);
   } else {
     sft = HI2SFT(hi);
     if (score >= sft->sft_score)
@@ -12142,8 +12096,6 @@ static void set_map_str(slang_T *lp, char_u *map)
         hashitem_T  *hi;
 
         b = alloc((unsigned)(cl + headcl + 2));
-        if (b == NULL)
-          return;
         mb_char2bytes(c, b);
         b[cl] = NUL;
         mb_char2bytes(headc, b + cl + 1);
@@ -13370,8 +13322,6 @@ static int spell_edit_score(slang_T *slang, char_u *badword, char_u *goodword)
 #define CNT(a, b)   cnt[(a) + (b) * (badlen + 1)]
   cnt = (int *)lalloc((long_u)(sizeof(int) * (badlen + 1) * (goodlen + 1)),
       TRUE);
-  if (cnt == NULL)
-    return 0;           /* out of memory */
 
   CNT(0, 0) = 0;
   for (j = 1; j <= goodlen; ++j)

--- a/src/tag.c
+++ b/src/tag.c
@@ -685,13 +685,6 @@ do_tag (
         fname = alloc(MAXPATHL + 1);
         cmd = alloc(CMDBUFFSIZE + 1);
         list = list_alloc();
-        if (list == NULL || fname == NULL || cmd == NULL) {
-          vim_free(cmd);
-          vim_free(fname);
-          if (list != NULL)
-            list_free(list, TRUE);
-          goto end_do_tag;
-        }
 
         for (i = 0; i < num_matches; ++i) {
           int len, cmd_len;
@@ -1202,11 +1195,6 @@ find_tags (
   tag_fname = alloc(MAXPATHL + 1);
   for (mtt = 0; mtt < MT_COUNT; ++mtt)
     ga_init(&ga_match[mtt], (int)sizeof(struct match_found *), 100);
-
-  /* check for out of memory situation */
-  if (lbuf == NULL || tag_fname == NULL
-      )
-    goto findtag_end;
 
   STRCPY(tag_fname, "from cscope");             /* for error messages */
 
@@ -1838,21 +1826,20 @@ parse_line:
               mfp = (struct match_found *)
                     alloc((int)sizeof(struct match_found) + len
                   + 10 + ML_EXTRA);
-              if (mfp != NULL) {
-                /* "len" includes the language and the NUL, but
-                 * not the priority. */
-                mfp->len = len + ML_EXTRA + 1;
+              /* "len" includes the language and the NUL, but
+               * not the priority. */
+              mfp->len = len + ML_EXTRA + 1;
 #define ML_HELP_LEN 6
-                p = mfp->match;
-                STRCPY(p, tagp.tagname);
-                p[len] = '@';
-                STRCPY(p + len + 1, help_lang);
-                sprintf((char *)p + len + 1 + ML_EXTRA, "%06d",
-                    help_heuristic(tagp.tagname,
-                        match_re ? matchoff : 0, !match_no_ic)
-                    + help_pri
-                    );
-              }
+              p = mfp->match;
+              STRCPY(p, tagp.tagname);
+              p[len] = '@';
+              STRCPY(p + len + 1, help_lang);
+              sprintf((char *)p + len + 1 + ML_EXTRA, "%06d",
+                  help_heuristic(tagp.tagname,
+                      match_re ? matchoff : 0, !match_no_ic)
+                  + help_pri
+                  );
+
               *tagp.tagname_end = TAB;
             } else if (name_only)   {
               if (get_it_again) {
@@ -1868,11 +1855,9 @@ parse_line:
                   len = (int)(temp_end - tagp.command - 2);
                   mfp = (struct match_found *)alloc(
                       (int)sizeof(struct match_found) + len);
-                  if (mfp != NULL) {
-                    mfp->len = len + 1;                 /* include the NUL */
-                    p = mfp->match;
-                    vim_strncpy(p, tagp.command + 2, len);
-                  }
+                  mfp->len = len + 1;                 /* include the NUL */
+                  p = mfp->match;
+                  vim_strncpy(p, tagp.command + 2, len);
                 } else
                   mfp = NULL;
                 get_it_again = FALSE;
@@ -1880,11 +1865,9 @@ parse_line:
                 len = (int)(tagp.tagname_end - tagp.tagname);
                 mfp = (struct match_found *)alloc(
                     (int)sizeof(struct match_found) + len);
-                if (mfp != NULL) {
-                  mfp->len = len + 1;               /* include the NUL */
-                  p = mfp->match;
-                  vim_strncpy(p, tagp.tagname, len);
-                }
+                mfp->len = len + 1;               /* include the NUL */
+                p = mfp->match;
+                vim_strncpy(p, tagp.tagname, len);
 
                 /* if wanted, re-read line to get long form too */
                 if (State & INSERT)
@@ -1900,19 +1883,17 @@ parse_line:
                     + (int)STRLEN(lbuf) + 3;
               mfp = (struct match_found *)alloc(
                   (int)sizeof(struct match_found) + len);
-              if (mfp != NULL) {
-                mfp->len = len;
-                p = mfp->match;
-                p[0] = mtt;
-                STRCPY(p + 1, tag_fname);
+              mfp->len = len;
+              p = mfp->match;
+              p[0] = mtt;
+              STRCPY(p + 1, tag_fname);
 #ifdef BACKSLASH_IN_FILENAME
-                /* Ignore differences in slashes, avoid adding
-                 * both path/file and path\file. */
-                slash_adjust(p + 1);
+              /* Ignore differences in slashes, avoid adding
+               * both path/file and path\file. */
+              slash_adjust(p + 1);
 #endif
-                s = p + 1 + STRLEN(tag_fname) + 1;
-                STRCPY(s, lbuf);
-              }
+              s = p + 1 + STRLEN(tag_fname) + 1;
+              STRCPY(s, lbuf);
             }
 
             if (mfp != NULL) {
@@ -2414,7 +2395,7 @@ jumpto_tag (
   pbuf = alloc(LSIZE);
 
   /* parse the match line into the tagp structure */
-  if (pbuf == NULL || parse_match(lbuf, &tagp) == FAIL) {
+  if (parse_match(lbuf, &tagp) == FAIL) {
     tagp.fname_end = NULL;
     goto erret;
   }
@@ -2705,15 +2686,13 @@ static char_u *expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
       && !vim_isAbsName(fname)
       && (p = path_tail(tag_fname)) != tag_fname) {
     retval = alloc(MAXPATHL);
-    if (retval != NULL) {
-      STRCPY(retval, tag_fname);
-      vim_strncpy(retval + (p - tag_fname), fname,
-          MAXPATHL - (p - tag_fname) - 1);
-      /*
-       * Translate names like "src/a/../b/file.c" into "src/b/file.c".
-       */
-      simplify_filename(retval);
-    }
+    STRCPY(retval, tag_fname);
+    vim_strncpy(retval + (p - tag_fname), fname,
+        MAXPATHL - (p - tag_fname) - 1);
+    /*
+     * Translate names like "src/a/../b/file.c" into "src/b/file.c".
+     */
+    simplify_filename(retval);
   } else
     retval = vim_strsave(fname);
 
@@ -2859,8 +2838,6 @@ add_tag_field (
     return FAIL;
   }
   buf = alloc(MAXPATHL);
-  if (buf == NULL)
-    return FAIL;
   if (start != NULL) {
     if (end == NULL) {
       end = start + STRLEN(start);

--- a/src/term.c
+++ b/src/term.c
@@ -3026,10 +3026,6 @@ void add_termcode(char_u *name, char_u *string, int flags)
     tc_max_len += 20;
     new_tc = (struct termcode *)alloc(
         (unsigned)(tc_max_len * sizeof(struct termcode)));
-    if (new_tc == NULL) {
-      tc_max_len -= 20;
-      return;
-    }
     for (i = 0; i < tc_len; ++i)
       new_tc[i] = termcodes[i];
     vim_free(termcodes);
@@ -4206,10 +4202,6 @@ replace_termcodes (
    * replaced by 6 bytes (shifted special key), plus a NUL at the end.
    */
   result = alloc((unsigned)STRLEN(from) * 6 + 1);
-  if (result == NULL) {         /* out of memory */
-    *bufp = NULL;
-    return from;
-  }
 
   src = from;
 
@@ -4416,8 +4408,6 @@ void show_termcodes(void)
   if (tc_len == 0)          /* no terminal codes (must be GUI) */
     return;
   items = (int *)alloc((unsigned)(sizeof(int) * tc_len));
-  if (items == NULL)
-    return;
 
   /* Highlight title */
   MSG_PUTS_TITLE(_("\n--- Terminal keys ---"));

--- a/src/ui.c
+++ b/src/ui.c
@@ -81,17 +81,15 @@ void ui_inchar_undo(char_u *s, int len)
   if (ta_str != NULL)
     newlen += ta_len - ta_off;
   new = alloc(newlen);
-  if (new != NULL) {
-    if (ta_str != NULL) {
-      memmove(new, ta_str + ta_off, (size_t)(ta_len - ta_off));
-      memmove(new + ta_len - ta_off, s, (size_t)len);
-      vim_free(ta_str);
-    } else
-      memmove(new, s, (size_t)len);
-    ta_str = new;
-    ta_len = newlen;
-    ta_off = 0;
-  }
+  if (ta_str != NULL) {
+    memmove(new, ta_str + ta_off, (size_t)(ta_len - ta_off));
+    memmove(new + ta_len - ta_off, s, (size_t)len);
+    vim_free(ta_str);
+  } else
+    memmove(new, s, (size_t)len);
+  ta_str = new;
+  ta_len = newlen;
+  ta_off = 0;
 }
 #endif
 
@@ -317,13 +315,12 @@ char_u *get_input_buf(void)
 
   /* We use a growarray to store the data pointer and the length. */
   gap = (garray_T *)alloc((unsigned)sizeof(garray_T));
-  if (gap != NULL) {
-    /* Add one to avoid a zero size. */
-    gap->ga_data = alloc((unsigned)inbufcount + 1);
-    if (gap->ga_data != NULL)
-      memmove(gap->ga_data, inbuf, (size_t)inbufcount);
-    gap->ga_len = inbufcount;
-  }
+  /* Add one to avoid a zero size. */
+  gap->ga_data = alloc((unsigned)inbufcount + 1);
+  if (gap->ga_data != NULL)
+    memmove(gap->ga_data, inbuf, (size_t)inbufcount);
+  gap->ga_len = inbufcount;
+
   trash_input_buf();
   return (char_u *)gap;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -2834,10 +2834,8 @@ static void new_frame(win_T *wp)
   frame_T *frp = (frame_T *)alloc_clear((unsigned)sizeof(frame_T));
 
   wp->w_frame = frp;
-  if (frp != NULL) {
-    frp->fr_layout = FR_LEAF;
-    frp->fr_win = wp;
-  }
+  frp->fr_layout = FR_LEAF;
+  frp->fr_win = wp;
 }
 
 /*
@@ -2861,8 +2859,6 @@ static tabpage_T *alloc_tabpage(void)
 
 
   tp = (tabpage_T *)alloc_clear((unsigned)sizeof(tabpage_T));
-  if (tp == NULL)
-    return NULL;
 
   /* init t: variables */
   tp->tp_vars = dict_alloc();
@@ -3596,8 +3592,6 @@ static win_T *win_alloc(win_T *after, int hidden)
    * allocate window structure and linesizes arrays
    */
   new_wp = (win_T *)alloc_clear((unsigned)sizeof(win_T));
-  if (new_wp == NULL)
-    return NULL;
 
   if (win_alloc_lines(new_wp) == FAIL) {
     vim_free(new_wp);
@@ -5063,8 +5057,6 @@ void make_snapshot(int idx)
 static void make_snapshot_rec(frame_T *fr, frame_T **frp)
 {
   *frp = (frame_T *)alloc_clear((unsigned)sizeof(frame_T));
-  if (*frp == NULL)
-    return;
   (*frp)->fr_layout = fr->fr_layout;
   (*frp)->fr_width = fr->fr_width;
   (*frp)->fr_height = fr->fr_height;


### PR DESCRIPTION
By simpler cases I mean cases where the OOM error is not expected to be handled
by the caller of the function that calls `alloc`, `lalloc`, `xrealloc`,
`xmalloc`, `alloc_clear`, and `lalloc_clear`.

These are the functions that:
- Do not return an allocated buffer
- Have OOM as the only error condition

I took note of the functions that expect the caller to handle the OOM error and
will go through them to check all the callers that may be handling OOM error in
future commits.

I'm ignoring eval.c and ex__.c in this series of commits. eval.c will soon be obsolete and I will deal with ex__.c in later PRs.
