### PR TITLE
[RDY] Remove `alloc_check`

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3861,10 +3861,6 @@ void do_sub(exarg_T *eap)
 
         if (sub_firstline == NULL) {
           sub_firstline = vim_strsave(ml_get(sub_firstlnum));
-          if (sub_firstline == NULL) {
-            vim_free(new_start);
-            goto outofmem;
-          }
         }
 
         /* Save the line number of the last change for the final
@@ -4154,8 +4150,7 @@ void do_sub(exarg_T *eap)
            * too many calls to alloc()/free()).
            */
           new_start_len = needed_len + 50;
-          if ((new_start = alloc_check(new_start_len)) == NULL)
-            goto outofmem;
+          new_start = (char_u *)xmalloc((size_t)new_start_len);
           *new_start = NUL;
           new_end = new_start;
         } else {
@@ -4168,10 +4163,7 @@ void do_sub(exarg_T *eap)
           needed_len += len;
           if (needed_len > (int)new_start_len) {
             new_start_len = needed_len + 50;
-            if ((p1 = alloc_check(new_start_len)) == NULL) {
-              vim_free(new_start);
-              goto outofmem;
-            }
+            p1 = (char_u *) xmalloc((size_t)new_start_len);
             memmove(p1, new_start, (size_t)(len + 1));
             vim_free(new_start);
             new_start = p1;
@@ -4388,7 +4380,6 @@ skip:
     changed_lines(first_line, 0, last_line - i, i);
   }
 
-outofmem:
   vim_free(sub_firstline);   /* may have to free allocated copy of the line */
 
   /* ":s/pat//n" doesn't move the cursor */

--- a/src/memory.c
+++ b/src/memory.c
@@ -73,22 +73,6 @@ char_u *alloc_clear(unsigned size)
 }
 
 /*
- * alloc() with check for maximum line length
- */
-char_u *alloc_check(unsigned size)
-{
-#if !defined(UNIX) && !defined(__EMX__)
-  if (sizeof(int) == 2 && size > 0x7fff) {
-    /* Don't hide this message */
-    emsg_silent = 0;
-    EMSG(_("E340: Line is becoming too long"));
-    return NULL;
-  }
-#endif
-  return lalloc((long_u)size, TRUE);
-}
-
-/*
  * Allocate memory like lalloc() and set all bytes to zero.
  */
 char_u *lalloc_clear(long_u size, int message)

--- a/src/memory.h
+++ b/src/memory.h
@@ -7,7 +7,6 @@
 
 char_u *alloc(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 char_u *alloc_clear(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
-char_u *alloc_check(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 char_u *lalloc_clear(long_u size, int message) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 
 /// malloc() wrapper

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1510,9 +1510,7 @@ void ins_char_bytes(char_u *buf, int charlen)
     }
   }
 
-  newp = alloc_check((unsigned)(linelen + newlen - oldlen));
-  if (newp == NULL)
-    return;
+  newp = (char_u *) xmalloc((size_t)(linelen + newlen - oldlen));
 
   /* Copy bytes before the cursor. */
   if (col > 0)
@@ -1580,9 +1578,7 @@ void ins_str(char_u *s)
   oldp = ml_get(lnum);
   oldlen = (int)STRLEN(oldp);
 
-  newp = alloc_check((unsigned)(oldlen + newlen + 1));
-  if (newp == NULL)
-    return;
+  newp = (char_u *) xmalloc((size_t)(oldlen + newlen + 1));
   if (col > 0)
     memmove(newp, oldp, (size_t)col);
   memmove(newp + col, s, (size_t)newlen);


### PR DESCRIPTION
`alloc_check` is just a wrapper around `xmalloc`, so we can remove it and use `xmalloc` directly. ref #487 / #488
