### PR TITLE
[RFC] More stream abstractions and improvements

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -405,10 +405,11 @@ static struct vimvar {
 static dictitem_T vimvars_var;                  /* variable used for v: */
 #define vimvarht  vimvardict.dv_hashtab
 
-static void apply_job_autocmds(int id,
-                               void *data,
-                               RStream *target,
-                               bool from_stdout);
+static void on_job_stdout(RStream *rstream, void *data, bool eof);
+static void on_job_stderr(RStream *rstream, void *data, bool eof);
+static void on_job_exit(Job *job, void *data);
+static void on_job_data(RStream *rstream, void *data, bool eof, char *type);
+static void apply_job_autocmds(Job *job, char *name, char *type, char *str);
 static void prepare_vimvar(int idx, typval_T *save_tv);
 static void restore_vimvar(int idx, typval_T *save_tv);
 static int ex_let_vars(char_u *arg, typval_T *tv, int copy,
@@ -11073,7 +11074,9 @@ static void f_job_start(typval_T *argvars, typval_T *rettv)
 
   rettv->vval.v_number = job_start(argv,
                                    xstrdup((char *)argvars[0].vval.v_string),
-                                   apply_job_autocmds);
+                                   on_job_stdout,
+                                   on_job_stderr,
+                                   on_job_exit);
 
   if (rettv->vval.v_number <= 0) {
     if (rettv->vval.v_number == 0) {
@@ -19796,31 +19799,56 @@ char_u *do_string_sub(char_u *str, char_u *pat, char_u *sub, char_u *flags)
   return ret;
 }
 
-static void apply_job_autocmds(int id,
-                               void *data,
-                               RStream *target,
-                               bool from_stdout)
+static void on_job_stdout(RStream *rstream, void *data, bool eof)
+{
+  if (!eof) {
+    on_job_data(rstream, data, eof, "stdout");
+  }
+}
+
+static void on_job_stderr(RStream *rstream, void *data, bool eof)
+{
+  if (!eof) {
+    on_job_data(rstream, data, eof, "stderr");
+  }
+}
+
+static void on_job_exit(Job *job, void *data)
+{
+  apply_job_autocmds(job, data, "exit", NULL);
+}
+
+static void on_job_data(RStream *rstream, void *data, bool eof, char *type)
+{
+  Job *job = data;
+  uint32_t read_count = rstream_available(rstream);
+  char *str = xmalloc(read_count + 1);
+
+  rstream_read(rstream, str, read_count);
+  str[read_count] = NUL;
+  apply_job_autocmds(job, job_data(job), type, str);
+}
+
+static void apply_job_autocmds(Job *job, char *name, char *type, char *str)
 {
   list_T *list;
-  char *str;
-  listitem_T *str_slot = listitem_alloc();
-  uint32_t read_count = rstream_available(target);
 
-  // Prepare the list item containing the data read
-  str = xmalloc(read_count + 1);
-  rstream_read(target, str, read_count);
-  str[read_count] = NUL;
-  str_slot->li_tv.v_type = VAR_STRING;
-  str_slot->li_tv.v_lock = 0;
-  str_slot->li_tv.vval.v_string = (char_u *)str;
   // Create the list which will be set to v:job_data
   list = list_alloc();
-  list_append_number(list, id);
-  list_append(list, str_slot);
-  list_append_string(list, (char_u *)(from_stdout ? "out" : "err"), 3);
+  list_append_number(list, job_id(job));
+  list_append_string(list, (uint8_t *)type, -1);
+
+  if (str) {
+    listitem_T *str_slot = listitem_alloc();
+    str_slot->li_tv.v_type = VAR_STRING;
+    str_slot->li_tv.v_lock = 0;
+    str_slot->li_tv.vval.v_string = (uint8_t *)str;
+    list_append(list, str_slot);
+  }
+
   // Update v:job_data for the autocommands
   set_vim_var_list(VV_JOB_DATA, list);
   // Call JobActivity autocommands
-  apply_autocmds(EVENT_JOBACTIVITY, (char_u *)data, NULL, TRUE, NULL);
+  apply_autocmds(EVENT_JOBACTIVITY, (uint8_t *)name, NULL, TRUE, NULL);
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -63,7 +63,6 @@
 #include "window.h"
 #include "os/os.h"
 #include "os/job.h"
-#include "os/shell.h"
 #include "os/rstream.h"
 #include "os/rstream_defs.h"
 
@@ -11023,7 +11022,7 @@ static void f_job_start(typval_T *argvars, typval_T *rettv)
   rettv->vval.v_number = 0;
 
   if (check_restricted() || check_secure()) {
-    goto cleanup;
+    return;
   }
 
   if (argvars[0].v_type != VAR_STRING
@@ -11032,7 +11031,7 @@ static void f_job_start(typval_T *argvars, typval_T *rettv)
       && argvars[2].v_type != VAR_UNKNOWN)) {
     // Wrong argument types
     EMSG(_(e_invarg));
-    goto cleanup;
+    return;
   }
 
   argsl = 0;
@@ -11043,7 +11042,7 @@ static void f_job_start(typval_T *argvars, typval_T *rettv)
     for (arg = args->lv_first; arg != NULL; arg = arg->li_next) {
       if (arg->li_tv.v_type != VAR_STRING) {
         EMSG(_(e_invarg));
-        goto cleanup;
+        return;
       }
     }
   }
@@ -11051,7 +11050,7 @@ static void f_job_start(typval_T *argvars, typval_T *rettv)
   if (!os_can_exe(get_tv_string(&argvars[1]))) {
     // String is not executable
     EMSG2(e_jobexe, get_tv_string(&argvars[1]));
-    goto cleanup;
+    return;
   }
 
   // Allocate extra memory for the argument vector and the NULL pointer
@@ -11085,14 +11084,6 @@ static void f_job_start(typval_T *argvars, typval_T *rettv)
       EMSG(_(e_jobexe));
     }
   }
-
-cleanup:
-  if (rettv->vval.v_number > 0) {
-    // Success
-    return;
-  }
-  // Cleanup argv memory in case the `job_start` call failed
-  shell_free_argv(argv);
 }
 
 // "jobstop()" function

--- a/src/os/event.c
+++ b/src/os/event.c
@@ -110,11 +110,11 @@ void event_process()
       case kEventSignal:
         signal_handle(event);
         break;
-      case kEventJobActivity:
-        job_handle(event);
-        break;
       case kEventRStreamData:
         rstream_read_event(event);
+        break;
+      case kEventJobExit:
+        job_exit_event(event);
         break;
       default:
         abort();

--- a/src/os/event.c
+++ b/src/os/event.c
@@ -8,6 +8,7 @@
 #include "os/event.h"
 #include "os/input.h"
 #include "os/signal.h"
+#include "os/rstream.h"
 #include "os/job.h"
 #include "vim.h"
 #include "memory.h"
@@ -111,6 +112,9 @@ void event_process()
         break;
       case kEventJobActivity:
         job_handle(event);
+        break;
+      case kEventRStreamData:
+        rstream_read_event(event);
         break;
       default:
         abort();

--- a/src/os/event_defs.h
+++ b/src/os/event_defs.h
@@ -6,8 +6,8 @@
 
 typedef enum {
   kEventSignal,
-  kEventJobActivity,
-  kEventRStreamData
+  kEventRStreamData,
+  kEventJobExit
 } EventType;
 
 typedef struct {
@@ -18,11 +18,7 @@ typedef struct {
       RStream *ptr;
       bool eof;
     } rstream;
-    struct {
-      Job *ptr;
-      RStream *target;
-      bool from_stdout;
-    } job;
+    Job *job;
   } data;
 } Event;
 

--- a/src/os/event_defs.h
+++ b/src/os/event_defs.h
@@ -6,13 +6,18 @@
 
 typedef enum {
   kEventSignal,
-  kEventJobActivity
+  kEventJobActivity,
+  kEventRStreamData
 } EventType;
 
 typedef struct {
   EventType type;
   union {
     int signum;
+    struct {
+      RStream *ptr;
+      bool eof;
+    } rstream;
     struct {
       Job *ptr;
       RStream *target;

--- a/src/os/input.c
+++ b/src/os/input.c
@@ -34,7 +34,7 @@ static int push_event_key(uint8_t *buf, int maxlen);
 
 void input_init()
 {
-  read_stream = rstream_new(read_cb, READ_BUFFER_SIZE, NULL);
+  read_stream = rstream_new(read_cb, READ_BUFFER_SIZE, NULL, false);
   rstream_set_file(read_stream, read_cmd_fd);
 }
 

--- a/src/os/job.c
+++ b/src/os/job.c
@@ -248,7 +248,6 @@ void job_exit_event(Event event)
   job->exit_cb(job, job->data);
 
   // Free the job resources
-  shell_free_argv(job->proc_opts.args);
   free_job(job);
 
   // Stop polling job status if this was the last
@@ -356,6 +355,7 @@ static void close_cb(uv_handle_t *handle)
     rstream_free(job->out);
     rstream_free(job->err);
     wstream_free(job->in);
+    shell_free_argv(job->proc_opts.args);
     free(job->data);
     free(job);
   }

--- a/src/os/job.c
+++ b/src/os/job.c
@@ -356,6 +356,7 @@ static void close_cb(uv_handle_t *handle)
     rstream_free(job->out);
     rstream_free(job->err);
     wstream_free(job->in);
+    free(job->data);
     free(job);
   }
 }

--- a/src/os/job.c
+++ b/src/os/job.c
@@ -159,8 +159,8 @@ int job_start(char **argv, void *data, job_read_cb cb)
   }
 
   // Start the readable streams
-  job->out = rstream_new(read_cb, JOB_BUFFER_SIZE, job);
-  job->err = rstream_new(read_cb, JOB_BUFFER_SIZE, job);
+  job->out = rstream_new(read_cb, JOB_BUFFER_SIZE, job, false);
+  job->err = rstream_new(read_cb, JOB_BUFFER_SIZE, job, false);
   rstream_set_stream(job->out, (uv_stream_t *)&job->proc_stdout);
   rstream_set_stream(job->err, (uv_stream_t *)&job->proc_stderr);
   rstream_start(job->out);

--- a/src/os/job.c
+++ b/src/os/job.c
@@ -212,8 +212,6 @@ bool job_stop(int id)
     return false;
   }
 
-  uv_read_stop((uv_stream_t *)&job->proc_stdout);
-  uv_read_stop((uv_stream_t *)&job->proc_stderr);
   job->stopped = true;
 
   return true;

--- a/src/os/job.h
+++ b/src/os/job.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "os/event_defs.h"
 #include "os/event.h"
 
 /// Initializes job control resources

--- a/src/os/job.h
+++ b/src/os/job.h
@@ -11,7 +11,7 @@
 #include <stdbool.h>
 
 #include "os/event_defs.h"
-#include "os/event.h"
+#include "os/rstream_defs.h"
 
 /// Initializes job control resources
 void job_init(void);
@@ -24,12 +24,19 @@ void job_teardown(void);
 /// @param argv Argument vector for the process. The first item is the
 ///        executable to run.
 /// @param data Caller data that will be associated with the job
-/// @param cb Callback that will be invoked everytime data is available in
-///        the job's stdout/stderr
+/// @param stdout_cb Callback that will be invoked when data is available
+///        on stdout
+/// @param stderr_cb Callback that will be invoked when data is available
+///        on stderr
+/// @param exit_cb Callback that will be invoked when the job exits
 /// @return The job id if the job started successfully. If the the first item /
 ///         of `argv`(the program) could not be executed, -1 will be returned.
 //          0 will be returned if the job table is full.
-int job_start(char **argv, void *data, job_read_cb cb);
+int job_start(char **argv,
+              void *data,
+              rstream_cb stdout_cb,
+              rstream_cb stderr_cb,
+              job_exit_cb exit_cb);
 
 /// Terminates a job. This is a non-blocking operation, but if the job exists
 /// it's guaranteed to succeed(SIGKILL will eventually be sent)
@@ -49,10 +56,22 @@ bool job_stop(int id);
 ///              id is invalid(probably because it has already stopped)
 bool job_write(int id, char *data, uint32_t len);
 
-/// Runs the read callback associated with the job/event
+/// Runs the read callback associated with the job exit event
 ///
 /// @param event Object containing data necessary to invoke the callback
-void job_handle(Event event);
+void job_exit_event(Event event);
+
+/// Get the job id
+///
+/// @param job A pointer to the job
+/// @return The job id
+int job_id(Job *job);
+
+/// Get data associated with a job
+///
+/// @param job A pointer to the job
+/// @return The job data
+void *job_data(Job *job);
 
 #endif  // NEOVIM_OS_JOB_H
 

--- a/src/os/job_defs.h
+++ b/src/os/job_defs.h
@@ -9,13 +9,7 @@ typedef struct job Job;
 ///
 /// @param id The job id
 /// @param data Some data associated with the job by the caller
-/// @param target The `RStream` instance containing data to be read
-/// @param from_stdout This is true if data was read from the job's stdout,
-///        false if it came from stderr.
-typedef void (*job_read_cb)(int id,
-                            void *data,
-                            RStream *target,
-                            bool from_stdout);
+typedef void (*job_exit_cb)(Job *job, void *data);
 
 #endif  // NEOVIM_OS_JOB_DEFS_H
 

--- a/src/os/rstream.h
+++ b/src/os/rstream.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <uv.h>
 
+#include "os/event_defs.h"
 #include "os/rstream_defs.h"
 
 /// Creates a new RStream instance. A RStream encapsulates all the boilerplate
@@ -14,8 +15,15 @@
 ///        for reading with `rstream_read`
 /// @param buffer_size Size in bytes of the internal buffer.
 /// @param data Some state to associate with the `RStream` instance
+/// @param async Flag that specifies if the callback should only be called
+///        outside libuv event loop(When processing async events with
+///        KE_EVENT). Only the RStream instance reading user input should set
+///        this to false
 /// @return The newly-allocated `RStream` instance
-RStream * rstream_new(rstream_cb cb, uint32_t buffer_size, void *data);
+RStream * rstream_new(rstream_cb cb,
+                      uint32_t buffer_size,
+                      void *data,
+                      bool async);
 
 /// Frees all memory allocated for a RStream instance
 ///
@@ -70,6 +78,11 @@ uint32_t rstream_read(RStream *rstream, char *buffer, uint32_t count);
 /// @param rstream The `RStream` instance
 /// @return The number of bytes available
 uint32_t rstream_available(RStream *rstream);
+
+/// Runs the read callback associated with the rstream
+///
+/// @param event Object containing data necessary to invoke the callback
+void rstream_read_event(Event event);
 
 #endif  // NEOVIM_OS_RSTREAM_H
 

--- a/src/os/rstream.h
+++ b/src/os/rstream.h
@@ -36,12 +36,6 @@ void rstream_free(RStream *rstream);
 /// @param stream The new `uv_stream_t` instance
 void rstream_set_stream(RStream *rstream, uv_stream_t *stream);
 
-/// Sets the underlying `uv_file_t` instance
-///
-/// @param rstream The `RStream` instance
-/// @param stream The new `uv_stream_t` instance
-void rstream_set_stream(RStream *rstream, uv_stream_t *stream);
-
 /// Sets the underlying file descriptor that will be read from. Only pipes
 /// and regular files are supported for now.
 ///

--- a/src/os/rstream_defs.h
+++ b/src/os/rstream_defs.h
@@ -3,7 +3,7 @@
 
 typedef struct rstream RStream;
 
-/// Function called when the RStream receives data
+/// Type of function called when the RStream receives data
 ///
 /// @param rstream The RStream instance
 /// @param data State associated with the RStream instance

--- a/src/os/wstream.c
+++ b/src/os/wstream.c
@@ -1,0 +1,114 @@
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <uv.h>
+
+#include "os/wstream.h"
+#include "os/wstream_defs.h"
+#include "vim.h"
+#include "memory.h"
+
+struct wstream {
+  uv_stream_t *stream;
+  // Memory currently used by pending buffers
+  uint32_t curmem;
+  // Maximum memory used by this instance
+  uint32_t maxmem;
+  // Number of pending requests
+  uint32_t pending_reqs;
+  bool freed;
+};
+
+typedef struct {
+  WStream *wstream;
+  // Buffer containing data to be written
+  char *buffer;
+  // Size of the buffer
+  uint32_t length;
+  // If it's our responsibility to free the buffer
+  bool free;
+} WriteData;
+
+static void write_cb(uv_write_t *req, int status);
+
+WStream * wstream_new(uint32_t maxmem)
+{
+  WStream *rv = xmalloc(sizeof(WStream));
+  rv->maxmem = maxmem;
+  rv->stream = NULL;
+  rv->curmem = 0;
+  rv->pending_reqs = 0;
+  rv->freed = false;
+
+  return rv;
+}
+
+void wstream_free(WStream *wstream)
+{
+  if (!wstream->pending_reqs) {
+    free(wstream);
+  } else {
+    wstream->freed = true;
+  }
+}
+
+void wstream_set_stream(WStream *wstream, uv_stream_t *stream)
+{
+  stream->data = wstream;
+  wstream->stream = stream;
+}
+
+bool wstream_write(WStream *wstream, char *buffer, uint32_t length, bool free)
+{
+  WriteData *data;
+  uv_buf_t uvbuf;
+  uv_write_t *req;
+
+  if (wstream->freed) {
+    // Don't accept write requests after the WStream instance was freed
+    return false;
+  }
+
+  if (wstream->curmem + length > wstream->maxmem) {
+    return false;
+  }
+
+  if (free) {
+    // We should only account for buffers that are ours to free
+    wstream->curmem += length;
+  }
+
+  data = xmalloc(sizeof(WriteData));
+  data->wstream = wstream;
+  data->buffer = buffer;
+  data->length = length;
+  data->free = free;
+  req = xmalloc(sizeof(uv_write_t));
+  req->data = data;
+  uvbuf.base = buffer;
+  uvbuf.len = length;
+  wstream->pending_reqs++;
+  uv_write(req, wstream->stream, &uvbuf, 1, write_cb);
+
+  return true;
+}
+
+static void write_cb(uv_write_t *req, int status)
+{
+  WriteData *data = req->data;
+
+  free(req);
+
+  if (data->free) {
+    // Free the data written to the stream
+    free(data->buffer);
+    data->wstream->curmem -= data->length;
+  }
+
+  if (data->wstream->freed && --data->wstream->pending_reqs == 0) {
+    // Last pending write, free the wstream;
+    free(data->wstream);
+  }
+
+  free(data);
+}

--- a/src/os/wstream.h
+++ b/src/os/wstream.h
@@ -1,0 +1,40 @@
+#ifndef NEOVIM_OS_WSTREAM_H
+#define NEOVIM_OS_WSTREAM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <uv.h>
+
+#include "os/wstream_defs.h"
+
+/// Creates a new WStream instance. A WStream encapsulates all the boilerplate
+/// necessary for writing to a libuv stream.
+///
+/// @param maxmem Maximum amount memory used by this `WStream` instance.
+/// @return The newly-allocated `WStream` instance
+WStream * wstream_new(uint32_t maxmem);
+
+/// Frees all memory allocated for a WStream instance
+///
+/// @param wstream The `WStream` instance
+void wstream_free(WStream *wstream);
+
+/// Sets the underlying `uv_stream_t` instance
+///
+/// @param wstream The `WStream` instance
+/// @param stream The new `uv_stream_t` instance
+void wstream_set_stream(WStream *wstream, uv_stream_t *stream);
+
+/// Queues data for writing to the backing file descriptor of a `WStream`
+/// instance. This will fail if the write would cause the WStream use more
+/// memory than specified by `maxmem`.
+///
+/// @param wstream The `WStream` instance
+/// @param buffer The buffer which contains data to be written
+/// @param length Number of bytes that should be written from `buffer`
+/// @param free If true, `buffer` will be freed after the write is complete
+/// @return true if the data was successfully queued, false otherwise.
+bool wstream_write(WStream *wstream, char *buffer, uint32_t length, bool free);
+
+#endif  // NEOVIM_OS_WSTREAM_H
+

--- a/src/os/wstream_defs.h
+++ b/src/os/wstream_defs.h
@@ -1,0 +1,7 @@
+#ifndef NEOVIM_OS_WSTREAM_DEFS_H
+#define NEOVIM_OS_WSTREAM_DEFS_H
+
+typedef struct wstream WStream;
+
+#endif  // NEOVIM_OS_WSTREAM_DEFS_H
+


### PR DESCRIPTION
This PR will add more fixes and improvements to how we deal with non-blocking reads/writes. I'm refactoring mainly because I want to reuse the same code for:
- Reading/writing msgpack-rpc(or any other protocol we may add in the future) from/to pipes and/or sockets
- Reading/writing job data

I will also add an abstraction for non-blocking write streams(wstream.c) but still need to decide how to handle some egde cases:
- For writing, should we use a static buffer that when filled will return an error(`jobwrite` could fail for example) or dynamic buffers?
- If using dynamic buffers(what is being done right now), what to do with failed allocations? Exiting vim with `xmalloc` is not acceptable, since that can happen when a external process hangs for long enough while vimscript constantly feeds it with data. I'm thinking freeing the `WStream` and killing the associated job/connection is the best approach, but suggestions are welcome.
