### PR TITLE
[RDY] vim-patch:7.4.204

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1854,9 +1854,12 @@ static int vgetorpeek(int advance)
 
                 /* Don't allow mapping the first byte(s) of a
                  * multi-byte char.  Happens when mapping
-                 * <M-a> and then changing 'encoding'. */
-                if (has_mbyte && MB_BYTE2LEN(c1)
-                    > (*mb_ptr2len)(mp->m_keys))
+                 * <M-a> and then changing 'encoding'. Beware
+                 * that 0x80 is escaped. */
+                char_u *p1 = mp->m_keys;
+                char_u *p2 = mb_unescape(&p1);
+
+                if (has_mbyte && p2 != NULL && MB_BYTE2LEN(c1) > MB_PTR2LEN(p2))
                   mlen = 0;
                 /*
                  * Check an entry whether it matches.

--- a/src/testdir/test75.in
+++ b/src/testdir/test75.in
@@ -1,8 +1,11 @@
 Tests for maparg().
+Also test utf8 map with a 0x80 byte.
 
 STARTTEST
 :so small.vim
+:so mbyte.vim
 :set cpo-=<
+:set encoding=utf8
 :" Test maparg() with a string result
 :map foo<C-V> is<F4>foo
 :vnoremap <script> <buffer> <expr> <silent> bar isbar
@@ -16,6 +19,20 @@ STARTTEST
 :call append('$', maparg('abc'))
 :map abc y<S-char-114>y
 :call append('$', maparg('abc'))
+:"
+Go:"
+:" Outside of the range, minimum
+:inoremap <Char-0x1040> a
+:call feedkeys("a\u1040\<Esc>")
+:" Inside of the range, minimum
+:inoremap <Char-0x103f> b
+:call feedkeys("a\u103f\<Esc>")
+:" Inside of the range, maximum
+:inoremap <Char-0xf03f> c
+:call feedkeys("a\uf03f\<Esc>")
+:" Outside of the range, maximum
+:inoremap <Char-0xf040> d
+:call feedkeys("a\uf040\<Esc>")
 :"
 :/^eof/+1,$w! test.out
 :qa!

--- a/src/testdir/test75.ok
+++ b/src/testdir/test75.ok
@@ -4,3 +4,4 @@ is<F4>foo
 {'silent': 0, 'noremap': 0, 'lhs': 'foo', 'mode': ' ', 'nowait': 1, 'expr': 0, 'sid': 0, 'rhs': 'bar', 'buffer': 1}
 xrx
 yRy
+abcd

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,7 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  204,
   203,
   //202,
   //201,


### PR DESCRIPTION
Merging vim-patch:7.4.204

Problem:    A mapping where the second byte is 0x80 doesn't work.
Solution:   Unescape before checking for incomplete multi-byte char. (Nobuhiro
            Takasaki)

https://code.google.com/p/vim/source/detail?r=f5120cbf16b9a9c6e0fbb599a6524e05ecf11393
