### PR TITLE
[RDY] Fix broken build due to unit tests

### DIFF
--- a/test/unit/path.moon
+++ b/test/unit/path.moon
@@ -16,7 +16,8 @@ char_u *path_next_component(char_u *fname);
 -- import constants parsed by ffi
 {:kEqualFiles, :kDifferentFiles, :kBothFilesMissing, :kOneFileMissing, :kEqualFileNames} = path
 NULL = ffi.cast 'void*', 0
-{:OK, :FAIL} = path
+OK = 1
+FAIL = 0
 
 describe 'path function', ->
   describe 'path_full_compare', ->


### PR DESCRIPTION
Thanks to @stefan991 for tracking this down!

 Commit 4348d1e6f74a87af55c6c01e7a0cb292e9dec114 introduced a bug that breaks the build unless the unit tests run in a certain order. Both path.moon and os/fs.moon tries to include the same Enum, which breaks since ffi.cdef can only include definitions once.

 This solves the bug by using Lua variables instead of ffi.cdef Enums.
