### PR TITLE
[RDY] Remove sizeof(int) < 4 related code

### DIFF
--- a/src/eval_defs.h
+++ b/src/eval_defs.h
@@ -3,11 +3,7 @@
 
 #include "hashtab.h"
 
-#if SIZEOF_INT <= 3             /* use long if int is smaller than 32 bits */
-typedef long varnumber_T;
-#else
 typedef int varnumber_T;
-#endif
 typedef double float_T;
 
 typedef struct listvar_S list_T;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -983,24 +983,9 @@ retry:
      * The amount is limited by the fact that read() only can read
      * upto max_unsigned characters (and other things).
      */
-#if SIZEOF_INT <= 2
-    if (linerest >= 0x7ff0) {
-      ++split;
-      *ptr = NL;                    /* split line by inserting a NL */
-      size = 1;
-    } else
-#endif
     {
       if (!skip_read) {
-#if SIZEOF_INT > 2
-# if defined(SSIZE_MAX) && (SSIZE_MAX < 0x10000L)
-        size = SSIZE_MAX;                           /* use max I/O size, 52K */
-# else
         size = 0x10000L;                            /* use buffer >= 64K */
-# endif
-#else
-        size = 0x7ff0L - linerest;                  /* limit buffer to 32K */
-#endif
 
         for (; size >= 10; size = (long)((long_u)size >> 1)) {
           if ((new_buffer = lalloc((long_u)(size + linerest + 1),

--- a/src/message.c
+++ b/src/message.c
@@ -3351,14 +3351,10 @@ int vim_vsnprintf(char *str, size_t str_m, char *fmt, va_list ap, typval_T *tvs)
           else {
             /* Don't put the #if inside memchr(), it can be a
              * macro. */
-#if SIZEOF_INT <= 2
-            char *q = memchr(str_arg, '\0', precision);
-#else
             /* memchr on HP does not like n > 2^31  !!! */
             char *q = memchr(str_arg, '\0',
                 precision <= (size_t)0x7fffffffL ? precision
                 : (size_t)0x7fffffffL);
-#endif
             str_arg_l = (q == NULL) ? precision
                         : (size_t)(q - str_arg);
           }

--- a/src/spell.c
+++ b/src/spell.c
@@ -341,11 +341,7 @@
 
 /* Type used for indexes in the word tree need to be at least 4 bytes.  If int
  * is 8 bytes we could use something smaller, but what? */
-#if SIZEOF_INT > 3
 typedef int idx_T;
-#else
-typedef long idx_T;
-#endif
 
 # define SPL_FNAME_TMPL  "%s.%s.spl"
 # define SPL_FNAME_ADD   ".add."

--- a/src/vim.h
+++ b/src/vim.h
@@ -1078,25 +1078,7 @@ typedef int colnr_T;                    /* column number type */
 typedef unsigned short disptick_T;      /* display tick type */
 
 #define MAXLNUM (0x7fffffffL)           /* maximum (invalid) line number */
-
-/*
- * Well, you won't believe it, but some S/390 machines ("host", now also known
- * as zServer) use 31 bit pointers. There are also some newer machines, that
- * use 64 bit pointers. I don't know how to distinguish between 31 and 64 bit
- * machines, so the best way is to assume 31 bits whenever we detect OS/390
- * Unix.
- * With this we restrict the maximum line length to 1073741823. I guess this is
- * not a real problem. BTW:  Longer lines are split.
- */
-#if SIZEOF_INT >= 4
-# ifdef __MVS__
-#  define MAXCOL (0x3fffffffL)          /* maximum column number, 30 bits */
-# else
-#  define MAXCOL (0x7fffffffL)          /* maximum column number, 31 bits */
-# endif
-#else
-# define MAXCOL (0x7fff)                /* maximum column number, 15 bits */
-#endif
+#define MAXCOL (0x7fffffffL)          /* maximum column number, 31 bits */
 
 #define SHOWCMD_COLS 10                 /* columns needed by shown command */
 #define STL_MAX_ITEM 80                 /* max nr of %<flag> in statusline */


### PR DESCRIPTION
If I have understood things correctly, sizeof(int) >= 4 on all systems supported by neovim. If that's not the case, then please close this PR. Otherwise, this removes some obsolete code dealing with ints smaller than 4 bytes.
