### PR TITLE
[RFC] Implement `xstrdup` and `xstrndup`

### DIFF
--- a/src/memory.h
+++ b/src/memory.h
@@ -27,6 +27,22 @@ void *xmalloc(size_t size)
 void *xrealloc(void *ptr, size_t size)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET;
 
+/// strdup() wrapper
+///
+/// @see {xmalloc}
+/// @param str 0-terminated string that will be copied
+/// @return pointer to a copy of the string
+char * xstrdup(const char *str)
+ FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET;
+
+/// strndup() wrapper
+///
+/// @see {xmalloc}
+/// @param str 0-terminated string that will be copied
+/// @return pointer to a copy of the string
+char * xstrndup(const char *str, size_t len)
+ FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET;
+
 /// Old low level memory allocation function.
 ///
 /// @deprecated use xmalloc() directly instead

--- a/src/os/shell.c
+++ b/src/os/shell.c
@@ -79,13 +79,13 @@ char ** shell_build_argv(char_u *cmd, char_u *extra_shell_opt)
 
   if (extra_shell_opt != NULL) {
     // Push a copy of `extra_shell_opt`
-    rv[i++] = strdup((char *)extra_shell_opt);
+    rv[i++] = xstrdup((char *)extra_shell_opt);
   }
 
   if (cmd != NULL) {
     // Split 'shellcmdflag'
     i += tokenize(p_shcf, rv + i);
-    rv[i++] = strdup((char *)cmd);
+    rv[i++] = xstrdup((char *)cmd);
   }
 
   rv[i] = NULL;


### PR DESCRIPTION
This is the `strdup` function but uses `xmalloc` to allocate memory, so it will succeed or exit the program.

I used 'strings.h' and not 'string.h' to make it more clear that it's not the header from standard library
