### PR TITLE
[RDY] Used bool in os module and added clint check for TRUE/FALSE

### DIFF
--- a/clint.py
+++ b/clint.py
@@ -172,6 +172,7 @@ _ERROR_CATEGORIES = [
   'build/printf_format',
   'build/storage_class',
   'readability/alt_tokens',
+  'readability/bool',
   'readability/braces',
   'readability/fn_size',
   'readability/multiline_comment',
@@ -2814,6 +2815,12 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
             'Do not use variable-length arrays.  Use an appropriately named '
             "('k' followed by CamelCase) compile-time constant for the size.")
 
+  # Detect TRUE and FALSE.
+  match = Search(r'(TRUE|FALSE)', line)
+  if match:
+    token = match.group(1)
+    error(filename, linenum, 'readability/bool', 4,
+          'Use %s instead of %s.' % (token.lower(), token))
 
 def ProcessLine(filename, file_extension, clean_lines, line,
                 include_state, function_state, nesting_state, error,

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -490,17 +490,13 @@ readfile (
   }
 
   if (fd < 0) {                     /* cannot open at all */
-#ifndef UNIX
-    int isdir_f;
-#endif
     msg_scroll = msg_save;
 #ifndef UNIX
     /*
      * On MSDOS and Amiga we can't open a directory, check here.
      */
-    isdir_f = (os_isdir(fname));
     perm = os_getperm(fname);      /* check if the file exists */
-    if (isdir_f) {
+    if (os_isdir(fname)) {
       filemess(curbuf, sfname, (char_u *)_("is a directory"), 0);
       curbuf->b_p_ro = TRUE;            /* must use "w!" now */
     } else
@@ -2496,7 +2492,7 @@ buf_write (
   int device = FALSE;                       /* writing to a device */
   struct stat st_old;
   int prev_got_int = got_int;
-  int file_readonly = FALSE;                /* overwritten file is read-only */
+  bool file_readonly = false;               /* overwritten file is read-only */
   static char     *err_readonly =
     "is read-only (cannot override: \"W\" in 'cpoptions')";
 #if defined(UNIX) || defined(__EMX__XX)     /*XXX fix me sometime? */
@@ -5021,7 +5017,7 @@ int vim_rename(char_u *from, char_u *to)
     STRCPY(tempname, from);
     for (n = 123; n < 99999; ++n) {
       sprintf((char *)path_tail(tempname), "%d", n);
-      if (os_file_exists(tempname) == FALSE) {
+      if (!os_file_exists(tempname)) {
         if (os_rename(from, tempname) == OK) {
           if (os_rename(tempname, to) == OK)
             return 0;

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -28,23 +28,23 @@ int os_get_absolute_path(char_u *fname, char_u *buf, int len, int force);
 /// Check if the given file is absolute.
 ///
 /// This just checks if the file name starts with '/' or '~'.
-/// @return `TRUE` if "fname" is absolute.
+/// @return `true` if "fname" is absolute.
 int os_is_absolute_path(const char_u *fname);
 
 /// Check if the given path is a directory or not.
 ///
-/// @return `TRUE` if `fname` is a directory.
-int os_isdir(const char_u *name);
+/// @return `true` if `fname` is a directory.
+bool os_isdir(const char_u *name);
 
 /// Check if the given path represents an executable file.
 ///
-/// @return `TRUE` if `name` is executable and
+/// @return `true` if `name` is executable and
 ///   - can be found in $PATH,
 ///   - is relative to current dir or
 ///   - is absolute.
 ///
-/// @return `FALSE` otherwise.
-int os_can_exe(const char_u *name);
+/// @return `false` otherwise.
+bool os_can_exe(const char_u *name);
 
 /// Get the file permissions for a given file.
 ///
@@ -58,13 +58,13 @@ int os_setperm(const char_u *name, int perm);
 
 /// Check if a file exists.
 ///
-/// @return `TRUE` if `name` exists.
-int os_file_exists(const char_u *name);
+/// @return `true` if `name` exists.
+bool os_file_exists(const char_u *name);
 
 /// Check if a file is readonly.
 ///
-/// @return `True` if `name` is readonly.
-int os_file_is_readonly(const char *name);
+/// @return `true` if `name` is readonly.
+bool os_file_is_readonly(const char *name);
 
 /// Check if a file is writable.
 ///

--- a/src/os/shell.c
+++ b/src/os/shell.c
@@ -222,7 +222,7 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
       // TODO for now this is only needed if the terminal is in raw mode, but
       // when the UI is externalized we'll also need it, so leave it here
       uv_process_kill(&proc, SIGINT);
-      got_int = FALSE;
+      got_int = false;
     }
   }
 

--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -73,7 +73,7 @@ void signal_handle(Event event)
 
   switch (signum) {
     case SIGINT:
-      got_int = TRUE;
+      got_int = true;
       break;
 #ifdef SIGPWR
     case SIGPWR:

--- a/src/os/users.c
+++ b/src/os/users.c
@@ -14,7 +14,7 @@
 int os_get_usernames(garray_T *users)
 {
   if (users == NULL) {
-    return FALSE;
+    return FAIL;
   }
   ga_init(users, sizeof(char *), 20);
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1039,7 +1039,7 @@ int flags;                      /* EW_* flags */
   int i;
   size_t len;
   char_u      *p;
-  int dir;
+  bool dir;
   char_u *extra_shell_arg = NULL;
   ShellOpts shellopts = kShellOptExpand | kShellOptSilent;
   /*

--- a/src/path.c
+++ b/src/path.c
@@ -1208,7 +1208,7 @@ addfile (
 )
 {
   char_u      *p;
-  int isdir;
+  bool isdir;
 
   /* if the file/dir doesn't exist, may not add it */
   if (!(flags & EW_NOTFOUND) && !os_file_exists(f))

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1174,7 +1174,7 @@ static char_u *qf_push_dir(char_u *dirbuf, struct dir_stack_T **stackptr)
       vim_free((*stackptr)->dirname);
       (*stackptr)->dirname = concat_fnames(ds_new->dirname, dirbuf,
           TRUE);
-      if (os_isdir((*stackptr)->dirname) == TRUE)
+      if (os_isdir((*stackptr)->dirname))
         break;
 
       ds_new = ds_new->next;


### PR DESCRIPTION
As stated in style guide we must use bool from stdbool.h instead of TRUE/FALSE int constants.

What has been done:
- Used bool in os module.
- Added clint check for warning on TRUE/FALSE.

Usage of these constants in codebase is too heavy. So I will probably refactor just a few other (preferable new) code in this PR, so it will not get bloated.
