### PR TITLE
[RDY] Remove more OOM error handling code

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1877,12 +1877,6 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
         break;
       if (round == 1) {
         *file = (char_u **)alloc((unsigned)(count * sizeof(char_u *)));
-        if (*file == NULL) {
-          vim_regfree(prog);
-          if (patc != pat)
-            vim_free(patc);
-          return FAIL;
-        }
       }
     }
     vim_regfree(prog);

--- a/src/charset.c
+++ b/src/charset.c
@@ -330,7 +330,7 @@ void trans_characters(char_u *buf, int bufsize)
 ///
 /// @param s
 ///
-/// @return translated string or NULL if out of memory.
+/// @return translated string
 char_u *transstr(char_u *s)
 {
   char_u *res;
@@ -371,26 +371,25 @@ char_u *transstr(char_u *s)
     res = alloc((unsigned)(vim_strsize(s) + 1));
   }
 
-  if (res != NULL) {
-    *res = NUL;
-    p = s;
+  *res = NUL;
+  p = s;
 
-    while (*p != NUL) {
-      if (has_mbyte && ((l = (*mb_ptr2len)(p)) > 1)) {
-        c = (*mb_ptr2char)(p);
+  while (*p != NUL) {
+    if (has_mbyte && ((l = (*mb_ptr2len)(p)) > 1)) {
+      c = (*mb_ptr2char)(p);
 
-        if (vim_isprintc(c)) {
-          // append printable multi-byte char
-          STRNCAT(res, p, l);
-        } else {
-          transchar_hex(res + STRLEN(res), c);
-        }
-        p += l;
+      if (vim_isprintc(c)) {
+        // append printable multi-byte char
+        STRNCAT(res, p, l);
       } else {
-        STRCAT(res, transchar_byte(*p++));
+        transchar_hex(res + STRLEN(res), c);
       }
+      p += l;
+    } else {
+      STRCAT(res, transchar_byte(*p++));
     }
   }
+
   return res;
 }
 

--- a/src/charset.c
+++ b/src/charset.c
@@ -423,9 +423,7 @@ char_u* str_foldcase(char_u *str, int orglen, char_u *buf, int buflen)
   if (buf == NULL) {
     ga_init(&ga, 1, 10);
 
-    if (ga_grow(&ga, len + 1) == FAIL) {
-      return NULL;
-    }
+    ga_grow(&ga, len + 1);
     memmove(ga.ga_data, str, (size_t)len);
     ga.ga_len = len;
   } else {
@@ -461,12 +459,14 @@ char_u* str_foldcase(char_u *str, int orglen, char_u *buf, int buflen)
           // characters forward or backward.
           if (olen != nlen) {
             if (nlen > olen) {
-              if ((buf == NULL)
-                  ? (ga_grow(&ga, nlen - olen + 1) == FAIL)
-                  : (len + nlen - olen >= buflen)) {
-                // out of memory, keep old char
-                lc = c;
-                nlen = olen;
+              if (buf == NULL) {
+                ga_grow(&ga, nlen - olen + 1);
+              } else {
+                if (len + nlen - olen >= buflen) {
+                  // out of memory, keep old char
+                  lc = c;
+                  nlen = olen;
+                }
               }
             }
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -266,10 +266,6 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1,
         && !diff_busy) {
       diff_T *dnext = diff_alloc_new(tp, dprev, dp);
 
-      if (dnext == NULL) {
-        return;
-      }
-
       dnext->df_lnum[idx] = line1;
       dnext->df_count[idx] = inserted;
       int i;
@@ -467,14 +463,14 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1,
 static diff_T* diff_alloc_new(tabpage_T *tp, diff_T *dprev, diff_T *dp)
 {
   diff_T *dnew = (diff_T *)alloc((unsigned)sizeof(diff_T));
-  if (dnew != NULL) {
-    dnew->df_next = dp;
-    if (dprev == NULL) {
-      tp->tp_first_diff = dnew;
-    } else {
-      dprev->df_next = dnew;
-    }
+
+  dnew->df_next = dp;
+  if (dprev == NULL) {
+    tp->tp_first_diff = dnew;
+  } else {
+    dprev->df_next = dnew;
   }
+
   return dnew;
 }
 
@@ -1372,9 +1368,6 @@ static void diff_read(int idx_orig, int idx_new, char_u *fname)
     } else {
       // Allocate a new diffblock.
       dp = diff_alloc_new(curtab, dprev, dp);
-      if (dp == NULL) {
-        goto done;
-      }
 
       dp->df_lnum[idx_orig] = lnum_orig;
       dp->df_count[idx_orig] = count_orig;

--- a/src/diff.c
+++ b/src/diff.c
@@ -1403,7 +1403,6 @@ static void diff_read(int idx_orig, int idx_new, char_u *fname)
     notset = TRUE;
   }
 
-done:
   fclose(fd);
 }
 

--- a/src/digraph.c
+++ b/src/digraph.c
@@ -1618,13 +1618,12 @@ void putdigraph(char_u *str)
 
     // Add a new digraph to the table.
     if (i == user_digraphs.ga_len) {
-      if (ga_grow(&user_digraphs, 1) == OK) {
-        dp = (digr_T *)user_digraphs.ga_data + user_digraphs.ga_len;
-        dp->char1 = char1;
-        dp->char2 = char2;
-        dp->result = n;
-        ++user_digraphs.ga_len;
-      }
+      ga_grow(&user_digraphs, 1);
+      dp = (digr_T *)user_digraphs.ga_data + user_digraphs.ga_len;
+      dp->char1 = char1;
+      dp->char2 = char2;
+      dp->result = n;
+      ++user_digraphs.ga_len;
     }
   }
 }
@@ -1809,9 +1808,8 @@ void ex_loadkeymap(exarg_T *eap)
 
     p = skipwhite(line);
 
-    if ((*p != '"')
-        && (*p != NUL)
-        && (ga_grow(&curbuf->b_kmap_ga, 1) == OK)) {
+    if ((*p != '"') && (*p != NUL)) {
+      ga_grow(&curbuf->b_kmap_ga, 1);
       kp = (kmap_T *)curbuf->b_kmap_ga.ga_data + curbuf->b_kmap_ga.ga_len;
       s = skiptowhite(p);
       kp->from = vim_strnsave(p, (int)(s - p));

--- a/src/edit.c
+++ b/src/edit.c
@@ -4345,8 +4345,6 @@ static int ins_complete(int c)
         /* we need up to 2 extra chars for the prefix */
         compl_pattern = alloc(quote_meta(NULL, line + compl_col,
                 compl_length) + 2);
-        if (compl_pattern == NULL)
-          return FAIL;
         if (!vim_iswordp(line + compl_col)
             || (compl_col > 0
                 && (
@@ -4392,16 +4390,12 @@ static int ins_complete(int c)
            * alloc(7) is enough  -- Acevedo
            */
           compl_pattern = alloc(7);
-          if (compl_pattern == NULL)
-            return FAIL;
           STRCPY((char *)compl_pattern, "\\<");
           (void)quote_meta(compl_pattern + 2, line + compl_col, 1);
           STRCAT((char *)compl_pattern, "\\k");
         } else {
           compl_pattern = alloc(quote_meta(NULL, line + compl_col,
                   compl_length) + 2);
-          if (compl_pattern == NULL)
-            return FAIL;
           STRCPY((char *)compl_pattern, "\\<");
           (void)quote_meta(compl_pattern + 2, line + compl_col,
               compl_length);

--- a/src/eval.c
+++ b/src/eval.c
@@ -1116,11 +1116,9 @@ void var_redir_str(char_u *value, int value_len)
   else
     len = value_len;                    /* Append only "value_len" characters */
 
-  if (ga_grow(&redir_ga, len) == OK) {
-    memmove((char *)redir_ga.ga_data + redir_ga.ga_len, value, len);
-    redir_ga.ga_len += len;
-  } else
-    var_redir_stop();
+  ga_grow(&redir_ga, len);
+  memmove((char *)redir_ga.ga_data + redir_ga.ga_len, value, len);
+  redir_ga.ga_len += len;
 }
 
 /*
@@ -5834,8 +5832,7 @@ list_join_inner (
    * multiple copy operations.  Add 2 for a tailing ']' and NUL. */
   if (join_gap->ga_len >= 2)
     sumlen += (int)STRLEN(sep) * (join_gap->ga_len - 1);
-  if (ga_grow(gap, sumlen + 2) == FAIL)
-    return FAIL;
+  ga_grow(gap, sumlen + 2);
 
   for (i = 0; i < join_gap->ga_len && !got_int; ++i) {
     if (first)
@@ -10813,13 +10810,10 @@ static void f_inputrestore(typval_T *argvars, typval_T *rettv)
 static void f_inputsave(typval_T *argvars, typval_T *rettv)
 {
   /* Add an entry to the stack of typeahead storage. */
-  if (ga_grow(&ga_userinput, 1) == OK) {
-    save_typeahead((tasave_T *)(ga_userinput.ga_data)
-        + ga_userinput.ga_len);
-    ++ga_userinput.ga_len;
-    /* default return is zero == OK */
-  } else
-    rettv->vval.v_number = 1;     /* Failed */
+  ga_grow(&ga_userinput, 1);
+  save_typeahead((tasave_T *)(ga_userinput.ga_data)
+          + ga_userinput.ga_len);
+  ++ga_userinput.ga_len;
 }
 
 /*
@@ -16537,7 +16531,8 @@ void new_script_vars(scid_T id)
   hashtab_T   *ht;
   scriptvar_T *sv;
 
-  if (ga_grow(&ga_scripts, (int)(id - ga_scripts.ga_len)) == OK) {
+  ga_grow(&ga_scripts, (int)(id - ga_scripts.ga_len));
+  {
     /* Re-allocating ga_data means that an ht_array pointing to
      * ht_smallarray becomes invalid.  We can recognize this: ht_mask is
      * at its init value.  Also reset "v_dict", it's always the same. */
@@ -17148,11 +17143,7 @@ void ex_execute(exarg_T *eap)
     if (!eap->skip) {
       p = get_tv_string(&rettv);
       len = (int)STRLEN(p);
-      if (ga_grow(&ga, len + 2) == FAIL) {
-        clear_tv(&rettv);
-        ret = FAIL;
-        break;
-      }
+      ga_grow(&ga, len + 2);
       if (ga.ga_len)
         ((char_u *)(ga.ga_data))[ga.ga_len++] = ' ';
       STRCPY((char_u *)(ga.ga_data) + ga.ga_len, p);
@@ -17440,8 +17431,7 @@ void ex_function(exarg_T *eap)
           EMSG2(_("E125: Illegal argument: %s"), arg);
         break;
       }
-      if (ga_grow(&newargs, 1) == FAIL)
-        goto erret;
+      ga_grow(&newargs, 1);
       c = *p;
       *p = NUL;
       arg = vim_strsave(arg);
@@ -17631,11 +17621,7 @@ void ex_function(exarg_T *eap)
     }
 
     /* Add the line to the function. */
-    if (ga_grow(&newlines, 1 + sourcing_lnum_off) == FAIL) {
-      if (line_arg == NULL)
-        vim_free(theline);
-      goto erret;
-    }
+    ga_grow(&newlines, 1 + sourcing_lnum_off);
 
     /* Copy the line to newly allocated memory.  get_one_sourceline()
      * allocates 250 bytes per line, this saves 80% on average.  The cost
@@ -18320,7 +18306,8 @@ script_autoload (
     ret = FALSE;            /* was loaded already */
   else {
     /* Remember the name if it wasn't loaded already. */
-    if (i == ga_loaded.ga_len && ga_grow(&ga_loaded, 1) == OK) {
+    if (i == ga_loaded.ga_len) {
+      ga_grow(&ga_loaded, 1);
       ((char_u **)ga_loaded.ga_data)[ga_loaded.ga_len++] = scriptname;
       tofree = NULL;
     }
@@ -19715,12 +19702,8 @@ char_u *do_string_sub(char_u *str, char_u *pat, char_u *sub, char_u *flags)
        * - The text after the match.
        */
       sublen = vim_regsub(&regmatch, sub, tail, FALSE, TRUE, FALSE);
-      if (ga_grow(&ga, (int)(STRLEN(tail) + sublen -
-                             (regmatch.endp[0] - regmatch.startp[0]))) ==
-          FAIL) {
-        ga_clear(&ga);
-        break;
-      }
+      ga_grow(&ga, (int)(STRLEN(tail) + sublen -
+                     (regmatch.endp[0] - regmatch.startp[0])));
 
       /* copy the text up to where the match is */
       i = (int)(regmatch.startp[0] - tail);

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5435,8 +5435,7 @@ void ex_helptags(exarg_T *eap)
           break;
       if (j == ga.ga_len) {
         /* New language, add it. */
-        if (ga_grow(&ga, 2) == FAIL)
-          break;
+        ga_grow(&ga, 2);
         ((char_u *)ga.ga_data)[ga.ga_len++] = lang[0];
         ((char_u *)ga.ga_data)[ga.ga_len++] = lang[1];
       }
@@ -5529,18 +5528,11 @@ helptags_one (
   ga_init(&ga, (int)sizeof(char_u *), 100);
   if (add_help_tags || path_full_compare((char_u *)"$VIMRUNTIME/doc",
           dir, FALSE) == kEqualFiles) {
-    if (ga_grow(&ga, 1) == FAIL)
-      got_int = TRUE;
-    else {
-      s = alloc(18 + (unsigned)STRLEN(tagfname));
-      if (s == NULL)
-        got_int = TRUE;
-      else {
-        sprintf((char *)s, "help-tags\t%s\t1\n", tagfname);
-        ((char_u **)ga.ga_data)[ga.ga_len] = s;
-        ++ga.ga_len;
-      }
-    }
+    ga_grow(&ga, 1);
+    s = alloc(18 + (unsigned)STRLEN(tagfname));
+    sprintf((char *)s, "help-tags\t%s\t1\n", tagfname);
+    ((char_u **)ga.ga_data)[ga.ga_len] = s;
+    ++ga.ga_len;
   }
 
   /*
@@ -5607,10 +5599,7 @@ helptags_one (
                   || s[1] == '\0')) {
             *p2 = '\0';
             ++p1;
-            if (ga_grow(&ga, 1) == FAIL) {
-              got_int = TRUE;
-              break;
-            }
+            ga_grow(&ga, 1);
             s = alloc((unsigned)(p2 - p1 + STRLEN(fname) + 2));
             if (s == NULL) {
               got_int = TRUE;

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -413,8 +413,8 @@ dbg_parsearg (
   struct debuggy *bp;
   int here = FALSE;
 
-  if (ga_grow(gap, 1) == FAIL)
-    return FAIL;
+  ga_grow(gap, 1);
+
   bp = &DEBUGGY(gap, gap->ga_len);
 
   /* Find "func" or "file". */
@@ -1543,10 +1543,7 @@ int get_arglist(garray_T *gap, char_u *str)
 {
   ga_init(gap, (int)sizeof(char_u *), 20);
   while (*str != NUL) {
-    if (ga_grow(gap, 1) == FAIL) {
-      ga_clear(gap);
-      return FAIL;
-    }
+    ga_grow(gap, 1);
     ((char_u **)gap->ga_data)[gap->ga_len++] = str;
 
     /* Isolate one argument, change it in-place, put a NUL after it. */
@@ -1771,15 +1768,15 @@ void ex_args(exarg_T *eap)
     /*
      * ":argslocal": make a local copy of the global argument list.
      */
-    if (ga_grow(gap, GARGCOUNT) == OK)
-      for (i = 0; i < GARGCOUNT; ++i)
-        if (GARGLIST[i].ae_fname != NULL) {
-          AARGLIST(curwin->w_alist)[gap->ga_len].ae_fname =
-            vim_strsave(GARGLIST[i].ae_fname);
-          AARGLIST(curwin->w_alist)[gap->ga_len].ae_fnum =
-            GARGLIST[i].ae_fnum;
-          ++gap->ga_len;
-        }
+    ga_grow(gap, GARGCOUNT);
+    for (i = 0; i < GARGCOUNT; ++i)
+      if (GARGLIST[i].ae_fname != NULL) {
+        AARGLIST(curwin->w_alist)[gap->ga_len].ae_fname =
+          vim_strsave(GARGLIST[i].ae_fname);
+        AARGLIST(curwin->w_alist)[gap->ga_len].ae_fnum =
+          GARGLIST[i].ae_fnum;
+        ++gap->ga_len;
+      }
   }
 }
 
@@ -2120,7 +2117,7 @@ void ex_listdo(exarg_T *eap)
  * Add files[count] to the arglist of the current window after arg "after".
  * The file names in files[count] must have been allocated and are taken over.
  * Files[] itself is not taken over.
- * Returns index of first added argument.  Returns -1 when failed (out of mem).
+ * Returns index of first added argument.
  */
 static int 
 alist_add_list (
@@ -2131,7 +2128,8 @@ alist_add_list (
 {
   int i;
 
-  if (ga_grow(&ALIST(curwin)->al_ga, count) == OK) {
+  ga_grow(&ALIST(curwin)->al_ga, count);
+  {
     if (after < 0)
       after = 0;
     if (after > ARGCOUNT)
@@ -2148,10 +2146,6 @@ alist_add_list (
       ++curwin->w_arg_idx;
     return after;
   }
-
-  for (i = 0; i < count; ++i)
-    vim_free(files[i]);
-  return -1;
 }
 
 
@@ -2661,9 +2655,7 @@ do_source (
   }
   if (current_SID == 0) {
     current_SID = ++last_current_SID;
-    if (ga_grow(&script_items, (int)(current_SID - script_items.ga_len))
-        == FAIL)
-      goto almosttheend;
+    ga_grow(&script_items, (int)(current_SID - script_items.ga_len));
     while (script_items.ga_len < current_SID) {
       ++script_items.ga_len;
       SCRIPT_ITEM(script_items.ga_len).sn_name = NULL;
@@ -2746,7 +2738,6 @@ do_source (
       && debug_break_level == ex_nesting_level)
     ++debug_break_level;
 
-almosttheend:
   current_SID = save_current_SID;
   restore_funccal(save_funccalp);
   if (do_profiling == PROF_YES)
@@ -2993,8 +2984,7 @@ static char_u *get_one_sourceline(struct source_cookie *sp)
   sourcing_lnum++;
   for (;; ) {
     /* make room to read at least 120 (more) characters */
-    if (ga_grow(&ga, 120) == FAIL)
-      break;
+    ga_grow(&ga, 120);
     buf = (char_u *)ga.ga_data;
 
 #ifdef USE_CR
@@ -3528,8 +3518,7 @@ static char_u **find_locales(void)
   loc = (char_u *)strtok((char *)locale_a, "\n");
 
   while (loc != NULL) {
-    if (ga_grow(&locales_ga, 1) == FAIL)
-      break;
+    ga_grow(&locales_ga, 1);
     loc = vim_strsave(loc);
     if (loc == NULL)
       break;
@@ -3538,10 +3527,7 @@ static char_u **find_locales(void)
     loc = (char_u *)strtok(NULL, "\n");
   }
   vim_free(locale_a);
-  if (ga_grow(&locales_ga, 1) == FAIL) {
-    ga_clear(&locales_ga);
-    return NULL;
-  }
+  ga_grow(&locales_ga, 1);
   ((char_u **)locales_ga.ga_data)[locales_ga.ga_len] = NULL;
   return (char_u **)locales_ga.ga_data;
 }

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1539,7 +1539,7 @@ static char_u *do_one_arg(char_u *str)
  * Separate the arguments in "str" and return a list of pointers in the
  * growarray "gap".
  */
-int get_arglist(garray_T *gap, char_u *str)
+void get_arglist(garray_T *gap, char_u *str)
 {
   ga_init(gap, (int)sizeof(char_u *), 20);
   while (*str != NUL) {
@@ -1549,7 +1549,6 @@ int get_arglist(garray_T *gap, char_u *str)
     /* Isolate one argument, change it in-place, put a NUL after it. */
     str = do_one_arg(str);
   }
-  return OK;
 }
 
 /*
@@ -1562,8 +1561,8 @@ int get_arglist_exp(char_u *str, int *fcountp, char_u ***fnamesp, int wig)
   garray_T ga;
   int i;
 
-  if (get_arglist(&ga, str) == FAIL)
-    return FAIL;
+  get_arglist(&ga, str);
+
   if (wig == TRUE)
     i = expand_wildcards(ga.ga_len, (char_u **)ga.ga_data,
         fcountp, fnamesp, EW_FILE|EW_NOTFOUND);
@@ -1600,8 +1599,7 @@ do_arglist (
   /*
    * Collect all file name arguments in "new_ga".
    */
-  if (get_arglist(&new_ga, str) == FAIL)
-    return FAIL;
+  get_arglist(&new_ga, str);
 
   if (what == AL_DEL) {
     regmatch_T regmatch;
@@ -1934,7 +1932,6 @@ void ex_argedit(exarg_T *eap)
       return;
     i = alist_add_list(1, &s,
         eap->addr_count > 0 ? (int)eap->line2 : curwin->w_arg_idx + 1);
-
     curwin->w_arg_idx = i;
   }
 

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1934,8 +1934,7 @@ void ex_argedit(exarg_T *eap)
       return;
     i = alist_add_list(1, &s,
         eap->addr_count > 0 ? (int)eap->line2 : curwin->w_arg_idx + 1);
-    if (i < 0)
-      return;
+
     curwin->w_arg_idx = i;
   }
 

--- a/src/ex_cmds2.h
+++ b/src/ex_cmds2.h
@@ -45,7 +45,7 @@ int can_abandon(buf_T *buf, int forceit);
 int check_changed_any(int hidden);
 int check_fname(void);
 int buf_write_all(buf_T *buf, int forceit);
-int get_arglist(garray_T *gap, char_u *str);
+void get_arglist(garray_T *gap, char_u *str);
 int get_arglist_exp(char_u *str, int *fcountp, char_u ***fnamesp,
                     int wig);
 void set_arglist(char_u *str);

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1,4 +1,4 @@
-/* vi:set ts=8 sts=4 sw=4:
+/* vi:set ts=2 sts=2 sw=2:
  *
  * VIM - Vi IMproved	by Bram Moolenaar
  *
@@ -1179,8 +1179,7 @@ static char_u *get_loop_line(int c, void *cookie, int indent)
  */
 static int store_loop_line(garray_T *gap, char_u *line)
 {
-  if (ga_grow(gap, 1) == FAIL)
-    return FAIL;
+  ga_grow(gap, 1);
   ((wcmd_T *)(gap->ga_data))[gap->ga_len].line = vim_strsave(line);
   ((wcmd_T *)(gap->ga_data))[gap->ga_len].lnum = sourcing_lnum;
   ++gap->ga_len;
@@ -4361,8 +4360,8 @@ static int uc_add_command(char_u *name, size_t name_len, char_u *rep, long argt,
 
   /* Extend the array unless we're replacing an existing command */
   if (cmp != 0) {
-    if (ga_grow(gap, 1) != OK)
-      goto fail;
+    ga_grow(gap, 1);
+
     if ((p = vim_strnsave(name, (int)name_len)) == NULL)
       goto fail;
 
@@ -5868,7 +5867,8 @@ void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum
   int i;
 
   alist_clear(al);
-  if (ga_grow(&al->al_ga, count) == OK) {
+  ga_grow(&al->al_ga, count);
+  {
     for (i = 0; i < count; ++i) {
       if (got_int) {
         /* When adding many buffers this can take a long time.  Allow
@@ -5887,8 +5887,8 @@ void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum
       ui_breakcheck();
     }
     vim_free(files);
-  } else
-    FreeWild(count, files);
+  }
+
   if (al == &global_alist)
     arg_had_last = FALSE;
 }

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1,4 +1,4 @@
-/* vi:set ts=8 sts=4 sw=4:
+/* vi:set ts=2 sts=2 sw=2:
  *
  * VIM - Vi IMproved	by Bram Moolenaar
  *
@@ -1807,8 +1807,7 @@ getexmodeline (
    */
   got_int = FALSE;
   while (!got_int) {
-    if (ga_grow(&line_ga, 40) == FAIL)
-      break;
+    ga_grow(&line_ga, 40);
 
     /* Get one character at a time.  Don't use inchar(), it can't handle
      * special characters. */
@@ -3999,9 +3998,8 @@ expand_shellcmd (
     /* Expand matches in one directory of $PATH. */
     ret = expand_wildcards(1, &buf, num_file, file, flags);
     if (ret == OK) {
-      if (ga_grow(&ga, *num_file) == FAIL)
-        FreeWild(*num_file, *file);
-      else {
+      ga_grow(&ga, *num_file);
+      {
         for (i = 0; i < *num_file; ++i) {
           s = (*file)[i];
           if (STRLEN(s) > l) {
@@ -4111,8 +4109,7 @@ static int ExpandUserDefined(expand_T *xp, regmatch_T *regmatch, int *num_file, 
       continue;
     }
 
-    if (ga_grow(&ga, 1) == FAIL)
-      break;
+    ga_grow(&ga, 1);
 
     ((char_u **)ga.ga_data)[ga.ga_len] = vim_strnsave(s, (int)(e - s));
     ++ga.ga_len;
@@ -4146,8 +4143,7 @@ static int ExpandUserList(expand_T *xp, int *num_file, char_u ***file)
     if (li->li_tv.v_type != VAR_STRING || li->li_tv.vval.v_string == NULL)
       continue;        /* Skip non-string items and empty strings */
 
-    if (ga_grow(&ga, 1) == FAIL)
-      break;
+    ga_grow(&ga, 1);
 
     ((char_u **)ga.ga_data)[ga.ga_len] =
       vim_strsave(li->li_tv.vval.v_string);
@@ -4195,8 +4191,7 @@ static int ExpandRTDir(char_u *pat, int *num_file, char_u ***file, char *dirname
       e = vim_strchr(s, '\n');
       if (e == NULL)
         e = s + STRLEN(s);
-      if (ga_grow(&ga, 1) == FAIL)
-        break;
+      ga_grow(&ga, 1);
       if (e - 4 > s && STRNICMP(e - 4, ".vim", 4) == 0) {
         for (s = e - 4; s > matches; mb_ptr_back(matches, s))
           if (*s == '\n' || vim_ispathsep(*s))
@@ -4263,15 +4258,15 @@ char_u *globpath(char_u *path, char_u *file, int expand_options)
           len += (int)STRLEN(p[i]) + 1;
 
         /* Concatenate new results to previous ones. */
-        if (ga_grow(&ga, len) == OK) {
-          cur = (char_u *)ga.ga_data + ga.ga_len;
-          for (i = 0; i < num_p; ++i) {
-            STRCPY(cur, p[i]);
-            cur += STRLEN(p[i]);
-            *cur++ = '\n';
-          }
-          ga.ga_len += len;
+        ga_grow(&ga, len);
+        cur = (char_u *)ga.ga_data + ga.ga_len;
+        for (i = 0; i < num_p; ++i) {
+          STRCPY(cur, p[i]);
+          cur += STRLEN(p[i]);
+          *cur++ = '\n';
         }
+        ga.ga_len += len;
+
         FreeWild(num_p, p);
       }
     }

--- a/src/file_search.c
+++ b/src/file_search.c
@@ -280,8 +280,6 @@ vim_findfile_init (
     search_ctx = search_ctx_arg;
   else {
     search_ctx = (ff_search_ctx_T*)alloc((unsigned)sizeof(ff_search_ctx_T));
-    if (search_ctx == NULL)
-      goto error_return;
     memset(search_ctx, 0, sizeof(ff_search_ctx_T));
   }
   search_ctx->ffsc_find_what = find_what;
@@ -309,8 +307,6 @@ vim_findfile_init (
 
   if (ff_expand_buffer == NULL) {
     ff_expand_buffer = (char_u*)alloc(MAXPATHL);
-    if (ff_expand_buffer == NULL)
-      goto error_return;
   }
 
   /* Store information on starting dir now if path is relative.
@@ -382,32 +378,30 @@ vim_findfile_init (
     search_ctx->ffsc_stopdirs_v =
       (char_u **)alloc((unsigned)sizeof(char_u *));
 
-    if (search_ctx->ffsc_stopdirs_v != NULL) {
-      do {
-        char_u  *helper;
-        void    *ptr;
+    do {
+      char_u  *helper;
+      void    *ptr;
 
-        helper = walker;
-        ptr = xrealloc(search_ctx->ffsc_stopdirs_v,
-            (dircount + 1) * sizeof(char_u *));
-        search_ctx->ffsc_stopdirs_v = ptr;
-        walker = vim_strchr(walker, ';');
-        if (walker) {
-          search_ctx->ffsc_stopdirs_v[dircount-1] =
-            vim_strnsave(helper, (int)(walker - helper));
-          walker++;
-        } else
-          /* this might be "", which means ascent till top
-           * of directory tree.
-           */
-          search_ctx->ffsc_stopdirs_v[dircount-1] =
-            vim_strsave(helper);
+      helper = walker;
+      ptr = xrealloc(search_ctx->ffsc_stopdirs_v,
+          (dircount + 1) * sizeof(char_u *));
+      search_ctx->ffsc_stopdirs_v = ptr;
+      walker = vim_strchr(walker, ';');
+      if (walker) {
+        search_ctx->ffsc_stopdirs_v[dircount-1] =
+          vim_strnsave(helper, (int)(walker - helper));
+        walker++;
+      } else
+        /* this might be "", which means ascent till top
+         * of directory tree.
+         */
+        search_ctx->ffsc_stopdirs_v[dircount-1] =
+          vim_strsave(helper);
 
-        dircount++;
+      dircount++;
 
-      } while (walker != NULL);
-      search_ctx->ffsc_stopdirs_v[dircount-1] = NULL;
-    }
+    } while (walker != NULL);
+    search_ctx->ffsc_stopdirs_v[dircount-1] = NULL;
   }
 
   search_ctx->ffsc_level = level;
@@ -1074,8 +1068,6 @@ static ff_visited_list_hdr_T *ff_get_visited_list(char_u *filename, ff_visited_l
    * if we reach this we didn't find a list and we have to allocate new list
    */
   retptr = (ff_visited_list_hdr_T*)alloc((unsigned)sizeof(*retptr));
-  if (retptr == NULL)
-    return NULL;
 
   retptr->ffvl_visited_list = NULL;
   retptr->ffvl_filename = vim_strsave(filename);
@@ -1212,8 +1204,6 @@ static ff_stack_T *ff_create_stack_element(char_u *fix_part, char_u *wc_part, in
   ff_stack_T  *new;
 
   new = (ff_stack_T *)alloc((unsigned)sizeof(ff_stack_T));
-  if (new == NULL)
-    return NULL;
 
   new->ffs_prev          = NULL;
   new->ffs_filearray     = NULL;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1,4 +1,4 @@
-/* vi:set ts=8 sts=4 sw=4:
+/* vi:set ts=2 sts=2 sw=2:
  *
  * VIM - Vi IMproved	by Bram Moolenaar
  *
@@ -6216,8 +6216,9 @@ static int au_new_group(char_u *name)
     for (i = 0; i < augroups.ga_len; ++i)
       if (AUGROUP_NAME(i) == NULL)
         break;
-    if (i == augroups.ga_len && ga_grow(&augroups, 1) == FAIL)
-      return AUGROUP_ERROR;
+    if (i == augroups.ga_len) {
+      ga_grow(&augroups, 1);
+    }
 
     AUGROUP_NAME(i) = vim_strsave(name);
     if (AUGROUP_NAME(i) == NULL)

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4739,8 +4739,6 @@ buf_modname (
    */
   if (fname == NULL || *fname == NUL) {
     retval = alloc((unsigned)(MAXPATHL + extlen + 3));
-    if (retval == NULL)
-      return NULL;
     if (os_dirname(retval, MAXPATHL) == FAIL ||
         (fnamelen = (int)STRLEN(retval)) == 0) {
       vim_free(retval);
@@ -4756,8 +4754,6 @@ buf_modname (
   } else {
     fnamelen = (int)STRLEN(fname);
     retval = alloc((unsigned)(fnamelen + extlen + 3));
-    if (retval == NULL)
-      return NULL;
     STRCPY(retval, fname);
   }
 
@@ -6772,8 +6768,6 @@ static int do_autocmd_event(event_T event, char_u *pat, int nested, char_u *cmd,
         }
 
         ap = (AutoPat *)alloc((unsigned)sizeof(AutoPat));
-        if (ap == NULL)
-          return FAIL;
         ap->pat = vim_strnsave(pat, patlen);
         ap->patlen = patlen;
         if (ap->pat == NULL) {
@@ -6815,8 +6809,6 @@ static int do_autocmd_event(event_T event, char_u *pat, int nested, char_u *cmd,
       while ((ac = *prev_ac) != NULL)
         prev_ac = &ac->next;
       ac = (AutoCmd *)alloc((unsigned)sizeof(AutoCmd));
-      if (ac == NULL)
-        return FAIL;
       ac->cmd = vim_strsave(cmd);
       ac->scriptID = current_SID;
       if (ac->cmd == NULL) {

--- a/src/fold.c
+++ b/src/fold.c
@@ -1891,7 +1891,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *gap, int level,
                                       linenr_T startlnum, fline_T *flp,
                                       void (*getlevel)(fline_T *), linenr_T bot,
                                       int topflags);
-static int foldInsert(garray_T *gap, int i);
+static void foldInsert(garray_T *gap, int i);
 static void foldSplit(garray_T *gap, int i, linenr_T top, linenr_T bot);
 static void foldRemove(garray_T *gap, linenr_T top, linenr_T bot);
 static void foldMerge(fold_T *fp1, garray_T *gap, fold_T *fp2);
@@ -2324,8 +2324,7 @@ int topflags;                   /* flags used by containing fold */
           /* Insert new fold.  Careful: ga_data may be NULL and it
            * may change! */
           i = (int)(fp - (fold_T *)gap->ga_data);
-          if (foldInsert(gap, i) != OK)
-            return bot;
+          foldInsert(gap, i);
           fp = (fold_T *)gap->ga_data + i;
           /* The new fold continues until bot, unless we find the
            * end earlier. */
@@ -2508,9 +2507,8 @@ int topflags;                   /* flags used by containing fold */
 /* foldInsert() {{{2 */
 /*
  * Insert a new fold in "gap" at position "i".
- * Returns OK for success, FAIL for failure.
  */
-static int foldInsert(garray_T *gap, int i)
+static void foldInsert(garray_T *gap, int i)
 {
   fold_T      *fp;
 
@@ -2521,7 +2519,6 @@ static int foldInsert(garray_T *gap, int i)
     memmove(fp + 1, fp, sizeof(fold_T) * (gap->ga_len - i));
   ++gap->ga_len;
   ga_init(&fp->fd_nested, (int)sizeof(fold_T), 10);
-  return OK;
 }
 
 /* foldSplit() {{{2 */
@@ -2542,8 +2539,8 @@ static void foldSplit(garray_T *gap, int i, linenr_T top, linenr_T bot)
   int len;
 
   /* The fold continues below bot, need to split it. */
-  if (foldInsert(gap, i + 1) == FAIL)
-    return;
+  foldInsert(gap, i + 1);
+
   fp = (fold_T *)gap->ga_data + i;
   fp[1].fd_top = bot + 1;
   fp[1].fd_len = fp->fd_len - (fp[1].fd_top - fp->fd_top);

--- a/src/fold.c
+++ b/src/fold.c
@@ -1,4 +1,4 @@
-/* vim:set ts=8 sts=4 sw=4:
+/* vim:set ts=2 sts=2 sw=2:
  * vim600:fdm=marker fdl=1 fdc=3:
  *
  * VIM - Vi IMproved	by Bram Moolenaar
@@ -606,7 +606,8 @@ void foldCreate(linenr_T start, linenr_T end)
   }
 
   i = (int)(fp - (fold_T *)gap->ga_data);
-  if (ga_grow(gap, 1) == OK) {
+  ga_grow(gap, 1);
+  {
     fp = (fold_T *)gap->ga_data + i;
     ga_init(&fold_ga, (int)sizeof(fold_T), 10);
 
@@ -614,7 +615,8 @@ void foldCreate(linenr_T start, linenr_T end)
     for (cont = 0; i + cont < gap->ga_len; ++cont)
       if (fp[cont].fd_top > end_rel)
         break;
-    if (cont > 0 && ga_grow(&fold_ga, cont) == OK) {
+    if (cont > 0) {
+      ga_grow(&fold_ga, cont);
       /* If the first fold starts before the new fold, let the new fold
        * start there.  Otherwise the existing fold would change. */
       if (start_rel > fp->fd_top)
@@ -659,6 +661,7 @@ void foldCreate(linenr_T start, linenr_T end)
     changed_window_setting();
   }
 }
+
 
 /* deleteFold() {{{2 */
 /*
@@ -1001,8 +1004,6 @@ void foldAdjustCursor(void)
 /* cloneFoldGrowArray() {{{2 */
 /*
  * Will "clone" (i.e deep copy) a garray_T of folds.
- *
- * Return FAIL if the operation cannot be completed, otherwise OK.
  */
 void cloneFoldGrowArray(garray_T *from, garray_T *to)
 {
@@ -1011,8 +1012,11 @@ void cloneFoldGrowArray(garray_T *from, garray_T *to)
   fold_T      *to_p;
 
   ga_init(to, from->ga_itemsize, from->ga_growsize);
-  if (from->ga_len == 0 || ga_grow(to, from->ga_len) == FAIL)
+
+  if (from->ga_len == 0)
     return;
+
+  ga_grow(to, from->ga_len);
 
   from_p = (fold_T *)from->ga_data;
   to_p = (fold_T *)to->ga_data;
@@ -1308,7 +1312,8 @@ static void deleteFoldEntry(garray_T *gap, int idx, int recursive)
     /* Move nested folds one level up, to overwrite the fold that is
      * deleted. */
     moved = fp->fd_nested.ga_len;
-    if (ga_grow(gap, (int)(moved - 1)) == OK) {
+    ga_grow(gap, (int)(moved - 1));
+    {
       /* Get "fp" again, the array may have been reallocated. */
       fp = (fold_T *)gap->ga_data + idx;
 
@@ -2509,8 +2514,8 @@ static int foldInsert(garray_T *gap, int i)
 {
   fold_T      *fp;
 
-  if (ga_grow(gap, 1) != OK)
-    return FAIL;
+  ga_grow(gap, 1);
+
   fp = (fold_T *)gap->ga_data + i;
   if (i < gap->ga_len)
     memmove(fp + 1, fp, sizeof(fold_T) * (gap->ga_len - i));
@@ -2552,7 +2557,8 @@ static void foldSplit(garray_T *gap, int i, linenr_T top, linenr_T bot)
   gap2 = &fp[1].fd_nested;
   (void)(foldFind(gap1, bot + 1 - fp->fd_top, &fp2));
   len = (int)((fold_T *)gap1->ga_data + gap1->ga_len - fp2);
-  if (len > 0 && ga_grow(gap2, len) == OK) {
+  if (len > 0) {
+    ga_grow(gap2, len);
     for (idx = 0; idx < len; ++idx) {
       ((fold_T *)gap2->ga_data)[idx] = fp2[idx];
       ((fold_T *)gap2->ga_data)[idx].fd_top
@@ -2652,7 +2658,8 @@ static void foldMerge(fold_T *fp1, garray_T *gap, fold_T *fp2)
     foldMerge(fp3, gap2, fp4);
 
   /* Move nested folds in fp2 to the end of fp1. */
-  if (gap2->ga_len > 0 && ga_grow(gap1, gap2->ga_len) == OK) {
+  if (gap2->ga_len > 0) {
+    ga_grow(gap1, gap2->ga_len);
     for (idx = 0; idx < gap2->ga_len; ++idx) {
       ((fold_T *)gap1->ga_data)[gap1->ga_len]
         = ((fold_T *)gap2->ga_data)[idx];

--- a/src/garray.c
+++ b/src/garray.c
@@ -55,9 +55,7 @@ void ga_init(garray_T *gap, int itemsize, int growsize)
 ///
 /// @param gap
 /// @param n
-///
-/// @return FAIL for failure, OK otherwise.
-int ga_grow(garray_T *gap, int n)
+void ga_grow(garray_T *gap, int n)
 {
   size_t old_len;
   size_t new_len;
@@ -72,15 +70,11 @@ int ga_grow(garray_T *gap, int n)
          ? alloc((unsigned)new_len)
          : xrealloc(gap->ga_data, new_len);
 
-    if (pp == NULL) {
-      return FAIL;
-    }
     old_len = gap->ga_itemsize * gap->ga_maxlen;
     memset(pp + old_len, 0, new_len - old_len);
     gap->ga_maxlen = gap->ga_len + n;
     gap->ga_data = pp;
   }
-  return OK;
 }
 
 /// Sort "gap" and remove duplicate entries.  "gap" is expected to contain a
@@ -140,10 +134,9 @@ char_u* ga_concat_strings(garray_T *gap)
 void ga_concat(garray_T *gap, char_u *s)
 {
   int len = (int)STRLEN(s);
-  if (ga_grow(gap, len) == OK) {
-    memmove((char *)gap->ga_data + gap->ga_len, s, (size_t)len);
-    gap->ga_len += len;
-  }
+  ga_grow(gap, len);
+  memmove((char *)gap->ga_data + gap->ga_len, s, (size_t)len);
+  gap->ga_len += len;
 }
 
 /// Append one byte to a growarray which contains bytes.
@@ -152,10 +145,9 @@ void ga_concat(garray_T *gap, char_u *s)
 /// @param c
 void ga_append(garray_T *gap, int c)
 {
-  if (ga_grow(gap, 1) == OK) {
-    *((char *) gap->ga_data + gap->ga_len) = c;
-    ++gap->ga_len;
-  }
+  ga_grow(gap, 1);
+  *((char *) gap->ga_data + gap->ga_len) = c;
+  ++gap->ga_len;
 }
 
 #if defined(UNIX) || defined(WIN3264)

--- a/src/garray.h
+++ b/src/garray.h
@@ -17,7 +17,7 @@ typedef struct growarray {
 void ga_clear(garray_T *gap);
 void ga_clear_strings(garray_T *gap);
 void ga_init(garray_T *gap, int itemsize, int growsize);
-int ga_grow(garray_T *gap, int n);
+void ga_grow(garray_T *gap, int n);
 char_u *ga_concat_strings(garray_T *gap);
 void ga_remove_duplicate_strings(garray_T *gap);
 void ga_concat(garray_T *gap, char_u *s);

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -1596,8 +1596,6 @@ static int prt_find_resource(char *name, struct prt_ps_resource_S *resource)
   int retval;
 
   buffer = alloc(MAXPATHL + 1);
-  if (buffer == NULL)
-    return FALSE;
 
   vim_strncpy(resource->name, (char_u *)name, 63);
   /* Look for named resource file in runtimepath */

--- a/src/main.c
+++ b/src/main.c
@@ -1426,8 +1426,8 @@ scripterror:
 
 
       /* Add the file to the global argument list. */
-      if (ga_grow(&global_alist.al_ga, 1) == FAIL
-          || (p = vim_strsave((char_u *)argv[0])) == NULL)
+      ga_grow(&global_alist.al_ga, 1);
+      if ((p = vim_strsave((char_u *)argv[0])) == NULL)
         mch_exit(2);
       if (parmp->diff_mode && os_isdir(p) && GARGCOUNT > 0
           && !os_isdir(alist_name(&GARGLIST[0]))) {

--- a/src/menu.c
+++ b/src/menu.c
@@ -1512,26 +1512,25 @@ void ex_menutranslate(exarg_T *eap)
     if (arg == to)
       EMSG(_(e_invarg));
     else {
-      if (ga_grow(&menutrans_ga, 1) == OK) {
-        tp = (menutrans_T *)menutrans_ga.ga_data;
-        from = vim_strsave(from);
-        if (from != NULL) {
-          from_noamp = menu_text(from, NULL, NULL);
-          to = vim_strnsave(to, (int)(arg - to));
-          if (from_noamp != NULL && to != NULL) {
-            menu_translate_tab_and_shift(from);
-            menu_translate_tab_and_shift(to);
-            menu_unescape_name(from);
-            menu_unescape_name(to);
-            tp[menutrans_ga.ga_len].from = from;
-            tp[menutrans_ga.ga_len].from_noamp = from_noamp;
-            tp[menutrans_ga.ga_len].to = to;
-            ++menutrans_ga.ga_len;
-          } else {
-            vim_free(from);
-            vim_free(from_noamp);
-            vim_free(to);
-          }
+      ga_grow(&menutrans_ga, 1);
+      tp = (menutrans_T *)menutrans_ga.ga_data;
+      from = vim_strsave(from);
+      if (from != NULL) {
+        from_noamp = menu_text(from, NULL, NULL);
+        to = vim_strnsave(to, (int)(arg - to));
+        if (from_noamp != NULL && to != NULL) {
+          menu_translate_tab_and_shift(from);
+          menu_translate_tab_and_shift(to);
+          menu_unescape_name(from);
+          menu_unescape_name(to);
+          tp[menutrans_ga.ga_len].from = from;
+          tp[menutrans_ga.ga_len].from_noamp = from_noamp;
+          tp[menutrans_ga.ga_len].to = to;
+          ++menutrans_ga.ga_len;
+        } else {
+          vim_free(from);
+          vim_free(from_noamp);
+          vim_free(to);
         }
       }
     }

--- a/src/message.c
+++ b/src/message.c
@@ -2293,26 +2293,25 @@ void mch_errmsg(char *str)
     error_ga.ga_growsize = 80;
     error_ga.ga_itemsize = 1;
   }
-  if (ga_grow(&error_ga, len) == OK) {
-    memmove((char_u *)error_ga.ga_data + error_ga.ga_len,
-        (char_u *)str, len);
+  ga_grow(&error_ga, len);
+  memmove((char_u *)error_ga.ga_data + error_ga.ga_len,
+      (char_u *)str, len);
 #ifdef UNIX
-    /* remove CR characters, they are displayed */
-    {
-      char_u      *p;
+  /* remove CR characters, they are displayed */
+  {
+    char_u      *p;
 
-      p = (char_u *)error_ga.ga_data + error_ga.ga_len;
-      for (;; ) {
-        p = vim_strchr(p, '\r');
-        if (p == NULL)
-          break;
-        *p = ' ';
-      }
+    p = (char_u *)error_ga.ga_data + error_ga.ga_len;
+    for (;; ) {
+      p = vim_strchr(p, '\r');
+      if (p == NULL)
+        break;
+      *p = ' ';
     }
-#endif
-    --len;              /* don't count the NUL at the end */
-    error_ga.ga_len += len;
   }
+#endif
+  --len;              /* don't count the NUL at the end */
+  error_ga.ga_len += len;
 }
 
 /*

--- a/src/message.c
+++ b/src/message.c
@@ -2941,12 +2941,8 @@ static char_u *msg_show_console_dialog(char_u *message, char_u *buttons, int dfl
        */
       vim_free(confirm_msg);
       confirm_msg = alloc(len);
-      if (confirm_msg == NULL)
-        return NULL;
       *confirm_msg = NUL;
       hotk = alloc(lenhotkey);
-      if (hotk == NULL)
-        return NULL;
 
       *confirm_msg = '\n';
       STRCPY(confirm_msg + 1, message);

--- a/src/option.c
+++ b/src/option.c
@@ -2001,14 +2001,13 @@ void set_init_1(void)
       if (p != NULL && *p != NUL) {
         /* First time count the NUL, otherwise count the ','. */
         len = (int)STRLEN(p) + 3;
-        if (ga_grow(&ga, len) == OK) {
-          if (ga.ga_len > 0)
-            STRCAT(ga.ga_data, ",");
-          STRCAT(ga.ga_data, p);
-          add_pathsep(ga.ga_data);
-          STRCAT(ga.ga_data, "*");
-          ga.ga_len += len;
-        }
+        ga_grow(&ga, len);
+        if (ga.ga_len > 0)
+          STRCAT(ga.ga_data, ",");
+        STRCAT(ga.ga_data, p);
+        add_pathsep(ga.ga_data);
+        STRCAT(ga.ga_data, "*");
+        ga.ga_len += len;
       }
       if (mustfree)
         vim_free(p);
@@ -7653,8 +7652,7 @@ static void langmap_set_entry(int from, int to)
       b = i;
   }
 
-  if (ga_grow(&langmap_mapga, 1) != OK)
-    return;      /* out of memory */
+  ga_grow(&langmap_mapga, 1);
 
   /* insert new entry at position "a" */
   entries = (langmap_entry_T *)(langmap_mapga.ga_data) + a;

--- a/src/os/users.c
+++ b/src/os/users.c
@@ -26,9 +26,7 @@ int os_get_usernames(garray_T *users)
   while ((pw = getpwent()) != NULL) {
     // pw->pw_name shouldn't be NULL but just in case...
     if (pw->pw_name != NULL) {
-      if (ga_grow(users, 1) == FAIL) {
-        return FAIL;
-      }
+      ga_grow(users, 1);
       user = (char *)vim_strsave((char_u*)pw->pw_name);
       if (user == NULL) {
         return FAIL;

--- a/src/path.c
+++ b/src/path.c
@@ -665,9 +665,7 @@ static void expand_path_option(char_u *curdir, garray_T *gap)
       simplify_filename(buf);
     }
 
-    if (ga_grow(gap, 1) == FAIL)
-      break;
-
+    ga_grow(gap, 1);
 
     p = vim_strsave(buf);
     if (p == NULL)
@@ -1231,8 +1229,7 @@ addfile (
     return;
 
   /* Make room for another item in the file list. */
-  if (ga_grow(gap, 1) == FAIL)
-    return;
+  ga_grow(gap, 1);
 
   p = alloc((unsigned)(STRLEN(f) + 1 + isdir));
 

--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -344,35 +344,34 @@ void pum_redraw(void)
             *p = saved;
 
             if (curwin->w_p_rl) {
-              if (st != NULL) {
-                char_u  *rt = reverse_text(st);
+              char_u  *rt = reverse_text(st);
 
-                if (rt != NULL) {
-                  char_u *rt_start = rt;
-                  int size;
+              if (rt != NULL) {
+                char_u *rt_start = rt;
+                int size;
 
-                  size = vim_strsize(rt);
+                size = vim_strsize(rt);
 
-                  if (size > pum_width) {
-                    do {
-                      size -= has_mbyte ? (*mb_ptr2cells)(rt) : 1;
-                      mb_ptr_adv(rt);
-                    } while (size > pum_width);
+                if (size > pum_width) {
+                  do {
+                    size -= has_mbyte ? (*mb_ptr2cells)(rt) : 1;
+                    mb_ptr_adv(rt);
+                  } while (size > pum_width);
 
-                    if (size < pum_width) {
-                      // Most left character requires 2-cells but only 1 cell
-                      // is available on screen.  Put a '<' on the left of the 
-                      // pum item
-                      *(--rt) = '<';
-                      size++;
-                    }
+                  if (size < pum_width) {
+                    // Most left character requires 2-cells but only 1 cell
+                    // is available on screen.  Put a '<' on the left of the 
+                    // pum item
+                    *(--rt) = '<';
+                    size++;
                   }
-                  screen_puts_len(rt, (int)STRLEN(rt), row, col - size + 1,
-                                  attr);
-                  vim_free(rt_start);
                 }
-                vim_free(st);
+                screen_puts_len(rt, (int)STRLEN(rt), row, col - size + 1,
+                                attr);
+                vim_free(rt_start);
               }
+              vim_free(st);
+
               col -= width;
             } else {
               if (st != NULL) {

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -4285,14 +4285,11 @@ regmatch (
               break;
           if (i == backpos.ga_len) {
             /* First time at this BACK, make room to store the pos. */
-            if (ga_grow(&backpos, 1) == FAIL)
-              status = RA_FAIL;
-            else {
-              /* get "ga_data" again, it may have changed */
-              bp = (backpos_T *)backpos.ga_data;
-              bp[i].bp_scan = scan;
-              ++backpos.ga_len;
-            }
+            ga_grow(&backpos, 1);
+            /* get "ga_data" again, it may have changed */
+            bp = (backpos_T *)backpos.ga_data;
+            bp[i].bp_scan = scan;
+            ++backpos.ga_len;
           } else if (reg_save_equal(&bp[i].bp_pos))
             /* Still at same position as last time, fail. */
             status = RA_NOMATCH;
@@ -4632,9 +4629,8 @@ regmatch (
             if ((long)((unsigned)regstack.ga_len >> 10) >= p_mmp) {
               EMSG(_(e_maxmempat));
               status = RA_FAIL;
-            } else if (ga_grow(&regstack, sizeof(regstar_T)) == FAIL)
-              status = RA_FAIL;
-            else {
+            } else {
+              ga_grow(&regstack, sizeof(regstar_T));
               regstack.ga_len += sizeof(regstar_T);
               rp = regstack_push(rst.minval <= rst.maxval
                   ? RS_STAR_LONG : RS_STAR_SHORT, scan);
@@ -4671,9 +4667,8 @@ regmatch (
           if ((long)((unsigned)regstack.ga_len >> 10) >= p_mmp) {
             EMSG(_(e_maxmempat));
             status = RA_FAIL;
-          } else if (ga_grow(&regstack, sizeof(regbehind_T)) == FAIL)
-            status = RA_FAIL;
-          else {
+          } else {
+            ga_grow(&regstack, sizeof(regbehind_T));
             regstack.ga_len += sizeof(regbehind_T);
             rp = regstack_push(RS_BEHIND1, scan);
             if (rp == NULL)
@@ -5094,8 +5089,7 @@ static regitem_T *regstack_push(regstate_T state, char_u *scan)
     EMSG(_(e_maxmempat));
     return NULL;
   }
-  if (ga_grow(&regstack, sizeof(regitem_T)) == FAIL)
-    return NULL;
+  ga_grow(&regstack, sizeof(regitem_T));
 
   rp = (regitem_T *)((char *)regstack.ga_data + regstack.ga_len);
   rp->rs_state = state;

--- a/src/screen.c
+++ b/src/screen.c
@@ -5163,10 +5163,8 @@ win_redr_custom (
 
   /* Make all characters printable. */
   p = transstr(buf);
-  if (p != NULL) {
-    vim_strncpy(buf, p, sizeof(buf) - 1);
-    vim_free(p);
-  }
+  vim_strncpy(buf, p, sizeof(buf) - 1);
+  vim_free(p);
 
   /* fill up with "fillchar" */
   len = (int)STRLEN(buf);

--- a/src/tag.c
+++ b/src/tag.c
@@ -1812,7 +1812,8 @@ parse_line:
            * Store the info we need later, which depends on the kind of
            * tags we are dealing with.
            */
-          if (ga_grow(&ga_match[mtt], 1) == OK) {
+          ga_grow(&ga_match[mtt], 1);
+          {
             int len;
 
             if (help_only) {
@@ -1922,10 +1923,6 @@ parse_line:
               } else
                 vim_free(mfp);
             }
-          } else {    /* Out of memory! Just forget about the rest. */
-            retval = OK;
-            stop_searching = TRUE;
-            break;
           }
         }
         if (use_cscope && eof)
@@ -2035,9 +2032,8 @@ static void found_tagfile_cb(char_u *fname, void *cookie);
  */
 static void found_tagfile_cb(char_u *fname, void *cookie)
 {
-  if (ga_grow(&tag_fnames, 1) == OK)
-    ((char_u **)(tag_fnames.ga_data))[tag_fnames.ga_len++] =
-      vim_strsave(fname);
+  ga_grow(&tag_fnames, 1);
+  ((char_u **)(tag_fnames.ga_data))[tag_fnames.ga_len++] = vim_strsave(fname);
 }
 
 #if defined(EXITFREE) || defined(PROTO)

--- a/src/undo.c
+++ b/src/undo.c
@@ -1,4 +1,4 @@
-/* vi:set ts=8 sts=4 sw=4:
+/* vi:set ts=2 sts=2 sw=2:
  *
  * VIM - Vi IMproved	by Bram Moolenaar
  *
@@ -2383,8 +2383,7 @@ void ex_undolist(exarg_T *eap)
   while (uhp != NULL) {
     if (uhp->uh_prev.ptr == NULL && uhp->uh_walk != nomark
         && uhp->uh_walk != mark) {
-      if (ga_grow(&ga, 1) == FAIL)
-        break;
+      ga_grow(&ga, 1);
       vim_snprintf((char *)IObuff, IOSIZE, "%6ld %7ld  ",
           uhp->uh_seq, changes);
       u_add_time(IObuff + STRLEN(IObuff), IOSIZE - STRLEN(IObuff),

--- a/src/window.c
+++ b/src/window.c
@@ -1,4 +1,4 @@
-/* vi:set ts=8 sts=4 sw=4:
+/* vi:set ts=2 sts=2 sw=2:
  *
  * VIM - Vi IMproved	by Bram Moolenaar
  *
@@ -3866,12 +3866,12 @@ void win_size_save(garray_T *gap)
   win_T       *wp;
 
   ga_init(gap, (int)sizeof(int), 1);
-  if (ga_grow(gap, win_count() * 2) == OK)
-    for (wp = firstwin; wp != NULL; wp = wp->w_next) {
-      ((int *)gap->ga_data)[gap->ga_len++] =
-        wp->w_width + wp->w_vsep_width;
-      ((int *)gap->ga_data)[gap->ga_len++] = wp->w_height;
-    }
+  ga_grow(gap, win_count() * 2);
+  for (wp = firstwin; wp != NULL; wp = wp->w_next) {
+    ((int *)gap->ga_data)[gap->ga_len++] =
+      wp->w_width + wp->w_vsep_width;
+    ((int *)gap->ga_data)[gap->ga_len++] = wp->w_height;
+  }
 }
 
 /*


### PR DESCRIPTION
- Removed code from more functions that cal any of `*alloc()`
  - ExpandBufnames
  - buf_modname()
  - do_autocmd_event()
  - ff_create_stack_element()
  - ff_get_visited_list()
  - ins_complete()
  - msg_show_console_dialog()
  - prt_find_resource()
  - vim_findfile_init()
- After #466 many functions don't need to return error codes. I went through calls to some of these functions (e.g. `ga_grow()`) and removed the now unnecessary error handling code.
  - diff_alloc_new()
  - transstr()
  - mf_hash_grow()
  - ga_grow()
  - foldInsert()
  - alist_add_list()
  - get_arg_list()
  - store_loop_line()
  - push_current_state()

call for reviewers: @schmee @lslah

This PR is much easier to review commit by commit.
