### PR TITLE
[RDY] Remove :winsize command

### DIFF
--- a/src/ex_cmds_defs.h
+++ b/src/ex_cmds_defs.h
@@ -1018,8 +1018,6 @@ enum CMD_index
       BANG|TRLBAR|CMDWIN),
   EX(CMD_while,           "while",        ex_while,
       EXTRA|NOTRLCOM|SBOXOK|CMDWIN),
-  EX(CMD_winsize,         "winsize",      ex_winsize,
-      EXTRA|NEEDARG|TRLBAR),
   EX(CMD_wincmd,          "wincmd",       ex_wincmd,
       NEEDARG|WORD1|RANGE|NOTADR),
   EX(CMD_windo,           "windo",        ex_listdo,

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -171,7 +171,6 @@ static void ex_pwd(exarg_T *eap);
 static void ex_equal(exarg_T *eap);
 static void ex_sleep(exarg_T *eap);
 static void do_exmap(exarg_T *eap, int isabbrev);
-static void ex_winsize(exarg_T *eap);
 static void ex_wincmd(exarg_T *eap);
 #if defined(FEAT_GUI) || defined(UNIX) || defined(VMS) || defined(MSWIN)
 static void ex_winpos(exarg_T *eap);
@@ -6717,25 +6716,6 @@ static void do_exmap(exarg_T *eap, int isabbrev)
   case 2: EMSG(isabbrev ? _(e_noabbr) : _(e_nomap));
     break;
   }
-}
-
-/*
- * ":winsize" command (obsolete).
- */
-static void ex_winsize(exarg_T *eap)
-{
-  int w, h;
-  char_u      *arg = eap->arg;
-  char_u      *p;
-
-  w = getdigits(&arg);
-  arg = skipwhite(arg);
-  p = arg;
-  h = getdigits(&arg);
-  if (*p != NUL && *arg == NUL)
-    set_shellsize(w, h, TRUE);
-  else
-    EMSG(_("E465: :winsize requires two number arguments"));
 }
 
 static void ex_wincmd(exarg_T *eap)

--- a/src/po/af.po
+++ b/src/po/af.po
@@ -1049,9 +1049,6 @@ msgstr "E186: Geen vorige gids nie"
 msgid "E187: Unknown"
 msgstr "E187: Onbekend"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: ':winsize' benodig twee nommer parameters"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Vensterposisie: X %d, Y %d"

--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -1266,9 +1266,6 @@ msgstr "E186: No hi ha cap directori anterior"
 msgid "E187: Unknown"
 msgstr "E187: Desconegut"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: L'ordre :winsize requereix dos arguments numèrics"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Posició de la finestra: X %d, Y %d"

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -1199,9 +1199,6 @@ msgstr "E186: Kein vorheriges Verzeichnis"
 msgid "E187: Unknown"
 msgstr "E187: Unbekannt"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize benötigt zwei numerische Argumente"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Fenster-Position: X %d, Y %d"

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -1377,9 +1377,6 @@ msgstr "E186: Neniu antaŭa dosierujo"
 msgid "E187: Unknown"
 msgstr "E187: Nekonata"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: \":winsize\" bezonas du numerajn argumentojn"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Pozicio de fenestro: X %d, Y %d"

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -1690,9 +1690,6 @@ msgid "E187: Unknown"
 msgstr "E187: Desconocido"
 
 #: ex_docmd.c:8084
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: \":winsize\" requiere de dos argumentos numéricos"
-
 #: ex_docmd.c:8146
 #, c-format
 msgid "Window position: X %d, Y %d"

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -1328,9 +1328,6 @@ msgstr "E186: Ei edellistä hakemistoa"
 msgid "E187: Unknown"
 msgstr "E187: Tuntematon"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize vaatii kaksi numeroargumenttia"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Ikkunan sijainti: X %d, Y %d"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -1564,9 +1564,6 @@ msgstr "E186: Pas de répertoire précédent"
 msgid "E187: Unknown"
 msgstr "E187: Inconnu"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize requiert deux arguments numériques"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Position de la fenêtre : X %d, Y %d"

--- a/src/po/ga.po
+++ b/src/po/ga.po
@@ -1306,9 +1306,6 @@ msgstr "E186: Níl aon chomhadlann roimhe seo"
 msgid "E187: Unknown"
 msgstr "E187: Anaithnid"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: ní foláir dhá argóint uimhriúla le :winsize"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Ionad na fuinneoige: X %d, Y %d"

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -1372,9 +1372,6 @@ msgstr "E186: Non c'è una directory precedente"
 msgid "E187: Unknown"
 msgstr "E187: Sconosciuto"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize richiede due argomenti numerici"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Posizione finestra: X %d, Y %d"

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -1367,9 +1367,6 @@ msgstr "E186: 前のディレクトリはありません"
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize には2つの数値の引数が必要です"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "ウィンドウ位置: X %d, Y %d"

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -1367,9 +1367,6 @@ msgstr "E186: 前のディレクトリはありません"
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize には2つの数値の引数が必要です"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "ウィンドウ位置: X %d, Y %d"

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -1367,9 +1367,6 @@ msgstr "E186: 前のディレクトリはありません"
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize には2つの数値の引数が必要です"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "ウィンドウ位置: X %d, Y %d"

--- a/src/po/ko.UTF-8.po
+++ b/src/po/ko.UTF-8.po
@@ -1313,9 +1313,6 @@ msgstr "E186: 이전 디렉토리가 없습니다"
 msgid "E187: Unknown"
 msgstr "E187: 모름"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize는 두개의 인자가 필요합니다"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "창 위치: X %d, Y %d"

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -1313,9 +1313,6 @@ msgstr "E186: 이전 디렉토리가 없습니다"
 msgid "E187: Unknown"
 msgstr "E187: 모름"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize는 두개의 인자가 필요합니다"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "창 위치: X %d, Y %d"

--- a/src/po/nb.po
+++ b/src/po/nb.po
@@ -1260,9 +1260,6 @@ msgstr "E186: Ingen tidligere katalog"
 msgid "E187: Unknown"
 msgstr "E187: Ukjent"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize trenger to numeriske parametere"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Vindusposisjon: X %d, Y %d"

--- a/src/po/nl.po
+++ b/src/po/nl.po
@@ -1309,9 +1309,6 @@ msgstr "E186: geen voorgaande map"
 msgid "E187: Unknown"
 msgstr "E187: onbekend"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize vereist twee getallen als argument"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Vensterpositie: X %d, Y %d"

--- a/src/po/no.po
+++ b/src/po/no.po
@@ -1260,9 +1260,6 @@ msgstr "E186: Ingen tidligere katalog"
 msgid "E187: Unknown"
 msgstr "E187: Ukjent"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize trenger to numeriske parametere"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Vindusposisjon: X %d, Y %d"

--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -1368,9 +1368,6 @@ msgstr "E186: Nie ma poprzedniego katalogu"
 msgid "E187: Unknown"
 msgstr "E187: Nieznany"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize wymaga dwóch argumentów numerycznych"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Pozycja okna: X %d, Y %d"

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -1368,9 +1368,6 @@ msgstr "E186: Nie ma poprzedniego katalogu"
 msgid "E187: Unknown"
 msgstr "E187: Nieznany"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize wymaga dwóch argumentów numerycznych"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Pozycja okna: X %d, Y %d"

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -1368,9 +1368,6 @@ msgstr "E186: Nie ma poprzedniego katalogu"
 msgid "E187: Unknown"
 msgstr "E187: Nieznany"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize wymaga dwóch argumentów numerycznych"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Pozycja okna: X %d, Y %d"

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -1289,9 +1289,6 @@ msgstr "E186: Não há diretório anterior"
 msgid "E187: Unknown"
 msgstr "E187: Desconhecido"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize requer dois argumentos numéricos"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Posição da janela: X %d, Y %d"

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -1379,9 +1379,6 @@ msgstr "E186: Нет предыдущего каталога"
 msgid "E187: Unknown"
 msgstr "E187: Неизвестно"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: Команда :winsize требует указания двух числовых параметров"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Положение окна: X %d, Y %d"

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -1379,9 +1379,6 @@ msgstr "E186: Нет предыдущего каталога"
 msgid "E187: Unknown"
 msgstr "E187: Неизвестно"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: Команда :winsize требует указания двух числовых параметров"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Положение окна: X %d, Y %d"

--- a/src/po/sk.cp1250.po
+++ b/src/po/sk.cp1250.po
@@ -1137,9 +1137,6 @@ msgstr "E186: iadny predchádzajúci adresár"
 msgid "E187: Unknown"
 msgstr "E187: Neznámy"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize (ve¾kos okna) vyaduje dva argumenty"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Pozícia okna: X %d, Y %d"

--- a/src/po/sk.po
+++ b/src/po/sk.po
@@ -1137,9 +1137,6 @@ msgstr "E186: ®iadny predchádzajúci adresár"
 msgid "E187: Unknown"
 msgstr "E187: Neznámy"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize (veµkos» okna) vy¾aduje dva argumenty"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Pozícia okna: X %d, Y %d"

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -1232,9 +1232,6 @@ msgstr "E186: Ingen tidigare katalog"
 msgid "E187: Unknown"
 msgstr "E187: Okänt"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize kräver två sifferargument"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Fönsterposition: X %d, Y %d"

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -1402,9 +1402,6 @@ msgstr "E186: Це вже найперший каталог"
 msgid "E187: Unknown"
 msgstr "E187: Невідомо"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize вимагає два числових аргументи"
-
 # msgstr "E187: "
 #, c-format
 msgid "Window position: X %d, Y %d"

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -1402,9 +1402,6 @@ msgstr "E186: Це вже найперший каталог"
 msgid "E187: Unknown"
 msgstr "E187: Невідомо"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize вимагає два числових аргументи"
-
 # msgstr "E187: "
 #, c-format
 msgid "Window position: X %d, Y %d"

--- a/src/po/vi.po
+++ b/src/po/vi.po
@@ -1044,9 +1044,6 @@ msgstr "E186: Không có thư mục trước"
 msgid "E187: Unknown"
 msgstr "E187: Không rõ"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: câu lệnh :winsize yêu cầu hai tham số bằng số"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "Vị trí cửa sổ: X %d, Y %d"

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -1215,9 +1215,6 @@ msgstr "E186: 前一个目录不存在"
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize 需要两个数字参数"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "窗口位置: X %d, Y %d"

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -1216,9 +1216,6 @@ msgstr "E186: 前一个目录不存在"
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize 需要两个数字参数"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "窗口位置: X %d, Y %d"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -1216,9 +1216,6 @@ msgstr "E186: 前一个目录不存在"
 msgid "E187: Unknown"
 msgstr "E187: 未知"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize 需要两个数字参数"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "窗口位置: X %d, Y %d"

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -1084,9 +1084,6 @@ msgstr "E186: 沒有前一個目錄"
 msgid "E187: Unknown"
 msgstr "E187: 無法辦識的標記"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize 需要兩個參數"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "視窗位置: X %d, Y %d"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -1077,9 +1077,6 @@ msgstr "E186: 沒有前一個目錄"
 msgid "E187: Unknown"
 msgstr "E187: 無法辦識的標記"
 
-msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize 需要兩個參數"
-
 #, c-format
 msgid "Window position: X %d, Y %d"
 msgstr "視窗位置: X %d, Y %d"


### PR DESCRIPTION
`:winsize` is obsolete. `&lines` and `&columns` should be set instead.
