### PR TITLE
[RDY] vim-patch:7.4.181

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -384,7 +384,7 @@ static int read_readbuf(buffheader_T *buf, int advance)
 }
 
 /*
- * Prepare the read buffers for reading (if they contains something).
+ * Prepare the read buffers for reading (if they contain something).
  */
 static void start_stuff(void)
 {
@@ -1939,6 +1939,10 @@ static int vgetorpeek(int advance)
                 msg_row = Rows - 1;
                 msg_clr_eos();                          /* clear ruler */
               }
+#ifdef FEAT_WINDOWS
+              status_redraw_all();
+              redraw_statuslines();
+#endif
               showmode();
               setcursor();
               continue;

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,9 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  181,
+  //180,
+  //179,
   178,
   //177,
   //176,


### PR DESCRIPTION
Merging vim-patch:7.4.181
Problem:    When using 'pastetoggle' the status lines are not updated. (Samuel
            Ferencik, Jan Christoph Ebersbach)
Solution:   Update the status lines. (Nobuhiro Takasaki)

https://code.google.com/p/vim/source/detail?r=cb5683bcde03796baa7e845fd9a2fcaec3383538
