### PR TITLE
[RFC] vim-patch:7.4.211

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1236,6 +1236,11 @@ return {
     func='ex_tag',
   },
   {
+    command='lunmap',
+    flags=bit.bor(EXTRA, TRLBAR, NOTRLCOM, USECTRLV, CMDWIN),
+    func='ex_unmap',
+  },
+  {
     command='lua',
     flags=bit.bor(RANGE, EXTRA, NEEDARG, CMDWIN),
     func='ex_script_ni',
@@ -1249,11 +1254,6 @@ return {
     command='luafile',
     flags=bit.bor(RANGE, FILE1, NEEDARG, CMDWIN),
     func='ex_ni',
-  },
-  {
-    command='lunmap',
-    flags=bit.bor(EXTRA, TRLBAR, NOTRLCOM, USECTRLV, CMDWIN),
-    func='ex_unmap',
   },
   {
     command='lvimgrep',

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -526,7 +526,7 @@ static int included_patches[] = {
   //214 NA
   213,
   //212 NA
-  //211,
+  211,
   210,
   209,
   //208 NA


### PR DESCRIPTION
Merging vim-patch:7.4.211
~~This PR is for documentation and marks patch 211 as included. ~~

Commit 807494578888d12ce55db67d73948bef208c2695 removed lua support, which automatically fixed the issue described in the patch notes (see https://github.com/neovim/neovim/commit/807494578888d12ce55db67d73948bef208c2695#diff-bfc66cd97afd06b1db0e877bf07713ceL570).

Problem:    ":lu" is an abbreviation for ":lua", but it should be ":lunmap".
            (ZyX)
Solution:   Move "lunmap" to above "lua".

https://code.google.com/p/vim/source/detail?r=e90bef2240c8d187da6e8d8fa5007ec5afc12284
