### PR TITLE
[RDY] vim-patch:7.4.203

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -713,9 +713,11 @@ restofline:
       if (fmt_ptr->conthere)
         fmt_start = fmt_ptr;
 
-      if (vim_strchr((char_u *)"AEWI", idx) != NULL)
-        multiline = TRUE;               /* start of a multi-line message */
-      else if (vim_strchr((char_u *)"CZ", idx) != NULL) { /* continuation of multi-line msg */
+      if (vim_strchr((char_u *)"AEWI", idx) != NULL) {
+        multiline = TRUE;    /* start of a multi-line message */
+        multiignore = FALSE; /* reset continuation */
+      } else if (vim_strchr((char_u *)"CZ", idx)
+                 != NULL) { /* continuation of multi-line msg */
         if (qfprev == NULL)
           goto error2;
         if (*errmsg && !multiignore) {

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -26,7 +26,7 @@ SCRIPTS := test1.out test2.out test3.out test4.out test5.out test6.out \
 		test89.out test90.out test91.out test92.out test93.out \
 		test94.out test95.out test96.out test97.out test98.out \
 		test99.out test100.out test101.out test102.out test103.out \
-		test104.out
+		test104.out test106.out
 
 SCRIPTS_GUI := test16.out
 

--- a/src/testdir/test106.in
+++ b/src/testdir/test106.in
@@ -1,0 +1,16 @@
+Tests for errorformat.  vim: set ft=vim ts=8 :
+
+STARTTEST
+:so small.vim
+:if !has('quickfix') | e! test.ok | wq! test.out | endif
+:set efm=%EEEE%m,%WWWW%m,%+CCCC%.%#,%-GGGG%.%#
+:cgetexpr ['WWWW', 'EEEE', 'CCCC']
+:$put =strtrans(string(map(getqflist(), '[v:val.text, v:val.valid]')))
+:cgetexpr ['WWWW', 'GGGG', 'EEEE', 'CCCC']
+:$put =strtrans(string(map(getqflist(), '[v:val.text, v:val.valid]')))
+:cgetexpr ['WWWW', 'GGGG', 'ZZZZ', 'EEEE', 'CCCC', 'YYYY']
+:$put =strtrans(string(map(getqflist(), '[v:val.text, v:val.valid]')))
+:/^Results/,$wq! test.out
+ENDTEST
+
+Results of test106:

--- a/src/testdir/test106.ok
+++ b/src/testdir/test106.ok
@@ -1,0 +1,4 @@
+Results of test106:
+[['W', 1], ['E^@CCCC', 1]]
+[['W', 1], ['E^@CCCC', 1]]
+[['W', 1], ['ZZZZ', 0], ['E^@CCCC', 1], ['YYYY', 0]]

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,10 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  203,
+  //202,
+  //201,
+  //200,
   199,
   //198,
   //197,


### PR DESCRIPTION
Merging vim-patch:7.4.203
Missing tests in Makefile have to be included if vim-patch:7.4.{167,191} are merged first.

Problem:    Parsing 'errorformat' is not correct.
Solution:   Reset "multiignore" at the start of a multi-line message. (Lcd)

https://code.google.com/p/vim/source/detail?r=fb24b025c7cf07db79a559a3091db42e02c1af86
