### PR TITLE
[RFC] More cleanup on unix.c

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1130,7 +1130,5 @@ EXTERN char *ignoredp;
 /* Temporarily moved these static variables to assist in migrating from
  * os_unix.c */
 EXTERN int curr_tmode INIT(= TMODE_COOK); /* contains current terminal mode */
-/* volatile because it is used in signal handler deathtrap(). */
-EXTERN volatile bool in_os_delay INIT(= false);  /* sleeping in os_delay() */
 
 #endif /* NEOVIM_GLOBALS_H */

--- a/src/os/time.c
+++ b/src/os/time.c
@@ -29,9 +29,7 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
 
   if (ignoreinput) {
     // Go to cooked mode without echo, to allow SIGINT interrupting us
-    // here.  But we don't want QUIT to kill us (CTRL-\ used in a
-    // shell may produce SIGQUIT).
-    in_os_delay = true;
+    // here
     old_tmode = curr_tmode;
 
     if (curr_tmode == TMODE_RAW)
@@ -40,7 +38,6 @@ void os_microdelay(uint64_t microseconds, bool ignoreinput)
     microdelay(microseconds);
 
     settmode(old_tmode);
-    in_os_delay = false;
   } else {
     microdelay(microseconds);
   }

--- a/src/os/time.h
+++ b/src/os/time.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 
 void time_init(void);
-void os_delay(uint64_t ms, bool ignoreinput);
+void os_delay(uint64_t milliseconds, bool ignoreinput);
+void os_microdelay(uint64_t microseconds, bool ignoreinput);
 
 #endif  // NEOVIM_OS_TIME_H
+

--- a/src/os/time.h
+++ b/src/os/time.h
@@ -4,9 +4,21 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/// Initializes the time module
 void time_init(void);
+
+/// Sleeps for a certain amount of milliseconds
+///
+/// @param milliseconds Number of milliseconds to sleep
+/// @param ignoreinput If true, allow a SIGINT to interrupt us
 void os_delay(uint64_t milliseconds, bool ignoreinput);
+
+/// Sleeps for a certain amount of microseconds
+///
+/// @param microseconds Number of microseconds to sleep
+/// @param ignoreinput If true, allow a SIGINT to interrupt us
 void os_microdelay(uint64_t microseconds, bool ignoreinput);
+
 
 #endif  // NEOVIM_OS_TIME_H
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -64,16 +64,6 @@
 static int selinux_enabled = -1;
 #endif
 
-/*
- * Use this prototype for select, some include files have a wrong prototype
- */
-# undef select
-
-
-#if defined(HAVE_SELECT)
-extern int select(int, fd_set *, fd_set *, fd_set *, struct timeval *);
-#endif
-
 static int get_x11_title(int);
 static int get_x11_icon(int);
 
@@ -81,14 +71,6 @@ static char_u   *oldtitle = NULL;
 static int did_set_title = FALSE;
 static char_u   *oldicon = NULL;
 static int did_set_icon = FALSE;
-
-#ifdef HAVE_UNION_WAIT
-typedef union wait waitstatus;
-#else
-typedef int waitstatus;
-#endif
-
-static int RealWaitForChar(int, long, int *);
 
 static int have_wildcard(int, char_u **);
 static int have_dollars(int, char_u **);
@@ -103,7 +85,7 @@ void mch_write(char_u *s, int len)
 {
   ignored = (int)write(1, (char *)s, len);
   if (p_wd)             /* Unix is too fast, slow down a bit more */
-    RealWaitForChar(read_cmd_fd, p_wd, NULL);
+    os_microdelay(p_wd, 0);
 }
 
 /*
@@ -1023,120 +1005,6 @@ void mch_set_shellsize()
     out_flush();
     screen_start();                     /* don't know where cursor is now */
   }
-}
-
-/*
- * Rows and/or Columns has changed.
- */
-void mch_new_shellsize()
-{
-  /* Nothing to do. */
-}
-
-/*
- * Wait "msec" msec until a character is available from file descriptor "fd".
- * "msec" == 0 will check for characters once.
- * "msec" == -1 will block until a character is available.
- * When a GUI is being used, this will not be used for input -- webb
- * Or when a Linux GPM mouse event is waiting.
- */
-static int RealWaitForChar(fd, msec, check_for_gpm)
-int fd;
-long msec;
-int         *check_for_gpm;
-{
-  int ret;
-
-#ifdef MAY_LOOP
-  for (;; )
-#endif
-  {
-#ifdef MAY_LOOP
-    int finished = TRUE;                 /* default is to 'loop' just once */
-#endif
-#ifndef HAVE_SELECT
-    struct pollfd fds[6];
-    int nfd;
-    int towait = (int)msec;
-
-    fds[0].fd = fd;
-    fds[0].events = POLLIN;
-    nfd = 1;
-
-
-    ret = poll(fds, nfd, towait);
-
-
-
-#else /* HAVE_SELECT */
-
-    struct timeval tv;
-    struct timeval  *tvp;
-    fd_set rfds, efds;
-    int maxfd;
-    long towait = msec;
-
-
-    if (towait >= 0) {
-      tv.tv_sec = towait / 1000;
-      tv.tv_usec = (towait % 1000) * (1000000/1000);
-      tvp = &tv;
-    } else
-      tvp = NULL;
-
-    /*
-     * Select on ready for reading and exceptional condition (end of file).
-     */
-select_eintr:
-    FD_ZERO(&rfds);
-    FD_ZERO(&efds);
-    FD_SET(fd, &rfds);
-    /* For QNX select() always returns 1 if this is set.  Why? */
-    FD_SET(fd, &efds);
-    maxfd = fd;
-
-
-    ret = select(maxfd + 1, &rfds, NULL, &efds, tvp);
-# ifdef EINTR
-    if (ret == -1 && errno == EINTR) {
-      /* Check whether window has been resized, EINTR may be caused by
-       * SIGWINCH. FIXME this is broken for now */
-
-      /* Interrupted by a signal, need to try again.  We ignore msec
-       * here, because we do want to check even after a timeout if
-       * characters are available.  Needed for reading output of an
-       * external command after the process has finished. */
-      goto select_eintr;
-    }
-# endif
-
-
-#endif /* HAVE_SELECT */
-
-#ifdef MAY_LOOP
-    if (finished || msec == 0)
-      break;
-
-    /* We're going to loop around again, find out for how long */
-    if (msec > 0) {
-# ifdef USE_START_TV
-      struct timeval mtv;
-
-      /* Compute remaining wait time. */
-      gettimeofday(&mtv, NULL);
-      msec -= (mtv.tv_sec - start_tv.tv_sec) * 1000L
-              + (mtv.tv_usec - start_tv.tv_usec) / 1000L;
-# else
-      /* Guess we got interrupted halfway. */
-      msec = msec / 2;
-# endif
-      if (msec <= 0)
-        break;          /* waited long enough */
-    }
-#endif
-  }
-
-  return ret > 0;
 }
 
 /*

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -85,7 +85,7 @@ void mch_write(char_u *s, int len)
 {
   ignored = (int)write(1, (char *)s, len);
   if (p_wd)             /* Unix is too fast, slow down a bit more */
-    os_microdelay(p_wd, 0);
+    os_microdelay(p_wd, false);
 }
 
 /*

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -37,7 +37,6 @@ void check_mouse_termcode(void);
 int mch_screenmode(char_u *arg);
 int mch_get_shellsize(void);
 void mch_set_shellsize(void);
-void mch_new_shellsize(void);
 int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
                          char_u ***file,
                          int flags);

--- a/src/term.c
+++ b/src/term.c
@@ -2465,8 +2465,6 @@ void win_new_shellsize(void)
   static int old_Rows = 0;
   static int old_Columns = 0;
 
-  if (old_Rows != Rows || old_Columns != Columns)
-    ui_new_shellsize();
   if (old_Rows != Rows) {
     /* if 'window' uses the whole screen, keep it using that */
     if (p_window == old_Rows - 1 || old_Rows == 0)

--- a/src/ui.c
+++ b/src/ui.c
@@ -237,22 +237,9 @@ int ui_get_shellsize(void)
  * new size.  If this is not possible, it will adjust Rows and Columns.
  */
 void 
-ui_set_shellsize (
-    int mustset             /* set by the user */
-)
+ui_set_shellsize(int mustset)
 {
   mch_set_shellsize();
-}
-
-/*
- * Called when Rows and/or Columns changed.  Adjust scroll region and mouse
- * region.
- */
-void ui_new_shellsize(void)
-{
-  if (full_screen && !exiting) {
-    mch_new_shellsize();
-  }
 }
 
 void ui_breakcheck(void)

--- a/src/ui.h
+++ b/src/ui.h
@@ -10,7 +10,6 @@ void ui_suspend(void);
 void suspend_shell(void);
 int ui_get_shellsize(void);
 void ui_set_shellsize(int mustset);
-void ui_new_shellsize(void);
 void ui_breakcheck(void);
 void clip_init(int can_use);
 void clip_update_selection(VimClipboard *clip);


### PR DESCRIPTION
This implements a new function, `os_microdelay` for sleeping microseconds and replaces the last `RealWaitForChar` occurrence for it. It also removes `{mch,ui}_new_shellsize` since they had no effect
