### PR TITLE
[RDY] vim-patch:7.4.186

### DIFF
--- a/src/buffer_defs.h
+++ b/src/buffer_defs.h
@@ -492,6 +492,7 @@ struct file_buffer {
    * start and end of an operator, also used for '[ and ']
    */
   pos_T b_op_start;
+  pos_T b_op_start_orig;  // used for Insstart_orig
   pos_T b_op_end;
 
   int b_marks_read;             /* Have we read viminfo marks yet? */

--- a/src/globals.h
+++ b/src/globals.h
@@ -585,6 +585,12 @@ EXTERN pos_T saved_cursor               /* w_cursor before formatting text. */
  */
 EXTERN pos_T Insstart;                  /* This is where the latest
                                          * insert/append mode started. */
+
+// This is where the latest insert/append mode started. In contrast to
+// Insstart, this won't be reset by certain keys and is needed for
+// op_insert(), to detect correctly where inserting by the user started.
+EXTERN pos_T Insstart_orig;
+
 /*
  * Stuff for VREPLACE mode.
  */

--- a/src/ops.c
+++ b/src/ops.c
@@ -2142,16 +2142,16 @@ void op_insert(oparg_T *oap, long count1)
 
     /* The user may have moved the cursor before inserting something, try
      * to adjust the block for that. */
-    if (oap->start.lnum == curbuf->b_op_start.lnum && !bd.is_MAX) {
+    if (oap->start.lnum == curbuf->b_op_start_orig.lnum && !bd.is_MAX) {
       if (oap->op_type == OP_INSERT
-          && oap->start.col != curbuf->b_op_start.col) {
-        oap->start.col = curbuf->b_op_start.col;
+          && oap->start.col != curbuf->b_op_start_orig.col) {
+        oap->start.col = curbuf->b_op_start_orig.col;
         pre_textlen -= getviscol2(oap->start.col, oap->start.coladd)
                        - oap->start_vcol;
         oap->start_vcol = getviscol2(oap->start.col, oap->start.coladd);
       } else if (oap->op_type == OP_APPEND
-                 && oap->end.col >= curbuf->b_op_start.col) {
-        oap->start.col = curbuf->b_op_start.col;
+		 && oap->end.col >= curbuf->b_op_start_orig.col) {
+        oap->start.col = curbuf->b_op_start_orig.col;
         /* reset pre_textlen to the value of OP_INSERT */
         pre_textlen += bd.textlen;
         pre_textlen -= getviscol2(oap->start.col, oap->start.coladd)

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,8 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  186,
+  //185,
   184,
   //183,
   //182,


### PR DESCRIPTION
Merging vim-patch:7.4.186

Problem:    Insert in Visual mode sometimes gives incorrect results.
            (Dominique Pelle)
Solution:   Remember the original insert start position. (Christian Brabandt,
            Dominique Pelle)

https://code.google.com/p/vim/source/detail?r=4d12112c5efae071aecbeed1a7196f18950457b3
