### PR TITLE
[RDY] Bring neovim up to date with recent libuv changes

### DIFF
--- a/src/os/event.c
+++ b/src/os/event.c
@@ -20,8 +20,8 @@ KLIST_INIT(Event, Event, _destroy_event)
 static klist_t(Event) *event_queue;
 static uv_timer_t timer;
 static uv_prepare_t timer_prepare;
-static void timer_cb(uv_timer_t *handle, int);
-static void timer_prepare_cb(uv_prepare_t *, int);
+static void timer_cb(uv_timer_t *handle);
+static void timer_prepare_cb(uv_prepare_t *);
 
 void event_init()
 {
@@ -119,12 +119,12 @@ void event_process()
 }
 
 // Set a flag in the `event_poll` loop for signaling of a timeout
-static void timer_cb(uv_timer_t *handle, int status)
+static void timer_cb(uv_timer_t *handle)
 {
   *((bool *)handle->data) = true;
 }
 
-static void timer_prepare_cb(uv_prepare_t *handle, int status)
+static void timer_prepare_cb(uv_prepare_t *handle)
 {
   uv_timer_start(&timer, timer_cb, *(uint32_t *)timer_prepare.data, 0);
   uv_prepare_stop(&timer_prepare);

--- a/src/os/input.c
+++ b/src/os/input.c
@@ -42,7 +42,7 @@ static InbufPollResult inbuf_poll(int32_t ms);
 static void stderr_switch(void);
 static void alloc_cb(uv_handle_t *, size_t, uv_buf_t *);
 static void read_cb(uv_stream_t *, ssize_t, const uv_buf_t *);
-static void fread_idle_cb(uv_idle_t *, int);
+static void fread_idle_cb(uv_idle_t *);
 
 void input_init()
 {
@@ -246,7 +246,7 @@ static void read_cb(uv_stream_t *stream, ssize_t cnt, const uv_buf_t *buf)
 }
 
 // Called by the by the 'idle' handle to emulate a reading event
-static void fread_idle_cb(uv_idle_t *handle, int status)
+static void fread_idle_cb(uv_idle_t *handle)
 {
   uv_fs_t req;
 

--- a/src/os/job.c
+++ b/src/os/job.c
@@ -55,7 +55,7 @@ static Job * find_job(int id);
 static void free_job(Job *job);
 
 // Callbacks for libuv
-static void job_prepare_cb(uv_prepare_t *handle, int status);
+static void job_prepare_cb(uv_prepare_t *handle);
 static void alloc_cb(uv_handle_t *handle, size_t suggested, uv_buf_t *buf);
 static void read_cb(uv_stream_t *stream, ssize_t cnt, const uv_buf_t *buf);
 static void write_cb(uv_write_t *req, int status);
@@ -257,7 +257,7 @@ static void free_job(Job *job)
 
 /// Iterates the table, sending SIGTERM to stopped jobs and SIGKILL to those
 /// that didn't die from SIGTERM after a while(exit_timeout is 0).
-static void job_prepare_cb(uv_prepare_t *handle, int status)
+static void job_prepare_cb(uv_prepare_t *handle)
 {
   Job *job;
   int i;

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -42,8 +42,8 @@ endif()
 
 include(ExternalProject)
 
-set(LIBUV_URL https://github.com/joyent/libuv/archive/v0.11.22.tar.gz)
-set(LIBUV_MD5 d0cb0fea847afa35333ccbda56ed16d4)
+set(LIBUV_URL https://github.com/joyent/libuv/archive/v0.11.23.tar.gz)
+set(LIBUV_MD5 e02a3da9fba9ebe72a84e4abd312ee4d)
 
 set(LUAJIT_URL http://luajit.org/download/LuaJIT-2.0.2.tar.gz)
 set(LUAJIT_MD5 112dfb82548b03377fbefbba2e0e3a5b)


### PR DESCRIPTION
As of v0.11.23 (more specifically joyent/libuv@db2a9072bce129630214904be5e2eedeaafc9835) libuv's uv_timer_cb, uv_async_cb, uv_prepare_cb, uv_check_cb and uv_idle_cb no longer require a status parameter (this went unused in the first place).
