### PR TITLE
[RFC] Simplify close_buffer() [codingstyle cleanup]

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -85,8 +85,7 @@ static void free_buffer(buf_T *);
 static void free_buffer_stuff(buf_T *buf, int free_options);
 static void clear_wininfo(buf_T *buf);
 static void decide_bufferaction(char, int*, int*, int*);
-static void wipe_or_delete_buffer(int wipe, int del, buf_T *buf, buf_T *first,
-        buf_T *lastbuf);
+static void wipe_or_delete_buffer(int wipe, int del, buf_T *buf);
 
 #ifdef UNIX
 # define dev_T dev_t
@@ -419,7 +418,7 @@ close_buffer (
   /* Change directories when the 'acd' option is set. */
   do_autochdir();
 
-  wipe_or_delete_buffer(wipe_buf, del_buf, buf, &firstbuf, &lastbuf);
+  wipe_or_delete_buffer(wipe_buf, del_buf, buf);
   return;
 
 aucmd_abort:
@@ -593,8 +592,7 @@ decide_bufferaction(char act, int *wipe, int *del, int *unload)
  * Remove the buffer from the list.
  */
 static void
-wipe_or_delete_buffer(int wipe_buf, int del_buf, buf_T *buf, buf_T *firstbuf,
-        buf_T *lastbuf)
+wipe_or_delete_buffer(int wipe_buf, int del_buf, buf_T *buf)
 {
   if (wipe_buf) {
     vim_free(buf->b_ffname);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -396,8 +396,9 @@ close_buffer (
     win->w_buffer = NULL;      /* make sure we don't use the buffer now */
 
   /* Autocommands may have deleted the buffer. */
-  /* autocmds may abort script processing */
-  if (!buf_valid(buf) || aborting())
+  if (!buf_valid(buf))
+    return;
+  if (aborting())           /* autocmds may abort script processing */
     return;
 
   /* Autocommands may have opened or closed windows for this buffer.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -326,7 +326,7 @@ close_buffer (
 
   // 'bufhidden' == "delete"
   case 'd':
-    del_bug = TRUE;
+    del_buf = TRUE;
     /* fallthrough */
 
   // 'bufhidden' == "unload"

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -84,6 +84,7 @@ static int append_arg_number(win_T *wp, char_u *buf, int buflen, int add_file);
 static void free_buffer(buf_T *);
 static void free_buffer_stuff(buf_T *buf, int free_options);
 static void clear_wininfo(buf_T *buf);
+static void decide_bufferaction(char, int*, int*, int*);
 
 #ifdef UNIX
 # define dev_T dev_t
@@ -317,21 +318,7 @@ close_buffer (
    * The caller must take care of NOT deleting/freeing when 'bufhidden' is
    * "hide" (otherwise we could never free or delete a buffer).
    */
-  switch (buf->b_p_bh[0])
-  {
-  case 'w': /* 'bufhidden' == "wipe" */
-    wipe_buf = TRUE;
-    /* fallthrough */
-
-  case 'd': /* 'bufhidden' == "delete" */
-    del_bug = TRUE;
-    /* fallthrough */
-
-  case 'u': /* 'bufhidden' == "unload" */
-    unload_buf = TRUE;
-    /* fallthrough */
-
-  }
+  decide_bufferaction(buf->b_p_bh[0], &wipe_buf, &del_bug, &unload_buf);
 
   if (win != NULL) {
     /* Set b_last_cursor when closing the last window for the buffer.
@@ -605,6 +592,27 @@ static void clear_wininfo(buf_T *buf)
     }
     vim_free(wip);
   }
+}
+
+static void
+decide_bufferaction(char act, int *wipe, int *del, int *unload)
+{
+  switch (act)
+  {
+  case 'w': /* 'bufhidden' == "wipe" */
+    *wipe = TRUE;
+    /* fallthrough */
+
+  case 'd': /* 'bufhidden' == "delete" */
+    *del = TRUE;
+    /* fallthrough */
+
+  case 'u': /* 'bufhidden' == "unload" */
+    *unload = TRUE;
+    /* fallthrough */
+
+  }
+
 }
 
 /*

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -418,9 +418,6 @@ close_buffer (
   /* Change directories when the 'acd' option is set. */
   do_autochdir();
 
-  /*
-   * Remove the buffer from the list.
-   */
   wipe_or_delete_buffer(wipe_buf, del_buf, buf, &firstbuf, &lastbuf);
   return;
 
@@ -591,6 +588,9 @@ decide_bufferaction(char act, int *wipe, int *del, int *unload)
 
 }
 
+/*
+ * Remove the buffer from the list.
+ */
 static void
 wipe_or_delete_buffer(int wipe_buf, int del_buf, buf_T *buf, buf_T *firstbuf,
         buf_T *lastbuf)

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -398,9 +398,8 @@ aucmd_abort:
     win->w_buffer = NULL;      /* make sure we don't use the buffer now */
 
   /* Autocommands may have deleted the buffer. */
-  if (!buf_valid(buf))
-    return;
-  if (aborting())           /* autocmds may abort script processing */
+  /* autocmds may abort script processing */
+  if (!buf_valid(buf) || aborting())
     return;
 
   /* Autocommands may have opened or closed windows for this buffer.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -332,7 +332,7 @@ close_buffer (
   // 'bufhidden' == "unload"
   case 'u':
     unload_buf = TRUE;
-    /* fallthrough */
+    break;
   }
 
   if (win != NULL) {

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -318,20 +318,21 @@ close_buffer (
    * The caller must take care of NOT deleting/freeing when 'bufhidden' is
    * "hide" (otherwise we could never free or delete a buffer).
    */
-  switch (buf->b_p_bh[0])
-  {
-  case 'w': /* 'bufhidden' == "wipe" */
+  switch (buf->b_p_bh[0]) {
+  // 'bufhidden' == "wipe"
+  case 'w':
     wipe_buf = TRUE;
     /* fallthrough */
 
-  case 'd': /* 'bufhidden' == "delete" */
+  // 'bufhidden' == "delete"
+  case 'd':
     del_bug = TRUE;
     /* fallthrough */
 
-  case 'u': /* 'bufhidden' == "unload" */
+  // 'bufhidden' == "unload"
+  case 'u':
     unload_buf = TRUE;
     /* fallthrough */
-
   }
 
   if (win != NULL) {

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -85,7 +85,7 @@ static void free_buffer(buf_T *);
 static void free_buffer_stuff(buf_T *buf, int free_options);
 static void clear_wininfo(buf_T *buf);
 static void decide_bufferaction(char, int*, int*, int*);
-static void rm_buffer_from_list(int wipe, int del, buf_T *buf, buf_T *first,
+static void wipe_or_delete_buffer(int wipe, int del, buf_T *buf, buf_T *first,
         buf_T *lastbuf);
 
 #ifdef UNIX
@@ -421,7 +421,7 @@ close_buffer (
   /*
    * Remove the buffer from the list.
    */
-  rm_buffer_from_list(wipe_buf, del_buf, buf, &firstbuf, &lastbuf);
+  wipe_or_delete_buffer(wipe_buf, del_buf, buf, &firstbuf, &lastbuf);
   return;
 
 aucmd_abort:
@@ -592,7 +592,7 @@ decide_bufferaction(char act, int *wipe, int *del, int *unload)
 }
 
 static void
-rm_buffer_from_list(int wipe_buf, int del_buf, buf_T *buf, buf_T *firstbuf,
+wipe_or_delete_buffer(int wipe_buf, int del_buf, buf_T *buf, buf_T *firstbuf,
         buf_T *lastbuf)
 {
   if (wipe_buf) {

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -84,7 +84,6 @@ static int append_arg_number(win_T *wp, char_u *buf, int buflen, int add_file);
 static void free_buffer(buf_T *);
 static void free_buffer_stuff(buf_T *buf, int free_options);
 static void clear_wininfo(buf_T *buf);
-static void decide_bufferaction(char, int*, int*, int*);
 static void wipe_or_delete_buffer(int wipe, int del, buf_T *buf);
 
 #ifdef UNIX
@@ -319,7 +318,21 @@ close_buffer (
    * The caller must take care of NOT deleting/freeing when 'bufhidden' is
    * "hide" (otherwise we could never free or delete a buffer).
    */
-  decide_bufferaction(buf->b_p_bh[0], &wipe_buf, &del_bug, &unload_buf);
+  switch (buf->b_p_bh[0])
+  {
+  case 'w': /* 'bufhidden' == "wipe" */
+    wipe_buf = TRUE;
+    /* fallthrough */
+
+  case 'd': /* 'bufhidden' == "delete" */
+    del_bug = TRUE;
+    /* fallthrough */
+
+  case 'u': /* 'bufhidden' == "unload" */
+    unload_buf = TRUE;
+    /* fallthrough */
+
+  }
 
   if (win != NULL) {
     /* Set b_last_cursor when closing the last window for the buffer.
@@ -565,27 +578,6 @@ static void clear_wininfo(buf_T *buf)
     }
     vim_free(wip);
   }
-}
-
-static void
-decide_bufferaction(char act, int *wipe, int *del, int *unload)
-{
-  switch (act)
-  {
-  case 'w': /* 'bufhidden' == "wipe" */
-    *wipe = TRUE;
-    /* fallthrough */
-
-  case 'd': /* 'bufhidden' == "delete" */
-    *del = TRUE;
-    /* fallthrough */
-
-  case 'u': /* 'bufhidden' == "unload" */
-    *unload = TRUE;
-    /* fallthrough */
-
-  }
-
 }
 
 /*

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -337,32 +337,39 @@ close_buffer (
   /* When the buffer is no longer in a window, trigger BufWinLeave */
   if (buf->b_nwindows == 1) {
     buf->b_closing = TRUE;
-    apply_autocmds(EVENT_BUFWINLEAVE, buf->b_fname, buf->b_fname,
-        FALSE, buf);
+    apply_autocmds(EVENT_BUFWINLEAVE, buf->b_fname, buf->b_fname, FALSE, buf);
+
     if (!buf_valid(buf)) {
       /* Autocommands deleted the buffer. */
 aucmd_abort:
       EMSG(_(e_auabort));
       return;
     }
+
     buf->b_closing = FALSE;
-    if (abort_if_last && one_window())
+
+    if (abort_if_last && one_window()) {
       /* Autocommands made this the only window. */
       goto aucmd_abort;
+    }
 
     /* When the buffer becomes hidden, but is not unloaded, trigger
      * BufHidden */
     if (!unload_buf) {
       buf->b_closing = TRUE;
-      apply_autocmds(EVENT_BUFHIDDEN, buf->b_fname, buf->b_fname,
-          FALSE, buf);
-      if (!buf_valid(buf))
+      apply_autocmds(EVENT_BUFHIDDEN, buf->b_fname, buf->b_fname, FALSE, buf);
+
+      if (!buf_valid(buf)) {
         /* Autocommands deleted the buffer. */
         goto aucmd_abort;
+      }
+
       buf->b_closing = FALSE;
-      if (abort_if_last && one_window())
+
+      if (abort_if_last && one_window()) {
         /* Autocommands made this the only window. */
         goto aucmd_abort;
+      }
     }
     if (aborting())         /* autocmds may abort script processing */
       return;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -341,7 +341,6 @@ close_buffer (
 
     if (!buf_valid(buf)) {
       /* Autocommands deleted the buffer. */
-aucmd_abort:
       EMSG(_(e_auabort));
       return;
     }
@@ -350,7 +349,8 @@ aucmd_abort:
 
     if (abort_if_last && one_window()) {
       /* Autocommands made this the only window. */
-      goto aucmd_abort;
+      EMSG(_(e_auabort));
+      return;
     }
 
     /* When the buffer becomes hidden, but is not unloaded, trigger
@@ -361,14 +361,16 @@ aucmd_abort:
 
       if (!buf_valid(buf)) {
         /* Autocommands deleted the buffer. */
-        goto aucmd_abort;
+        EMSG(_(e_auabort));
+        return;
       }
 
       buf->b_closing = FALSE;
 
       if (abort_if_last && one_window()) {
         /* Autocommands made this the only window. */
-        goto aucmd_abort;
+        EMSG(_(e_auabort));
+        return;
       }
     }
     if (aborting())         /* autocmds may abort script processing */

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -317,15 +317,21 @@ close_buffer (
    * The caller must take care of NOT deleting/freeing when 'bufhidden' is
    * "hide" (otherwise we could never free or delete a buffer).
    */
-  if (buf->b_p_bh[0] == 'd') {          /* 'bufhidden' == "delete" */
-    del_buf = TRUE;
-    unload_buf = TRUE;
-  } else if (buf->b_p_bh[0] == 'w') { /* 'bufhidden' == "wipe" */
-    del_buf = TRUE;
-    unload_buf = TRUE;
+  switch (buf->b_p_bh[0])
+  {
+  case 'w': /* 'bufhidden' == "wipe" */
     wipe_buf = TRUE;
-  } else if (buf->b_p_bh[0] == 'u')     /* 'bufhidden' == "unload" */
+    /* fallthrough */
+
+  case 'd': /* 'bufhidden' == "delete" */
+    del_bug = TRUE;
+    /* fallthrough */
+
+  case 'u': /* 'bufhidden' == "unload" */
     unload_buf = TRUE;
+    /* fallthrough */
+
+  }
 
   if (win != NULL) {
     /* Set b_last_cursor when closing the last window for the buffer.


### PR DESCRIPTION
Hi,

this is a bunch of patches which simplifies the `close_buffer()` function in `src/buffer.c` by outsourcing code chunks to own functions and replacing a bit of duplicated code with a macro.

I would like to try to build my changes, but currently I'm stuck. I'll notify you as soon as possible if I was able to get my build environment running.
