### PR TITLE
[RDY] Use /2 and 2* instead of >>1 and <<1 which are tricky with signed types

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -7164,7 +7164,7 @@ find_internal_func (
    * Find the function name in the table. Binary search.
    */
   while (first <= last) {
-    x = first + ((unsigned)(last - first) >> 1);
+    x = first + (last - first) / 2;
     cmp = STRCMP(name, functions[x].f_name);
     if (cmp < 0)
       last = x - 1;

--- a/src/eval.c
+++ b/src/eval.c
@@ -7157,15 +7157,13 @@ find_internal_func (
 {
   int first = 0;
   int last = (int)(sizeof(functions) / sizeof(struct fst)) - 1;
-  int cmp;
-  int x;
 
   /*
    * Find the function name in the table. Binary search.
    */
   while (first <= last) {
-    x = first + (last - first) / 2;
-    cmp = STRCMP(name, functions[x].f_name);
+    int x = first + ((unsigned)(last - first)) / 2;
+    int cmp = STRCMP(name, functions[x].f_name);
     if (cmp < 0)
       last = x - 1;
     else if (cmp > 0)

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -141,7 +141,7 @@ hashitem_T* hash_lookup(hashtab_T *ht, char_u *key, hash_T hash)
     // count a "miss" for hashtab lookup
     hash_count_perturb++;
 #endif  // ifdef HT_DEBUG
-    idx = (unsigned)((idx << 2U) + idx + perturb + 1U);
+    idx = 5 * idx + perturb + 1;
     hi = &ht->ht_array[idx & ht->ht_mask];
 
     if (hi->hi_key == NULL) {
@@ -376,7 +376,7 @@ static int hash_may_resize(hashtab_T *ht, int minitems)
       newitem = &newarray[newi];
       if (newitem->hi_key != NULL) {
         for (perturb = olditem->hi_hash;; perturb >>= PERTURB_SHIFT) {
-          newi = (unsigned)((newi << 2U) + newi + perturb + 1U);
+          newi = 5 * newi + perturb + 1;
           newitem = &newarray[newi & newmask];
           if (newitem->hi_key == NULL) {
             break;

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -192,7 +192,7 @@ memfile_T *mf_open(char_u *fname, int flags)
     unsigned page_size = mfp->mf_page_size;
 
     while (shift > 0 && (page_size & 1) == 0) {
-      page_size = page_size >> 1;
+      page_size /= 2;
       --shift;
     }
     mfp->mf_used_count_max = (p_mm << shift) / page_size;

--- a/src/option.c
+++ b/src/option.c
@@ -2042,8 +2042,8 @@ void set_init_1(void)
     /* Initialize the 'cdpath' option's default value. */
     cdpath = vim_getenv((char_u *)"CDPATH", &mustfree);
     if (cdpath != NULL) {
-      buf = alloc((unsigned)((STRLEN(cdpath) << 1) + 2));
-      if (buf != NULL) {
+      buf = xmalloc(2 * STRLEN(cdpath) + 2);
+      {
         buf[0] = ',';               /* start with ",", current dir first */
         j = 1;
         for (i = 0; cdpath[i] != NUL; ++i) {
@@ -2376,7 +2376,7 @@ void set_init_2(void)
    * 'scroll' defaults to half the window height. Note that this default is
    * wrong when the window height changes.
    */
-  set_number_default("scroll", (long)((long_u)Rows >> 1));
+  set_number_default("scroll", Rows / 2);
   idx = findoption((char_u *)"scroll");
   if (idx >= 0 && !(options[idx].flags & P_WAS_SET))
     set_option_default(idx, OPT_LOCAL, p_cp);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -314,7 +314,7 @@ qf_init_ext (
   /*
    * Get some space to modify the format string into.
    */
-  i = (FMT_PATTERNS * 3) + ((int)STRLEN(efm) << 2);
+  i = 3 * FMT_PATTERNS + 4 * (int)STRLEN(efm);
   for (round = FMT_PATTERNS; round > 0; )
     i += (int)STRLEN(fmt_pat[--round].pattern);
 #ifdef COLON_IN_FILENAME

--- a/src/window.c
+++ b/src/window.c
@@ -1520,8 +1520,7 @@ win_equal_rec (
         if (totwincount == 0)
           new_size = room;
         else
-          new_size = (wincount * room + ((unsigned)totwincount >> 1))
-                     / totwincount;
+          new_size = (wincount * room + (totwincount / 2)) / totwincount;
         if (hnc) {                  /* add next_curwin size */
           next_curwin_size -= p_wiw - (m - n);
           new_size += next_curwin_size;
@@ -1642,8 +1641,7 @@ win_equal_rec (
         if (totwincount == 0)
           new_size = room;
         else
-          new_size = (wincount * room + ((unsigned)totwincount >> 1))
-                     / totwincount;
+          new_size = (wincount * room + (totwincount / 2)) / totwincount;
         if (hnc) {                  /* add next_curwin size */
           next_curwin_size -= p_wh - (m - n);
           new_size += next_curwin_size;
@@ -4678,7 +4676,7 @@ void win_new_width(win_T *wp, int width)
 
 void win_comp_scroll(win_T *wp)
 {
-  wp->w_p_scr = ((unsigned)wp->w_height >> 1);
+  wp->w_p_scr = wp->w_height / 2;
   if (wp->w_p_scr == 0)
     wp->w_p_scr = 1;
 }


### PR DESCRIPTION
Today's compilers generate shift instructions to perform division and
multiplications by powers of 2 [1]. `(x >> 1)` looks straightforward enough, but
if x is signed the code will fail when x < 0. The compiler knows better: use
`x / 2`.

That's why we have code like this:

```
(long)((long_u)Rows >> 1))
```

instead of the cleaner version that generates the same or better machine code:

```
Rows / 2
```

[1] http://goo.gl/J4WpG7
