### PR TITLE
[RDY] fix -Wconversion warnings for rstream

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ set(CONV_SRCS
   os/signal.c
   os/users.c
   os/wstream.c
+  os/rstream.c
   )
 
 set_source_files_properties(

--- a/src/os/rstream.h
+++ b/src/os/rstream.h
@@ -65,13 +65,13 @@ void rstream_stop(RStream *rstream);
 /// @param buffer The buffer which will receive the data
 /// @param count Number of bytes that `buffer` can accept
 /// @return The number of bytes copied into `buffer`
-uint32_t rstream_read(RStream *rstream, char *buffer, uint32_t count);
+size_t rstream_read(RStream *rstream, char *buffer, uint32_t count);
 
 /// Returns the number of bytes available for reading from `rstream`
 ///
 /// @param rstream The `RStream` instance
 /// @return The number of bytes available
-uint32_t rstream_available(RStream *rstream);
+size_t rstream_available(RStream *rstream);
 
 /// Runs the read callback associated with the rstream
 ///


### PR DESCRIPTION
I'd like to request comments for how we should handle these things in general. What do you guys think about the assert? How do you guys feel about `size_t` for these types (an unsigned type). Especially ping @tarruda who made the rstream class.
