### PR TITLE
[RFC] Handle special KE_EVENT case where maxlen < 3

### DIFF
--- a/src/os/input.h
+++ b/src/os/input.h
@@ -4,15 +4,14 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "types.h"
-
 void input_init(void);
 bool input_ready(void);
 void input_start(void);
 void input_stop(void);
 uint32_t input_read(char *buf, uint32_t count);
-int os_inchar(char_u *, int, int32_t, int);
+int os_inchar(uint8_t *, int, int32_t, int);
 bool os_char_avail(void);
 void os_breakcheck(void);
 
 #endif  // NEOVIM_OS_INPUT_H
+


### PR DESCRIPTION
Possible bug reported by @oni-link [here](https://github.com/neovim/neovim/pull/485/files#r11664573).

It was handled by doing a circular walk through a key buffer and saving the index between calls with a static variable.

Also replaced some `char_u` occurrences by `uint8_t` and removed unused headers in input.c module.
