### PR TITLE
Allow USERNAME to be specified on the command line.

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -17,7 +17,7 @@ configure_file (
 find_program(WHOAMI_PROG whoami)
 find_program(HOSTNAME_PROG hostname)
 
-if (EXISTS ${WHOAMI_PROG})
+if (NOT DEFINED USERNAME AND EXISTS ${WHOAMI_PROG})
   execute_process(COMMAND ${WHOAMI_PROG}
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE USERNAME)


### PR DESCRIPTION
There are some systems that have usernames of the form DOMAIN\username,
which causes an invalid escape character to be inserted.  I was going to
add some escaping, but decided it would be best to just outright set the
value, since I don't want the DOMAIN portion in there anyways.
