### PR TITLE
[RDY] try_malloc(), verbose_try_malloc(), and more removal of unnecessary OOM error handling code

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4659,10 +4659,7 @@ int buf_contents_changed(buf_T *buf)
     return TRUE;
 
   /* Force the 'fileencoding' and 'fileformat' to be equal. */
-  if (prep_exarg(&ea, buf) == FAIL) {
-    wipe_buffer(newbuf, FALSE);
-    return TRUE;
-  }
+  prep_exarg(&ea, buf);
 
   /* set curwin/curbuf to buf and save a few things */
   aucmd_prepbuf(&aco, newbuf);

--- a/src/eval.c
+++ b/src/eval.c
@@ -6105,23 +6105,21 @@ void set_ref_in_item(typval_T *tv, int copyID)
  */
 dict_T *dict_alloc(void)
 {
-  dict_T *d;
+  dict_T *d = xmalloc(sizeof(dict_T));
 
-  d = (dict_T *)alloc(sizeof(dict_T));
-  if (d != NULL) {
-    /* Add the dict to the list of dicts for garbage collection. */
-    if (first_dict != NULL)
-      first_dict->dv_used_prev = d;
-    d->dv_used_next = first_dict;
-    d->dv_used_prev = NULL;
-    first_dict = d;
+  /* Add the dict to the list of dicts for garbage collection. */
+  if (first_dict != NULL)
+    first_dict->dv_used_prev = d;
+  d->dv_used_next = first_dict;
+  d->dv_used_prev = NULL;
+  first_dict = d;
 
-    hash_init(&d->dv_hashtab);
-    d->dv_lock = 0;
-    d->dv_scope = 0;
-    d->dv_refcount = 0;
-    d->dv_copyID = 0;
-  }
+  hash_init(&d->dv_hashtab);
+  d->dv_lock = 0;
+  d->dv_scope = 0;
+  d->dv_refcount = 0;
+  d->dv_copyID = 0;
+
   return d;
 }
 

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4020,22 +4020,14 @@ void do_sub(exarg_T *eap)
                 orig_line = vim_strsave(ml_get(lnum));
                 if (orig_line != NULL) {
                   char_u *new_line = concat_str(new_start,
-                      sub_firstline + copycol);
+                                                sub_firstline + copycol);
 
-                  if (new_line == NULL) {
-                    vim_free(orig_line);
-                    orig_line = NULL;
-                  } else {
-                    /* Position the cursor relative to the
-                     * end of the line, the previous
-                     * substitute may have inserted or
-                     * deleted characters before the
-                     * cursor. */
-                    len_change = (int)STRLEN(new_line)
-                                 - (int)STRLEN(orig_line);
-                    curwin->w_cursor.col += len_change;
-                    ml_replace(lnum, new_line, FALSE);
-                  }
+                  // Position the cursor relative to the end of the line, the
+                  // previous substitute may have inserted or deleted characters
+                  // before the cursor.
+                  len_change = (int)STRLEN(new_line) - (int)STRLEN(orig_line);
+                  curwin->w_cursor.col += len_change;
+                  ml_replace(lnum, new_line, FALSE);
                 }
               }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -8056,7 +8056,7 @@ int match_file_list(char_u *list, char_u *sfname, char_u *ffname)
  * If FEAT_OSFILETYPE defined then pass initial <type> through unchanged. Eg:
  * '<html>myfile' becomes '<html>^myfile$' -- leonard.
  *
- * Returns NULL when out of memory.
+ * Returns NULL on failure.
  */
 char_u *
 file_pat_to_reg_pat (
@@ -8066,7 +8066,7 @@ file_pat_to_reg_pat (
     int no_bslash             /* Don't use a backward slash as pathsep */
 )
 {
-  int size;
+  size_t size;
   char_u      *endp;
   char_u      *reg_pat;
   char_u      *p;
@@ -8093,9 +8093,7 @@ file_pat_to_reg_pat (
       check_length = p - pat + 1;
       if (p + 1 >= pat_end) {
         /* The 'pattern' is a filetype check ONLY */
-        reg_pat = (char_u *)alloc(check_length + 1);
-        memmove(reg_pat, pat, (size_t)check_length);
-        reg_pat[check_length] = NUL;
+        reg_pat = xmemdupz(pat, (size_t)check_length);
         return reg_pat;
       }
     }
@@ -8103,7 +8101,7 @@ file_pat_to_reg_pat (
 
   }
   pat += check_length;
-  size = 2 + check_length;
+  size = 2 + (size_t)check_length;
 #else
   size = 2;             /* '^' at start, '$' at end */
 #endif
@@ -8133,9 +8131,7 @@ file_pat_to_reg_pat (
       break;
     }
   }
-  reg_pat = alloc(size + 1);
-  if (reg_pat == NULL)
-    return NULL;
+  reg_pat = xmalloc(size + 1);
 
 #ifdef FEAT_OSFILETYPE
   /* Copy the type check in to the start. */

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -2062,15 +2062,10 @@ readfile_linenr (
 /*
  * Fill "*eap" to force the 'fileencoding', 'fileformat' and 'binary to be
  * equal to the buffer "buf".  Used for calling readfile().
- * Returns OK or FAIL.
  */
-int prep_exarg(exarg_T *eap, buf_T *buf)
+void prep_exarg(exarg_T *eap, buf_T *buf)
 {
-  eap->cmd = alloc((unsigned)(STRLEN(buf->b_p_ff)
-                              + STRLEN(buf->b_p_fenc)
-                              + 15));
-  if (eap->cmd == NULL)
-    return FAIL;
+  eap->cmd = xmalloc(STRLEN(buf->b_p_ff) + STRLEN(buf->b_p_fenc) + 15);
 
   sprintf((char *)eap->cmd, "e ++ff=%s ++enc=%s", buf->b_p_ff, buf->b_p_fenc);
   eap->force_enc = 14 + (int)STRLEN(buf->b_p_ff);
@@ -2080,7 +2075,6 @@ int prep_exarg(exarg_T *eap, buf_T *buf)
   eap->force_bin = buf->b_p_bin ? FORCE_BIN : FORCE_NOBIN;
   eap->read_edit = FALSE;
   eap->forceit = FALSE;
-  return OK;
 }
 
 /*
@@ -5464,114 +5458,114 @@ void buf_reload(buf_T *buf, int orig_mode)
   /* set curwin/curbuf for "buf" and save some things */
   aucmd_prepbuf(&aco, buf);
 
-  /* We only want to read the text from the file, not reset the syntax
-   * highlighting, clear marks, diff status, etc.  Force the fileformat
-   * and encoding to be the same. */
-  if (prep_exarg(&ea, buf) == OK) {
-    old_cursor = curwin->w_cursor;
-    old_topline = curwin->w_topline;
+  // We only want to read the text from the file, not reset the syntax
+  // highlighting, clear marks, diff status, etc.  Force the fileformat and
+  // encoding to be the same.
 
-    if (p_ur < 0 || curbuf->b_ml.ml_line_count <= p_ur) {
-      /* Save all the text, so that the reload can be undone.
-       * Sync first so that this is a separate undo-able action. */
-      u_sync(FALSE);
-      saved = u_savecommon(0, curbuf->b_ml.ml_line_count + 1, 0, TRUE);
-      flags |= READ_KEEP_UNDO;
-    }
+  prep_exarg(&ea, buf);
+  old_cursor = curwin->w_cursor;
+  old_topline = curwin->w_topline;
 
-    /*
-     * To behave like when a new file is edited (matters for
-     * BufReadPost autocommands) we first need to delete the current
-     * buffer contents.  But if reading the file fails we should keep
-     * the old contents.  Can't use memory only, the file might be
-     * too big.  Use a hidden buffer to move the buffer contents to.
-     */
-    if (bufempty() || saved == FAIL)
-      savebuf = NULL;
-    else {
-      /* Allocate a buffer without putting it in the buffer list. */
-      savebuf = buflist_new(NULL, NULL, (linenr_T)1, BLN_DUMMY);
-      if (savebuf != NULL && buf == curbuf) {
-        /* Open the memline. */
-        curbuf = savebuf;
-        curwin->w_buffer = savebuf;
-        saved = ml_open(curbuf);
-        curbuf = buf;
-        curwin->w_buffer = buf;
-      }
-      if (savebuf == NULL || saved == FAIL || buf != curbuf
-          || move_lines(buf, savebuf) == FAIL) {
-        EMSG2(_("E462: Could not prepare for reloading \"%s\""),
-            buf->b_fname);
-        saved = FAIL;
-      }
-    }
-
-    if (saved == OK) {
-      curbuf->b_flags |= BF_CHECK_RO;           /* check for RO again */
-      keep_filetype = TRUE;                     /* don't detect 'filetype' */
-      if (readfile(buf->b_ffname, buf->b_fname, (linenr_T)0,
-              (linenr_T)0,
-              (linenr_T)MAXLNUM, &ea, flags) == FAIL) {
-        if (!aborting())
-          EMSG2(_("E321: Could not reload \"%s\""), buf->b_fname);
-        if (savebuf != NULL && buf_valid(savebuf) && buf == curbuf) {
-          /* Put the text back from the save buffer.  First
-           * delete any lines that readfile() added. */
-          while (!bufempty())
-            if (ml_delete(buf->b_ml.ml_line_count, FALSE) == FAIL)
-              break;
-          (void)move_lines(savebuf, buf);
-        }
-      } else if (buf == curbuf) {  /* "buf" still valid */
-        /* Mark the buffer as unmodified and free undo info. */
-        unchanged(buf, TRUE);
-        if ((flags & READ_KEEP_UNDO) == 0) {
-          u_blockfree(buf);
-          u_clearall(buf);
-        } else {
-          /* Mark all undo states as changed. */
-          u_unchanged(curbuf);
-        }
-      }
-    }
-    vim_free(ea.cmd);
-
-    if (savebuf != NULL && buf_valid(savebuf))
-      wipe_buffer(savebuf, FALSE);
-
-    /* Invalidate diff info if necessary. */
-    diff_invalidate(curbuf);
-
-    /* Restore the topline and cursor position and check it (lines may
-     * have been removed). */
-    if (old_topline > curbuf->b_ml.ml_line_count)
-      curwin->w_topline = curbuf->b_ml.ml_line_count;
-    else
-      curwin->w_topline = old_topline;
-    curwin->w_cursor = old_cursor;
-    check_cursor();
-    update_topline();
-    keep_filetype = FALSE;
-    {
-      win_T       *wp;
-      tabpage_T   *tp;
-
-      /* Update folds unless they are defined manually. */
-      FOR_ALL_TAB_WINDOWS(tp, wp)
-      if (wp->w_buffer == curwin->w_buffer
-          && !foldmethodIsManual(wp))
-        foldUpdateAll(wp);
-    }
-    /* If the mode didn't change and 'readonly' was set, keep the old
-     * value; the user probably used the ":view" command.  But don't
-     * reset it, might have had a read error. */
-    if (orig_mode == curbuf->b_orig_mode)
-      curbuf->b_p_ro |= old_ro;
-
-    /* Modelines must override settings done by autocommands. */
-    do_modelines(0);
+  if (p_ur < 0 || curbuf->b_ml.ml_line_count <= p_ur) {
+    /* Save all the text, so that the reload can be undone.
+     * Sync first so that this is a separate undo-able action. */
+    u_sync(FALSE);
+    saved = u_savecommon(0, curbuf->b_ml.ml_line_count + 1, 0, TRUE);
+    flags |= READ_KEEP_UNDO;
   }
+
+  /*
+   * To behave like when a new file is edited (matters for
+   * BufReadPost autocommands) we first need to delete the current
+   * buffer contents.  But if reading the file fails we should keep
+   * the old contents.  Can't use memory only, the file might be
+   * too big.  Use a hidden buffer to move the buffer contents to.
+   */
+  if (bufempty() || saved == FAIL)
+    savebuf = NULL;
+  else {
+    /* Allocate a buffer without putting it in the buffer list. */
+    savebuf = buflist_new(NULL, NULL, (linenr_T)1, BLN_DUMMY);
+    if (savebuf != NULL && buf == curbuf) {
+      /* Open the memline. */
+      curbuf = savebuf;
+      curwin->w_buffer = savebuf;
+      saved = ml_open(curbuf);
+      curbuf = buf;
+      curwin->w_buffer = buf;
+    }
+    if (savebuf == NULL || saved == FAIL || buf != curbuf
+        || move_lines(buf, savebuf) == FAIL) {
+      EMSG2(_("E462: Could not prepare for reloading \"%s\""),
+          buf->b_fname);
+      saved = FAIL;
+    }
+  }
+
+  if (saved == OK) {
+    curbuf->b_flags |= BF_CHECK_RO;           /* check for RO again */
+    keep_filetype = TRUE;                     /* don't detect 'filetype' */
+    if (readfile(buf->b_ffname, buf->b_fname, (linenr_T)0,
+            (linenr_T)0,
+            (linenr_T)MAXLNUM, &ea, flags) == FAIL) {
+      if (!aborting())
+        EMSG2(_("E321: Could not reload \"%s\""), buf->b_fname);
+      if (savebuf != NULL && buf_valid(savebuf) && buf == curbuf) {
+        /* Put the text back from the save buffer.  First
+         * delete any lines that readfile() added. */
+        while (!bufempty())
+          if (ml_delete(buf->b_ml.ml_line_count, FALSE) == FAIL)
+            break;
+        (void)move_lines(savebuf, buf);
+      }
+    } else if (buf == curbuf) {  /* "buf" still valid */
+      /* Mark the buffer as unmodified and free undo info. */
+      unchanged(buf, TRUE);
+      if ((flags & READ_KEEP_UNDO) == 0) {
+        u_blockfree(buf);
+        u_clearall(buf);
+      } else {
+        /* Mark all undo states as changed. */
+        u_unchanged(curbuf);
+      }
+    }
+  }
+  vim_free(ea.cmd);
+
+  if (savebuf != NULL && buf_valid(savebuf))
+    wipe_buffer(savebuf, FALSE);
+
+  /* Invalidate diff info if necessary. */
+  diff_invalidate(curbuf);
+
+  /* Restore the topline and cursor position and check it (lines may
+   * have been removed). */
+  if (old_topline > curbuf->b_ml.ml_line_count)
+    curwin->w_topline = curbuf->b_ml.ml_line_count;
+  else
+    curwin->w_topline = old_topline;
+  curwin->w_cursor = old_cursor;
+  check_cursor();
+  update_topline();
+  keep_filetype = FALSE;
+  {
+    win_T       *wp;
+    tabpage_T   *tp;
+
+    /* Update folds unless they are defined manually. */
+    FOR_ALL_TAB_WINDOWS(tp, wp)
+    if (wp->w_buffer == curwin->w_buffer
+        && !foldmethodIsManual(wp))
+      foldUpdateAll(wp);
+  }
+  /* If the mode didn't change and 'readonly' was set, keep the old
+   * value; the user probably used the ":view" command.  But don't
+   * reset it, might have had a read error. */
+  if (orig_mode == curbuf->b_orig_mode)
+    curbuf->b_p_ro |= old_ro;
+
+  /* Modelines must override settings done by autocommands. */
+  do_modelines(0);
 
   /* restore curwin/curbuf and a few other things */
   aucmd_restbuf(&aco);

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -190,7 +190,7 @@ void filemess(buf_T *buf, char_u *name, char_u *s, int attr)
 /*
  * Read lines from file "fname" into the buffer after line "from".
  *
- * 1. We allocate blocks with lalloc, as big as possible.
+ * 1. We allocate blocks with try_malloc, as big as possible.
  * 2. Each block is filled with characters from the file with a single read().
  * 3. The lines are inserted in the buffer with ml_append().
  *
@@ -987,10 +987,15 @@ retry:
       if (!skip_read) {
         size = 0x10000L;                            /* use buffer >= 64K */
 
-        for (; size >= 10; size = (long)((long_u)size >> 1)) {
-          if ((new_buffer = lalloc((long_u)(size + linerest + 1),
-                   FALSE)) != NULL)
-              break;
+        for (; size >= 10; size /= 2) {
+          new_buffer = verbose_try_malloc((size_t)size + (size_t)linerest + 1);
+          if (new_buffer) {
+            break;
+          }
+        }
+        if (new_buffer == NULL) {
+          error = TRUE;
+          break;
         }
         if (linerest)           /* copy characters from the previous buffer */
           memmove(new_buffer, ptr - linerest, (size_t)linerest);
@@ -2763,10 +2768,7 @@ buf_write (
         (char_u *)"", 0);               /* show that we are busy */
   msg_scroll = FALSE;               /* always overwrite the file message now */
 
-  buffer = alloc(BUFSIZE);
-  // TODO: decide how to handle this now that alloc never returns NULL. The fact
-  // that the OOM handling code calls this should be considered.
-  //
+  buffer = verbose_try_malloc(BUFSIZE);
   // can't allocate big buffer, use small one (to be able to write when out of
   // memory)
   if (buffer == NULL) {
@@ -3006,7 +3008,12 @@ buf_write (
       int did_set_shortname;
 #endif
 
-      copybuf = alloc(BUFSIZE + 1);
+      copybuf = verbose_try_malloc(BUFSIZE + 1);
+      if (copybuf == NULL) {
+        // out of memory
+        some_error = TRUE;
+        goto nobackup;
+      }
 
       /*
        * Try to make the backup in each directory in the 'bdir' option.
@@ -3372,8 +3379,10 @@ nobackup:
         write_info.bw_conv_buflen = bufsize * 2;
       else       /* FIO_UCS4 */
         write_info.bw_conv_buflen = bufsize * 4;
-      write_info.bw_conv_buf
-        = lalloc((long_u)write_info.bw_conv_buflen, TRUE);
+      write_info.bw_conv_buf = verbose_try_malloc(write_info.bw_conv_buflen);
+      if (!write_info.bw_conv_buf) {
+        end = 0;
+      }
     }
   }
 
@@ -3390,8 +3399,10 @@ nobackup:
     if (write_info.bw_iconv_fd != (iconv_t)-1) {
       /* We're going to use iconv(), allocate a buffer to convert in. */
       write_info.bw_conv_buflen = bufsize * ICONV_MULT;
-      write_info.bw_conv_buf
-        = lalloc((long_u)write_info.bw_conv_buflen, TRUE);
+      write_info.bw_conv_buf = verbose_try_malloc(write_info.bw_conv_buflen);
+      if (!write_info.bw_conv_buf) {
+        end = 0;
+      }
       write_info.bw_first = TRUE;
     } else
 #  endif
@@ -5056,7 +5067,9 @@ int vim_rename(char_u *from, char_u *to)
     return -1;
   }
 
-  buffer = (char *)alloc(BUFSIZE);
+  // Avoid xmalloc() here as vim_rename() is called by buf_write() when neovim
+  // is `preserve_exit()`ing.
+  buffer = try_malloc(BUFSIZE);
   if (buffer == NULL) {
     close(fd_out);
     close(fd_in);
@@ -5624,14 +5637,14 @@ void vim_deltempdir(void)
  */
 static void vim_settempdir(char_u *tempdir)
 {
-  char_u      *buf;
-
-  buf = alloc((unsigned)MAXPATHL + 2);
-  if (vim_FullName(tempdir, buf, MAXPATHL, FALSE) == FAIL)
-    STRCPY(buf, tempdir);
-  add_pathsep(buf);
-  vim_tempdir = vim_strsave(buf);
-  vim_free(buf);
+  char_u *buf = verbose_try_malloc((size_t)MAXPATHL + 2);
+  if (buf) {
+    if (vim_FullName(tempdir, buf, MAXPATHL, FALSE) == FAIL)
+      STRCPY(buf, tempdir);
+    add_pathsep(buf);
+    vim_tempdir = vim_strsave(buf);
+    vim_free(buf);
+  }
 }
 #endif
 

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -21,7 +21,7 @@ void filemess(buf_T *buf, char_u *name, char_u *s, int attr);
 int readfile(char_u *fname, char_u *sfname, linenr_T from,
              linenr_T lines_to_skip, linenr_T lines_to_read, exarg_T *eap,
              int flags);
-int prep_exarg(exarg_T *eap, buf_T *buf);
+void prep_exarg(exarg_T *eap, buf_T *buf);
 void set_file_options(int set_options, exarg_T *eap);
 void set_forced_fenc(exarg_T *eap);
 int prepare_crypt_read(FILE *fp);

--- a/src/garray.c
+++ b/src/garray.c
@@ -102,28 +102,26 @@ void ga_remove_duplicate_strings(garray_T *gap)
 ///
 /// @param gap
 ///
-/// @returns NULL when out of memory.
+/// @returns the concatenated strings
 char_u* ga_concat_strings(garray_T *gap)
 {
-  int i;
-  int len = 0;
-  char_u *s;
+  size_t len = 0;
 
-  for (i = 0; i < gap->ga_len; ++i) {
-    len += (int)STRLEN(((char_u **)(gap->ga_data))[i]) + 1;
+  for (int i = 0; i < gap->ga_len; ++i) {
+    len += strlen(((char **)(gap->ga_data))[i]) + 1;
   }
 
-  s = alloc(len + 1);
+  char *s = xmallocz(len);
 
   *s = NUL;
-  for (i = 0; i < gap->ga_len; ++i) {
+  for (int i = 0; i < gap->ga_len; ++i) {
     if (*s != NUL) {
-      STRCAT(s, ",");
+      strcat(s, ",");
     }
-    STRCAT(s, ((char_u **)(gap->ga_data))[i]);
+    strcat(s, ((char **)(gap->ga_data))[i]);
   }
 
-  return s;
+  return (char_u *)s;
 }
 
 /// Concatenate a string to a growarray which contains characters.

--- a/src/garray.h
+++ b/src/garray.h
@@ -1,6 +1,8 @@
 #ifndef NEOVIM_GARRAY_H
 #define NEOVIM_GARRAY_H
 
+#include "func_attr.h"
+
 /// Structure used for growing arrays.
 /// This is used to store information that only grows, is deleted all at
 /// once, and needs to be accessed by index.  See ga_clear() and ga_grow().
@@ -18,7 +20,7 @@ void ga_clear(garray_T *gap);
 void ga_clear_strings(garray_T *gap);
 void ga_init(garray_T *gap, int itemsize, int growsize);
 void ga_grow(garray_T *gap, int n);
-char_u *ga_concat_strings(garray_T *gap);
+char_u *ga_concat_strings(garray_T *gap) FUNC_ATTR_NONNULL_RET;
 void ga_remove_duplicate_strings(garray_T *gap);
 void ga_concat(garray_T *gap, char_u *s);
 void ga_append(garray_T *gap, int c);

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -2161,7 +2161,7 @@ static char *cs_resolve_file(int i, char *name)
       && (strncmp(name, csinfo[i].ppath, strlen(csinfo[i].ppath)) != 0)
       && (name[0] != '/')
       ) {
-    fullname = (char *)alloc(len);
+    fullname = xmalloc(len);
     (void)sprintf(fullname, "%s/%s", csinfo[i].ppath, name);
   } else if (csdir != NULL && csinfo[i].fname != NULL && *csdir != NUL) {
     /* Check for csdir to be non empty to avoid empty path concatenated to

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1456,19 +1456,16 @@ static char *cs_make_vim_style_matches(char *fname, char *slno, char *search, ch
    * by new ones on the tag stack.
    */
   char *buf;
-  int amt;
+  size_t amt;
 
   if (search != NULL) {
-    amt =
-      (int)(strlen(fname) + strlen(slno) + strlen(tagstr) + strlen(search)+6);
-    if ((buf = (char *)alloc(amt)) == NULL)
-      return NULL;
+    amt = strlen(fname) + strlen(slno) + strlen(tagstr) + strlen(search) + 6;
+    buf = xmalloc(amt);
 
     (void)sprintf(buf, "%s\t%s\t%s;\"\t%s", tagstr, fname, slno, search);
   } else {
-    amt = (int)(strlen(fname) + strlen(slno) + strlen(tagstr) + 5);
-    if ((buf = (char *)alloc(amt)) == NULL)
-      return NULL;
+    amt = strlen(fname) + strlen(slno) + strlen(tagstr) + 5;
+    buf = xmalloc(amt);
 
     (void)sprintf(buf, "%s\t%s\t%s;\"", tagstr, fname, slno);
   }
@@ -1669,10 +1666,9 @@ static void cs_fill_results(char *tagstr, int totmatches, int *nummatches_a, cha
 
   assert(totmatches > 0);
 
-  buf = (char *)alloc(CSREAD_BUFSIZE);
-
-  matches = (char **)alloc(sizeof(char *) * totmatches);
-  cntxts = (char **)alloc(sizeof(char *) * totmatches);
+  buf = xmalloc(CSREAD_BUFSIZE);
+  matches = xmalloc(sizeof(char *) * totmatches);
+  cntxts = xmalloc(sizeof(char *) * totmatches);
 
   for (i = 0; i < csinfo_size; i++) {
     if (nummatches_a[i] < 1)
@@ -1683,21 +1679,21 @@ static void cs_fill_results(char *tagstr, int totmatches, int *nummatches_a, cha
                &slno, &search)) == NULL)
         continue;
 
-      matches[totsofar] = cs_make_vim_style_matches(fullname, slno,
-          search, tagstr);
+      matches[totsofar] = cs_make_vim_style_matches(fullname, slno, search,
+                                                    tagstr);
 
       vim_free(fullname);
 
       if (strcmp(cntx, "<global>") == 0)
         cntxts[totsofar] = NULL;
-      else
+      else {
         /* note: if vim_strsave returns NULL, then the context
          * will be "<global>", which is misleading.
          */
         cntxts[totsofar] = (char *)vim_strsave((char_u *)cntx);
+      }
 
-      if (matches[totsofar] != NULL)
-        totsofar++;
+      totsofar++;
 
     }     /* for all matches */
 
@@ -2080,9 +2076,9 @@ static int cs_reset(exarg_T *eap)
     return CSCOPE_SUCCESS;
 
   /* malloc our db and ppath list */
-  dblist = (char **)alloc(csinfo_size * sizeof(char *));
-  pplist = (char **)alloc(csinfo_size * sizeof(char *));
-  fllist = (char **)alloc(csinfo_size * sizeof(char *));
+  dblist = xmalloc(csinfo_size * sizeof(char *));
+  pplist = xmalloc(csinfo_size * sizeof(char *));
+  fllist = xmalloc(csinfo_size * sizeof(char *));
 
   for (i = 0; i < csinfo_size; i++) {
     dblist[i] = csinfo[i].fname;

--- a/src/main.c
+++ b/src/main.c
@@ -1433,10 +1433,8 @@ scripterror:
         char_u      *r;
 
         r = concat_fnames(p, path_tail(alist_name(&GARGLIST[0])), TRUE);
-        if (r != NULL) {
-          vim_free(p);
-          p = r;
-        }
+        vim_free(p);
+        p = r;
       }
 
 #ifdef USE_FNAME_CASE

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -948,8 +948,6 @@ static int mf_write_block(memfile_T *mfp, bhdr_T *hp, off_t offset, unsigned siz
   /* Encrypt if 'key' is set and this is a data block. */
   if (*mfp->mf_buffer->b_p_key != NUL) {
     data = ml_encrypt_data(mfp, data, offset, size);
-    if (data == NULL)
-      return FAIL;
   }
 
   if ((unsigned)write_eintr(mfp->mf_fd, data, size) != size)

--- a/src/memline.c
+++ b/src/memline.c
@@ -1586,16 +1586,10 @@ recover_names (
           tail = make_percent_swname(dir_name, fname_res);
         } else
 #endif
-        {
-          tail = path_tail(fname_res);
-          tail = concat_fnames(dir_name, tail, TRUE);
-        }
-        if (tail == NULL)
-          num_names = 0;
-        else {
-          num_names = recov_file_names(names, tail, FALSE);
-          vim_free(tail);
-        }
+        tail = path_tail(fname_res);
+        tail = concat_fnames(dir_name, tail, TRUE);
+        num_names = recov_file_names(names, tail, FALSE);
+        vim_free(tail);
       }
     }
 
@@ -1709,8 +1703,7 @@ static char_u *make_percent_swname(char_u *dir, char_u *name)
   f = fix_fname(name != NULL ? name : (char_u *) "");
   d = NULL;
   if (f != NULL) {
-    s = alloc((unsigned)(STRLEN(f) + 1));
-    STRCPY(s, f);
+    s = (char_u *)xstrdup((char *)f);
     for (d = s; *d != NUL; mb_ptr_adv(d))
       if (vim_ispathsep(*d))
         *d = '%';
@@ -1855,12 +1848,8 @@ static int recov_file_names(char_u **names, char_u *path, int prepend_dot)
     ++num_names;
   }
 
-  /*
-   * Form the normal swap file name pattern by appending ".sw?".
-   */
+  // Form the normal swap file name pattern by appending ".sw?".
   names[num_names] = concat_fnames(path, (char_u *)".sw?", FALSE);
-  if (names[num_names] == NULL)
-    goto end;
   if (num_names >= 1) {     /* check if we have the same name twice */
     p = names[num_names - 1];
     i = (int)STRLEN(names[num_names - 1]) - (int)STRLEN(names[num_names]);
@@ -3497,16 +3486,12 @@ get_file_in_dir (
       *tail = NUL;
       t = concat_fnames(fname, dname + 2, TRUE);
       *tail = save_char;
-      if (t == NULL)                /* out of memory */
-        retval = NULL;
-      else {
-        retval = concat_fnames(t, tail, TRUE);
-        vim_free(t);
-      }
+      retval = concat_fnames(t, tail, TRUE);
+      vim_free(t);
     }
-  } else
+  } else {
     retval = concat_fnames(dname, tail, TRUE);
-
+  }
 
   return retval;
 }

--- a/src/memline.c
+++ b/src/memline.c
@@ -508,10 +508,7 @@ void ml_set_crypt_key(buf_T *buf, char_u *old_key, int old_cm)
 
             /* going one block deeper in the tree, new entry in
              * stack */
-            if ((top = ml_add_stack(buf)) < 0) {
-              ++error;
-              break;                                /* out of memory */
-            }
+            top = ml_add_stack(buf);
             ip = &(buf->b_ml.ml_stack[top]);
             ip->ip_bnum = bnum;
             ip->ip_index = idx;
@@ -1310,10 +1307,7 @@ void ml_recover(void)
           /*
            * going one block deeper in the tree
            */
-          if ((top = ml_add_stack(buf)) < 0) {          /* new entry in stack */
-            ++error;
-            break;                          /* out of memory */
-          }
+          top = ml_add_stack(buf);  // new entry in stack
           ip = &(buf->b_ml.ml_stack[top]);
           ip->ip_bnum = bnum;
           ip->ip_index = idx;
@@ -3190,8 +3184,7 @@ static bhdr_T *ml_find_line(buf_T *buf, linenr_T lnum, int action)
       goto error_block;
     }
 
-    if ((top = ml_add_stack(buf)) < 0)          /* add new entry to stack */
-      goto error_block;
+    top = ml_add_stack(buf);  // add new entry to stack
     ip = &(buf->b_ml.ml_stack[top]);
     ip->ip_bnum = bnum;
     ip->ip_low = low;
@@ -3262,25 +3255,19 @@ error_noblock:
 /*
  * add an entry to the info pointer stack
  *
- * return -1 for failure, number of the new entry otherwise
+ * return number of the new entry
  */
 static int ml_add_stack(buf_T *buf)
 {
-  int top;
-  infoptr_T   *newstack;
-
-  top = buf->b_ml.ml_stack_top;
+  int top = buf->b_ml.ml_stack_top;
 
   /* may have to increase the stack size */
   if (top == buf->b_ml.ml_stack_size) {
     CHECK(top > 0, _("Stack size increases"));     /* more than 5 levels??? */
 
-    newstack = (infoptr_T *)alloc((unsigned)sizeof(infoptr_T) *
-        (buf->b_ml.ml_stack_size + STACK_INCR));
-    if (newstack == NULL)
-      return -1;
-    memmove(newstack, buf->b_ml.ml_stack,
-        (size_t)top * sizeof(infoptr_T));
+    infoptr_T *newstack = xmalloc(sizeof(infoptr_T) *
+                                    (buf->b_ml.ml_stack_size + STACK_INCR));
+    memmove(newstack, buf->b_ml.ml_stack, (size_t)top * sizeof(infoptr_T));
     vim_free(buf->b_ml.ml_stack);
     buf->b_ml.ml_stack = newstack;
     buf->b_ml.ml_stack_size += STACK_INCR;
@@ -4160,8 +4147,7 @@ void ml_setflags(buf_T *buf)
 
 /*
  * If "data" points to a data block encrypt the text in it and return a copy
- * in allocated memory.  Return NULL when out of memory.
- * Otherwise return "data".
+ * in allocated memory.
  */
 char_u *ml_encrypt_data(memfile_T *mfp, char_u *data, off_t offset, unsigned size)
 {
@@ -4174,9 +4160,7 @@ char_u *ml_encrypt_data(memfile_T *mfp, char_u *data, off_t offset, unsigned siz
   if (dp->db_id != DATA_ID)
     return data;
 
-  new_data = (char_u *)alloc(size);
-  if (new_data == NULL)
-    return NULL;
+  new_data = xmalloc(size);
   head_end = (char_u *)(&dp->db_index[dp->db_line_count]);
   text_start = (char_u *)dp + dp->db_txt_start;
   text_len = size - dp->db_txt_start;
@@ -4290,12 +4274,7 @@ static void ml_updatechunk(buf_T *buf, linenr_T line, long len, int updtype)
   if (buf->b_ml.ml_usedchunks == -1 || len == 0)
     return;
   if (buf->b_ml.ml_chunksize == NULL) {
-    buf->b_ml.ml_chunksize = (chunksize_T *)
-                             alloc((unsigned)sizeof(chunksize_T) * 100);
-    if (buf->b_ml.ml_chunksize == NULL) {
-      buf->b_ml.ml_usedchunks = -1;
-      return;
-    }
+    buf->b_ml.ml_chunksize = xmalloc(sizeof(chunksize_T) * 100);
     buf->b_ml.ml_numchunks = 100;
     buf->b_ml.ml_usedchunks = 1;
     buf->b_ml.ml_chunksize[0].mlcs_numlines = 1;

--- a/src/memline.h
+++ b/src/memline.h
@@ -1,6 +1,9 @@
 #ifndef NEOVIM_MEMLINE_H
 #define NEOVIM_MEMLINE_H
-/* memline.c */
+
+#include "types.h"
+#include "func_attr.h"
+
 int ml_open(buf_T *buf);
 void ml_set_crypt_key(buf_T *buf, char_u *old_key, int old_cm);
 void ml_setname(buf_T *buf);
@@ -35,7 +38,7 @@ char_u *makeswapname(char_u *fname, char_u *ffname, buf_T *buf,
 char_u *get_file_in_dir(char_u *fname, char_u *dname);
 void ml_setflags(buf_T *buf);
 char_u *ml_encrypt_data(memfile_T *mfp, char_u *data, off_t offset,
-                        unsigned size);
+                        unsigned size) FUNC_ATTR_NONNULL_RET;
 void ml_decrypt_data(memfile_T *mfp, char_u *data, off_t offset,
                      unsigned size);
 long ml_find_line_or_offset(buf_T *buf, linenr_T lnum, long *offp);

--- a/src/memory.c
+++ b/src/memory.c
@@ -81,24 +81,40 @@ static void try_to_free_memory()
   trying_to_free = false;
 }
 
-void *xmalloc(size_t size)
+void *try_malloc(size_t size)
 {
   void *ret = malloc(size);
 
-  if (!ret && !size)
+  if (!ret && !size) {
     ret = malloc(1);
-
+  }
   if (!ret) {
     try_to_free_memory();
     ret = malloc(size);
-    if (!ret && !size)
+    if (!ret && !size) {
       ret = malloc(1);
-    if (!ret) {
-      OUT_STR("Vim: Error: Out of memory.\n");
-      preserve_exit();
     }
   }
+  return ret;
+}
 
+void *verbose_try_malloc(size_t size)
+{
+  void *ret = try_malloc(size);
+  if (!ret) {
+    do_outofmem_msg((long_u)size);
+  }
+  return ret;
+}
+
+void *xmalloc(size_t size)
+{
+  void *ret = try_malloc(size);
+
+  if (!ret) {
+    OUT_STR("Vim: Error: Out of memory.\n");
+    preserve_exit();
+  }
   return ret;
 }
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -43,17 +43,6 @@
 #include "os/os.h"
 
 static void try_to_free_memory();
-static void *xmallocz(size_t size);
-
-/// Allocates (len + 1) bytes of memory, duplicates `len` bytes of
-/// `data` to the allocated memory, zero terminates the allocated memory,
-/// and returns a pointer to the allocated memory. If the allocation fails,
-/// the program dies.
-///
-/// @see {xmalloc}
-/// @param data Pointer to the data that will be copied
-/// @param len number of bytes that will be copied
-static void *xmemdupz(const void *data, size_t len);
 
 /*
  * Note: if unsigned is 16 bits we can only allocate up to 64K with alloc().
@@ -153,6 +142,27 @@ void *xrealloc(void *ptr, size_t size)
   }
 
   return ret;
+}
+
+void *xmallocz(size_t size)
+{
+  size_t total_size = size + 1;
+  void *ret;
+
+  if (total_size < size) {
+    OUT_STR("Vim: Data too large to fit into virtual memory space\n");
+    preserve_exit();
+  }
+
+  ret = xmalloc(total_size);
+  ((char*)ret)[size] = 0;
+
+  return ret;
+}
+
+void *xmemdupz(const void *data, size_t len)
+{
+  return memcpy(xmallocz(len), data, len);
 }
 
 char * xstrdup(const char *str)
@@ -349,25 +359,4 @@ void free_all_mem(void)
 }
 
 #endif
-
-static void *xmallocz(size_t size)
-{
-  size_t total_size = size + 1;
-  void *ret;
-
-  if (total_size < size) {
-    OUT_STR("Vim: Data too large to fit into virtual memory space\n");
-    preserve_exit();
-  }
-
-  ret = xmalloc(total_size);
-  ((char*)ret)[size] = 0;
-
-  return ret;
-}
-
-static void *xmemdupz(const void *data, size_t len)
-{
-  return memcpy(xmallocz(len), data, len);
-}
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -36,6 +36,23 @@ void *xcalloc(size_t count, size_t size)
 void *xrealloc(void *ptr, size_t size)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET;
 
+/// xmalloc() wrapper that allocates size + 1 bytes and zeroes the last byte
+///
+/// @see {xmalloc}
+/// @param size
+/// @return pointer to allocated space. Never NULL
+void *xmallocz(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET;
+
+/// Allocates (len + 1) bytes of memory, duplicates `len` bytes of
+/// `data` to the allocated memory, zero terminates the allocated memory,
+/// and returns a pointer to the allocated memory. If the allocation fails,
+/// the program dies.
+///
+/// @see {xmalloc}
+/// @param data Pointer to the data that will be copied
+/// @param len number of bytes that will be copied
+void *xmemdupz(const void *data, size_t len);
+
 /// strdup() wrapper
 ///
 /// @see {xmalloc}

--- a/src/memory.h
+++ b/src/memory.h
@@ -10,6 +10,24 @@ char_u *alloc_clear(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
 
 /// malloc() wrapper
 ///
+/// try_malloc() is a malloc() wrapper that tries to free some memory before
+/// trying again.
+///
+/// @see {try_to_free_memory}
+/// @param size
+/// @return pointer to allocated space. NULL if out of memory
+void *try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
+
+/// try_malloc() wrapper that shows an out-of-memory error message to the user
+/// before returning NULL
+///
+/// @see {try_malloc}
+/// @param size
+/// @return pointer to allocated space. NULL if out of memory
+void *verbose_try_malloc(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
+
+/// malloc() wrapper that never returns NULL
+///
 /// xmalloc() succeeds or gracefully aborts when out of memory.
 /// Before aborting try to free some memory and call malloc again.
 ///
@@ -51,7 +69,7 @@ void *xmallocz(size_t size) FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET;
 /// @see {xmalloc}
 /// @param data Pointer to the data that will be copied
 /// @param len number of bytes that will be copied
-void *xmemdupz(const void *data, size_t len);
+void *xmemdupz(const void *data, size_t len) FUNC_ATTR_NONNULL_RET;
 
 /// strdup() wrapper
 ///

--- a/src/menu.c
+++ b/src/menu.c
@@ -905,9 +905,7 @@ char_u *set_context_in_menu_cmd(expand_T *xp, char_u *cmd, char_u *arg, int forc
 
     menu = root_menu;
     if (after_dot != arg) {
-      path_name = alloc((unsigned)(after_dot - arg));
-      if (path_name == NULL)
-        return NULL;
+      path_name = xmalloc(after_dot - arg);
       vim_strncpy(path_name, arg, after_dot - arg - 1);
     }
     name = path_name;

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3125,11 +3125,11 @@ static char_u *vim_version_dir(char_u *vimdir)
   if (vimdir == NULL || *vimdir == NUL)
     return NULL;
   p = concat_fnames(vimdir, (char_u *)VIM_VERSION_NODOT, TRUE);
-  if (p != NULL && os_isdir(p))
+  if (os_isdir(p))
     return p;
   vim_free(p);
   p = concat_fnames(vimdir, (char_u *)RUNTIME_DIRNAME, TRUE);
-  if (p != NULL && os_isdir(p))
+  if (os_isdir(p))
     return p;
   vim_free(p);
   return NULL;
@@ -3163,11 +3163,8 @@ void vim_setenv(char_u *name, char_u *val)
    */
   if (*val != NUL && STRICMP(name, "VIMRUNTIME") == 0) {
     char_u  *buf = concat_str(val, (char_u *)"/lang");
-
-    if (buf != NULL) {
-      bindtextdomain(VIMPACKAGE, (char *)buf);
-      vim_free(buf);
-    }
+    bindtextdomain(VIMPACKAGE, (char *)buf);
+    vim_free(buf);
   }
 }
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1234,19 +1234,17 @@ int call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
         if (ecmd == NULL)
           ecmd = cmd;
       }
-      ncmd = alloc((unsigned)(STRLEN(ecmd) + STRLEN(p_sxq) * 2 + 1));
-      if (ncmd != NULL) {
-        STRCPY(ncmd, p_sxq);
-        STRCAT(ncmd, ecmd);
-        /* When 'shellxquote' is ( append ).
-         * When 'shellxquote' is "( append )". */
-        STRCAT(ncmd, STRCMP(p_sxq, "(") == 0 ? (char_u *)")"
-            : STRCMP(p_sxq, "\"(") == 0 ? (char_u *)")\""
-            : p_sxq);
-        retval = os_call_shell(ncmd, opts, extra_shell_arg);
-        vim_free(ncmd);
-      } else
-        retval = -1;
+      ncmd = xmalloc(STRLEN(ecmd) + STRLEN(p_sxq) * 2 + 1);
+      STRCPY(ncmd, p_sxq);
+      STRCAT(ncmd, ecmd);
+      /* When 'shellxquote' is ( append ).
+       * When 'shellxquote' is "( append )". */
+      STRCAT(ncmd, STRCMP(p_sxq, "(") == 0 ? (char_u *)")"
+          : STRCMP(p_sxq, "\"(") == 0 ? (char_u *)")\""
+          : p_sxq);
+      retval = os_call_shell(ncmd, opts, extra_shell_arg);
+      vim_free(ncmd);
+
       if (ecmd != cmd)
         vim_free(ecmd);
     }
@@ -1432,16 +1430,14 @@ time_t get8ctime(FILE *fd)
 
 /*
  * Read a string of length "cnt" from "fd" into allocated memory.
- * Returns NULL when out of memory or unable to read that many bytes.
+ * Returns NULL when unable to read that many bytes.
  */
 char_u *read_string(FILE *fd, int cnt)
 {
-  char_u      *str;
   int i;
   int c;
 
-  /* allocate memory */
-  str = alloc((unsigned)cnt + 1);
+  char_u *str = xmallocz(cnt);
   /* Read the string.  Quit when running into the EOF. */
   for (i = 0; i < cnt; ++i) {
     c = getc(fd);

--- a/src/ops.c
+++ b/src/ops.c
@@ -793,7 +793,7 @@ get_register (
   if (copy) {
     if (reg->y_size == 0) {
       reg->y_array = NULL;
-    } else
+    } else {
       reg->y_array = xmalloc(reg->y_size * sizeof(char_u *));
       for (linenr_T i = 0; i < reg->y_size; ++i) {
         reg->y_array[i] = vim_strsave(y_current->y_array[i]);

--- a/src/ops.c
+++ b/src/ops.c
@@ -105,7 +105,7 @@ static void stuffescaped(char_u *arg, int literally);
 static void mb_adjust_opend(oparg_T *oap);
 static void free_yank(long);
 static void free_yank_all(void);
-static int yank_copy_line(struct block_def *bd, long y_idx);
+static void yank_copy_line(struct block_def *bd, long y_idx);
 static void dis_msg(char_u *p, int skip_esc);
 static char_u   *skip_comment(char_u *line, int process,
                               int include_space,
@@ -786,23 +786,18 @@ get_register (
     int copy               /* make a copy, if FALSE make register empty. */
 )
 {
-  struct yankreg      *reg;
-  int i;
-
-
   get_yank_register(name, 0);
-  reg = (struct yankreg *)alloc((unsigned)sizeof(struct yankreg));
+
+  struct yankreg *reg = xmalloc(sizeof(struct yankreg));
   *reg = *y_current;
   if (copy) {
-    /* If we run out of memory some or all of the lines are empty. */
-    if (reg->y_size == 0)
+    if (reg->y_size == 0) {
       reg->y_array = NULL;
-    else
-      reg->y_array = (char_u **)alloc((unsigned)(sizeof(char_u *)
-                                                 * reg->y_size));
-    if (reg->y_array != NULL) {
-      for (i = 0; i < reg->y_size; ++i)
+    } else
+      reg->y_array = xmalloc(reg->y_size * sizeof(char_u *));
+      for (linenr_T i = 0; i < reg->y_size; ++i) {
         reg->y_array[i] = vim_strsave(y_current->y_array[i]);
+      }
     }
   } else
     y_current->y_array = NULL;
@@ -2433,8 +2428,7 @@ int op_yank(oparg_T *oap, int deleting, int mess)
     switch (y_current->y_type) {
     case MBLOCK:
       block_prep(oap, &bd, lnum, FALSE);
-      if (yank_copy_line(&bd, y_idx) == FAIL)
-        goto fail;
+      yank_copy_line(&bd, y_idx);
       break;
 
     case MLINE:
@@ -2501,8 +2495,7 @@ int op_yank(oparg_T *oap, int deleting, int mess)
         bd.textlen = endcol - startcol + oap->inclusive;
       }
       bd.textstart = p + startcol;
-      if (yank_copy_line(&bd, y_idx) == FAIL)
-        goto fail;
+      yank_copy_line(&bd, y_idx);
       break;
     }
       /* NOTREACHED */
@@ -2583,13 +2576,10 @@ fail:           /* free the allocated lines */
   return FAIL;
 }
 
-static int yank_copy_line(struct block_def *bd, long y_idx)
+static void yank_copy_line(struct block_def *bd, long y_idx)
 {
-  char_u      *pnew;
+  char_u *pnew = xmallocz(bd->startspaces + bd->endspaces + bd->textlen);
 
-  if ((pnew = alloc(bd->startspaces + bd->endspaces + bd->textlen + 1))
-      == NULL)
-    return FAIL;
   y_current->y_array[y_idx] = pnew;
   copy_spaces(pnew, (size_t)bd->startspaces);
   pnew += bd->startspaces;
@@ -2598,7 +2588,6 @@ static int yank_copy_line(struct block_def *bd, long y_idx)
   copy_spaces(pnew, (size_t)bd->endspaces);
   pnew += bd->endspaces;
   *pnew = NUL;
-  return OK;
 }
 
 

--- a/src/ops.h
+++ b/src/ops.h
@@ -1,5 +1,9 @@
 #ifndef NEOVIM_OPS_H
 #define NEOVIM_OPS_H
+
+#include "func_attr.h"
+#include "types.h"
+
 /* ops.c */
 int get_op_type(int char1, int char2);
 int op_on_lines(int op);
@@ -15,7 +19,7 @@ char_u *get_expr_line_src(void);
 int valid_yank_reg(int regname, int writing);
 void get_yank_register(int regname, int writing);
 int may_get_selection(int regname);
-void *get_register(int name, int copy);
+void *get_register(int name, int copy) FUNC_ATTR_NONNULL_RET;
 void put_register(int name, void *reg);
 void free_register(void *reg);
 int yank_register_mline(int regname);

--- a/src/option.c
+++ b/src/option.c
@@ -5048,13 +5048,11 @@ static char_u *compile_cap_prog(synblock_T *synblock)
   else {
     /* Prepend a ^ so that we only match at one column */
     re = concat_str((char_u *)"^", synblock->b_p_spc);
-    if (re != NULL) {
-      synblock->b_cap_prog = vim_regcomp(re, RE_MAGIC);
-      vim_free(re);
-      if (synblock->b_cap_prog == NULL) {
-        synblock->b_cap_prog = rp;         /* restore the previous program */
-        return e_invarg;
-      }
+    synblock->b_cap_prog = vim_regcomp(re, RE_MAGIC);
+    vim_free(re);
+    if (synblock->b_cap_prog == NULL) {
+      synblock->b_cap_prog = rp;         /* restore the previous program */
+      return e_invarg;
     }
   }
 

--- a/src/path.c
+++ b/src/path.c
@@ -272,32 +272,26 @@ int vim_fnamencmp(char_u *x, char_u *y, size_t len)
  */
 char_u *concat_fnames(char_u *fname1, char_u *fname2, int sep)
 {
-  char_u  *dest;
+  char_u *dest = xmalloc(STRLEN(fname1) + STRLEN(fname2) + 3);
 
-  dest = alloc((unsigned)(STRLEN(fname1) + STRLEN(fname2) + 3));
-  if (dest != NULL) {
-    STRCPY(dest, fname1);
-    if (sep)
-      add_pathsep(dest);
-    STRCAT(dest, fname2);
+  STRCPY(dest, fname1);
+  if (sep) {
+    add_pathsep(dest);
   }
+  STRCAT(dest, fname2);
+
   return dest;
 }
 
 /*
  * Concatenate two strings and return the result in allocated memory.
- * Returns NULL when out of memory.
  */
 char_u *concat_str(char_u *str1, char_u *str2)
 {
-  char_u  *dest;
   size_t l = STRLEN(str1);
-
-  dest = alloc((unsigned)(l + STRLEN(str2) + 1L));
-  if (dest != NULL) {
-    STRCPY(dest, str1);
-    STRCPY(dest + l, str2);
-  }
+  char_u *dest = xmalloc(l + STRLEN(str2) + 1);
+  STRCPY(dest, str1);
+  STRCPY(dest + l, str2);
   return dest;
 }
 
@@ -916,8 +910,6 @@ expand_in_path (
 
   paths = ga_concat_strings(&path_ga);
   ga_clear_strings(&path_ga);
-  if (paths == NULL)
-    return 0;
 
   files = globpath(paths, pattern, (flags & EW_ICASE) ? WILD_ICASE : 0);
   vim_free(paths);

--- a/src/path.h
+++ b/src/path.h
@@ -1,6 +1,9 @@
 #ifndef NEOVIM_PATH_H
 #define NEOVIM_PATH_H
 
+#include "func_attr.h"
+#include "types.h"
+
 /// Return value for the comparison of two files. Also @see path_full_compare.
 typedef enum file_comparison {
   kEqualFiles = 1,        ///< Both exist and are the same file.
@@ -54,7 +57,8 @@ void shorten_dir(char_u *str);
 int dir_of_file_exists(char_u *fname);
 int vim_fnamecmp(char_u *x, char_u *y);
 int vim_fnamencmp(char_u *x, char_u *y, size_t len);
-char_u *concat_fnames(char_u *fname1, char_u *fname2, int sep);
+char_u *concat_fnames(char_u *fname1, char_u *fname2, int sep)
+  FUNC_ATTR_NONNULL_RET;
 int unix_expandpath(garray_T *gap, char_u *path, int wildoff, int flags,
                     int didstar);
 int gen_expand_wildcards(int num_pat, char_u **pat, int *num_file,
@@ -62,7 +66,7 @@ int gen_expand_wildcards(int num_pat, char_u **pat, int *num_file,
                          int flags);
 void addfile(garray_T *gap, char_u *f, int flags);
 char_u *get_past_head(char_u *path);
-char_u *concat_str(char_u *str1, char_u *str2);
+char_u *concat_str(char_u *str1, char_u *str2) FUNC_ATTR_NONNULL_RET;
 void add_pathsep(char_u *p);
 char_u *FullName_save(char_u *fname, int force);
 void simplify_filename(char_u *filename);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1119,8 +1119,8 @@ static int qf_get_fnum(char_u *directory, char_u *fname)
       slash_adjust(directory);
     slash_adjust(fname);
 #endif
-    if (directory != NULL && !vim_isAbsName(fname)
-        && (ptr = concat_fnames(directory, fname, TRUE)) != NULL) {
+    if (directory != NULL && !vim_isAbsName(fname)) {
+      ptr = concat_fnames(directory, fname, TRUE);
       /*
        * Here we check if the file really exists.
        * This should normally be true, but if make works without
@@ -1280,10 +1280,7 @@ static char_u *qf_guess_filepath(char_u *filename)
     vim_free(fullname);
     fullname = concat_fnames(ds_ptr->dirname, filename, TRUE);
 
-    /* If concat_fnames failed, just go on. The worst thing that can happen
-     * is that we delete the entire stack.
-     */
-    if (fullname != NULL && os_file_exists(fullname))
+    if (os_file_exists(fullname))
       break;
 
     ds_ptr = ds_ptr->next;

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -200,8 +200,6 @@ qf_init (
 
   if (wp != NULL) {
     qi = ll_get_or_alloc_list(wp);
-    if (qi == NULL)
-      return FAIL;
   }
 
   return qf_init_ext(qi, efile, curbuf, NULL, errorformat, newlist,
@@ -977,10 +975,7 @@ qf_add_entry (
  */
 static qf_info_T *ll_new_list(void)
 {
-  qf_info_T *qi;
-
-  qi = (qf_info_T *)alloc((unsigned)sizeof(qf_info_T));
-  memset(qi, 0, (size_t)(sizeof(qf_info_T)));
+  qf_info_T *qi = xcalloc(1, sizeof(qf_info_T));
   qi->qf_refcount++;
 
   return qi;
@@ -1030,8 +1025,7 @@ void copy_loclist(win_T *from, win_T *to)
     return;
 
   /* allocate a new location list */
-  if ((to->w_llist = ll_new_list()) == NULL)
-    return;
+  to->w_llist = ll_new_list();
 
   to->w_llist->qf_listcount = qi->qf_listcount;
 
@@ -2797,8 +2791,6 @@ void ex_vimgrep(exarg_T *eap)
       || eap->cmdidx == CMD_lgrepadd
       || eap->cmdidx == CMD_lvimgrepadd) {
     qi = ll_get_or_alloc_list(curwin);
-    if (qi == NULL)
-      return;
   }
 
   if (eap->addr_count > 0)
@@ -3339,8 +3331,6 @@ int set_errorlist(win_T *wp, list_T *list, int action, char_u *title)
 
   if (wp != NULL) {
     qi = ll_get_or_alloc_list(wp);
-    if (qi == NULL)
-      return FAIL;
   }
 
   if (action == ' ' || qi->qf_curlist == qi->qf_listcount)
@@ -3442,8 +3432,6 @@ void ex_cbuffer(exarg_T *eap)
   if (eap->cmdidx == CMD_lbuffer || eap->cmdidx == CMD_lgetbuffer
       || eap->cmdidx == CMD_laddbuffer) {
     qi = ll_get_or_alloc_list(curwin);
-    if (qi == NULL)
-      return;
   }
 
   if (*eap->arg == NUL)
@@ -3495,8 +3483,6 @@ void ex_cexpr(exarg_T *eap)
   if (eap->cmdidx == CMD_lexpr || eap->cmdidx == CMD_lgetexpr
       || eap->cmdidx == CMD_laddexpr) {
     qi = ll_get_or_alloc_list(curwin);
-    if (qi == NULL)
-      return;
   }
 
   /* Evaluate the expression.  When the result is a string or a list we can
@@ -3570,8 +3556,7 @@ void ex_helpgrep(exarg_T *eap)
 
     if (qi == NULL) {
       /* Allocate a new location list for help text matches */
-      if ((qi = ll_new_list()) == NULL)
-        return;
+      qi = ll_new_list();
       new_qi = TRUE;
     }
   }

--- a/src/screen.c
+++ b/src/screen.c
@@ -6279,15 +6279,11 @@ retry:
 
   FOR_ALL_TAB_WINDOWS(tp, wp)
   {
-    if (win_alloc_lines(wp) == FAIL) {
-      outofmem = TRUE;
-      goto give_up;
-    }
+    win_alloc_lines(wp);
   }
-  if (aucmd_win != NULL && aucmd_win->w_lines == NULL
-      && win_alloc_lines(aucmd_win) == FAIL)
-    outofmem = TRUE;
-give_up:
+  if (aucmd_win != NULL && aucmd_win->w_lines == NULL) {
+    win_alloc_lines(aucmd_win);
+  }
 
   for (i = 0; i < p_mco; ++i)
     if (new_ScreenLinesC[i] == NULL)

--- a/src/undo.c
+++ b/src/undo.c
@@ -721,11 +721,11 @@ char_u *u_get_undo_file_name(char_u *buf_ffname, int reading)
       }
     }
 
-    /* When reading check if the file exists. */
-    if (undo_file_name != NULL && (!reading
-                                   || mch_stat((char *)undo_file_name,
-                                       &st) >= 0))
+    // When reading check if the file exists.
+    if (undo_file_name != NULL &&
+        (!reading || mch_stat((char *)undo_file_name, &st) >= 0)) {
       break;
+    }
     vim_free(undo_file_name);
     undo_file_name = NULL;
   }

--- a/src/window.h
+++ b/src/window.h
@@ -41,7 +41,7 @@ win_T *buf_jump_open_win(buf_T *buf);
 win_T *buf_jump_open_tab(buf_T *buf);
 void win_append(win_T *after, win_T *wp);
 void win_remove(win_T *wp, tabpage_T *tp);
-int win_alloc_lines(win_T *wp);
+void win_alloc_lines(win_T *wp);
 void win_free_lsize(win_T *wp);
 void shell_new_rows(void);
 void shell_new_columns(void);


### PR DESCRIPTION
Other highlights:
- Reimplemented xmalloc() using try_malloc()
- xmallocz() is not static anymore.

See individual commit messages for more details.

This is a WIP anyone can start reviewing commit by commit (easier this way). I'll be pushing more commits that remove OOM error handling here.
