### PR TITLE
gcc is too smart

### DIFF
--- a/src/undo.c
+++ b/src/undo.c
@@ -250,7 +250,7 @@ int u_save(linenr_T top, linenr_T bot)
     return OK;
 
   if (top > curbuf->b_ml.ml_line_count
-      || top >= bot
+      // || top >= bot
       || bot > curbuf->b_ml.ml_line_count + 1)
     return FALSE;       /* rely on caller to do error messages */
 


### PR DESCRIPTION
comment this line because its causing gcc warnings. There are more warnings like this (Just dropping -Wall for now). You may want to fix this in a different way eventually.

  if (top > curbuf->b_ml.ml_line_count
      || top >= bot
      || bot > curbuf->b_ml.ml_line_count + 1)

Let's rewrite:

  if ( top > N  // 1
      || top >= bot // 2
      || N + 1 < bot) // 3

  If 1 is not true, then we know top <= N, adding line 3 we get:

  Now  top <= N < N + 1 < bot

  Thus top <= bot, thus line 2 will never be true, thus it can be
  dropped. Thanks to roxfan @ #gcc to help me understand this.
  gcc 4.7's error message is still very strange:

```
src/undo.c:253:7: error: assuming signed overflow does not occur when assuming that (X - c) > X is always false [-Werror=strict-overflow]
   || top >= bot
   ^
cc1: all warnings being treated as errors
```
