### PR TITLE
[RDY] Moved mch_get_{pid,host_name} to os.h

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -10530,11 +10530,11 @@ static void f_hlexists(typval_T *argvars, typval_T *rettv)
  */
 static void f_hostname(typval_T *argvars, typval_T *rettv)
 {
-  char_u hostname[256];
+  char hostname[256];
 
-  mch_get_host_name(hostname, 256);
+  os_get_hostname(hostname, 256);
   rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = vim_strsave(hostname);
+  rettv->vval.v_string = vim_strsave((char_u *)hostname);
 }
 
 /*

--- a/src/eval.c
+++ b/src/eval.c
@@ -9872,7 +9872,7 @@ static void f_getmatches(typval_T *argvars, typval_T *rettv)
  */
 static void f_getpid(typval_T *argvars, typval_T *rettv)
 {
-  rettv->vval.v_number = mch_get_pid();
+  rettv->vval.v_number = os_get_pid();
 }
 
 /*

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5730,7 +5730,7 @@ vim_tempname (
          * unlikely that it already exists it will be faster,
          * otherwise it doesn't matter.  The use of mkdir() avoids any
          * security problems because of the predictable number. */
-        nr = (mch_get_pid() + (long)time(NULL)) % 1000000L;
+        nr = (os_get_pid() + (long)time(NULL)) % 1000000L;
         itmplen = STRLEN(itmp);
 
         /* Try up to 10000 different values until we find a name that

--- a/src/memline.c
+++ b/src/memline.c
@@ -345,7 +345,7 @@ int ml_open(buf_T *buf)
     set_b0_fname(b0p, buf);
     (void)os_get_user_name((char *)b0p->b0_uname, B0_UNAME_SIZE);
     b0p->b0_uname[B0_UNAME_SIZE - 1] = NUL;
-    mch_get_host_name(b0p->b0_hname, B0_HNAME_SIZE);
+    os_get_hostname((char *)b0p->b0_hname, B0_HNAME_SIZE);
     b0p->b0_hname[B0_HNAME_SIZE - 1] = NUL;
     long_to_char(os_get_pid(), b0p->b0_pid);
     if (*buf->b_p_key != NUL)

--- a/src/memline.c
+++ b/src/memline.c
@@ -347,7 +347,7 @@ int ml_open(buf_T *buf)
     b0p->b0_uname[B0_UNAME_SIZE - 1] = NUL;
     mch_get_host_name(b0p->b0_hname, B0_HNAME_SIZE);
     b0p->b0_hname[B0_HNAME_SIZE - 1] = NUL;
-    long_to_char(mch_get_pid(), b0p->b0_pid);
+    long_to_char(os_get_pid(), b0p->b0_pid);
     if (*buf->b_p_key != NUL)
       ml_set_b0_crypt(buf, b0p);
   }

--- a/src/os/env.c
+++ b/src/os/env.c
@@ -9,6 +9,10 @@
 #include <crt_externs.h>
 #endif
 
+#ifdef HAVE_SYS_UTSNAME_H
+#include <sys/utsname.h>
+#endif
+
 const char *os_getenv(const char *name)
 {
   return getenv(name);
@@ -57,6 +61,24 @@ long os_get_pid()
   return (long)GetCurrentProcessId();
 #else
   return (long)getpid();
+#endif
+}
+
+void os_get_hostname(char *hostname, size_t len)
+{
+#ifdef HAVE_SYS_UTSNAME_H
+  struct utsname vutsname;
+
+  if (uname(&vutsname) < 0) {
+    *hostname = '\0';
+  } else {
+    strncpy(hostname, vutsname.nodename, len - 1);
+    hostname[len - 1] = '\0';
+  }
+#else
+  // TODO: Implement this for windows. See the implementation used in vim:
+  // https://code.google.com/p/vim/source/browse/src/os_win32.c?r=6b69d8dde19e32909f4ee3a6337e6a2ecfbb6f72#2899
+  *hostname = '\0';
 #endif
 }
 

--- a/src/os/env.c
+++ b/src/os/env.c
@@ -50,3 +50,13 @@ char *os_getenvname_at_index(size_t index)
 # endif
 }
 
+
+long os_get_pid()
+{
+#ifdef _WIN32
+  return (long)GetCurrentProcessId();
+#else
+  return (long)getpid();
+#endif
+}
+

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -82,6 +82,11 @@ long_u os_total_mem(int special);
 const char *os_getenv(const char *name);
 int os_setenv(const char *name, const char *value, int overwrite);
 char *os_getenvname_at_index(size_t index);
+
+/// Get the process ID of the Neovim process.
+///
+/// @return the process ID.
+long os_get_pid(void);
 int os_get_usernames(garray_T *usernames);
 int os_get_user_name(char *s, size_t len);
 int os_get_uname(uid_t uid, char *s, size_t len);

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -87,6 +87,13 @@ char *os_getenvname_at_index(size_t index);
 ///
 /// @return the process ID.
 long os_get_pid(void);
+
+/// Get the hostname of the machine runing Neovim.
+///
+/// @param hostname Buffer to store the hostname.
+/// @param len Length of `hostname`.
+void os_get_hostname(char *hostname, size_t len);
+
 int os_get_usernames(garray_T *usernames);
 int os_get_user_name(char *s, size_t len);
 int os_get_uname(uid_t uid, char *s, size_t len);

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -424,14 +424,6 @@ void mch_get_host_name(char_u *s, int len)
 }
 #endif /* HAVE_SYS_UTSNAME_H */
 
-/*
- * return process ID
- */
-long mch_get_pid()
-{
-  return (long)getpid();
-}
-
 #if defined(USE_FNAME_CASE) || defined(PROTO)
 /*
  * Set the case of the file name, if it already exists.  This will cause the

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -397,33 +397,6 @@ int vim_is_fastterm(char_u *name)
          || STRNICMP(name, "dtterm", 6) == 0;
 }
 
-/*
- * Insert host name is s[len].
- */
-
-#ifdef HAVE_SYS_UTSNAME_H
-void mch_get_host_name(char_u *s, int len)
-{
-  struct utsname vutsname;
-
-  if (uname(&vutsname) < 0)
-    *s = NUL;
-  else
-    vim_strncpy(s, (char_u *)vutsname.nodename, len - 1);
-}
-#else /* HAVE_SYS_UTSNAME_H */
-
-# ifdef HAVE_SYS_SYSTEMINFO_H
-#  define gethostname(nam, len) sysinfo(SI_HOSTNAME, nam, len)
-# endif
-
-void mch_get_host_name(char_u *s, int len)
-{
-  gethostname((char *)s, len);
-  s[len - 1] = NUL;     /* make sure it's terminated */
-}
-#endif /* HAVE_SYS_UTSNAME_H */
-
 #if defined(USE_FNAME_CASE) || defined(PROTO)
 /*
  * Set the case of the file name, if it already exists.  This will cause the

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -20,7 +20,6 @@ int vim_is_iris(char_u *name);
 int vim_is_vt300(char_u *name);
 int vim_is_fastterm(char_u *name);
 void mch_get_host_name(char_u *s, int len);
-long mch_get_pid(void);
 void slash_adjust(char_u *p);
 void fname_case(char_u *name, int len);
 void mch_copy_sec(char_u *from_file, char_u *to_file);

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -19,7 +19,6 @@ int use_xterm_mouse(void);
 int vim_is_iris(char_u *name);
 int vim_is_vt300(char_u *name);
 int vim_is_fastterm(char_u *name);
-void mch_get_host_name(char_u *s, int len);
 void slash_adjust(char_u *p);
 void fname_case(char_u *name, int len);
 void mch_copy_sec(char_u *from_file, char_u *to_file);

--- a/src/os_unixx.h
+++ b/src/os_unixx.h
@@ -58,10 +58,6 @@
 # include <sys/stream.h>
 #endif
 
-#ifdef HAVE_SYS_UTSNAME_H
-# include <sys/utsname.h>
-#endif
-
 #ifdef HAVE_SYS_SYSTEMINFO_H
 /*
  * foolish Sinix <sys/systeminfo.h> uses SYS_NMLN but doesn't include

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2605,7 +2605,7 @@ static char_u *get_mef_name(void)
   /* Keep trying until the name doesn't exist yet. */
   for (;; ) {
     if (start == -1)
-      start = mch_get_pid();
+      start = os_get_pid();
     else
       off += 19;
 

--- a/test/unit/os/env.moon
+++ b/test/unit/os/env.moon
@@ -8,6 +8,7 @@ ffi.cdef [[
 const char *os_getenv(const char *name);
 int os_setenv(const char *name, const char *value, int override);
 char *os_getenvname_at_index(size_t index);
+long os_get_pid(void);
 ]]
 
 NULL = ffi.cast 'void*', 0
@@ -89,4 +90,17 @@ describe 'env function', ->
         -- maxuint64 = ffi.new 'size_t', 18446744073709551615
         maxuint64 = ffi.new 'size_t', 18446744073709000000
         eq NULL, env.os_getenvname_at_index maxuint64
+
+  describe 'os_get_pid', ->
+
+    it 'returns the process ID', ->
+      stat_file = io.open '/proc/self/stat'
+      if stat_file
+        stat_str = stat_file\read '*l'
+        stat_file\close!
+        pid = tonumber (stat_str\match '%d+')
+        eq pid, tonumber env.os_get_pid!
+      else
+        -- /proc is not avaliable on all systems, test if pid is nonzero.
+        eq true, (env.os_get_pid! > 0)
 

--- a/test/unit/os/env.moon
+++ b/test/unit/os/env.moon
@@ -9,6 +9,7 @@ const char *os_getenv(const char *name);
 int os_setenv(const char *name, const char *value, int override);
 char *os_getenvname_at_index(size_t index);
 long os_get_pid(void);
+void os_get_hostname(char *hostname, size_t len);
 ]]
 
 NULL = ffi.cast 'void*', 0
@@ -103,4 +104,14 @@ describe 'env function', ->
       else
         -- /proc is not avaliable on all systems, test if pid is nonzero.
         eq true, (env.os_get_pid! > 0)
+
+  describe 'os_get_hostname', ->
+
+    it 'returns the hostname', ->
+      handle = io.popen 'hostname'
+      hostname = handle\read '*l'
+      handle\close!
+      hostname_buf = cstr 255, ''
+      env.os_get_hostname hostname_buf, 255
+      eq hostname,  (ffi.string hostname_buf)
 


### PR DESCRIPTION
Moved `mch_get_pid` and `mch_get_host_name` to `os.h` and renamed them. I put the implementations into `src/os/env.c`, but I'm not sure about this. Does anyone have a better idea where to put them?
