### PR TITLE
[RDY] Remove `lalloc_clear`

### DIFF
--- a/src/memfile.c
+++ b/src/memfile.c
@@ -1264,7 +1264,7 @@ static void mf_hash_grow(mf_hashtab_T *mht)
   size_t size;
 
   size = (mht->mht_mask + 1) * MHT_GROWTH_FACTOR * sizeof(void *);
-  buckets = (mf_hashitem_T **)lalloc_clear(size, FALSE);
+  buckets = xcalloc(1, size);
 
   shift = 0;
   while ((mht->mht_mask >> shift) != 0)

--- a/src/memory.c
+++ b/src/memory.c
@@ -72,14 +72,6 @@ char_u *alloc_clear(unsigned size)
   return (char_u *)xcalloc(1, (size_t)size);
 }
 
-/*
- * Allocate memory like lalloc() and set all bytes to zero.
- */
-char_u *lalloc_clear(long_u size, int message)
-{
-  return (char_u *)xcalloc(1, (size_t)size);
-}
-
 /// Try to free memory. Used when trying to recover from out of memory errors.
 /// @see {xmalloc}
 static void try_to_free_memory()

--- a/src/memory.h
+++ b/src/memory.h
@@ -7,7 +7,6 @@
 
 char_u *alloc(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 char_u *alloc_clear(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
-char_u *lalloc_clear(long_u size, int message) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 
 /// malloc() wrapper
 ///

--- a/src/ops.c
+++ b/src/ops.c
@@ -2415,8 +2415,7 @@ int op_yank(oparg_T *oap, int deleting, int mess)
   y_current->y_size = yanklines;
   y_current->y_type = yanktype;     /* set the yank register type */
   y_current->y_width = 0;
-  y_current->y_array = (char_u **)lalloc_clear((long_u)(sizeof(char_u *) *
-                                                        yanklines), TRUE);
+  y_current->y_array = xcalloc(yanklines, sizeof(char_u *));
 
   y_idx = 0;
   lnum = oap->start.lnum;
@@ -3465,9 +3464,9 @@ int do_join(long count, int insert_space, int save_undo, int use_formatoptions)
   /* Allocate an array to store the number of spaces inserted before each
    * line.  We will use it to pre-compute the length of the new line and the
    * proper placement of each original line in the new one. */
-  spaces = lalloc_clear((long_u)count, TRUE);
+  spaces = xcalloc(count, 1);
   if (remove_comments) {
-    comments = (int *)lalloc_clear((long_u)count * sizeof(int), TRUE);
+    comments = xcalloc(count, sizeof(*comments));
   }
 
   /*
@@ -4862,7 +4861,7 @@ str_to_reg (
   long start;
   long i;
   int extra;
-  int newlines;                         /* number of lines added */
+  size_t newlines;                         /* number of lines added */
   int extraline = 0;                    /* extra line at the end */
   int append = FALSE;                   /* append to last line in register */
   char_u      *s;
@@ -4898,8 +4897,7 @@ str_to_reg (
    * Allocate an array to hold the pointers to the new register lines.
    * If the register was not empty, move the existing lines to the new array.
    */
-  pp = (char_u **)lalloc_clear((y_ptr->y_size + newlines)
-      * sizeof(char_u *), TRUE);
+  pp = xcalloc((y_ptr->y_size + newlines), sizeof(char_u *));
   for (lnum = 0; lnum < y_ptr->y_size; ++lnum)
     pp[lnum] = y_ptr->y_array[lnum];
   vim_free(y_ptr->y_array);

--- a/src/screen.c
+++ b/src/screen.c
@@ -6265,8 +6265,7 @@ retry:
     new_ScreenLinesUC = (u8char_T *)lalloc((long_u)(
           (Rows + 1) * Columns * sizeof(u8char_T)), FALSE);
     for (i = 0; i < p_mco; ++i)
-      new_ScreenLinesC[i] = (u8char_T *)lalloc_clear((long_u)(
-            (Rows + 1) * Columns * sizeof(u8char_T)), FALSE);
+      new_ScreenLinesC[i] = xcalloc((Rows + 1) * Columns, sizeof(u8char_T));
   }
   if (enc_dbcs == DBCS_JPNU)
     new_ScreenLines2 = (schar_T *)lalloc((long_u)(

--- a/src/search.c
+++ b/src/search.c
@@ -4057,8 +4057,7 @@ find_pattern_in_path (
       goto fpip_end;
     def_regmatch.rm_ic = FALSE;         /* don't ignore case in define pat. */
   }
-  files = (SearchedFile *)lalloc_clear((long_u)
-      (max_path_depth * sizeof(SearchedFile)), TRUE);
+  files = xcalloc(max_path_depth, sizeof(SearchedFile));
   if (files == NULL)
     goto fpip_end;
   old_files = max_path_depth;

--- a/src/spell.c
+++ b/src/spell.c
@@ -3657,7 +3657,7 @@ spell_read_tree (
     *bytsp = bp;
 
     /* Allocate the index array. */
-    ip = (idx_T *)lalloc_clear((long_u)(len * sizeof(int)), TRUE);
+    ip = xcalloc(len, sizeof(*ip));
     *idxsp = ip;
 
     /* Recursively read the tree and store it in the array. */


### PR DESCRIPTION
Call `xcalloc` directly. Following the advice of @aktau to not cast void pointers. However I cast the arguments and leave any change of local variables for another PR. ref #487 / #488
