### PR TITLE
[RFC] Configure travis to use prebuilt dependencies

### DIFF
--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -44,3 +44,7 @@ wget -q -O - http://llvm.org/releases/3.4/clang+llvm-3.4-x86_64-unknown-ubuntu12
 # 	apt-get -qq -y --no-install-recommends install clang-3.4 lldb-3.4
 
 pip install cpp-coveralls --use-mirrors
+
+# install prebuilt dependencies
+cd /opt
+sudo git clone --depth=1 git://github.com/tarruda/neovim-deps

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -17,6 +17,12 @@ check_and_report() {
 	)
 }
 
+# setup environment for using the /opt/neovim-deps prefix
+export PATH="/opt/neovim-deps/bin:$PATH"
+export PKG_CONFIG_PATH="/opt/neovim-deps/lib/pkgconfig"
+export DEPS_CMAKE_FLAGS="-DUSE_BUNDLED_LIBUV=OFF -DUSE_BUNDLED_LUAJIT=OFF -DUSE_BUNDLED_MSGPACK=OFF -DUSE_BUNDLED_LUAROCKS=OFF"
+eval $(/opt/neovim-deps/bin/luarocks path)
+
 # Travis reports back that it has 32-cores via /proc/cpuinfo, but it's not
 # what we really have available.  According to their documentation, it only has
 # 1.5 virtual cores.


### PR DESCRIPTION
Dependencies are now hosted in a github repository and this brings two advantages:
- Improved build time with travis since we no longer have to build each dependency
- Less chance of build errors due to external servers being down since Github is now the single point of failure

This is a temporary solution until we have prebuilt packages in a ppa or something like that
