### PR TITLE
[RDY] Remove proto as an include directory.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,5 +76,3 @@ if(NOT DEFINED ENV{SKIP_UNITTEST})
   add_library(nvim-test MODULE EXCLUDE_FROM_ALL ${NEOVIM_SOURCES} ${OS_SOURCES})
   target_link_libraries(nvim-test ${NVIM_LINK_LIBRARIES})
 endif()
-
-include_directories("${PROJECT_SOURCE_DIR}/src/proto")


### PR DESCRIPTION
Remove proto as an include directory, as the proto directory was removed in 0ef90c13b72b74928bfb3c183c7a5bd7240b51ad.
