### PR TITLE
[RDY] Reimplement the event queue in event.c using klist.h 

### DIFF
--- a/src/func_attr.h
+++ b/src/func_attr.h
@@ -34,6 +34,7 @@
   #define FUNC_ATTR_CONST __attribute__((const))
   #define FUNC_ATTR_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
   #define FUNC_ATTR_ALWAYS_INLINE __attribute__((always_inline))
+  #define FUNC_ATTR_UNUSED __attribute__((unused))
 
   #ifdef __clang__
     // clang only
@@ -88,6 +89,10 @@
 
 #ifndef FUNC_ATTR_ALWAYS_INLINE
   #define FUNC_ATTR_ALWAYS_INLINE
+#endif
+
+#ifndef FUNC_ATTR_UNUSED
+  #define FUNC_ATTR_UNUSED
 #endif
 
 #ifndef FUNC_ATTR_NONNULL_ALL

--- a/src/lib/klist.h
+++ b/src/lib/klist.h
@@ -28,13 +28,15 @@
 
 #include <stdlib.h>
 
+#include "memory.h"
+
 #define KMEMPOOL_INIT(name, kmptype_t, kmpfree_f)                       \
     typedef struct {                                                    \
         size_t cnt, n, max;                                             \
         kmptype_t **buf;                                                \
     } kmp_##name##_t;                                                   \
     static inline kmp_##name##_t *kmp_init_##name() {                   \
-        return calloc(1, sizeof(kmp_##name##_t));                       \
+        return xcalloc(1, sizeof(kmp_##name##_t));                      \
     }                                                                   \
     static inline void kmp_destroy_##name(kmp_##name##_t *mp) {         \
         size_t k;                                                       \
@@ -45,14 +47,14 @@
     }                                                                   \
     static inline kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) {     \
         ++mp->cnt;                                                      \
-        if (mp->n == 0) return calloc(1, sizeof(kmptype_t));            \
+        if (mp->n == 0) return xcalloc(1, sizeof(kmptype_t));           \
         return mp->buf[--mp->n];                                        \
     }                                                                   \
     static inline void kmp_free_##name(kmp_##name##_t *mp, kmptype_t *p) { \
         --mp->cnt;                                                      \
         if (mp->n == mp->max) {                                         \
             mp->max = mp->max? mp->max<<1 : 16;                         \
-            mp->buf = realloc(mp->buf, sizeof(void*) * mp->max);        \
+            mp->buf = xrealloc(mp->buf, sizeof(void*) * mp->max);       \
         }                                                               \
         mp->buf[mp->n++] = p;                                           \
     }
@@ -76,7 +78,7 @@
         size_t size;                                                    \
     } kl_##name##_t;                                                    \
     static inline kl_##name##_t *kl_init_##name() {                     \
-        kl_##name##_t *kl = calloc(1, sizeof(kl_##name##_t));           \
+        kl_##name##_t *kl = xcalloc(1, sizeof(kl_##name##_t));          \
         kl->mp = kmp_init(name);                                        \
         kl->head = kl->tail = kmp_alloc(name, kl->mp);                  \
         kl->head->next = 0;                                             \

--- a/src/lib/klist.h
+++ b/src/lib/klist.h
@@ -1,0 +1,121 @@
+/* The MIT License
+
+   Copyright (c) 2008-2009, by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#ifndef _AC_KLIST_H
+#define _AC_KLIST_H
+
+#include <stdlib.h>
+
+#define KMEMPOOL_INIT(name, kmptype_t, kmpfree_f)                       \
+    typedef struct {                                                    \
+        size_t cnt, n, max;                                             \
+        kmptype_t **buf;                                                \
+    } kmp_##name##_t;                                                   \
+    static inline kmp_##name##_t *kmp_init_##name() {                   \
+        return calloc(1, sizeof(kmp_##name##_t));                       \
+    }                                                                   \
+    static inline void kmp_destroy_##name(kmp_##name##_t *mp) {         \
+        size_t k;                                                       \
+        for (k = 0; k < mp->n; ++k) {                                   \
+            kmpfree_f(mp->buf[k]); free(mp->buf[k]);                    \
+        }                                                               \
+        free(mp->buf); free(mp);                                        \
+    }                                                                   \
+    static inline kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) {     \
+        ++mp->cnt;                                                      \
+        if (mp->n == 0) return calloc(1, sizeof(kmptype_t));            \
+        return mp->buf[--mp->n];                                        \
+    }                                                                   \
+    static inline void kmp_free_##name(kmp_##name##_t *mp, kmptype_t *p) { \
+        --mp->cnt;                                                      \
+        if (mp->n == mp->max) {                                         \
+            mp->max = mp->max? mp->max<<1 : 16;                         \
+            mp->buf = realloc(mp->buf, sizeof(void*) * mp->max);        \
+        }                                                               \
+        mp->buf[mp->n++] = p;                                           \
+    }
+
+#define kmempool_t(name) kmp_##name##_t
+#define kmp_init(name) kmp_init_##name()
+#define kmp_destroy(name, mp) kmp_destroy_##name(mp)
+#define kmp_alloc(name, mp) kmp_alloc_##name(mp)
+#define kmp_free(name, mp, p) kmp_free_##name(mp, p)
+
+#define KLIST_INIT(name, kltype_t, kmpfree_t)                           \
+    struct __kl1_##name {                                               \
+        kltype_t data;                                                  \
+        struct __kl1_##name *next;                                      \
+    };                                                                  \
+    typedef struct __kl1_##name kl1_##name;                             \
+    KMEMPOOL_INIT(name, kl1_##name, kmpfree_t)                          \
+    typedef struct {                                                    \
+        kl1_##name *head, *tail;                                        \
+        kmp_##name##_t *mp;                                             \
+        size_t size;                                                    \
+    } kl_##name##_t;                                                    \
+    static inline kl_##name##_t *kl_init_##name() {                     \
+        kl_##name##_t *kl = calloc(1, sizeof(kl_##name##_t));           \
+        kl->mp = kmp_init(name);                                        \
+        kl->head = kl->tail = kmp_alloc(name, kl->mp);                  \
+        kl->head->next = 0;                                             \
+        return kl;                                                      \
+    }                                                                   \
+    static inline void kl_destroy_##name(kl_##name##_t *kl) {           \
+        kl1_##name *p;                                                  \
+        for (p = kl->head; p != kl->tail; p = p->next)                  \
+            kmp_free(name, kl->mp, p);                                  \
+        kmp_free(name, kl->mp, p);                                      \
+        kmp_destroy(name, kl->mp);                                      \
+        free(kl);                                                       \
+    }                                                                   \
+    static inline kltype_t *kl_pushp_##name(kl_##name##_t *kl) {        \
+        kl1_##name *q, *p = kmp_alloc(name, kl->mp);                    \
+        q = kl->tail; p->next = 0; kl->tail->next = p; kl->tail = p;    \
+        ++kl->size;                                                     \
+        return &q->data;                                                \
+    }                                                                   \
+    static inline int kl_shift_##name(kl_##name##_t *kl, kltype_t *d) { \
+        kl1_##name *p;                                                  \
+        if (kl->head->next == 0) return -1;                             \
+        --kl->size;                                                     \
+        p = kl->head; kl->head = kl->head->next;                        \
+        if (d) *d = p->data;                                            \
+        kmp_free(name, kl->mp, p);                                      \
+        return 0;                                                       \
+    }
+
+#define kliter_t(name) kl1_##name
+#define klist_t(name) kl_##name##_t
+#define kl_val(iter) ((iter)->data)
+#define kl_next(iter) ((iter)->next)
+#define kl_begin(kl) ((kl)->head)
+#define kl_end(kl) ((kl)->tail)
+
+#define kl_init(name) kl_init_##name()
+#define kl_destroy(name, kl) kl_destroy_##name(kl)
+#define kl_pushp(name, kl) kl_pushp_##name(kl)
+#define kl_shift(name, kl, d) kl_shift_##name(kl, d)
+
+#endif

--- a/src/lib/klist.h
+++ b/src/lib/klist.h
@@ -26,8 +26,10 @@
 #ifndef _AC_KLIST_H
 #define _AC_KLIST_H
 
+#include <stdbool.h>
 #include <stdlib.h>
 
+#include "func_attr.h"
 #include "memory.h"
 
 #define KMEMPOOL_INIT(name, kmptype_t, kmpfree_f)                       \
@@ -84,6 +86,8 @@
         kl->head->next = 0;                                             \
         return kl;                                                      \
     }                                                                   \
+    static inline void kl_destroy_##name(kl_##name##_t *kl)             \
+        FUNC_ATTR_UNUSED;                                               \
     static inline void kl_destroy_##name(kl_##name##_t *kl) {           \
         kl1_##name *p;                                                  \
         for (p = kl->head; p != kl->tail; p = p->next)                  \
@@ -119,5 +123,6 @@
 #define kl_destroy(name, kl) kl_destroy_##name(kl)
 #define kl_pushp(name, kl) kl_pushp_##name(kl)
 #define kl_shift(name, kl, d) kl_shift_##name(kl, d)
+#define kl_empty(kl) ((kl)->size == 0)
 
 #endif

--- a/src/memory.h
+++ b/src/memory.h
@@ -2,6 +2,8 @@
 #define NEOVIM_MEMORY_H
 
 #include "func_attr.h"
+#include "types.h"
+#include "vim.h"
 
 char_u *alloc(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 char_u *alloc_clear(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
@@ -18,6 +20,15 @@ char_u *lalloc_clear(long_u size, int message) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_
 /// @return pointer to allocated space. Never NULL
 void *xmalloc(size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1) FUNC_ATTR_NONNULL_RET;
+
+/// calloc() wrapper
+///
+/// @see {xmalloc}
+/// @param count
+/// @param size
+/// @return pointer to allocated space. Never NULL
+void *xcalloc(size_t count, size_t size)
+  FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE_PROD(1, 2) FUNC_ATTR_NONNULL_RET;
 
 /// realloc() wrapper
 ///

--- a/src/os/event.c
+++ b/src/os/event.c
@@ -12,7 +12,7 @@
 #include "memory.h"
 #include "misc2.h"
 
-// event.data will be cleaned up after the event is processed
+// event will be cleaned up after it gets processed
 #define _destroy_event(x)  // do nothing
 KLIST_INIT(Event, Event, _destroy_event)
 

--- a/src/os/event.h
+++ b/src/os/event.h
@@ -15,7 +15,7 @@ typedef struct {
 
 void event_init(void);
 bool event_poll(int32_t ms);
-void event_push(Event *event);
+void event_push(Event event);
 
 #endif  // NEOVIM_OS_EVENT_H
 

--- a/src/os/event.h
+++ b/src/os/event.h
@@ -10,7 +10,9 @@ typedef enum {
 
 typedef struct {
   EventType type;
-  void *data;
+  union {
+    int signum;
+  } data;
 } Event;
 
 void event_init(void);

--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -67,12 +67,11 @@ void signal_accept_deadly()
   rejecting_deadly = false;
 }
 
-void signal_handle(Event *event)
+void signal_handle(Event event)
 {
-  int signum = *(int *)event->data;
+  int signum = *(int *)event.data;
 
-  free(event->data);
-  free(event);
+  free(event.data);
 
   switch (signum) {
     case SIGINT:
@@ -148,8 +147,6 @@ static void deadly_signal(int signum)
 
 static void signal_cb(uv_signal_t *handle, int signum)
 {
-  Event *event;
-
   if (rejecting_deadly) {
     if (signum == SIGINT) {
       got_int = true;
@@ -158,9 +155,10 @@ static void signal_cb(uv_signal_t *handle, int signum)
     return;
   } 
 
-  event = (Event *)xmalloc(sizeof(Event));
-  event->type = kEventSignal;
-  event->data = xmalloc(sizeof(int));
-  *(int *)event->data = signum;
+  Event event = {
+    .type = kEventSignal,
+    .data = xmalloc(sizeof(int))
+  };
+  *(int *)event.data = signum;
   event_push(event);
 }

--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -69,9 +69,7 @@ void signal_accept_deadly()
 
 void signal_handle(Event event)
 {
-  int signum = *(int *)event.data;
-
-  free(event.data);
+  int signum = event.data.signum;
 
   switch (signum) {
     case SIGINT:
@@ -157,8 +155,9 @@ static void signal_cb(uv_signal_t *handle, int signum)
 
   Event event = {
     .type = kEventSignal,
-    .data = xmalloc(sizeof(int))
+    .data = {
+      .signum = signum
+    }
   };
-  *(int *)event.data = signum;
   event_push(event);
 }

--- a/src/os/signal.h
+++ b/src/os/signal.h
@@ -7,7 +7,7 @@ void signal_init(void);
 void signal_stop(void);
 void signal_accept_deadly(void);
 void signal_reject_deadly(void);
-void signal_handle(Event *event);
+void signal_handle(Event event);
 
 #endif
 


### PR DESCRIPTION
- Add a new macro to klist.h: kl_empty()
  
  The whole point of abstract data structures is to avoid reimplementing
  common actions. The emptiness test seems to be such an action.
- Add a new function attribute to func_attr.h: FUNC_ATTR_UNUSED
  
  Some of the many functions created by the macros in klist.h may end up not
  being used. Unused functions cause compilation errors as we compile with
  -Werror. To mark those functions as possibly unused we can use the
  FUNC_ATTR_UNUSED now.
- Pass `Event` by value
  
  `Event` is such a small struct that I don't think we should allocate heap space
  and pass it by reference. Let's use the stack and memory cache in our favor
  passing it by value.
- Turn Event into a tagged union
  
  If we ever need arbitrary data or more than very few bytes on `Events` we just
  have to add a `void *` field in the `data` union.
