### PR TITLE
[RDY] Remove mch_screenmode

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6159,15 +6159,16 @@ static void ex_tabs(exarg_T *eap)
 
 
 /*
- * ":mode": Set screen mode.
- * If no argument given, just get the screen size and redraw.
+ * ":mode":
+ * If no argument given, get the screen size and redraw.
  */
 static void ex_mode(exarg_T *eap)
 {
-  if (*eap->arg == NUL)
+  if (*eap->arg == NUL) {
     shell_resized();
-  else
-    mch_screenmode(eap->arg);
+  } else {
+    EMSG(_(e_screenmode));
+  }
 }
 
 /*

--- a/src/globals.h
+++ b/src/globals.h
@@ -1080,11 +1080,8 @@ EXTERN char_u e_readerrf[] INIT(= N_("E47: Error while reading errorfile"));
 EXTERN char_u e_sandbox[] INIT(= N_("E48: Not allowed in sandbox"));
 #endif
 EXTERN char_u e_secure[] INIT(= N_("E523: Not allowed here"));
-#if defined(AMIGA) || defined(MACOS) || defined(MSWIN)  \
-  || defined(UNIX) || defined(VMS) || defined(OS2)
 EXTERN char_u e_screenmode[] INIT(= N_(
         "E359: Screen mode setting not supported"));
-#endif
 EXTERN char_u e_scroll[] INIT(= N_("E49: Invalid scroll size"));
 EXTERN char_u e_shellempty[] INIT(= N_("E91: 'shell' option is empty"));
 EXTERN char_u e_signdata[] INIT(= N_("E255: Couldn't read in sign data!"));

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -890,17 +890,6 @@ void check_mouse_termcode()
 }
 
 /*
- * set screen mode, always fails.
- */
-int mch_screenmode(arg)
-char_u   *arg;
-{
-  EMSG(_(e_screenmode));
-  return FAIL;
-}
-
-
-/*
  * Try to get the current window size:
  * 1. with an ioctl(), most accurate method
  * 2. from the environment variables LINES and COLUMNS

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -32,7 +32,6 @@ void mch_settmode(int tmode);
 void get_stty(void);
 void mch_setmouse(int on);
 void check_mouse_termcode(void);
-int mch_screenmode(char_u *arg);
 int mch_get_shellsize(void);
 void mch_set_shellsize(void);
 int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,


### PR DESCRIPTION
This function was only implemented on MSDOS. It is used by the `:mode` ex-command.
