### PR TITLE
[RDY] Cleanup os_unix.h

### DIFF
--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -7,8 +7,6 @@
 void mch_write(char_u *s, int len);
 void mch_suspend(void);
 void mch_init(void);
-void reset_signals(void);
-int vim_handle_signal(int sig);
 int mch_check_win(int argc, char **argv);
 int mch_input_isatty(void);
 int mch_can_restore_title(void);
@@ -51,16 +49,5 @@ int mch_has_wildcard(char_u *p);
 int mch_libcall(char_u *libname, char_u *funcname, char_u *argstring,
                 int argint, char_u **string_result,
                 int *number_result);
-void setup_term_clip(void);
-void start_xterm_trace(int button);
-void stop_xterm_trace(void);
-void clear_xterm_clip(void);
-int clip_xterm_own_selection(VimClipboard *cbd);
-void clip_xterm_lose_selection(VimClipboard *cbd);
-void clip_xterm_request_selection(VimClipboard *cbd);
-void clip_xterm_set_selection(VimClipboard *cbd);
-int xsmp_handle_requests(void);
-void xsmp_init(void);
-void xsmp_close(void);
 /* vim: set ft=c : */
 #endif /* NEOVIM_OS_UNIX_H */

--- a/src/vim.h
+++ b/src/vim.h
@@ -1418,14 +1418,6 @@ typedef int VimClipboard;       /* This is required for the prototypes. */
 # undef NBDEBUG
 # define nbdebug(a)
 
-
-/* values for vim_handle_signal() that are not a signal */
-#define SIGNAL_BLOCK    -1
-#define SIGNAL_UNBLOCK  -2
-#if !defined(UNIX) && !defined(VMS) && !defined(OS2)
-# define vim_handle_signal(x) 0
-#endif
-
 /* flags for skip_vimgrep_pat() */
 #define VGR_GLOBAL      1
 #define VGR_NOJUMP      2


### PR DESCRIPTION
Removed not defined prototypes in `os_unix.h`:  
- reset_signals, vim_handle_signal:
  signal handling was rewritten, not defined anywhere
- related to x clipboard handling, not defined anywhere:
  - {setup,start,stop,clear}_xterm_clip
  - stop_xterm_trace
  - clip_xterm_{own_selection,lose_selection,request_selection,set_selection}
- related to XSMP (x session management protocol):
  - xsmp_{handle_requests,init,close}
