### PR TITLE
[RFC] Adjust modelines to project's coding style

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/src/arabic.c
+++ b/src/arabic.c
@@ -1,3 +1,4 @@
+// vim: set et sts=2 sw=2
 /// @file arabic.c
 ///
 /// Functions for Arabic language.

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/charset.c
+++ b/src/charset.c
@@ -1,3 +1,4 @@
+// vim: set et sts=2 sw=2
 /// @file charset.c
 ///
 /// Code related to character sets.

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -1,3 +1,4 @@
+// vim: set et sts=2 sw=2
 /*
  * Optional encryption support.
  * Mohsin Ahmed, mosh@sasi.com, 98-09-24

--- a/src/cursor_shape.c
+++ b/src/cursor_shape.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 #include "vim.h"
 #include "cursor_shape.h"
 #include "misc2.h"

--- a/src/diff.c
+++ b/src/diff.c
@@ -1,3 +1,4 @@
+// vim: set et sts=2 sw=2
 /// @file diff.c
 ///
 /// Code for diff'ing two, three or four buffers.

--- a/src/digraph.c
+++ b/src/digraph.c
@@ -1,3 +1,4 @@
+// vim: set et sts=2 sw=2
 /// @file digraph.c
 ///
 /// code for digraphs

--- a/src/edit.c
+++ b/src/edit.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/eval.c
+++ b/src/eval.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1,5 +1,5 @@
-/* vi:set ts=2 sts=2 sw=2:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1,5 +1,5 @@
-/* vi:set ts=2 sts=2 sw=2:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/farsi.c
+++ b/src/farsi.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 /// @file farsi.c
 ///
 /// Functions for Farsi language

--- a/src/file_search.c
+++ b/src/file_search.c
@@ -1,3 +1,4 @@
+// vim: set et sts=2 sw=2
 /* TODO: make some #ifdef for this */
 /*--------[ file searching ]-------------------------------------------------*/
 /*

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1,5 +1,5 @@
-/* vi:set ts=2 sts=2 sw=2:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/fold.c
+++ b/src/fold.c
@@ -1,5 +1,5 @@
-/* vim:set ts=2 sts=2 sw=2:
- * vim600:fdm=marker fdl=1 fdc=3:
+// vim: set et sts=2 sw=2
+/*
  *
  * VIM - Vi IMproved	by Bram Moolenaar
  *

--- a/src/garray.c
+++ b/src/garray.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 /// @file garray.c
 ///
 /// Functions for handling growing arrays.

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -1,3 +1,4 @@
+// vim: set et sts=2 sw=2
 /// @file hashtab.c
 ///
 /// Handling of a hashtable with Vim-specific properties.

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * CSCOPE support for Vim added by Andy Kahn <kahn@zk3.dec.com>
  * Ported to Win32 by Sergey Khorev <sergey.khorev@gmail.com>
  *

--- a/src/indent.c
+++ b/src/indent.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 #include "indent.h"
 #include "eval.h"
 #include "charset.h"

--- a/src/indent_c.c
+++ b/src/indent_c.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 #include "vim.h"
 #include "misc1.h"
 #include "charset.h"

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 /************************************************************************
  * functions that use lookup tables for various things, generally to do with
  * special key codes.

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/mark.c
+++ b/src/mark.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  * Multibyte extensions partly by Sung-Hoon Baek
  *

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/memline.c
+++ b/src/memline.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,4 +1,5 @@
- // Various routines dealing with allocation and deallocation of memory.
+// vim: set et sts=2 sw=2
+// Various routines dealing with allocation and deallocation of memory.
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/menu.c
+++ b/src/menu.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved		by Bram Moolenaar
  *				GUI/Motif support by Robert Webb
  *

--- a/src/message.c
+++ b/src/message.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/move.c
+++ b/src/move.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/msgpack_rpc.c
+++ b/src/msgpack_rpc.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 #include <msgpack.h>
 
 #include "msgpack_rpc.h"

--- a/src/normal.c
+++ b/src/normal.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/ops.c
+++ b/src/ops.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/option.c
+++ b/src/option.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *	      OS/2 port by Paul Slootman
  *	      VMS merge by Zoltan Arpadffy

--- a/src/path.c
+++ b/src/path.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 #include <stdlib.h>
 
 #include "vim.h"

--- a/src/popupmnu.c
+++ b/src/popupmnu.c
@@ -1,3 +1,4 @@
+// vim: set et sts=2 sw=2
 /// @file popupmnu.c
 ///
 /// Popup menu (PUM)

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * Handling of regular expressions: vim_regcomp(), vim_regexec(), vim_regsub()
  *
  * NOTICE:

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * NFA regular expression implementation.
  *
  * This file is included in "regexp.c".

--- a/src/screen.c
+++ b/src/screen.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/search.c
+++ b/src/search.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -1,3 +1,4 @@
+// vim: set et sts=2 sw=2
 /// @file sha256.c
 ///
 /// FIPS-180-2 compliant SHA-256 implementation

--- a/src/spell.c
+++ b/src/spell.c
@@ -1,5 +1,5 @@
-/* vi:set ts=2 sts=2 sw=2:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -1,5 +1,5 @@
-/* vi:set ts=2 sts=2 sw=2:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/tag.c
+++ b/src/tag.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/term.c
+++ b/src/term.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,5 +1,5 @@
-/* vi:set ts=8 sts=4 sw=4:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/undo.c
+++ b/src/undo.c
@@ -1,5 +1,5 @@
-/* vi:set ts=2 sts=2 sw=2:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read copying and usage conditions.

--- a/src/version.c
+++ b/src/version.c
@@ -1,3 +1,5 @@
+// vim: set et sts=2 sw=2
+
 /// @file version.c
 ///
 /// Vim originated from Stevie version 3.6 (Fish disk 217) by GRWalter (Fred)

--- a/src/window.c
+++ b/src/window.c
@@ -1,5 +1,5 @@
-/* vi:set ts=2 sts=2 sw=2:
- *
+// vim: set et sts=2 sw=2
+/*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
  * Do ":help uganda"  in Vim to read a list of people who contributed.


### PR DESCRIPTION
This patch changes all modelines to: `vim: set et sts=2 sw=2`

I think it makes sense to adjust it to our guidelines, since the old modelines often differed from file to file anyway.

If you want the changes, I'd like to do the same changes to all header files.
