### PR TITLE
Clean up of memory.c and friends

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -272,14 +272,13 @@ open_buffer (
 /*
  * Return TRUE if "buf" points to a valid buffer (in the buffer list).
  */
-int buf_valid(buf_T *buf)
+bool buf_valid(const buf_T *buf)
 {
-  buf_T       *bp;
-
-  for (bp = firstbuf; bp != NULL; bp = bp->b_next)
+  for (buf_T *bp = firstbuf; bp != NULL; bp = bp->b_next)
     if (bp == buf)
-      return TRUE;
-  return FALSE;
+      return true;
+
+  return false;
 }
 
 /*
@@ -4364,7 +4363,7 @@ static void insert_sign(
 {
     signlist_T	*newsign;
 
-    newsign = (signlist_T *)lalloc((long_u)sizeof(signlist_T), FALSE);
+    newsign = (signlist_T *)lalloc((long_u)sizeof(signlist_T));
     newsign->id = id;
     newsign->lnum = lnum;
     newsign->typenr = typenr;

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -2,7 +2,7 @@
 #define NEOVIM_BUFFER_H
 /* buffer.c */
 int open_buffer(int read_stdin, exarg_T *eap, int flags);
-int buf_valid(buf_T *buf);
+bool buf_valid(const buf_T *buf);
 void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last);
 void buf_clear_file(buf_T *buf);
 void buf_freeall(buf_T *buf, int flags);

--- a/src/edit.c
+++ b/src/edit.c
@@ -6295,7 +6295,7 @@ replace_push (
     return;
   if (replace_stack_len <= replace_stack_nr) {
     replace_stack_len += 50;
-    p = lalloc(sizeof(char_u) * replace_stack_len, TRUE);
+    p = lalloc(sizeof(char_u) * replace_stack_len);
     if (replace_stack != NULL) {
       memmove(p, replace_stack,
           (size_t)(replace_stack_nr * sizeof(char_u)));

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -368,7 +368,7 @@ void ex_sort(exarg_T *eap)
   sortbuf1 = NULL;
   sortbuf2 = NULL;
   regmatch.regprog = NULL;
-  nrs = (sorti_T *)lalloc((long_u)(count * sizeof(sorti_T)), TRUE);
+  nrs = (sorti_T *)lalloc((long_u)(count * sizeof(sorti_T)));
   if (nrs == NULL)
     goto sortend;
 
@@ -626,8 +626,7 @@ void ex_retab(exarg_T *eap)
             /* len is actual number of white characters used */
             len = num_spaces + num_tabs;
             old_len = (long)STRLEN(ptr);
-            new_line = lalloc(old_len - col + start_col + len + 1,
-                TRUE);
+            new_line = lalloc(old_len - col + start_col + len + 1);
             if (new_line == NULL)
               break;
             if (start_col > 0)
@@ -1340,7 +1339,7 @@ make_filter_cmd (
     len += (long_u)STRLEN(itmp) + 9;                    /* " { < " + " } " */
   if (otmp != NULL)
     len += (long_u)STRLEN(otmp) + (long_u)STRLEN(p_srr) + 2;     /* "  " */
-  buf = lalloc(len, TRUE);
+  buf = lalloc(len);
   if (buf == NULL)
     return NULL;
 
@@ -1940,7 +1939,7 @@ viminfo_readstring (
 
   if (virp->vir_line[off] == Ctrl_V && vim_isdigit(virp->vir_line[off + 1])) {
     len = atol((char *)virp->vir_line + off + 1);
-    retval = lalloc(len, TRUE);
+    retval = lalloc(len);
     if (retval == NULL) {
       /* Line too long?  File messed up?  Skip next line. */
       (void)vim_fgets(virp->vir_line, 10, virp->vir_fd);

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2957,7 +2957,7 @@ ExpandOne (
     len = 0;
     for (i = 0; i < xp->xp_numfiles; ++i)
       len += (long_u)STRLEN(xp->xp_files[i]) + 1;
-    ss = lalloc(len, TRUE);
+    ss = lalloc(len);
     if (ss != NULL) {
       *ss = NUL;
       for (i = 0; i < xp->xp_numfiles; ++i) {
@@ -4362,8 +4362,7 @@ void init_history(void)
   if (newlen != hislen) {                       /* history length changed */
     for (type = 0; type < HIST_COUNT; ++type) {     /* adjust the tables */
       if (newlen) {
-        temp = (histentry_T *)lalloc(
-            (long_u)(newlen * sizeof(histentry_T)), TRUE);
+        temp = (histentry_T *)lalloc((long_u)(newlen * sizeof(histentry_T)));
         if (temp == NULL) {         /* out of memory! */
           if (type == 0) {          /* first one: just keep the old length */
             newlen = hislen;
@@ -5013,7 +5012,7 @@ void prepare_viminfo_history(int asklen, int writing)
       viminfo_history[type] = NULL;
     else
       viminfo_history[type] =
-        (char_u **)lalloc((long_u)(len * sizeof(char_u *)), FALSE);
+        (char_u **)lalloc((long_u)(len * sizeof(char_u *)));
     if (viminfo_history[type] == NULL)
       len = 0;
     viminfo_hislen[type] = len;
@@ -5042,7 +5041,7 @@ int read_viminfo_history(vir_T *virp, int writing)
               viminfo_add_at_front, sep, writing)) {
         /* Need to re-allocate to append the separator byte. */
         len = STRLEN(val);
-        p = lalloc(len + 2, TRUE);
+        p = lalloc(len + 2);
         if (p != NULL) {
           if (type == HIST_SEARCH) {
             /* Search entry: Move the separator from the first

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1004,8 +1004,7 @@ retry:
 #endif
 
         for (; size >= 10; size = (long)((long_u)size >> 1)) {
-          if ((new_buffer = lalloc((long_u)(size + linerest + 1),
-                   FALSE)) != NULL)
+          if ((new_buffer = lalloc((long_u)(size + linerest + 1))) != NULL)
               break;
         }
         if (linerest)           /* copy characters from the previous buffer */
@@ -3387,8 +3386,7 @@ nobackup:
         write_info.bw_conv_buflen = bufsize * 2;
       else       /* FIO_UCS4 */
         write_info.bw_conv_buflen = bufsize * 4;
-      write_info.bw_conv_buf
-        = lalloc((long_u)write_info.bw_conv_buflen, TRUE);
+      write_info.bw_conv_buf = lalloc((long_u)write_info.bw_conv_buflen);
     }
   }
 
@@ -3405,9 +3403,8 @@ nobackup:
     if (write_info.bw_iconv_fd != (iconv_t)-1) {
       /* We're going to use iconv(), allocate a buffer to convert in. */
       write_info.bw_conv_buflen = bufsize * ICONV_MULT;
-      write_info.bw_conv_buf
-        = lalloc((long_u)write_info.bw_conv_buflen, TRUE);
-      write_info.bw_first = TRUE;
+      write_info.bw_conv_buf    = lalloc((long_u)write_info.bw_conv_buflen);
+      write_info.bw_first       = TRUE;
     } else
 #  endif
 

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -199,7 +199,7 @@ static char_u *get_buffcont(buffheader_T *buffer,
     count += (long_u)STRLEN(bp->b_str);
 
   if (count || dozero) {
-    p = lalloc(count + 1, TRUE);
+    p = lalloc(count + 1);
     p2 = p;
     for (bp = buffer->bh_first.b_next; bp != NULL; bp = bp->b_next)
       for (str = bp->b_str; *str; )
@@ -291,7 +291,7 @@ add_buff (
       len = MINIMAL_SIZE;
     else
       len = slen;
-    p = (buffblock_T *)lalloc((long_u)(sizeof(buffblock_T) + len), TRUE);
+    p = (buffblock_T *)lalloc((long_u)(sizeof(buffblock_T) + len));
     buf->bh_space = (int)(len - slen);
     vim_strncpy(p->b_str, s, (size_t)slen);
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -811,7 +811,7 @@ EXTERN reg_extmatch_T *re_extmatch_in INIT(= NULL); /* Used by vim_regexec():
 EXTERN reg_extmatch_T *re_extmatch_out INIT(= NULL); /* Set by vim_regexec()
                                                       * to store \z\(...\) matches */
 
-EXTERN int did_outofmem_msg INIT(= FALSE);
+EXTERN bool did_outofmem_msg INIT(= false);
 /* set after out of memory msg */
 EXTERN int did_swapwrite_msg INIT(= FALSE);
 /* set after swap write error msg */

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -1268,7 +1268,7 @@ static int mf_hash_grow(mf_hashtab_T *mht)
   size_t size;
 
   size = (mht->mht_mask + 1) * MHT_GROWTH_FACTOR * sizeof(void *);
-  buckets = (mf_hashitem_T **)lalloc_clear(size, FALSE);
+  buckets = (mf_hashitem_T **)lalloc_clear(size);
   if (buckets == NULL)
     return FAIL;
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,4 +1,4 @@
- // Various routines dealing with allocation and deallocation of memory.
+// Various routines dealing with allocation and deallocation of memory.
 
 #include <stdlib.h>
 #include <string.h>
@@ -51,69 +51,42 @@ static void *xmallocz(size_t size);
 /// the program dies.
 ///
 /// @see {xmalloc}
-/// @param data Pointer to the data that will be copied
-/// @param len number of bytes that will be copied
+/// @param data Pointer to the data that will be copied.
+/// @param len Number of bytes that will be copied.
+/// @return Pointer to allocated memory.
 static void *xmemdupz(const void *data, size_t len);
 
-/*
- * Note: if unsigned is 16 bits we can only allocate up to 64K with alloc().
- * Use lalloc for larger blocks.
- */
+// Note: if unsigned is 16 bits we can only allocate up to 64K with alloc().
+// Use lalloc for larger blocks.
 char_u *alloc(unsigned size)
 {
-  return lalloc((long_u)size, TRUE);
+  return lalloc((long_u)size);
 }
 
-/*
- * Allocate memory and set all bytes to zero.
- */
+// Allocate memory and set all bytes to zero.
 char_u *alloc_clear(unsigned size)
 {
   return (char_u *)xcalloc(1, (size_t)size);
 }
 
-/*
- * alloc() with check for maximum line length
- */
+// alloc() with check for maximum line length.
 char_u *alloc_check(unsigned size)
 {
 #if !defined(UNIX) && !defined(__EMX__)
   if (sizeof(int) == 2 && size > 0x7fff) {
-    /* Don't hide this message */
+    // Don't hide this message.
     emsg_silent = 0;
     EMSG(_("E340: Line is becoming too long"));
     return NULL;
   }
 #endif
-  return lalloc((long_u)size, TRUE);
+  return lalloc((long_u)size);
 }
 
-/*
- * Allocate memory like lalloc() and set all bytes to zero.
- */
-char_u *lalloc_clear(long_u size, int message)
+// Allocate memory like lalloc() and set all bytes to zero.
+char_u *lalloc_clear(long_u size)
 {
   return (char_u *)xcalloc(1, (size_t)size);
-}
-
-/// Try to free memory. Used when trying to recover from out of memory errors.
-/// @see {xmalloc}
-static void try_to_free_memory()
-{
-  static bool trying_to_free = false;
-  // avoid recursive calls
-  if (trying_to_free)
-    return;
-  trying_to_free = true;
-
-  // free any scrollback text
-  clear_sb_text();
-  // Try to save all buffers and release as many blocks as possible
-  mf_release_all();
-  // cleanup recursive lists/dicts
-  garbage_collect();
-
-  trying_to_free = false;
 }
 
 void *xmalloc(size_t size)
@@ -179,7 +152,7 @@ void *xrealloc(void *ptr, size_t size)
   return ret;
 }
 
-char * xstrdup(const char *str)
+char *xstrdup(const char *str)
 {
   char *ret = strdup(str);
 
@@ -198,28 +171,26 @@ char * xstrdup(const char *str)
 char *xstrndup(const char *str, size_t len)
 {
   char *p = memchr(str, '\0', len);
+
   return xmemdupz(str, p ? (size_t)(p - str) : len);
 }
 
-
-char_u *lalloc(long_u size, int message)
+char_u *lalloc(long_u size)
 {
   return (char_u *)xmalloc((size_t)size);
 }
 
-/*
- * Avoid repeating the error message many times (they take 1 second each).
- * Did_outofmem_msg is reset when a character is read.
- */
+// Avoid repeating the error message many times (they take 1 second each).
+// Did_outofmem_msg is reset when a character is read.
 void do_outofmem_msg(long_u size)
 {
   if (!did_outofmem_msg) {
-    /* Don't hide this message */
+    // Don't hide this message.
     emsg_silent = 0;
 
-    /* Must come first to avoid coming back here when printing the error
-     * message fails, e.g. when setting v:errmsg. */
-    did_outofmem_msg = TRUE;
+    // Must come first to avoid coming back here when printing the error
+    // message fails, e.g. when setting v:errmsg.
+    did_outofmem_msg = true;
 
     EMSGN(_("E342: Out of memory!  (allocating %lu bytes)"), size);
   }
@@ -227,44 +198,40 @@ void do_outofmem_msg(long_u size)
 
 #if defined(EXITFREE) || defined(PROTO)
 
-/*
- * Free everything that we allocated.
- * Can be used to detect memory leaks, e.g., with ccmalloc.
- * NOTE: This is tricky!  Things are freed that functions depend on.  Don't be
- * surprised if Vim crashes...
- * Some things can't be freed, esp. things local to a library function.
- */
+// Free everything that we allocated.
+// Can be used to detect memory leaks, e.g., with ccmalloc.
+// NOTE: This is tricky!  Things are freed that functions depend on.  Don't be
+// surprised if Vim crashes...
+// Some things can't be freed, esp. things local to a library function.
 void free_all_mem(void)
 {
-  buf_T       *buf, *nextbuf;
-  static int entered = FALSE;
-
-  /* When we cause a crash here it is caught and Vim tries to exit cleanly.
-   * Don't try freeing everything again. */
+  static bool entered = false;
+  // When we cause a crash here it is caught and Vim tries to exit cleanly.
+  // Don't try freeing everything again.
   if (entered)
     return;
-  entered = TRUE;
+  entered = true;
 
-  block_autocmds();         /* don't want to trigger autocommands here */
+  block_autocmds();   // Don't want to trigger autocommands here.
 
-  /* Close all tabs and windows.  Reset 'equalalways' to avoid redraws. */
+  // Close all tabs and windows. Reset 'equalalways' to avoid redraws.
   p_ea = FALSE;
-  if (first_tabpage->tp_next != NULL)
+  if (first_tabpage->tp_next)
     do_cmdline_cmd((char_u *)"tabonly!");
   if (firstwin != lastwin)
     do_cmdline_cmd((char_u *)"only!");
 
-  /* Free all spell info. */
+  // Free all spell info.
   spell_free_all();
 
-  /* Clear user commands (before deleting buffers). */
+  // Clear user commands (before deleting buffers).
   ex_comclear(NULL);
 
-  /* Clear menus. */
+  // Clear menus.
   do_cmdline_cmd((char_u *)"aunmenu *");
   do_cmdline_cmd((char_u *)"menutranslate clear");
 
-  /* Clear mappings, abbreviations, breakpoints. */
+  // Clear mappings, abbreviations, breakpoints.
   do_cmdline_cmd((char_u *)"lmapclear");
   do_cmdline_cmd((char_u *)"xmapclear");
   do_cmdline_cmd((char_u *)"mapclear");
@@ -277,7 +244,7 @@ void free_all_mem(void)
   free_titles();
   free_findfile();
 
-  /* Obviously named calls. */
+  // Obviously named calls.
   free_all_autocmds();
   clear_termcodes();
   free_all_options();
@@ -295,83 +262,76 @@ void free_all_mem(void)
   free_signs();
   set_expr_line(NULL);
   diff_clear(curtab);
-  clear_sb_text();            /* free any scrollback text */
+  clear_sb_text();   // Free any scrollback text.
 
-  /* Free some global vars. */
+  // Free some global vars.
   vim_free(last_cmdline);
   vim_free(new_last_cmdline);
   set_keep_msg(NULL, 0);
 
-  /* Clear cmdline history. */
+  // Clear cmdline history.
   p_hi = 0;
   init_history();
 
   {
-    win_T       *win;
-    tabpage_T   *tab;
+    win_T     *win;
+    tabpage_T *tab;
 
     qf_free_all(NULL);
-    /* Free all location lists */
+    // Free all location lists.
     FOR_ALL_TAB_WINDOWS(tab, win)
     qf_free_all(win);
   }
 
-  /* Close all script inputs. */
+  // Close all script inputs.
   close_all_scripts();
 
-  /* Destroy all windows.  Must come before freeing buffers. */
+  // Destroy all windows. Must come before freeing buffers.
   win_free_all();
 
-  /* Free all buffers.  Reset 'autochdir' to avoid accessing things that
-   * were freed already. */
+  // Free all buffers. Reset 'autochdir' to avoid accessing things that
+  // were freed already.
   p_acd = FALSE;
-  for (buf = firstbuf; buf != NULL; ) {
-    nextbuf = buf->b_next;
+  buf_T *buf = firstbuf;
+
+  while (buf) {
+    buf_T *nextbuf = buf->b_next;
     close_buffer(NULL, buf, DOBUF_WIPE, FALSE);
-    if (buf_valid(buf))
-      buf = nextbuf;            /* didn't work, try next one */
-    else
-      buf = firstbuf;
+
+    // If freeing a buffer fails, try next one.
+    buf = buf_valid(buf) ? nextbuf : firstbuf;
   }
 
   free_cmdline_buf();
 
-  /* Clear registers. */
+  // Clear registers.
   clear_registers();
   ResetRedobuff();
   ResetRedobuff();
 
-
-  /* highlight info */
+  // Highlight info.
   free_highlight();
-
   reset_last_sourcing();
 
   free_tabpage(first_tabpage);
   first_tabpage = NULL;
 
 # ifdef UNIX
-  /* Machine-specific free. */
+  // Machine-specific free.
   mch_free_mem();
 # endif
 
-  /* message history */
-  for (;; )
+  // Message history.
+  while (1)
     if (delete_first_msg() == FAIL)
       break;
 
   eval_clear();
-
   free_termoptions();
-
-  /* screenlines (can't display anything now!) */
-  free_screenlines();
-
+  free_screenlines();   // Can't display anything now!
   clear_hl_tables();
-
   vim_free(NameBuff);
 }
-
 #endif
 
 static void *xmallocz(size_t size)
@@ -379,6 +339,7 @@ static void *xmallocz(size_t size)
   size_t total_size = size + 1;
   void *ret;
 
+  // Overflow check.
   if (total_size < size) {
     OUT_STR("Vim: Data too large to fit into virtual memory space\n");
     preserve_exit();
@@ -395,3 +356,23 @@ static void *xmemdupz(const void *data, size_t len)
   return memcpy(xmallocz(len), data, len);
 }
 
+// Try to free memory. Used when trying to recover from out of
+// memory errors.
+static void try_to_free_memory()
+{
+  static bool trying_to_free = false;
+
+  // Avoid recursive calls.
+  if (trying_to_free)
+    return;
+  trying_to_free = true;
+
+  // Free any scrollback text.
+  clear_sb_text();
+  // Try to save all buffers and release as many blocks as possible.
+  mf_release_all();
+  // Cleanup recursive lists/dicts.
+  garbage_collect();
+
+  trying_to_free = false;
+}

--- a/src/memory.h
+++ b/src/memory.h
@@ -8,7 +8,7 @@
 char_u *alloc(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 char_u *alloc_clear(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 char_u *alloc_check(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
-char_u *lalloc_clear(long_u size, int message) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
+char_u *lalloc_clear(long_u size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 
 /// malloc() wrapper
 ///
@@ -17,7 +17,7 @@ char_u *lalloc_clear(long_u size, int message) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_
 ///
 /// @see {try_to_free_memory}
 /// @param size
-/// @return pointer to allocated space. Never NULL
+/// @return Pointer to allocated space. Never NULL.
 void *xmalloc(size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1) FUNC_ATTR_NONNULL_RET;
 
@@ -26,7 +26,7 @@ void *xmalloc(size_t size)
 /// @see {xmalloc}
 /// @param count
 /// @param size
-/// @return pointer to allocated space. Never NULL
+/// @return pointer to allocated space. Never NULL.
 void *xcalloc(size_t count, size_t size)
   FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE_PROD(1, 2) FUNC_ATTR_NONNULL_RET;
 
@@ -34,32 +34,34 @@ void *xcalloc(size_t count, size_t size)
 ///
 /// @see {xmalloc}
 /// @param size
-/// @return pointer to reallocated space. Never NULL
+/// @return Pointer to reallocated space. Never NULL.
 void *xrealloc(void *ptr, size_t size)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET;
 
 /// strdup() wrapper
 ///
 /// @see {xmalloc}
-/// @param str 0-terminated string that will be copied
-/// @return pointer to a copy of the string
-char * xstrdup(const char *str)
- FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET;
+/// @param str NUL-terminated string that will be copied.
+/// @return Pointer to a copy of the string.
+char *xstrdup(const char *str)
+  FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET;
 
 /// strndup() wrapper
 ///
 /// @see {xmalloc}
-/// @param str 0-terminated string that will be copied
-/// @return pointer to a copy of the string
-char * xstrndup(const char *str, size_t len)
- FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET;
+/// @param str NUL-terminated string that will be copied.
+/// @return Pointer to a copy of the string.
+char *xstrndup(const char *str, size_t len)
+  FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET;
 
 /// Old low level memory allocation function.
 ///
-/// @deprecated use xmalloc() directly instead
+/// @deprecated Use xmalloc() directly instead.
 /// @param size
-/// @return pointer to allocated space. Never NULL
-char_u *lalloc(long_u size, int message) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
+/// @return Pointer to allocated space. Never NULL.
+char_u *lalloc(long_u size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
+
 void do_outofmem_msg(long_u size);
 void free_all_mem(void);
+
 #endif

--- a/src/ops.c
+++ b/src/ops.c
@@ -929,7 +929,7 @@ static int stuff_yank(int regname, char_u *p)
   get_yank_register(regname, TRUE);
   if (y_append && y_current->y_array != NULL) {
     pp = &(y_current->y_array[y_current->y_size - 1]);
-    lp = lalloc((long_u)(STRLEN(*pp) + STRLEN(p) + 1), TRUE);
+    lp = lalloc((long_u)(STRLEN(*pp) + STRLEN(p) + 1));
     STRCPY(lp, *pp);
     STRCAT(lp, p);
     vim_free(p);
@@ -2428,11 +2428,11 @@ int op_yank(oparg_T *oap, int deleting, int mess)
     --yanklines;
   }
 
-  y_current->y_size = yanklines;
-  y_current->y_type = yanktype;     /* set the yank register type */
+  y_current->y_size  = yanklines;
+  y_current->y_type  = yanktype;     /* set the yank register type */
   y_current->y_width = 0;
-  y_current->y_array = (char_u **)lalloc_clear((long_u)(sizeof(char_u *) *
-                                                        yanklines), TRUE);
+  y_current->y_array =
+      (char_u **)lalloc_clear((long_u)(sizeof(char_u *) * yanklines));
 
   y_idx = 0;
   lnum = oap->start.lnum;
@@ -2528,9 +2528,7 @@ int op_yank(oparg_T *oap, int deleting, int mess)
 
   if (curr != y_current) {      /* append the new block to the old block */
     new_ptr = (char_u **)lalloc(
-        (long_u)(sizeof(char_u *) *
-                 (curr->y_size + y_current->y_size)),
-        TRUE);
+        (long_u)(sizeof(char_u *) * (curr->y_size + y_current->y_size)));
     for (j = 0; j < curr->y_size; ++j)
       new_ptr[j] = curr->y_array[j];
     vim_free(curr->y_array);
@@ -2543,7 +2541,7 @@ int op_yank(oparg_T *oap, int deleting, int mess)
      * the new block, unless being Vi compatible. */
     if (curr->y_type == MCHAR && vim_strchr(p_cpo, CPO_REGAPPEND) == NULL) {
       pnew = lalloc((long_u)(STRLEN(curr->y_array[curr->y_size - 1])
-                             + STRLEN(y_current->y_array[0]) + 1), TRUE);
+                             + STRLEN(y_current->y_array[0]) + 1));
       STRCPY(pnew, curr->y_array[--j]);
       STRCAT(pnew, y_current->y_array[0]);
       vim_free(curr->y_array[j]);
@@ -3489,9 +3487,9 @@ int do_join(long count, int insert_space, int save_undo, int use_formatoptions)
   /* Allocate an array to store the number of spaces inserted before each
    * line.  We will use it to pre-compute the length of the new line and the
    * proper placement of each original line in the new one. */
-  spaces = lalloc_clear((long_u)count, TRUE);
+  spaces = lalloc_clear((long_u)count);
   if (remove_comments) {
-    comments = (int *)lalloc_clear((long_u)count * sizeof(int), TRUE);
+    comments = (int *)lalloc_clear((long_u)count * sizeof(int));
   }
 
   /*
@@ -4774,7 +4772,7 @@ get_reg_contents (
       ++len;
   }
 
-  retval = lalloc(len + 1, TRUE);
+  retval = lalloc(len + 1);
 
   /*
    * Copy the lines of the yank register into the string.
@@ -4922,8 +4920,7 @@ str_to_reg (
    * Allocate an array to hold the pointers to the new register lines.
    * If the register was not empty, move the existing lines to the new array.
    */
-  pp = (char_u **)lalloc_clear((y_ptr->y_size + newlines)
-      * sizeof(char_u *), TRUE);
+  pp = (char_u **)lalloc_clear((y_ptr->y_size + newlines) * sizeof(char_u *));
   for (lnum = 0; lnum < y_ptr->y_size; ++lnum)
     pp[lnum] = y_ptr->y_array[lnum];
   vim_free(y_ptr->y_array);

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -554,7 +554,7 @@ void mch_early_init()
 }
 
 #if defined(EXITFREE) || defined(PROTO)
-void mch_free_mem()          {
+void mch_free_mem() {
   vim_free(oldtitle);
   vim_free(oldicon);
 }

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -1221,7 +1221,7 @@ static regprog_T *bt_regcomp(char_u *expr, int re_flags)
 #endif
 
   /* Allocate space. */
-  r = (bt_regprog_T *)lalloc(sizeof(bt_regprog_T) + regsize, TRUE);
+  r = (bt_regprog_T *)lalloc(sizeof(bt_regprog_T) + regsize);
 
   /*
    * Second pass: emit code.
@@ -6918,7 +6918,7 @@ char_u *reg_submatch(int no)
       }
 
       if (retval == NULL) {
-        retval = lalloc((long_u)len, TRUE);
+        retval = lalloc((long_u)len);
       }
     }
   } else {

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -351,7 +351,7 @@ nfa_regcomp_start (
   /* Size for postfix representation of expr. */
   postfix_size = sizeof(int) * nstate_max;
 
-  post_start = (int *)lalloc(postfix_size, TRUE);
+  post_start = (int *)lalloc(postfix_size);
   if (post_start == NULL)
     return FAIL;
   post_ptr = post_start;
@@ -548,7 +548,7 @@ static int realloc_post_list(void)
   int   *new_start;
   int   *old_start;
 
-  new_start = (int *)lalloc(new_max * sizeof(int), TRUE);
+  new_start = (int *)lalloc(new_max * sizeof(int));
   if (new_start == NULL)
     return FAIL;
   memmove(new_start, post_start, nstate_max * sizeof(int));
@@ -2890,7 +2890,7 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
 
   if (nfa_calc_size == FALSE) {
     /* Allocate space for the stack. Max states on the stack : nstate */
-    stack = (Frag_T *)lalloc((nstate + 1) * sizeof(Frag_T), TRUE);
+    stack = (Frag_T *)lalloc((nstate + 1) * sizeof(Frag_T));
     stackp = stack;
     stack_end = stack + (nstate + 1);
   }
@@ -4546,7 +4546,7 @@ static int recursive_regmatch(nfa_state_T *state, nfa_pim_T *pim, nfa_regprog_T 
     /* Already calling nfa_regmatch() recursively.  Save the lastlist[1]
      * values and clear them. */
     if (*listids == NULL) {
-      *listids = (int *)lalloc(sizeof(int) * nstate, TRUE);
+      *listids = (int *)lalloc(sizeof(int) * nstate);
     }
     nfa_save_listids(prog, *listids);
     need_restore = TRUE;
@@ -4874,9 +4874,9 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
 
   /* Allocate memory for the lists of nodes. */
   size = (nstate + 1) * sizeof(nfa_thread_T);
-  list[0].t = (nfa_thread_T *)lalloc(size, TRUE);
+  list[0].t = (nfa_thread_T *)lalloc(size);
   list[0].len = nstate + 1;
-  list[1].t = (nfa_thread_T *)lalloc(size, TRUE);
+  list[1].t = (nfa_thread_T *)lalloc(size);
   list[1].len = nstate + 1;
 
 #ifdef ENABLE_LOG
@@ -6303,7 +6303,7 @@ static regprog_T *nfa_regcomp(char_u *expr, int re_flags)
 
   /* allocate the regprog with space for the compiled regexp */
   prog_size = sizeof(nfa_regprog_T) + sizeof(nfa_state_T) * (nstate - 1);
-  prog = (nfa_regprog_T *)lalloc(prog_size, TRUE);
+  prog = (nfa_regprog_T *)lalloc(prog_size);
   state_ptr = prog->state;
 
   /*

--- a/src/screen.c
+++ b/src/screen.c
@@ -290,22 +290,22 @@ int redraw_asap(int type)
   /* Allocate space to save the text displayed in the command line area. */
   rows = Rows - cmdline_row;
   screenline = (schar_T *)lalloc(
-      (long_u)(rows * Columns * sizeof(schar_T)), FALSE);
+      (long_u)(rows * Columns * sizeof(schar_T)));
   screenattr = (sattr_T *)lalloc(
-      (long_u)(rows * Columns * sizeof(sattr_T)), FALSE);
+      (long_u)(rows * Columns * sizeof(sattr_T)));
 
   if (enc_utf8) {
     screenlineUC = (u8char_T *)lalloc(
-        (long_u)(rows * Columns * sizeof(u8char_T)), FALSE);
+        (long_u)(rows * Columns * sizeof(u8char_T)));
 
     for (i = 0; i < p_mco; ++i) {
       screenlineC[i] = (u8char_T *)lalloc(
-          (long_u)(rows * Columns * sizeof(u8char_T)), FALSE);
+          (long_u)(rows * Columns * sizeof(u8char_T)));
     }
   }
   if (enc_dbcs == DBCS_JPNU) {
     screenline2 = (schar_T *)lalloc(
-        (long_u)(rows * Columns * sizeof(schar_T)), FALSE);
+        (long_u)(rows * Columns * sizeof(schar_T)));
   }
 
   /* Save the text displayed in the command line area. */
@@ -6262,24 +6262,24 @@ retry:
     win_free_lsize(aucmd_win);
 
   new_ScreenLines = (schar_T *)lalloc((long_u)(
-        (Rows + 1) * Columns * sizeof(schar_T)), FALSE);
+        (Rows + 1) * Columns * sizeof(schar_T)));
   memset(new_ScreenLinesC, 0, sizeof(u8char_T *) * MAX_MCO);
   if (enc_utf8) {
     new_ScreenLinesUC = (u8char_T *)lalloc((long_u)(
-          (Rows + 1) * Columns * sizeof(u8char_T)), FALSE);
+          (Rows + 1) * Columns * sizeof(u8char_T)));
     for (i = 0; i < p_mco; ++i)
       new_ScreenLinesC[i] = (u8char_T *)lalloc_clear((long_u)(
-            (Rows + 1) * Columns * sizeof(u8char_T)), FALSE);
+            (Rows + 1) * Columns * sizeof(u8char_T)));
   }
   if (enc_dbcs == DBCS_JPNU)
     new_ScreenLines2 = (schar_T *)lalloc((long_u)(
-          (Rows + 1) * Columns * sizeof(schar_T)), FALSE);
+          (Rows + 1) * Columns * sizeof(schar_T)));
   new_ScreenAttrs = (sattr_T *)lalloc((long_u)(
-        (Rows + 1) * Columns * sizeof(sattr_T)), FALSE);
+        (Rows + 1) * Columns * sizeof(sattr_T)));
   new_LineOffset = (unsigned *)lalloc((long_u)(
-        Rows * sizeof(unsigned)), FALSE);
-  new_LineWraps = (char_u *)lalloc((long_u)(Rows * sizeof(char_u)), FALSE);
-  new_TabPageIdxs = (short *)lalloc((long_u)(Columns * sizeof(short)), FALSE);
+        Rows * sizeof(unsigned)));
+  new_LineWraps = (char_u *)lalloc((long_u)(Rows * sizeof(char_u)));
+  new_TabPageIdxs = (short *)lalloc((long_u)(Columns * sizeof(short)));
 
   FOR_ALL_TAB_WINDOWS(tp, wp)
   {

--- a/src/search.c
+++ b/src/search.c
@@ -4059,7 +4059,7 @@ find_pattern_in_path (
     def_regmatch.rm_ic = FALSE;         /* don't ignore case in define pat. */
   }
   files = (SearchedFile *)lalloc_clear((long_u)
-      (max_path_depth * sizeof(SearchedFile)), TRUE);
+      (max_path_depth * sizeof(SearchedFile)));
   if (files == NULL)
     goto fpip_end;
   old_files = max_path_depth;
@@ -4198,7 +4198,7 @@ find_pattern_in_path (
         /* Push the new file onto the file stack */
         if (depth + 1 == old_files) {
           bigger = (SearchedFile *)lalloc((long_u)(
-                max_path_depth * 2 * sizeof(SearchedFile)), TRUE);
+                max_path_depth * 2 * sizeof(SearchedFile)));
           for (i = 0; i <= depth; i++)
             bigger[i] = files[i];
           for (i = depth + 1; i < old_files + max_path_depth; i++) {

--- a/src/spell.c
+++ b/src/spell.c
@@ -3658,11 +3658,11 @@ spell_read_tree (
     return SP_TRUNCERROR;
   if (len > 0) {
     /* Allocate the byte array. */
-    bp = lalloc((long_u)len, TRUE);
+    bp = lalloc((long_u)len);
     *bytsp = bp;
 
     /* Allocate the index array. */
-    ip = (idx_T *)lalloc_clear((long_u)(len * sizeof(int)), TRUE);
+    ip = (idx_T *)lalloc_clear((long_u)(len * sizeof(int)));
     *idxsp = ip;
 
     /* Recursively read the tree and store it in the array. */
@@ -13320,8 +13320,7 @@ static int spell_edit_score(slang_T *slang, char_u *badword, char_u *goodword)
 
   /* We use "cnt" as an array: CNT(badword_idx, goodword_idx). */
 #define CNT(a, b)   cnt[(a) + (b) * (badlen + 1)]
-  cnt = (int *)lalloc((long_u)(sizeof(int) * (badlen + 1) * (goodlen + 1)),
-      TRUE);
+  cnt = (int *)lalloc((long_u)(sizeof(int) * (badlen + 1) * (goodlen + 1)));
 
   CNT(0, 0) = 0;
   for (j = 1; j <= goodlen; ++j)

--- a/src/tag.c
+++ b/src/tag.c
@@ -1995,8 +1995,7 @@ findtag_end:
     match_count = 0;
 
   if (match_count > 0)
-    matches = (char_u **)lalloc((long_u)(match_count * sizeof(char_u *)),
-        TRUE);
+    matches = (char_u **)lalloc((long_u)(match_count * sizeof(char_u *)));
   else
     matches = NULL;
   match_count = 0;

--- a/src/undo.c
+++ b/src/undo.c
@@ -135,7 +135,7 @@ static void serialize_visualinfo(visualinfo_T *info, FILE *fp);
 static void unserialize_visualinfo(visualinfo_T *info, FILE *fp);
 static void put_header_ptr(FILE *fp, u_header_T *uhp);
 
-#define U_ALLOC_LINE(size) lalloc((long_u)(size), FALSE)
+#define U_ALLOC_LINE(size) lalloc((long_u)(size));
 static char_u *u_save_line(linenr_T);
 
 /* used in undo_end() to report number of added and deleted lines */
@@ -769,7 +769,7 @@ static size_t fwrite_crypt(buf_T *buf, char_u *ptr, size_t len, FILE *fp)
   if (len < 100)
     copy = small_buf;      /* no malloc()/free() for short strings */
   else {
-    copy = lalloc(len, FALSE);
+    copy = lalloc(len);
   }
   crypt_encode(ptr, len, copy);
   i = fwrite(copy, len, (size_t)1, fp);


### PR DESCRIPTION
Apparently there's a lot to do. Especially when trying to conform to the developer guidelines. ;-)

I mostly cleaned up `memory.c` and `memory.h` and all those files that called `lalloc*()` and provided a second argument to that function that was never used.
