### PR TITLE
[RDY] Remove 'textmode' option

### DIFF
--- a/src/buffer_defs.h
+++ b/src/buffer_defs.h
@@ -607,7 +607,6 @@ struct file_buffer {
   long b_p_smc;                 /* 'synmaxcol' */
   char_u      *b_p_syn;         /* 'syntax' */
   long b_p_ts;                  /* 'tabstop' */
-  int b_p_tx;                   /* 'textmode' */
   long b_p_tw;                  /* 'textwidth' */
   long b_p_tw_nobin;            /* b_p_tw saved for binary mode */
   long b_p_tw_nopaste;          /* b_p_tw saved for paste mode */

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1608,9 +1608,10 @@ rewind_retry:
         if (fileformat == EOL_UNKNOWN)
           fileformat = default_fileformat();
 
-        /* if editing a new file: may set p_tx and p_ff */
-        if (set_options)
+        // May set 'p_ff' if editing a new file.
+        if (set_options) {
           set_fileformat(fileformat, OPT_LOCAL);
+        }
       }
     }
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1147,41 +1147,41 @@ get_fileformat_force (
   return EOL_DOS;
 }
 
-/*
- * Set the current end-of-line type to EOL_DOS, EOL_UNIX or EOL_MAC.
- * Sets both 'textmode' and 'fileformat'.
- * Note: Does _not_ set global value of 'textmode'!
- */
-void 
-set_fileformat (
-    int t,
-    int opt_flags                  /* OPT_LOCAL and/or OPT_GLOBAL */
-)
+/// Set the current end-of-line type to EOL_UNIX, EOL_MAC, or EOL_DOS.
+///
+/// Sets 'fileformat'.
+///
+/// @param eol_style End-of-line style.
+/// @param opt_flags OPT_LOCAL and/or OPT_GLOBAL
+void set_fileformat(int eol_style, int opt_flags)
 {
-  char        *p = NULL;
+  char *p = NULL;
 
-  switch (t) {
-  case EOL_DOS:
-    p = FF_DOS;
-    curbuf->b_p_tx = TRUE;
-    break;
-  case EOL_UNIX:
-    p = FF_UNIX;
-    curbuf->b_p_tx = FALSE;
-    break;
-  case EOL_MAC:
-    p = FF_MAC;
-    curbuf->b_p_tx = FALSE;
-    break;
+  switch (eol_style) {
+      case EOL_UNIX:
+          p = FF_UNIX;
+          break;
+      case EOL_MAC:
+          p = FF_MAC;
+          break;
+      case EOL_DOS:
+          p = FF_DOS;
+          break;
   }
-  if (p != NULL)
-    set_string_option_direct((char_u *)"ff", -1, (char_u *)p,
-        OPT_FREE | opt_flags, 0);
 
-  /* This may cause the buffer to become (un)modified. */
+  // p is NULL if "eol_style" is EOL_UNKNOWN.
+  if (p != NULL) {
+    set_string_option_direct((char_u *)"ff",
+                             -1,
+                             (char_u *)p,
+                             OPT_FREE | opt_flags,
+                             0);
+  }
+
+  // This may cause the buffer to become (un)modified.
   check_status(curbuf);
   redraw_tabline = TRUE;
-  need_maketitle = TRUE;            /* set window title later */
+  need_maketitle = TRUE;  // Set window title later.
 }
 
 /*


### PR DESCRIPTION
`'textmode'` is an option obsoleted for at least 10 years in favor of `'fileformat'`.

Reference: https://github.com/neovim/neovim/issues/537
