### PR TITLE
[RDY] vim-patch:7.4.207

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,8 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  207,
+  //206,
   205,
   204,
   203,


### PR DESCRIPTION
Merging vim-patch:7.4.207

Problem:    The cursor report sequence is sometimes not recognized and results
            in entering replace mode.
Solution:   Also check for the cursor report when not asked for.

https://code.google.com/p/vim/source/detail?r=2aa909427e44cd3aac7def024b66e41d0c9d0e0d
