### PR TITLE
[RDY] vim-patch:7.4.192

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -17452,6 +17452,7 @@ void ex_function(exarg_T *eap)
       for (i = 0; i < newargs.ga_len; ++i)
         if (STRCMP(((char_u **)(newargs.ga_data))[i], arg) == 0) {
           EMSG2(_("E853: Duplicate argument name: %s"), arg);
+          vim_free(arg);
           goto erret;
         }
 

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,11 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  192,
+  //191,
+  //190,
+  //189,
+  //188,
   187,
   186,
   //185,


### PR DESCRIPTION
Merging vim-patch:7.4.192

Problem:    Memory leak when giving E853.
Solution:   Free the argument. (Dominique Pelle)

https://code.google.com/p/vim/source/detail?r=04c4ef8c0a1b757494500e46400552b135135e94
