### PR TITLE
[RDY] Allow a single unittest file to be run.

### DIFF
--- a/cmake/RunUnittests.cmake
+++ b/cmake/RunUnittests.cmake
@@ -2,6 +2,9 @@ get_filename_component(BUSTED_DIR ${BUSTED_PRG} PATH)
 set(ENV{PATH} "${BUSTED_DIR}:$ENV{PATH}")
 set(ENV{NVIM_TEST_LIB} ${NVIM_TEST_LIB})
 set(ENV{TEST_INCLUDES} ${TEST_INCLUDES})
+if(DEFINED ENV{TEST_FILE})
+  set(TEST_DIR $ENV{TEST_FILE})
+endif()
 
 execute_process(
   COMMAND ${BUSTED_PRG} -o ${BUSTED_OUTPUT_TYPE} --pattern=.moon ${TEST_DIR}


### PR DESCRIPTION
With this, you can now run a single unit test file using:

```
TEST_FILE=/path/to/file make unittest
```

For example, to just run the path unit tests, you can do:

```
TEST_FILE=test/unit/path.moon make unittest
```
