### PR TITLE
Use portable format specifiers

### DIFF
--- a/clint.py
+++ b/clint.py
@@ -1428,7 +1428,7 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
   not standard C++.  Warning about these in lint is one way to ease the
   transition to new compilers.
   - put storage class first (e.g. "static const" instead of "const static").
-  - "%lld" instead of %qd" in printf-type functions.
+  - "%" PRId64 instead of %qd" in printf-type functions.
   - "%1$d" is non-standard in printf-type functions.
   - "\%" is an undefined character escape sequence.
   - text after #endif is not allowed.
@@ -1454,7 +1454,7 @@ def CheckForNonStandardConstructs(filename, clean_lines, linenum,
 
   if Search(r'printf\s*\(.*".*%[-+ ]?\d*q', line):
     error(filename, linenum, 'runtime/printf_format', 3,
-          '%q in format strings is deprecated.  Use %ll instead.')
+          '"%q" in format strings is deprecated.  Use "%" PRId64 instead.')
 
   if Search(r'printf\s*\(.*".*%\d+\$', line):
     error(filename, linenum, 'runtime/printf_format', 2,

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -916,7 +916,7 @@ do_buffer (
     if (start == DOBUF_FIRST) {
       /* don't warn when deleting */
       if (!unload)
-        EMSGN(_("E86: Buffer %ld does not exist"), count);
+        EMSGN(_("E86: Buffer %" PRId64 " does not exist"), count);
     } else if (dir == FORWARD)
       EMSG(_("E87: Cannot go beyond last buffer"));
     else
@@ -948,9 +948,9 @@ do_buffer (
         if (bufIsChanged(buf))
           return FAIL;
       } else {
-        EMSGN(_(
-                "E89: No write since last change for buffer %ld (add ! to override)"),
-            buf->b_fnum);
+        EMSGN(_("E89: No write since last change for buffer %" PRId64
+                " (add ! to override)"),
+              buf->b_fnum);
         return FAIL;
       }
     }
@@ -1575,7 +1575,7 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
     if ((options & GETF_ALT) && n == 0)
       EMSG(_(e_noalt));
     else
-      EMSGN(_("E92: Buffer %ld not found"), n);
+      EMSGN(_("E92: Buffer %" PRId64 " not found"), n);
     return FAIL;
   }
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4306,8 +4306,8 @@ void write_viminfo_bufferlist(FILE *fp)
       break;
     putc('%', fp);
     home_replace(NULL, buf->b_ffname, line, MAXPATHL, TRUE);
-    vim_snprintf_add((char *)line, LINE_BUF_LEN, "\t%ld\t%d",
-        (long)buf->b_last_cursor.lnum,
+    vim_snprintf_add((char *)line, LINE_BUF_LEN, "\t%" PRId64 "\t%d",
+        (int64_t)buf->b_last_cursor.lnum,
         buf->b_last_cursor.col);
     viminfo_writestring(fp, line);
   }

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2578,9 +2578,9 @@ fileinfo (
           (int64_t)curbuf->b_ml.ml_line_count, n);
   } else {
     vim_snprintf_add((char *)buffer, IOSIZE,
-        _("line %ld of %ld --%d%%-- col "),
-        (long)curwin->w_cursor.lnum,
-        (long)curbuf->b_ml.ml_line_count,
+        _("line %" PRId64 " of %" PRId64 " --%d%%-- col "),
+        (int64_t)curwin->w_cursor.lnum,
+        (int64_t)curbuf->b_ml.ml_line_count,
         n);
     validate_virtcol();
     len = STRLEN(buffer);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2184,8 +2184,8 @@ void buflist_list(exarg_T *eap)
       IObuff[len++] = ' ';
     } while (--i > 0 && len < IOSIZE - 18);
     vim_snprintf((char *)IObuff + len, (size_t)(IOSIZE - len),
-        _("line %ld"), buf == curbuf ? curwin->w_cursor.lnum
-        : (long)buflist_findlnum(buf));
+        _("line %" PRId64), buf == curbuf ? (int64_t)curwin->w_cursor.lnum
+        : (int64_t)buflist_findlnum(buf));
     msg_outtrans(IObuff);
     out_flush();            /* output one line at a time */
     ui_breakcheck();
@@ -2574,8 +2574,8 @@ fileinfo (
     if (curbuf->b_ml.ml_line_count == 1)
       vim_snprintf_add((char *)buffer, IOSIZE, _("1 line --%d%%--"), n);
     else
-      vim_snprintf_add((char *)buffer, IOSIZE, _("%ld lines --%d%%--"),
-          (long)curbuf->b_ml.ml_line_count, n);
+      vim_snprintf_add((char *)buffer, IOSIZE, _("%" PRId64 " lines --%d%%--"),
+          (int64_t)curbuf->b_ml.ml_line_count, n);
   } else {
     vim_snprintf_add((char *)buffer, IOSIZE,
         _("line %ld of %ld --%d%%-- col "),
@@ -4595,8 +4595,8 @@ void sign_list_placed(buf_T *rbuf)
             msg_putchar('\n');
         }
         for (p = buf->b_signlist; p != NULL && !got_int; p = p->next) {
-            vim_snprintf(lbuf, BUFSIZ, _("    line=%ld  id=%d  name=%s"),
-                    (long)p->lnum, p->id, sign_typenr2name(p->typenr));
+            vim_snprintf(lbuf, BUFSIZ, _("    line=%" PRId64 "  id=%d  name=%s"),
+                    (int64_t)p->lnum, p->id, sign_typenr2name(p->typenr));
             MSG_PUTS(lbuf);
             msg_putchar('\n');
         }

--- a/src/diff.c
+++ b/src/diff.c
@@ -142,7 +142,7 @@ void diff_buf_add(buf_T *buf)
     }
   }
 
-  EMSGN(_("E96: Can not diff more than %ld buffers"), DB_COUNT);
+  EMSGN(_("E96: Can not diff more than %" PRId64 " buffers"), DB_COUNT);
 }
 
 /// Find buffer "buf" in the list of diff buffers for the current tab page.

--- a/src/eval.c
+++ b/src/eval.c
@@ -11660,7 +11660,7 @@ static void f_matchadd(typval_T *argvars, typval_T *rettv)
   if (error == TRUE)
     return;
   if (id >= 1 && id <= 3) {
-    EMSGN("E798: ID is reserved for \":match\": %ld", id);
+    EMSGN("E798: ID is reserved for \":match\": %" PRId64, id);
     return;
   }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -18819,8 +18819,8 @@ call_user_func (
     if (aborting())
       smsg((char_u *)_("%s aborted"), sourcing_name);
     else if (fc->rettv->v_type == VAR_NUMBER)
-      smsg((char_u *)_("%s returning #%ld"), sourcing_name,
-          (long)fc->rettv->vval.v_number);
+      smsg((char_u *)_("%s returning #%" PRId64 ""),
+           sourcing_name, (int64_t)fc->rettv->vval.v_number);
     else {
       char_u buf[MSG_BUF_LEN];
       char_u numbuf2[NUMBUFLEN];

--- a/src/eval.c
+++ b/src/eval.c
@@ -133,7 +133,7 @@ typedef struct lval_S {
 
 
 static char *e_letunexp = N_("E18: Unexpected characters in :let");
-static char *e_listidx = N_("E684: list index out of range: %ld");
+static char *e_listidx = N_("E684: list index out of range: %" PRId64);
 static char *e_undefvar = N_("E121: Undefined variable: %s");
 static char *e_missbrac = N_("E111: Missing ']'");
 static char *e_listarg = N_("E686: Argument of %s must be a List");

--- a/src/eval.c
+++ b/src/eval.c
@@ -1984,7 +1984,7 @@ static void list_buf_vars(int *first)
   list_hashtable_vars(&curbuf->b_vars->dv_hashtab, (char_u *)"b:",
       TRUE, first);
 
-  sprintf((char *)numbuf, "%ld", (long)curbuf->b_changedtick);
+  sprintf((char *)numbuf, "%" PRId64, (int64_t)curbuf->b_changedtick);
   list_one_var_a((char_u *)"b:", (char_u *)"changedtick", VAR_NUMBER,
       numbuf, first);
 }
@@ -7320,7 +7320,7 @@ call_func (
       if (current_SID <= 0)
         error = ERROR_SCRIPT;
       else {
-        sprintf((char *)fname_buf + 3, "%ld_", (long)current_SID);
+        sprintf((char *)fname_buf + 3, "%" PRId64 "_", (int64_t)current_SID);
         i = (int)STRLEN(fname_buf);
       }
     }
@@ -9360,7 +9360,7 @@ static void f_function(typval_T *argvars, typval_T *rettv)
        * also be called from another script. Using trans_function_name()
        * would also work, but some plugins depend on the name being
        * printable text. */
-      sprintf(sid_buf, "<SNR>%ld_", (long)current_SID);
+      sprintf(sid_buf, "<SNR>%" PRId64 "_", (int64_t)current_SID);
       rettv->vval.v_string =
         alloc((int)(STRLEN(sid_buf) + STRLEN(s + off) + 1));
       if (rettv->vval.v_string != NULL) {
@@ -9992,7 +9992,7 @@ static void f_getregtype(typval_T *argvars, typval_T *rettv)
   case MCHAR: buf[0] = 'v'; break;
   case MBLOCK:
     buf[0] = Ctrl_V;
-    sprintf((char *)buf + 1, "%ld", reglen + 1);
+    sprintf((char *)buf + 1, "%" PRId64, (int64_t)reglen + 1);
     break;
   }
   rettv->v_type = VAR_STRING;
@@ -16431,7 +16431,7 @@ static char_u *get_tv_string_buf_chk(typval_T *varp, char_u *buf)
 {
   switch (varp->v_type) {
   case VAR_NUMBER:
-    sprintf((char *)buf, "%ld", (long)varp->vval.v_number);
+    sprintf((char *)buf, "%" PRId64, (int64_t)varp->vval.v_number);
     return buf;
   case VAR_FUNC:
     EMSG(_("E729: using Funcref as a String"));
@@ -17998,7 +17998,7 @@ trans_function_name (
         EMSG(_(e_usingsid));
         goto theend;
       }
-      sprintf((char *)sid_buf, "%ld_", (long)current_SID);
+      sprintf((char *)sid_buf, "%" PRId64 "_", (int64_t)current_SID);
       lead += (int)STRLEN(sid_buf);
     }
   } else if (!(flags & TFN_INT) && builtin_function(lv.ll_name)) {

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4488,14 +4488,16 @@ do_sub_msg (
           "%s", count_only ? _("1 match") : _("1 substitution"));
     else
       vim_snprintf_add((char *)msg_buf, sizeof(msg_buf),
-          count_only ? _("%ld matches") : _("%ld substitutions"),
-          sub_nsubs);
+          count_only ?
+          _("%" PRId64 " matches") :
+          _("%" PRId64 " substitutions"),
+          (int64_t)sub_nsubs);
     if (sub_nlines == 1)
       vim_snprintf_add((char *)msg_buf, sizeof(msg_buf),
           "%s", _(" on 1 line"));
     else
       vim_snprintf_add((char *)msg_buf, sizeof(msg_buf),
-          _(" on %ld lines"), (long)sub_nlines);
+          _(" on %" PRId64 " lines"), (int64_t)sub_nlines);
     if (msg(msg_buf))
       /* save message to display it after redraw */
       set_keep_msg(msg_buf, 0);

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1190,7 +1190,7 @@ do_filter (
     if (linecount > p_report) {
       if (do_in) {
         vim_snprintf((char *)msg_buf, sizeof(msg_buf),
-            _("%ld lines filtered"), (long)linecount);
+            _("%" PRId64 " lines filtered"), (int64_t)linecount);
         if (msg(msg_buf) && !msg_scroll)
           /* save message to display it after redraw */
           set_keep_msg(msg_buf, 0);

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2460,7 +2460,7 @@ void do_wqall(exarg_T *eap)
         break;
       }
       if (buf->b_ffname == NULL) {
-        EMSGN(_("E141: No file name for buffer %ld"), (long)buf->b_fnum);
+        EMSGN(_("E141: No file name for buffer %" PRId64), buf->b_fnum);
         ++error;
       } else if (check_readonly(&eap->forceit, buf)
                  || check_overwrite(eap, buf, buf->b_fname, buf->b_ffname,
@@ -6123,7 +6123,7 @@ void ex_sign(exarg_T *eap)
 		foldOpenCursor();
 	    }
 	    else
-		EMSGN(_("E157: Invalid sign ID: %ld"), id);
+		EMSGN(_("E157: Invalid sign ID: %" PRId64), id);
 	}
 	else if (idx == SIGNCMD_UNPLACE)
 	{

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -756,7 +756,7 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
     if (num_lines == 1)
       MSG(_("1 line moved"));
     else
-      smsg((char_u *)_("%ld lines moved"), num_lines);
+      smsg((char_u *)_("%" PRId64 " lines moved"), (int64_t)num_lines);
   }
 
   /*

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2738,7 +2738,7 @@ do_ecmd (
       if (command != NULL)
         vim_snprintf((char *)p, len, ":%s\r", command);
       else
-        vim_snprintf((char *)p, len, "%ldG", (long)newlnum);
+        vim_snprintf((char *)p, len, "%" PRId64 "G", (int64_t)newlnum);
       set_vim_var_string(VV_SWAPCOMMAND, p, -1);
       did_set_swapcommand = TRUE;
       vim_free(p);

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -6112,7 +6112,8 @@ void ex_sign(exarg_T *eap)
 		    cmd = alloc((unsigned)STRLEN(buf->b_fname) + 25);
 		    if (cmd == NULL)
 			return;
-		    sprintf((char *)cmd, "e +%ld %s", (long)lnum, buf->b_fname);
+		    sprintf((char *)cmd, "e +%" PRId64 " %s",
+                    (int64_t)lnum, buf->b_fname);
 		    do_cmdline_cmd(cmd);
 		    vim_free(cmd);
 		}

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -141,7 +141,7 @@ void do_debug(char_u *cmd)
   if (sourcing_name != NULL)
     msg(sourcing_name);
   if (sourcing_lnum != 0)
-    smsg((char_u *)_("line %ld: %s"), (long)sourcing_lnum, cmd);
+    smsg((char_u *)_("line %" PRId64 ": %s"), (int64_t)sourcing_lnum, cmd);
   else
     smsg((char_u *)_("cmd: %s"), cmd);
 
@@ -320,10 +320,10 @@ void dbg_check_breakpoint(exarg_T *eap)
         p = (char_u *)"<SNR>";
       else
         p = (char_u *)"";
-      smsg((char_u *)_("Breakpoint in \"%s%s\" line %ld"),
+      smsg((char_u *)_("Breakpoint in \"%s%s\" line %" PRId64),
           p,
           debug_breakpoint_name + (*p == NUL ? 0 : 3),
-          (long)debug_breakpoint_lnum);
+          (int64_t)debug_breakpoint_lnum);
       debug_breakpoint_name = NULL;
       do_debug(eap->cmd);
     } else {
@@ -615,11 +615,11 @@ void ex_breaklist(exarg_T *eap)
       bp = &BREAKP(i);
       if (bp->dbg_type == DBG_FILE)
         home_replace(NULL, bp->dbg_name, NameBuff, MAXPATHL, TRUE);
-      smsg((char_u *)_("%3d  %s %s  line %ld"),
+      smsg((char_u *)_("%3d  %s %s  line %" PRId64),
           bp->dbg_nr,
           bp->dbg_type == DBG_FUNC ? "func" : "file",
           bp->dbg_type == DBG_FUNC ? bp->dbg_name : NameBuff,
-          (long)bp->dbg_lnum);
+          (int64_t)bp->dbg_lnum);
     }
 }
 
@@ -2532,8 +2532,8 @@ do_source (
       if (sourcing_name == NULL)
         smsg((char_u *)_("could not source \"%s\""), fname);
       else
-        smsg((char_u *)_("line %ld: could not source \"%s\""),
-            sourcing_lnum, fname);
+        smsg((char_u *)_("line %" PRId64 ": could not source \"%s\""),
+            (int64_t)sourcing_lnum, fname);
       verbose_leave();
     }
     goto theend;
@@ -2549,8 +2549,8 @@ do_source (
     if (sourcing_name == NULL)
       smsg((char_u *)_("sourcing \"%s\""), fname);
     else
-      smsg((char_u *)_("line %ld: sourcing \"%s\""),
-          sourcing_lnum, fname);
+      smsg((char_u *)_("line %" PRId64 ": sourcing \"%s\""),
+          (int64_t)sourcing_lnum, fname);
     verbose_leave();
   }
   if (is_vimrc == DOSO_VIMRC)

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -4267,7 +4267,7 @@ check_more (
       if (n == 1)
         EMSG(_("E173: 1 more file to edit"));
       else
-        EMSGN(_("E173: %ld more files to edit"), n);
+        EMSGN(_("E173: %" PRId64 " more files to edit"), n);
       quitmore = 2;                 /* next try to quit is allowed */
     }
     return FAIL;

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -4493,13 +4493,13 @@ static void uc_list(char_u *name, size_t name_len)
       if (a & (RANGE|COUNT)) {
         if (a & COUNT) {
           /* -count=N */
-          sprintf((char *)IObuff + len, "%ldc", cmd->uc_def);
+          sprintf((char *)IObuff + len, "%" PRId64 "c", (int64_t)cmd->uc_def);
           len += (int)STRLEN(IObuff + len);
         } else if (a & DFLALL)
           IObuff[len++] = '%';
         else if (cmd->uc_def >= 0) {
           /* -range=N */
-          sprintf((char *)IObuff + len, "%ld", cmd->uc_def);
+          sprintf((char *)IObuff + len, "%" PRId64 "", (int64_t)cmd->uc_def);
           len += (int)STRLEN(IObuff + len);
         } else
           IObuff[len++] = '.';
@@ -4999,7 +4999,7 @@ uc_check_code (
                (eap->addr_count > 0) ? eap->line2 : cmd->uc_def;
     size_t num_len;
 
-    sprintf(num_buf, "%ld", num);
+    sprintf(num_buf, "%" PRId64, (int64_t)num);
     num_len = STRLEN(num_buf);
     result = num_len;
 
@@ -8003,7 +8003,7 @@ eval_vars (
         *errormsg = (char_u *)_("E842: no line number to use for \"<slnum>\"");
         return NULL;
       }
-      sprintf((char *)strbuf, "%ld", (long)sourcing_lnum);
+      sprintf((char *)strbuf, "%" PRId64, (int64_t)sourcing_lnum);
       result = strbuf;
       break;
     }

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -763,8 +763,8 @@ int flags;
       ++no_wait_return;
       verbose_enter_scroll();
 
-      smsg((char_u *)_("line %ld: %s"),
-          (long)sourcing_lnum, cmdline_copy);
+      smsg((char_u *)_("line %" PRId64 ": %s"),
+          (int64_t)sourcing_lnum, cmdline_copy);
       if (msg_silent == 0)
         msg_puts((char_u *)"\n");           /* don't overwrite this */
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6663,7 +6663,7 @@ static void ex_pwd(exarg_T *eap)
  */
 static void ex_equal(exarg_T *eap)
 {
-  smsg((char_u *)"%ld", (long)eap->line2);
+  smsg((char_u *)"%" PRId64, (int64_t)eap->line2);
   ex_may_print(eap);
 }
 

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -602,8 +602,8 @@ static void catch_exception(except_T *excp)
   set_vim_var_string(VV_EXCEPTION, excp->value, -1);
   if (*excp->throw_name != NUL) {
     if (excp->throw_lnum != 0)
-      vim_snprintf((char *)IObuff, IOSIZE, _("%s, line %ld"),
-          excp->throw_name, (long)excp->throw_lnum);
+      vim_snprintf((char *)IObuff, IOSIZE, _("%s, line %" PRId64),
+          excp->throw_name, (int64_t)excp->throw_lnum);
     else
       vim_snprintf((char *)IObuff, IOSIZE, "%s", excp->throw_name);
     set_vim_var_string(VV_THROWPOINT, IObuff, -1);
@@ -648,8 +648,8 @@ static void finish_exception(except_T *excp)
     if (*caught_stack->throw_name != NUL) {
       if (caught_stack->throw_lnum != 0)
         vim_snprintf((char *)IObuff, IOSIZE,
-            _("%s, line %ld"), caught_stack->throw_name,
-            (long)caught_stack->throw_lnum);
+            _("%s, line %" PRId64), caught_stack->throw_name,
+            (int64_t)caught_stack->throw_lnum);
       else
         vim_snprintf((char *)IObuff, IOSIZE, "%s",
             caught_stack->throw_name);

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4164,7 +4164,7 @@ void msg_add_lines(int insert_space, long lnum, off_t nchars)
       STRCPY(p, _("1 character"));
     else {
 #ifdef LONG_LONG_OFF_T
-      sprintf((char *)p, _("%lld characters"), nchars);
+      sprintf((char *)p, _("%" PRId64 " characters"), nchars);
 #else
       sprintf((char *)p, _("%ld characters"), (long)nchars);
 #endif

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4147,12 +4147,7 @@ void msg_add_lines(int insert_space, long lnum, off_t nchars)
   if (insert_space)
     *p++ = ' ';
   if (shortmess(SHM_LINES)) {
-#ifdef LONG_LONG_OFF_T
      sprintf((char *)p, "%ldL, %" PRId64 "C", lnum, (int64_t)nchars);
-#else
-     /* Explicit typecast avoids warning on Mac OS X 10.6 */
-     sprintf((char *)p, "%ldL, %ldC", lnum, (long)nchars);
-#endif
   }
   else {
     if (lnum == 1)
@@ -4163,11 +4158,7 @@ void msg_add_lines(int insert_space, long lnum, off_t nchars)
     if (nchars == 1)
       STRCPY(p, _("1 character"));
     else {
-#ifdef LONG_LONG_OFF_T
       sprintf((char *)p, _("%" PRId64 " characters"), nchars);
-#else
-      sprintf((char *)p, _("%ld characters"), (long)nchars);
-#endif
     }
   }
 }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4147,7 +4147,8 @@ void msg_add_lines(int insert_space, long lnum, off_t nchars)
   if (insert_space)
     *p++ = ' ';
   if (shortmess(SHM_LINES)) {
-     sprintf((char *)p, "%ldL, %" PRId64 "C", lnum, (int64_t)nchars);
+     sprintf((char *)p, "%" PRId64 "L, %" PRId64 "C",
+             (int64_t)lnum, (int64_t)nchars);
   }
   else {
     if (lnum == 1)
@@ -5696,7 +5697,7 @@ vim_tempname (
           mode_t umask_save;
 #  endif
 
-          sprintf((char *)itmp + itmplen, "v%ld", nr + off);
+          sprintf((char *)itmp + itmplen, "v%" PRId64, (int64_t)nr + off);
 #  ifndef EEXIST
           /* If mkdir() does not set errno to EEXIST, check for
            * existing file here.  There is a race condition then,
@@ -5735,7 +5736,7 @@ vim_tempname (
   if (vim_tempdir != NULL) {
     /* There is no need to check if the file exists, because we own the
      * directory and nobody else creates a file in it. */
-    sprintf((char *)itmp, "%s%ld", vim_tempdir, temp_count++);
+    sprintf((char *)itmp, "%s%" PRId64, vim_tempdir, (int64_t)temp_count++);
     return vim_strsave(itmp);
   }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4148,7 +4148,7 @@ void msg_add_lines(int insert_space, long lnum, off_t nchars)
     *p++ = ' ';
   if (shortmess(SHM_LINES)) {
 #ifdef LONG_LONG_OFF_T
-     sprintf((char *)p, "%ldL, %lldC", lnum, nchars);
+     sprintf((char *)p, "%ldL, %" PRId64 "C", lnum, (int64_t)nchars);
 #else
      /* Explicit typecast avoids warning on Mac OS X 10.6 */
      sprintf((char *)p, "%ldL, %ldC", lnum, (long)nchars);

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1884,11 +1884,11 @@ failed:
       }
       if (conv_error != 0) {
         sprintf((char *)IObuff + STRLEN(IObuff),
-            _("[CONVERSION ERROR in line %ld]"), (long)conv_error);
+            _("[CONVERSION ERROR in line %" PRId64 "]"), (int64_t)conv_error);
         c = TRUE;
       } else if (illegal_byte > 0) {
         sprintf((char *)IObuff + STRLEN(IObuff),
-            _("[ILLEGAL BYTE in line %ld]"), (long)illegal_byte);
+            _("[ILLEGAL BYTE in line %" PRId64 "]"), (int64_t)illegal_byte);
         c = TRUE;
       } else if (error)  {
         STRCAT(IObuff, _("[READ ERRORS]"));
@@ -4154,12 +4154,12 @@ void msg_add_lines(int insert_space, long lnum, off_t nchars)
     if (lnum == 1)
       STRCPY(p, _("1 line, "));
     else
-      sprintf((char *)p, _("%ld lines, "), lnum);
+      sprintf((char *)p, _("%" PRId64 " lines, "), (int64_t)lnum);
     p += STRLEN(p);
     if (nchars == 1)
       STRCPY(p, _("1 character"));
     else {
-      sprintf((char *)p, _("%" PRId64 " characters"), nchars);
+      sprintf((char *)p, _("%" PRId64 " characters"), (int64_t)nchars);
     }
   }
 }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3749,9 +3749,9 @@ restore_backup:
           errmsg_allocated = TRUE;
           errmsg = alloc(300);
           vim_snprintf((char *)errmsg, 300,
-              _(
-                  "E513: write error, conversion failed in line %ld (make 'fenc' empty to override)"),
-              (long)write_info.bw_conv_error_lnum);
+              _("E513: write error, conversion failed in line %" PRId64
+                " (make 'fenc' empty to override)"),
+              (int64_t)write_info.bw_conv_error_lnum);
         }
       } else if (got_int)
         errmsg = (char_u *)_(e_interr);
@@ -3817,8 +3817,8 @@ restore_backup:
       STRCAT(IObuff, _(" CONVERSION ERROR"));
       c = TRUE;
       if (write_info.bw_conv_error_lnum != 0)
-        vim_snprintf_add((char *)IObuff, IOSIZE, _(" in line %ld;"),
-            (long)write_info.bw_conv_error_lnum);
+        vim_snprintf_add((char *)IObuff, IOSIZE, _(" in line %" PRId64 ";"),
+            (int64_t)write_info.bw_conv_error_lnum);
     } else if (notconverted) {
       STRCAT(IObuff, _("[NOT converted]"));
       c = TRUE;

--- a/src/fold.c
+++ b/src/fold.c
@@ -2957,8 +2957,9 @@ static int put_folds_recurse(FILE *fd, garray_T *gap, linenr_T off)
     /* Do nested folds first, they will be created closed. */
     if (put_folds_recurse(fd, &fp->fd_nested, off + fp->fd_top) == FAIL)
       return FAIL;
-    if (fprintf(fd, "%ld,%ldfold", fp->fd_top + off,
-            fp->fd_top + off + fp->fd_len - 1) < 0
+    if (fprintf(fd, "%" PRId64 ",%" PRId64 "fold",
+                (int64_t)fp->fd_top + off,
+                (int64_t)fp->fd_top + off + fp->fd_len - 1) < 0
         || put_eol(fd) == FAIL)
       return FAIL;
     ++fp;
@@ -2982,7 +2983,7 @@ static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off
     if (fp->fd_flags != FD_LEVEL) {
       if (fp->fd_nested.ga_len > 0) {
         /* open nested folds while this fold is open */
-        if (fprintf(fd, "%ld", fp->fd_top + off) < 0
+        if (fprintf(fd, "%" PRId64, (int64_t)fp->fd_top + off) < 0
             || put_eol(fd) == FAIL
             || put_line(fd, "normal! zo") == FAIL)
           return FAIL;
@@ -3019,7 +3020,7 @@ static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off
  */
 static int put_fold_open_close(FILE *fd, fold_T *fp, linenr_T off)
 {
-  if (fprintf(fd, "%ld", fp->fd_top + off) < 0
+  if (fprintf(fd, "%" PRId64, (int64_t)fp->fd_top + off) < 0
       || put_eol(fd) == FAIL
       || fprintf(fd, "normal! z%c",
           fp->fd_flags == FD_CLOSED ? 'c' : 'o') < 0

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -308,7 +308,7 @@ static void add_num_buff(buffheader_T *buf, long n)
 {
   char_u number[32];
 
-  sprintf((char *)number, "%ld", n);
+  sprintf((char *)number, "%" PRId64, (int64_t)n);
   add_buff(buf, number, -1L);
 }
 

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -167,10 +167,12 @@ void hash_debug_results(void)
 {
 #ifdef HT_DEBUG
   fprintf(stderr, "\r\n\r\n\r\n\r\n");
-  fprintf(stderr, "Number of hashtable lookups: %ld\r\n", hash_count_lookup);
-  fprintf(stderr, "Number of perturb loops: %ld\r\n", hash_count_perturb);
-  fprintf(stderr, "Percentage of perturb loops: %ld%%\r\n",
-          hash_count_perturb * 100 / hash_count_lookup);
+  fprintf(stderr, "Number of hashtable lookups: %" PRId64 "\r\n",
+          (int64_t)hash_count_lookup);
+  fprintf(stderr, "Number of perturb loops: %" PRId64 "\r\n",
+          (int64_t)hash_count_perturb);
+  fprintf(stderr, "Percentage of perturb loops: %" PRId64 "%%\r\n",
+          (int64_t)hash_count_perturb * 100 / hash_count_lookup);
 #endif  // ifdef HT_DEBUG
 }
 

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -623,7 +623,7 @@ cs_reading_emsg (
     int idx        /* connection index */
 )
 {
-  EMSGN(_("E262: error reading cscope connection %ld"), idx);
+  EMSGN(_("E262: error reading cscope connection %" PRId64), idx);
 }
 
 #define CSREAD_BUFSIZE  2048

--- a/src/mark.c
+++ b/src/mark.c
@@ -1294,8 +1294,8 @@ static void write_one_filemark(FILE *fp, xfmark_T *fm, int c1, int c2)
   else
     name = fm->fname;                   /* use name from .viminfo */
   if (name != NULL && *name != NUL) {
-    fprintf(fp, "%c%c  %ld  %ld  ", c1, c2, (long)fm->fmark.mark.lnum,
-        (long)fm->fmark.mark.col);
+    fprintf(fp, "%c%c  %" PRId64 "  %" PRId64 "  ",
+            c1, c2, (int64_t)fm->fmark.mark.lnum, (int64_t)fm->fmark.mark.col);
     viminfo_writestring(fp, name);
   }
 
@@ -1393,7 +1393,8 @@ int write_viminfo_marks(FILE *fp_out)
 static void write_one_mark(FILE *fp_out, int c, pos_T *pos)
 {
   if (pos->lnum != 0)
-    fprintf(fp_out, "\t%c\t%ld\t%d\n", c, (long)pos->lnum, (int)pos->col);
+    fprintf(fp_out, "\t%c\t%" PRId64 "\t%d\n", c,
+            (int64_t)pos->lnum, (int)pos->col);
 }
 
 /*

--- a/src/memline.c
+++ b/src/memline.c
@@ -2085,7 +2085,7 @@ ml_get_buf (
       /* Avoid giving this message for a recursive call, may happen when
        * the GUI redraws part of the text. */
       ++recursive;
-      EMSGN(_("E315: ml_get: invalid lnum: %ld"), lnum);
+      EMSGN(_("E315: ml_get: invalid lnum: %" PRId64), lnum);
       --recursive;
     }
 errorret:
@@ -2117,7 +2117,7 @@ errorret:
         /* Avoid giving this message for a recursive call, may happen
          * when the GUI redraws part of the text. */
         ++recursive;
-        EMSGN(_("E316: ml_get: cannot find line %ld"), lnum);
+        EMSGN(_("E316: ml_get: cannot find line %" PRId64), lnum);
         --recursive;
       }
       goto errorret;
@@ -2977,7 +2977,7 @@ static void ml_flush_line(buf_T *buf)
 
     hp = ml_find_line(buf, lnum, ML_FIND);
     if (hp == NULL)
-      EMSGN(_("E320: Cannot find line %ld"), lnum);
+      EMSGN(_("E320: Cannot find line %" PRId64), lnum);
     else {
       dp = (DATA_BL *)(hp->bh_data);
       idx = lnum - buf->b_ml.ml_locked_low;
@@ -3237,11 +3237,11 @@ static bhdr_T *ml_find_line(buf_T *buf, linenr_T lnum, int action)
     }
     if (idx >= (int)pp->pb_count) {         /* past the end: something wrong! */
       if (lnum > buf->b_ml.ml_line_count)
-        EMSGN(_("E322: line number out of range: %ld past the end"),
+        EMSGN(_("E322: line number out of range: %" PRId64 " past the end"),
             lnum - buf->b_ml.ml_line_count);
 
       else
-        EMSGN(_("E323: line count wrong in block %ld"), bnum);
+        EMSGN(_("E323: line count wrong in block %" PRId64), bnum);
       goto error_block;
     }
     if (action == ML_DELETE) {

--- a/src/memline.c
+++ b/src/memline.c
@@ -4263,12 +4263,13 @@ static void ml_crypt_prepare(memfile_T *mfp, off_t offset, int reading)
 
   use_crypt_method = method;    /* select pkzip or blowfish */
   if (method == 0) {
-    vim_snprintf((char *)salt, sizeof(salt), "%s%ld", key, (long)offset);
+    vim_snprintf((char *)salt, sizeof(salt), "%s%" PRId64 "",
+                 key, (int64_t)offset);
     crypt_init_keys(salt);
   } else {
     /* Using blowfish, add salt and seed. We use the byte offset of the
      * block for the salt. */
-    vim_snprintf((char *)salt, sizeof(salt), "%ld", (long)offset);
+    vim_snprintf((char *)salt, sizeof(salt), "%" PRId64, (int64_t)offset);
     bf_key_init(key, salt, (int)STRLEN(salt));
     bf_cfb_init(seed, MF_SEED_LEN);
   }

--- a/src/memory.c
+++ b/src/memory.c
@@ -197,7 +197,7 @@ void do_outofmem_msg(long_u size)
      * message fails, e.g. when setting v:errmsg. */
     did_outofmem_msg = TRUE;
 
-    EMSGN(_("E342: Out of memory!  (allocating %lu bytes)"), size);
+    EMSGN(_("E342: Out of memory!  (allocating %" PRIu64 " bytes)"), size);
   }
 }
 

--- a/src/message.c
+++ b/src/message.c
@@ -1064,7 +1064,7 @@ void msg_outnum(long n)
 {
   char_u buf[20];
 
-  sprintf((char *)buf, "%ld", n);
+  sprintf((char *)buf, "%" PRId64, (int64_t)n);
   msg_puts(buf);
 }
 

--- a/src/message.c
+++ b/src/message.c
@@ -1813,8 +1813,8 @@ static void inc_msg_scrolled(void)
     else {
       len = (int)STRLEN(p) + 40;
       tofree = alloc(len);
-      vim_snprintf((char *)tofree, len, _("%s line %ld"),
-          p, (long)sourcing_lnum);
+      vim_snprintf((char *)tofree, len, _("%s line %" PRId64),
+          p, (int64_t)sourcing_lnum);
       p = tofree;
     }
     set_vim_var_string(VV_SCROLLSTART, p, -1);

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2604,10 +2604,10 @@ void msgmore(long n)
     } else {
       if (n > 0)
         vim_snprintf((char *)msg_buf, MSG_BUF_LEN,
-            _("%ld more lines"), pn);
+            _("%" PRId64 " more lines"), (int64_t)pn);
       else
         vim_snprintf((char *)msg_buf, MSG_BUF_LEN,
-            _("%ld fewer lines"), pn);
+            _("%" PRId64 " fewer lines"), (int64_t)pn);
     }
     if (got_int)
       vim_strcat(msg_buf, (char_u *)_(" (Interrupted)"), MSG_BUF_LEN);

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1365,10 +1365,10 @@ int emsg3(char_u *s, char_u *a1, char_u *a2)
 }
 
 /*
- * Print an error message with one "%ld" and one long int argument.
+ * Print an error message with one "%" PRId64 and one (int64_t) argument.
  * This is not in message.c to avoid a warning for prototypes.
  */
-int emsgn(char_u *s, long n)
+int emsgn(char_u *s, int64_t n)
 {
   if (emsg_not_now())
     return TRUE;                /* no error messages at the moment */

--- a/src/misc2.h
+++ b/src/misc2.h
@@ -61,7 +61,7 @@ int illegal_slash(char *name);
 int vim_chdir(char_u *new_dir);
 void sort_strings(char_u **files, int count);
 int emsg3(char_u *s, char_u *a1, char_u *a2);
-int emsgn(char_u *s, long n);
+int emsgn(char_u *s, int64_t n);
 int get2c(FILE *fd);
 int get3c(FILE *fd);
 int get4c(FILE *fd);

--- a/src/normal.c
+++ b/src/normal.c
@@ -3024,10 +3024,10 @@ void clear_showcmd(void)
       p_sbr = empty_option;
       getvcols(curwin, &curwin->w_cursor, &VIsual, &leftcol, &rightcol);
       p_sbr = saved_sbr;
-      sprintf((char *)showcmd_buf, "%ldx%ld", lines,
-          (long)(rightcol - leftcol + 1));
+      sprintf((char *)showcmd_buf, "%" PRId64 "x%" PRId64,
+              (int64_t)lines, (int64_t)(rightcol - leftcol + 1));
     } else if (VIsual_mode == 'V' || VIsual.lnum != curwin->w_cursor.lnum)
-      sprintf((char *)showcmd_buf, "%ld", lines);
+      sprintf((char *)showcmd_buf, "%" PRId64, (int64_t)lines);
     else {
       char_u  *s, *e;
       int l;
@@ -4451,7 +4451,7 @@ static void nv_ident(cmdarg_T *cap)
       isman = (STRCMP(kp, "man") == 0);
       isman_s = (STRCMP(kp, "man -s") == 0);
       if (cap->count0 != 0 && !(isman || isman_s))
-        sprintf((char *)buf, ".,.+%ld", cap->count0 - 1);
+        sprintf((char *)buf, ".,.+%" PRId64, (int64_t)cap->count0 - 1);
 
       STRCAT(buf, "! ");
       if (cap->count0 == 0 && isman_s)
@@ -4460,7 +4460,7 @@ static void nv_ident(cmdarg_T *cap)
         STRCAT(buf, kp);
       STRCAT(buf, " ");
       if (cap->count0 != 0 && (isman || isman_s)) {
-        sprintf((char *)buf + STRLEN(buf), "%ld", cap->count0);
+        sprintf((char *)buf + STRLEN(buf), "%" PRId64, (int64_t)cap->count0);
         STRCAT(buf, " ");
       }
     }
@@ -4482,7 +4482,7 @@ static void nv_ident(cmdarg_T *cap)
       if (g_cmd)
         STRCPY(buf, "tj ");
       else
-        sprintf((char *)buf, "%ldta ", cap->count0);
+        sprintf((char *)buf, "%" PRId64 "ta ", (int64_t)cap->count0);
     }
   }
 

--- a/src/ops.c
+++ b/src/ops.c
@@ -4451,13 +4451,13 @@ int do_addsub(int command, linenr_T Prenum1)
      * Put the number characters in buf2[].
      */
     if (hex == 0)
-      sprintf((char *)buf2, "%lu", n);
+      sprintf((char *)buf2, "%" PRIu64, (uint64_t)n);
     else if (hex == '0')
-      sprintf((char *)buf2, "%lo", n);
+      sprintf((char *)buf2, "%" PRIo64, (uint64_t)n);
     else if (hex && hexupper)
-      sprintf((char *)buf2, "%lX", n);
+      sprintf((char *)buf2, "%" PRIX64, (uint64_t)n);
     else
-      sprintf((char *)buf2, "%lx", n);
+      sprintf((char *)buf2, "%" PRIx64, (uint64_t)n);
     length -= (int)STRLEN(buf2);
 
     /*

--- a/src/ops.c
+++ b/src/ops.c
@@ -255,11 +255,11 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
         sprintf((char *)IObuff, _("1 line %sed %d times"), s, amount);
     } else {
       if (amount == 1)
-        sprintf((char *)IObuff, _("%ld lines %sed 1 time"),
-            oap->line_count, s);
+        sprintf((char *)IObuff, _("%" PRId64 " lines %sed 1 time"),
+            (int64_t)oap->line_count, s);
       else
-        sprintf((char *)IObuff, _("%ld lines %sed %d times"),
-            oap->line_count, s, amount);
+        sprintf((char *)IObuff, _("%" PRId64 " lines %sed %d times"),
+            (int64_t)oap->line_count, s, amount);
     }
     msg(IObuff);
   }
@@ -5192,8 +5192,8 @@ void cursor_pos_info(void)
 
     byte_count = bomb_size();
     if (byte_count > 0)
-      sprintf((char *)IObuff + STRLEN(IObuff), _("(+%ld for BOM)"),
-          byte_count);
+      sprintf((char *)IObuff + STRLEN(IObuff), _("(+%" PRId64 " for BOM)"),
+          (int64_t)byte_count);
     /* Don't shorten this message, the user asked for it. */
     p = p_shm;
     p_shm = (char_u *)"";

--- a/src/ops.c
+++ b/src/ops.c
@@ -5141,28 +5141,30 @@ void cursor_pos_info(void)
       if (VIsual_mode == Ctrl_V && curwin->w_curswant < MAXCOL) {
         getvcols(curwin, &min_pos, &max_pos, &min_pos.col,
             &max_pos.col);
-        vim_snprintf((char *)buf1, sizeof(buf1), _("%ld Cols; "),
-            (long)(oparg.end_vcol - oparg.start_vcol + 1));
+        vim_snprintf((char *)buf1, sizeof(buf1), _("%" PRId64 " Cols; "),
+            (int64_t)(oparg.end_vcol - oparg.start_vcol + 1));
       } else
         buf1[0] = NUL;
 
       if (char_count_cursor == byte_count_cursor
           && char_count == byte_count)
         vim_snprintf((char *)IObuff, IOSIZE,
-            _("Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"),
-            buf1, line_count_selected,
-            (long)curbuf->b_ml.ml_line_count,
-            word_count_cursor, word_count,
-            byte_count_cursor, byte_count);
+            _("Selected %s%" PRId64 " of %" PRId64 " Lines; %" PRId64
+              " of %" PRId64 " Words; %" PRId64 " of %" PRId64 " Bytes"),
+            buf1, (int64_t)line_count_selected,
+            (int64_t)curbuf->b_ml.ml_line_count,
+            (int64_t)word_count_cursor, (int64_t)word_count,
+            (int64_t)byte_count_cursor, (int64_t)byte_count);
       else
         vim_snprintf((char *)IObuff, IOSIZE,
-            _(
-                "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld Bytes"),
-            buf1, line_count_selected,
-            (long)curbuf->b_ml.ml_line_count,
-            word_count_cursor, word_count,
-            char_count_cursor, char_count,
-            byte_count_cursor, byte_count);
+            _("Selected %s%" PRId64 " of %" PRId64 " Lines; %" PRId64
+              " of %" PRId64 " Words; %" PRId64 " of %" PRId64
+              " Chars; %" PRId64 " of %" PRId64 " Bytes"),
+            buf1, (int64_t)line_count_selected,
+            (int64_t)curbuf->b_ml.ml_line_count,
+            (int64_t)word_count_cursor, (int64_t)word_count,
+            (int64_t)char_count_cursor, (int64_t)char_count,
+            (int64_t)byte_count_cursor, (int64_t)byte_count);
     } else {
       p = ml_get_curline();
       validate_virtcol();
@@ -5173,22 +5175,25 @@ void cursor_pos_info(void)
       if (char_count_cursor == byte_count_cursor
           && char_count == byte_count)
         vim_snprintf((char *)IObuff, IOSIZE,
-            _("Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"),
+            _("Col %s of %s; Line %" PRId64 " of %" PRId64 "; Word %" PRId64
+              " of %" PRId64 "; Byte %" PRId64 " of %" PRId64 ""),
             (char *)buf1, (char *)buf2,
-            (long)curwin->w_cursor.lnum,
-            (long)curbuf->b_ml.ml_line_count,
-            word_count_cursor, word_count,
-            byte_count_cursor, byte_count);
+            (int64_t)curwin->w_cursor.lnum,
+            (int64_t)curbuf->b_ml.ml_line_count,
+            (int64_t)word_count_cursor, (int64_t)word_count,
+            (int64_t)byte_count_cursor, (int64_t)byte_count);
       else
         vim_snprintf((char *)IObuff, IOSIZE,
             _(
-                "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of %ld"),
+                "Col %s of %s; Line %" PRId64 " of %" PRId64 "; Word %" PRId64
+                " of %" PRId64 "; Char %" PRId64 " of %" PRId64
+                "; Byte %" PRId64 " of %" PRId64 ""),
             (char *)buf1, (char *)buf2,
-            (long)curwin->w_cursor.lnum,
-            (long)curbuf->b_ml.ml_line_count,
-            word_count_cursor, word_count,
-            char_count_cursor, char_count,
-            byte_count_cursor, byte_count);
+            (int64_t)curwin->w_cursor.lnum,
+            (int64_t)curbuf->b_ml.ml_line_count,
+            (int64_t)word_count_cursor, (int64_t)word_count,
+            (int64_t)char_count_cursor, (int64_t)char_count,
+            (int64_t)byte_count_cursor, (int64_t)byte_count);
     }
 
     byte_count = bomb_size();

--- a/src/ops.c
+++ b/src/ops.c
@@ -594,7 +594,7 @@ int         (*how)(void);
     if (i > 1
         && (i % 50 == 0 || i == oap->line_count - 1)
         && oap->line_count > p_report)
-      smsg((char_u *)_("%ld lines to indent... "), i);
+      smsg((char_u *)_("%" PRId64 " lines to indent... "), (int64_t)i);
 
     /*
      * Be vi-compatible: For lisp indenting the first line is not
@@ -638,7 +638,7 @@ int         (*how)(void);
     if (i == 1)
       MSG(_("1 line indented "));
     else
-      smsg((char_u *)_("%ld lines indented "), i);
+      smsg((char_u *)_("%" PRId64 " lines indented "), (int64_t)i);
   }
   /* set '[ and '] marks */
   curbuf->b_op_start = oap->start;
@@ -1953,7 +1953,7 @@ void op_tilde(oparg_T *oap)
     if (oap->line_count == 1)
       MSG(_("1 line changed"));
     else
-      smsg((char_u *)_("%ld lines changed"), oap->line_count);
+      smsg((char_u *)_("%" PRId64 " lines changed"), (int64_t)oap->line_count);
   }
 }
 
@@ -2556,9 +2556,10 @@ int op_yank(oparg_T *oap, int deleting, int mess)
         else
           MSG(_("1 line yanked"));
       } else if (oap->block_mode)
-        smsg((char_u *)_("block of %ld lines yanked"), yanklines);
+        smsg((char_u *)_("block of %" PRId64 " lines yanked"),
+             (int64_t)yanklines);
       else
-        smsg((char_u *)_("%ld lines yanked"), yanklines);
+        smsg((char_u *)_("%" PRId64 " lines yanked"), (int64_t)yanklines);
     }
   }
 

--- a/src/option.c
+++ b/src/option.c
@@ -6447,7 +6447,7 @@ static int put_setnum(FILE *fd, char *cmd, char *name, long *valuep)
     /* print 'wildchar' and 'wildcharm' as a key name */
     if (fputs((char *)get_special_key_name((int)wc, 0), fd) < 0)
       return FAIL;
-  } else if (fprintf(fd, "%ld", *valuep) < 0)
+  } else if (fprintf(fd, "%" PRId64, (int64_t)*valuep) < 0)
     return FAIL;
   if (put_eol(fd) < 0)
     return FAIL;

--- a/src/option.c
+++ b/src/option.c
@@ -7535,7 +7535,7 @@ option_value2string (
     else if (wc != 0)
       STRCPY(NameBuff, transchar((int)wc));
     else
-      sprintf((char *)NameBuff, "%ld", *(long *)varp);
+      sprintf((char *)NameBuff, "%" PRId64, (int64_t)*(long *)varp);
   } else { /* P_STRING */
     varp = *(char_u **)(varp);
     if (varp == NULL)                       /* just in case */

--- a/src/po/af.po
+++ b/src/po/af.po
@@ -3279,17 +3279,17 @@ msgstr "FOUT: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[grepe] totaal 'alloc'-vrygelaat %lu-%lu, in gebruik %lu, piekgebruik %lu\n"
+"[grepe] totaal 'alloc'-vrygelaat %<PRIu64>-%<PRIu64>, in gebruik %<PRIu64>, piekgebruik %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[roepe] totaal re/malloc()'s %lu, totale free()'s %lu\n"
+"[roepe] totaal re/malloc()'s %<PRIu64>, totale free()'s %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3300,8 +3300,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Interne fout: 'lalloc(%<PRId64>, )'"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Geheue is op! (ken %lu grepe toe)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Geheue is op! (ken %<PRIu64> grepe toe)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/af.po
+++ b/src/po/af.po
@@ -77,8 +77,8 @@ msgstr "E84: Geen veranderde buffer gevind nie"
 msgid "E85: There is no listed buffer"
 msgstr "E85: Daar is geen gelyste buffer nie"
 
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Buffer %ld bestaan nie"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Buffer %<PRId64> bestaan nie"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kan nie verby laaste buffer gaan nie"
@@ -86,8 +86,8 @@ msgstr "E87: Kan nie verby laaste buffer gaan nie"
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kan nie vóór eerste buffer gaan nie"
 
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Buffer %ld nog ongestoor sedert vorige wysiging (gebruik ! om te dwing)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Buffer %<PRId64> nog ongestoor sedert vorige wysiging (gebruik ! om te dwing)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Kan nie laaste buffer uitlaai nie"
@@ -96,8 +96,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Waarskuwing: Lêerlys loop oor"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: buffer %ld kon nie gevind word nie"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: buffer %<PRId64> kon nie gevind word nie"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -108,8 +108,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Geen buffer wat by %s pas nie"
 
 #, c-format
-msgid "line %ld"
-msgstr "reël %ld"
+msgid "line %<PRId64>"
+msgstr "reël %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer met hierdie naam bestaan alreeds"
@@ -134,12 +134,12 @@ msgid "1 line --%d%%--"
 msgstr "1 reël --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld reëls --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> reëls --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "reël %ld van %ld --%d%%-- kolom "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "reël %<PRId64> van %<PRId64> --%d%%-- kolom "
 
 msgid "[No file]"
 msgstr "[Geen lêer]"
@@ -189,12 +189,12 @@ msgid "Signs for %s:"
 msgstr "Tekens vir %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    reël=%ld  id=%d  naam=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    reël=%<PRId64>  id=%d  naam=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Kan nie meer as %ld buffers 'diff' nie"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Kan nie meer as %<PRId64> buffers 'diff' nie"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kan nie 'diffs' skep nie "
@@ -479,8 +479,8 @@ msgid "%s aborted"
 msgstr "%s gekanselleer"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s lewer #%ld op"
+msgid "%s returning #%<PRId64>"
+msgstr "%s lewer #%<PRId64> op"
 
 #, c-format
 msgid "%s returning \"%s\""
@@ -506,16 +506,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Ontfoutmodus begin nou.  Tik \"cont\" om te verlaat."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "reël %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "reël %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Inspeksiepunt in \"%s%s\" reël %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Inspeksiepunt in \"%s%s\" reël %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -525,8 +525,8 @@ msgid "No breakpoints defined"
 msgstr "Geen inspeksiepunte gedefinieer nie"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  reël %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  reël %<PRId64>"
 
 msgid "Save As"
 msgstr "Stoor As"
@@ -581,16 +581,16 @@ msgid "could not source \"%s\""
 msgstr "kon nie \"%s\" uitvoer nie"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "reël %ld: kon nie \"%s\" uitvoer nie"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "reël %<PRId64>: kon nie \"%s\" uitvoer nie"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "besig om \"%s\" uit te voer"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "reël %ld: voer nou \"%s\" uit"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "reël %<PRId64>: voer nou \"%s\" uit"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -699,12 +699,12 @@ msgid "1 line moved"
 msgstr "1 reël geskuif"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld reëls geskuif"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> reëls geskuif"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld reëls filtreer"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> reëls filtreer"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Outobevele mag nie die huidige buffer verander nie"
@@ -779,8 +779,8 @@ msgid "Overwrite existing file \"%.*s\"?"
 msgstr "Oorskryf bestaande lêer \"%.*s\"?"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Geen lêernaam vir buffer %ld nie"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Geen lêernaam vir buffer %<PRId64> nie"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Lêer nie gestoor nie: Stoor is afgeskakel deur die 'write' opsie"
@@ -820,15 +820,15 @@ msgid "1 substitution"
 msgstr "1 vervanging"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld vervangings"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> vervangings"
 
 msgid " on 1 line"
 msgstr " op 1 reël"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " op %ld reëls"
+msgid " on %<PRId64> lines"
+msgstr " op %<PRId64> reëls"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kan nie :global rekursief doen nie "
@@ -909,8 +909,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ongeldige buffernaam: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Ongeldige teken ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Ongeldige teken ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NIE GEVIND NIE)"
@@ -972,8 +972,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: Nog 1 lêer om te bewerk"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Nog %ld lêers om te bewerk"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Nog %<PRId64> lêers om te bewerk"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Bevel bestaan alreeds: gebruik ! om te herdefinieer"
@@ -1134,8 +1134,8 @@ msgstr "Uitsondering het klaar gemaak: %s"
 msgid "Exception discarded: %s"
 msgstr "Uitsondering weg gegooi: %s"
 
-msgid "%s, line %ld"
-msgstr "%s, reël %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, reël %<PRId64>"
 
 #. always scroll up, don't overwrite
 msgid "Exception caught: %s"
@@ -1316,8 +1316,8 @@ msgid "[CONVERSION ERROR]"
 msgstr "[OMSETTINGSFOUT]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[ONWETTIGE GREEP in reël %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[ONWETTIGE GREEP in reël %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[LEESFOUTE]"
@@ -1453,15 +1453,15 @@ msgid "1 line, "
 msgstr "1 reël, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld reëls, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> reëls, "
 
 msgid "1 character"
 msgstr "1 karakter"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld karakters"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> karakters"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -1814,19 +1814,19 @@ msgstr "Font0: %s\n"
 msgid "Font1: %s\n"
 msgstr "Font1: %s\n"
 
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Font%ld wydte is nie twee keer díe van font0 nie\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Font%<PRId64> wydte is nie twee keer díe van font0 nie\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Font0 wydte: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Font0 wydte: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Font1 wydte: %ld\n"
+"Font1 wydte: %<PRId64>\n"
 "\n"
 
 msgid "E256: Hangul automata ERROR"
@@ -1876,8 +1876,8 @@ msgstr "E564: %s is nie 'n gids of 'n geldige 'cscope' databasis nie"
 msgid "Added cscope database %s"
 msgstr "'cscope' databasis %s bygevoeg"
 
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: 'cscope' verbinding %ld kon nie gelees word nie"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: 'cscope' verbinding %<PRId64> kon nie gelees word nie"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: onbekende 'cscope' soektipe"
@@ -2985,12 +2985,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Kon nie bewaar nie"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: 'ml_get': ongeldige 'lnum': %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: 'ml_get': ongeldige 'lnum': %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: 'ml_get': kan reël %ld nie vind nie"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: 'ml_get': kan reël %<PRId64> nie vind nie"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: wyser blok id verkeerd 3"
@@ -3008,8 +3008,8 @@ msgid "deleted block 1?"
 msgstr "verwyder blok 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Kan nie reël %ld vind nie"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Kan nie reël %<PRId64> vind nie"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: wyser blok id verkeerd"
@@ -3018,12 +3018,12 @@ msgid "pe_line_count is zero"
 msgstr "'pe_line_count' is nul"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: reëlnommer buite perke: %ld verby die einde"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: reëlnommer buite perke: %<PRId64> verby die einde"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: reëltelling mag verkeerd wees in blok %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: reëltelling mag verkeerd wees in blok %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Stapel grootte verhoog"
@@ -3255,12 +3255,12 @@ msgid "1 line less"
 msgstr "1 reël minder"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld meer reëls"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> meer reëls"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld minder reëls"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> minder reëls"
 
 msgid " (Interrupted)"
 msgstr " (Onderbreek)"
@@ -3296,8 +3296,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Rëel word te lank"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Interne fout: 'lalloc(%ld, )'"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Interne fout: 'lalloc(%<PRId64>, )'"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3378,8 +3378,8 @@ msgstr "E668: Verkeerde toegangsmodue vir NetBeans konneksie inligtingslêer: \"%
 msgid "read from Netbeans socket"
 msgstr "lees vanaf Netbeans 'socket'"
 
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: NetBeans konneksie vir buffer %ld verloor"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: NetBeans konneksie vir buffer %<PRId64> verloor"
 
 msgid "Warning: terminal cannot highlight"
 msgstr "Waarskuwing: terminaal kan nie teks uitlig nie"
@@ -3415,23 +3415,23 @@ msgid "1 line %sed %d times"
 msgstr "1 reël ge-%s %d keer"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld reëls 1 keer ge-%s"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> reëls 1 keer ge-%s"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld reëls ge-%s %d keer"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> reëls ge-%s %d keer"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld reëls om in te keep..."
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> reëls om in te keep..."
 
 msgid "1 line indented "
 msgstr "1 reël ingekeep "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld reëls ingekeep "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> reëls ingekeep "
 
 #. must display the prompt
 msgid "cannot yank; delete anyway"
@@ -3440,19 +3440,19 @@ msgstr "kan nie pluk nie: verwyder in elk geval"
 msgid "1 line changed"
 msgstr "1 reël verander"
 
-msgid "%ld lines changed"
-msgstr "%ld reëls verander"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> reëls verander"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "laat %ld reëls gaan"
+msgid "freeing %<PRId64> lines"
+msgstr "laat %<PRId64> reëls gaan"
 
 msgid "1 line yanked"
 msgstr "1 reël gepluk"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld reëls gepluk"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> reëls gepluk"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3485,21 +3485,21 @@ msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Ongeldige registernaam: '%s'"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Kolomme; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Kolomme; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "%s%ld van %ld reëls gekies; %ld van %ld Woorde; %ld van %ld Grepe"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "%s%<PRId64> van %<PRId64> reëls gekies; %<PRId64> van %<PRId64> Woorde; %<PRId64> van %<PRId64> Grepe"
 
 # njj: Karakters kan meerdere grepe wees, sien ':h multibyte'
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Kol %s van %s; Reël %ld van %ld; Woord %ld van %ld; Greep %ld van %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Kol %s van %s; Reël %<PRId64> van %<PRId64>; Woord %<PRId64> van %<PRId64>; Greep %<PRId64> van %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld vir 'BOM')"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> vir 'BOM')"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Bladsy %N"
@@ -3666,8 +3666,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Benodig Amigados weergawe 2.04 of later\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Benodig %s weergawe %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Benodig %s weergawe %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Kan nie NIL: oopmaak nie\n"
@@ -3751,8 +3751,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Het dodelike sein gevang\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Om die X-vertoonskerm oop te maak het %ld msek gevat"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Om die X-vertoonskerm oop te maak het %<PRId64> msek gevat"
 
 msgid ""
 "\n"
@@ -4393,8 +4393,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Formaatfout in etiketlêer \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Voor greep %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Voor greep %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -4457,8 +4457,8 @@ msgid "1 change"
 msgstr "1 verandering"
 
 #, c-format
-msgid "%ld changes"
-msgstr "%ld veranderinge"
+msgid "%<PRId64> changes"
+msgstr "%<PRId64> veranderinge"
 
 msgid "E439: undo list corrupt"
 msgstr "E439: herstellys korrup"
@@ -5175,8 +5175,8 @@ msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
 #~ msgid "1 line ~ed"
 #~ msgstr "1 reël ge-~"
 
-#~ msgid "%ld lines ~ed"
-#~ msgstr "%ld reëls ge-~"
+#~ msgid "%<PRId64> lines ~ed"
+#~ msgstr "%<PRId64> reëls ge-~"
 
 #~ msgid " BLOCK"
 #~ msgstr " BLOK"
@@ -5202,14 +5202,14 @@ msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
 #~ msgid "Missing filename"
 #~ msgstr "Ontbrekende lêernaam"
 
-#~ msgid "Invalid line number: %ld"
-#~ msgstr "Ongeldige reëlnommer: %ld"
+#~ msgid "Invalid line number: %<PRId64>"
+#~ msgstr "Ongeldige reëlnommer: %<PRId64>"
 
 #~ msgid "Cannot use :normal from event handler"
 #~ msgstr "Kan ':normal' nie vanuit gebeurtenishanteerder gebruik nie"
 
-#~ msgid "%ldL, %ldC"
-#~ msgstr "%ldR, %ldK"
+#~ msgid "%<PRId64>L, %<PRId64>C"
+#~ msgstr "%<PRId64>R, %<PRId64>K"
 
 #~ msgid "VIM - Help on..."
 #~ msgstr "VIM - Hulp met.."
@@ -5350,8 +5350,8 @@ msgstr "E463: Omgewing is onder bewaking, kan nie verander nie"
 #~ msgid "Security error: new viminfo file is a symbolic link"
 #~ msgstr "Sekuriteitsfout: nuwe viminfo lêer is a simboliese skakel"
 
-#~ msgid "line ~%ld: %s"
-#~ msgstr "reël ~%ld: %s"
+#~ msgid "line ~%<PRId64>: %s"
+#~ msgstr "reël ~%<PRId64>: %s"
 
 #~ msgid "makeef option not set"
 #~ msgstr "'makeef' opsie nie aan nie"

--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -3795,17 +3795,17 @@ msgstr "ERROR: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[octets] total assignat-alliberat %lu-%lu, en ús %lu, màxim ús %lu\n"
+"[octets] total assignat-alliberat %<PRIu64>-%<PRIu64>, en ús %<PRIu64>, màxim ús %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[crides] total re/malloc() %lu, total free() %lu\n"
+"[crides] total re/malloc() %<PRIu64>, total free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3816,8 +3816,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Error intern: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Memòria exhaurida! (assignant %lu octets)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Memòria exhaurida! (assignant %<PRIu64> octets)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -61,8 +61,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: No hi ha cap buffer a la llista"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: El buffer %ld no existeix"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: El buffer %<PRId64> no existeix"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: No es pot anar més enllà de l'últim buffer"
@@ -71,8 +71,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: No es pot anar més enllà del primer buffer"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: No s'ha desat el buffer %ld (afegiu ! per confirmar)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: No s'ha desat el buffer %<PRId64> (afegiu ! per confirmar)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: No es pot alliberar l'últim buffer"
@@ -81,8 +81,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Atenció: S'ha desbordat la llista de noms de fitxers"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: No s'ha trobat el buffer %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: No s'ha trobat el buffer %<PRId64>"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -93,8 +93,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: No hi ha cap coincidència per a %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "línia %ld"
+msgid "line %<PRId64>"
+msgstr "línia %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Ja existeix un buffer amb aquest nom"
@@ -119,12 +119,12 @@ msgid "1 line --%d%%--"
 msgstr "1 línia --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld línies --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> línies --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "línia %ld de %ld --%d%%-- col "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "línia %<PRId64> de %<PRId64> --%d%%-- col "
 
 msgid "[No Name]"
 msgstr "[Sense nom]"
@@ -174,12 +174,12 @@ msgid "Signs for %s:"
 msgstr "Senyals per a %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    línia=%ld  id=%d  nom=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    línia=%<PRId64>  id=%d  nom=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: No es poden mostrar diferències amb més de %ld buffers"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: No es poden mostrar diferències amb més de %<PRId64> buffers"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: No s'han pogut mostrar les diferències"
@@ -340,8 +340,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Caràcters inesperats :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: índex de llista fora d'abast: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: índex de llista fora d'abast: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -692,8 +692,8 @@ msgid "%s aborted"
 msgstr "s'ha avortat %s"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s ha retornat #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s ha retornat #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -725,16 +725,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Entrant en mode de depuració. Escriviu \"cont\" per a continuar."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "línia %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "línia %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "ordre: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Punt de ruptura a \"%s%s\" línia %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Punt de ruptura a \"%s%s\" línia %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -744,8 +744,8 @@ msgid "No breakpoints defined"
 msgstr "No s'han definit punts de ruptura"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  línia %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  línia %<PRId64>"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: Primer useu :profile start <nomfitxer>"
@@ -807,16 +807,16 @@ msgid "could not source \"%s\""
 msgstr "no s'ha pogut interpretar \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "línia %ld: no s'ha pogut interpretar \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "línia %<PRId64>: no s'ha pogut interpretar \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "interpretant \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "línia %ld: interpretant \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "línia %<PRId64>: interpretant \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -879,12 +879,12 @@ msgid "1 line moved"
 msgstr "1 línia desplaçada"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld línies desplaçades"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> línies desplaçades"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld línies filtrades"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> línies filtrades"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Les auto-ordres *Filter* no poden canviar el buffer actual"
@@ -965,8 +965,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: El fitxer d'intercanvi existeix: %s (:silent! per a confirmar)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: No hi ha nom de fitxer per al buffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: No hi ha nom de fitxer per al buffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: No s'ha escrit el fitxer: L'opció 'write' ho impedeix"
@@ -1011,19 +1011,19 @@ msgid "1 substitution"
 msgstr "1 substitució"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld coincidències"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> coincidències"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld substitucions"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> substitucions"
 
 msgid " on 1 line"
 msgstr " en 1 línia"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " en %ld línies"
+msgid " on %<PRId64> lines"
+msgstr " en %<PRId64> línies"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: No es pot executar una ordre global de forma recursiva"
@@ -1106,8 +1106,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: El nom del buffer no és vàlid: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: L'ID del senyal no és vàlida: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: L'ID del senyal no és vàlida: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NO TROBAT)"
@@ -1170,8 +1170,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: Queda 1 fitxer per editar"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Queden %ld fitxers per editar"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Queden %<PRId64> fitxers per editar"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: L'ordre ja existeix: afegiu ! per substituir-la"
@@ -1359,8 +1359,8 @@ msgid "Exception discarded: %s"
 msgstr "Exepció descartada: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, línia %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, línia %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1562,12 +1562,12 @@ msgid "[crypted]"
 msgstr "[xifrat]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ERROR DE CONVERSIÓ a la línia %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ERROR DE CONVERSIÓ a la línia %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[OCTET IL·LEGAL a la línia %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[OCTET IL·LEGAL a la línia %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[ERRORS DE LECTURA]"
@@ -1710,15 +1710,15 @@ msgid "1 line, "
 msgstr "1 línia, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld línies, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> línies, "
 
 msgid "1 character"
 msgstr "1 caràcter"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld caràcters"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> caràcters"
 
 # «no final de línia»  eac
 msgid "[noeol]"
@@ -2133,19 +2133,19 @@ msgid "Font1: %s\n"
 msgstr "Fosa1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "L'amplada de la fosa%ld no és el doble que la de la fosa0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "L'amplada de la fosa%<PRId64> no és el doble que la de la fosa0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Amplada de de la Fosa0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Amplada de de la Fosa0: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Amplada de la Fosa1: %ld\n"
+"Amplada de la Fosa1: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2322,8 +2322,8 @@ msgid "Added cscope database %s"
 msgstr "S'ha afegit la base de dades cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Error en llegir la connexió cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Error en llegir la connexió cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: Tipus de cerca cscope desconeguda"
@@ -3475,12 +3475,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: La preservació ha fallat"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: lnum no vàlid: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: lnum no vàlid: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: no s'ha trobat la línia %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: no s'ha trobat la línia %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Punter a la id d'un bloc incorrecte 3"
@@ -3498,8 +3498,8 @@ msgid "deleted block 1?"
 msgstr "s'ha eliminat el bloc 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: No s'ha trobat la línia %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: No s'ha trobat la línia %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: Punter a la id d'un bloc incorrecte"
@@ -3508,12 +3508,12 @@ msgid "pe_line_count is zero"
 msgstr "po_line_count és zero"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: Nombre de línia fora d'abast: %ld passat el final"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: Nombre de línia fora d'abast: %<PRId64> passat el final"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: Comptador de línia incorrecte al bloc %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: Comptador de línia incorrecte al bloc %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "La mida de la pila s'incrementa"
@@ -3701,8 +3701,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Premeu ENTRAR o introduïu una ordre per a continuar"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s línia %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s línia %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Més --"
@@ -3768,12 +3768,12 @@ msgid "1 line less"
 msgstr "1 línia menys"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld línies més"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> línies més"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld línies menys"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> línies menys"
 
 msgid " (Interrupted)"
 msgstr " (Interromput)"
@@ -3812,8 +3812,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: La línia s'està tornant massa llarga"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Error intern: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Error intern: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3882,8 +3882,8 @@ msgid "read from Netbeans socket"
 msgstr "lectura d'un socket Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: S'ha perdut la connexió NetBeans per al buffer %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: S'ha perdut la connexió NetBeans per al buffer %<PRId64>"
 
 msgid "E505: "
 msgstr "E505:"
@@ -3928,23 +3928,23 @@ msgid "1 line %sed %d times"
 msgstr "1 línia %sada %d vegades"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld línies %sades 1 vegada"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> línies %sades 1 vegada"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld línies %sades %d vegades"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> línies %sades %d vegades"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld línies a sagnar... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> línies a sagnar... "
 
 msgid "1 line indented "
 msgstr "1 línia sagnada "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld línies sagnades "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> línies sagnades "
 
 msgid "E748: No previously used register"
 msgstr "E748: No hi ha cap registre usat amb anterioritat"
@@ -3957,12 +3957,12 @@ msgid "1 line changed"
 msgstr "1 línia canviada"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld línies canviades"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> línies canviades"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "alliberant %ld línies"
+msgid "freeing %<PRId64> lines"
+msgstr "alliberant %<PRId64> línies"
 
 msgid "block of 1 line yanked"
 msgstr "bloc d'1 línia copiat"
@@ -3971,12 +3971,12 @@ msgid "1 line yanked"
 msgstr "1 línia copiada"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "bloc de %ld línies copiat"
+msgid "block of %<PRId64> lines yanked"
+msgstr "bloc de %<PRId64> línies copiat"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld línies copiades"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> línies copiades"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4006,28 +4006,28 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: El tipus de registre %d és desconegut"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Cols; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Cols; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Selecció %s%ld de %ld Línies; %ld de %ld Paraules; %ld de %ld Octets"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Selecció %s%<PRId64> de %<PRId64> Línies; %<PRId64> de %<PRId64> Paraules; %<PRId64> de %<PRId64> Octets"
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld Bytes"
-msgstr "Selecció %s%ld de %ld Línies; %ld de %ld Paraules; %ld de %ld Caràcters; %ld de %ld Octets"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr "Selecció %s%<PRId64> de %<PRId64> Línies; %<PRId64> de %<PRId64> Paraules; %<PRId64> de %<PRId64> Caràcters; %<PRId64> de %<PRId64> Octets"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Col %s de %s; Línia %ld de %ld; Paraula %ld de %ld; Octet %ld de %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Col %s de %s; Línia %<PRId64> de %<PRId64>; Paraula %<PRId64> de %<PRId64>; Octet %<PRId64> de %<PRId64>"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of %ld"
-msgstr "Col %s de %s; Línia %ld de %ld; Paraula %ld de %ld; Caràcter %ld de %ld; Octet %ld de %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Col %s de %s; Línia %<PRId64> de %<PRId64>; Paraula %<PRId64> de %<PRId64>; Caràcter %<PRId64> de %<PRId64>; Octet %<PRId64> de %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld per la BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> per la BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Pàgina %N"
@@ -4193,8 +4193,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Es requereix Amigados versió 2.04 o posterior\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Es requereix %s versió %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Es requereix %s versió %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "No s'ha pogut obrir NIL:\n"
@@ -4278,8 +4278,8 @@ msgstr "Vim: S'ha rebut un senyal letal\n"
 
 # display
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "S'ha trigat %ld mseg en obrir el display X"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "S'ha trigat %<PRId64> mseg en obrir el display X"
 
 msgid ""
 "\n"
@@ -4934,8 +4934,8 @@ msgid "Performing soundfolding..."
 msgstr "Efectuant expansió per similitud fonètica..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Nombre de paraules després de l'expansió per similitud fonètica: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Nombre de paraules després de l'expansió per similitud fonètica: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -4970,8 +4970,8 @@ msgid "Done!"
 msgstr "Fet!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' no té %ld entrades"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' no té %<PRId64> entrades"
 
 #, c-format
 msgid "Word removed from %s"
@@ -4988,8 +4988,8 @@ msgid "Sorry, no suggestions"
 msgstr "Cap suggeriment"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Llàstima, només %ld suggeriments"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Llàstima, només %<PRId64> suggeriments"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5292,8 +5292,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Error de format en el fitxer d'etiquetes \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Abans de l'octet %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Abans de l'octet %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5357,8 +5357,8 @@ msgid "Already at newest change"
 msgstr "Ja sou en el canvi més recent"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "Línia de desfer número %ld no trobada"
+msgid "Undo number %<PRId64> not found"
+msgstr "Línia de desfer número %<PRId64> no trobada"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: els nombres de línia no són correctes"
@@ -5382,8 +5382,8 @@ msgid "changes"
 msgstr "canvis"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "abans"
@@ -5398,8 +5398,8 @@ msgid "number changes  time"
 msgstr "número canvis   hora"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "fa %ld segons"
+msgid "%<PRId64> seconds ago"
+msgstr "fa %<PRId64> segons"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin no està permès després de undo"

--- a/src/po/cs.cp1250.po
+++ b/src/po/cs.cp1250.po
@@ -3062,18 +3062,18 @@ msgstr "CHYBA: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bajtù] celkem uvolnìno-alokováno %lu-%lu, využito %lu, maximální využití "
-"%lu\n"
+"[bajtù] celkem uvolnìno-alokováno %<PRIu64>-%<PRIu64>, využito %<PRIu64>, maximální využití "
+"%<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[volání] celkem re/malloc(): %lu, celkem free() %lu\n"
+"[volání] celkem re/malloc(): %<PRIu64>, celkem free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3084,8 +3084,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Vnitøní chyba: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Nedostatek pamìti! (potøebuji alokovat bajtù: %lu)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Nedostatek pamìti! (potøebuji alokovat bajtù: %<PRIu64>)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/cs.cp1250.po
+++ b/src/po/cs.cp1250.po
@@ -60,8 +60,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Seznam bufferù je prázdný"
 
 #, c-format
-msgid "E86: Cannot go to buffer %ld"
-msgstr "E86: Nelze pøeskoèit na buffer %ld"
+msgid "E86: Cannot go to buffer %<PRId64>"
+msgstr "E86: Nelze pøeskoèit na buffer %<PRId64>"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Za poslední buffer nelze pøeskoèit"
@@ -70,8 +70,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Pøed první buffer nelze pøeskoèit"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (use ! to override)"
-msgstr "E89: Zmìny v bufferu %ld nebyly uloženy (! pro vynucení)"
+msgid "E89: No write since last change for buffer %<PRId64> (use ! to override)"
+msgstr "E89: Zmìny v bufferu %<PRId64> nebyly uloženy (! pro vynucení)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Poslední buffer nelze deaktivovat"
@@ -80,8 +80,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varování: pøeteèení seznamu s názvy souborù"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Buffer %ld nenalezen"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Buffer %<PRId64> nenalezen"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -92,8 +92,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Vzoru %s nevyhovuje žádný buffer"
 
 #, c-format
-msgid "line %ld"
-msgstr "øádek %ld"
+msgid "line %<PRId64>"
+msgstr "øádek %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer tohoto jména již existuje"
@@ -116,11 +116,11 @@ msgstr "[Pouze pro ètení]"
 msgid "1 line --%d%%--"
 msgstr "øádkù: --%d%%--"
 
-msgid "%ld lines --%d%%--"
-msgstr "øádkù: %ld --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "øádkù: %<PRId64> --%d%%--"
 
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "øádek %ld/%ld --%d%%-- sloupec"
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "øádek %<PRId64>/%<PRId64> --%d%%-- sloupec"
 
 msgid "[No file]"
 msgstr "[Žádný soubor]"
@@ -169,12 +169,12 @@ msgid "Signs for %s:"
 msgstr "Znaky pro %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    øádek=%ld id=%d jméno=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    øádek=%<PRId64> id=%d jméno=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Nelze pøekroèit maximální poèet %ld diff bufferù"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Nelze pøekroèit maximální poèet %<PRId64> diff bufferù"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nelze vytvoøit diffy"
@@ -446,8 +446,8 @@ msgid "E133: :return not inside a function"
 msgstr "E133: :return mimo funkci"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "dokonèeno provádìní %s. Návratová hodnota #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "dokonèeno provádìní %s. Návratová hodnota #%<PRId64>"
 
 #, c-format
 msgid "%s returning \"%s\""
@@ -471,12 +471,12 @@ msgid "1 line moved"
 msgstr "poèet pøesunutých øádkù: 1"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "Poèet pøesunutých øádkù: %ld"
+msgid "%<PRId64> lines moved"
+msgstr "Poèet pøesunutých øádkù: %<PRId64>"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "Poèet filtrovaných øádkù: %ld"
+msgid "%<PRId64> lines filtered"
+msgstr "Poèet filtrovaných øádkù: %<PRId64>"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Automatické pøíkazy *Filter* nesmí mìnit aktuální buffer"
@@ -552,8 +552,8 @@ msgid "Overwrite existing file \"%.*s\"?"
 msgstr "Pøepsat soubor \"%.*s\"?"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Žádný název souboru pro buffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Žádný název souboru pro buffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Soubor nebyl uložen: Ukládání je zakázáno volbou 'write'"
@@ -593,15 +593,15 @@ msgid "1 substitution"
 msgstr "1 nahrazení"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld nahrazení"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> nahrazení"
 
 msgid " on 1 line"
 msgstr " na jednom øádku"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " na %ld øádcích"
+msgid " on %<PRId64> lines"
+msgstr " na %<PRId64> øádcích"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global nelze volat rekurzivnì"
@@ -672,8 +672,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: chybné jméno bufferu: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Chybné ID volby: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Chybné ID volby: %<PRId64>"
 
 msgid "[Deleted]"
 msgstr "[Vymazáno]"
@@ -682,16 +682,16 @@ msgid "Entering Debug mode.  Type \"cont\" to leave."
 msgstr "Spouštím ladící režim. Pro ukonèení napište \"cont\"."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "øádek %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "øádek %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "pøíkaz: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Bod pøerušení v \"%s%s\" na øádku %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Bod pøerušení v \"%s%s\" na øádku %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -701,8 +701,8 @@ msgid "No breakpoints defined"
 msgstr "Nebyly definovánu žádné body pøerušení"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  øádek %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  øádek %<PRId64>"
 
 #, c-format
 msgid "Save changes to \"%.*s\"?"
@@ -752,16 +752,16 @@ msgid "could not source \"%s\""
 msgstr "nelze interpretovat \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "øádek %ld: nelze interpretovat \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "øádek %<PRId64>: nelze interpretovat \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "interpretuji \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "øádek %ld: interpretuji %s"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "øádek %<PRId64>: interpretuji %s"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -873,8 +873,8 @@ msgid "%d more files to edit.  Quit anyway?"
 msgstr "Ještì zbývají soubory k editaci (%d). Chcete pøesto ukonèit editor?"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Ještì zbývají soubory k editaci (%ld)."
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Ještì zbývají soubory k editaci (%<PRId64>)."
 
 msgid "E174: Command already exists: use ! to redefine"
 msgstr "E174: Pøíkaz již existuje: použijte ! pro pøedefinování"
@@ -1262,15 +1262,15 @@ msgid "1 line, "
 msgstr "1 øádek, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld øádkù, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> øádkù, "
 
 msgid "1 character"
 msgstr "1 znak"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld znakù, "
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znakù, "
 
 msgid "[noeol]"
 msgstr "[žádný eol]"
@@ -1630,15 +1630,15 @@ msgid "Font%d width is not twice that of font0\n"
 msgstr "Šíøka písma%d není dvojnásoblem šíøky písma0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Šíøka písma0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Šíøka písma0: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Šíøka písma1: %ld\n"
+"Šíøka písma1: %<PRId64>\n"
 "\n"
 
 #, c-format
@@ -2764,12 +2764,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Uchování se nezdaøilo"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: chybné èíslo øádku: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: chybné èíslo øádku: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: nelze nalézt øádek %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: nelze nalézt øádek %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: chybné id ukazatele na blok 3"
@@ -2787,8 +2787,8 @@ msgid "deleted block 1?"
 msgstr "smazán blok 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Nelze nalézt øádek %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Nelze nalézt øádek %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: chybné id ukazatele na blok"
@@ -2797,12 +2797,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count má nulovou hodnotu"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: poèet øádkù mimo rozsah: %ld > celkový poèet øádkù"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: poèet øádkù mimo rozsah: %<PRId64> > celkový poèet øádkù"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: chybný poèet øádkù v bloku %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: chybný poèet øádkù v bloku %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Nárùst velikosti zásobníku"
@@ -3039,12 +3039,12 @@ msgid "1 line less"
 msgstr "poèet smazaných øádkù: 1"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "poèet nových øádkù: %ld"
+msgid "%<PRId64> more lines"
+msgstr "poèet nových øádkù: %<PRId64>"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "poèet smazaných øádkù: %ld"
+msgid "%<PRId64> fewer lines"
+msgstr "poèet smazaných øádkù: %<PRId64>"
 
 msgid " (Interrupted)"
 msgstr "(Pøerušeno)"
@@ -3080,8 +3080,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Øádek se stává pøíliš dlouhým"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Vnitøní chyba: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Vnitøní chyba: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3163,23 +3163,23 @@ msgid "1 line %sed %d times"
 msgstr "Poèet øádkù posunutých pomocí %s %d-krát : 1"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "Poèet øádkù: %ld (posunutých jednou pomocí %s)"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "Poèet øádkù: %<PRId64> (posunutých jednou pomocí %s)"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "Poèet øádkù: %ld (posunutých pomocí %s %d-krát)"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "Poèet øádkù: %<PRId64> (posunutých pomocí %s %d-krát)"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "poèet øádkù k odsazení: %ld"
+msgid "%<PRId64> lines to indent... "
+msgstr "poèet øádkù k odsazení: %<PRId64>"
 
 msgid "1 line indented "
 msgstr "poèet øádkù k odsazení: 1"
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "poèet odsazených øádkù: %ld"
+msgid "%<PRId64> lines indented "
+msgstr "poèet odsazených øádkù: %<PRId64>"
 
 #. must display the prompt
 msgid "cannot yank; delete anyway"
@@ -3189,19 +3189,19 @@ msgid "1 line changed"
 msgstr "poèet øádek se zmìnìnou velikostí písmen: 1"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "poèet øádek se zmìnìnou velikostí písmen: %ld"
+msgid "%<PRId64> lines changed"
+msgstr "poèet øádek se zmìnìnou velikostí písmen: %<PRId64>"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "poèet uvolòovaných øádkù: %ld"
+msgid "freeing %<PRId64> lines"
+msgstr "poèet uvolòovaných øádkù: %<PRId64>"
 
 msgid "1 line yanked"
 msgstr "poèet zkopírovaných øádkù: 1"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "poèet zkopírovaných øádkù: %ld"
+msgid "%<PRId64> lines yanked"
+msgstr "poèet zkopírovaných øádkù: %<PRId64>"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3234,20 +3234,20 @@ msgid "E354: Invalid register name: '%s'"
 msgstr "E354: '%s' není pøípustné jméno registru"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "øádkù: %ld;"
+msgid "%<PRId64> Cols; "
+msgstr "øádkù: %<PRId64>;"
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Vybráno %s%ld z %ld øádkù; %ld z %ld slov; %ld z %ld Bytù"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Vybráno %s%<PRId64> z %<PRId64> øádkù; %<PRId64> z %<PRId64> slov; %<PRId64> z %<PRId64> Bytù"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Sloupec %s z %s; Øádek %ld z %ld; Slovo %ld z %ld; Byte %ld z %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Sloupec %s z %s; Øádek %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Byte %<PRId64> z %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld pro BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> pro BOM)"
 
 msgid "Thanks for flying Vim"
 msgstr "Dìkuji za použití Vim"
@@ -3416,8 +3416,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Vyžaduje Amigados verze 2.04 nebo vyšší\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Vyžaduje %s verze %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Vyžaduje %s verze %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Nelze otevøít NIL:\n"
@@ -3507,8 +3507,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Zachycen smrtelný signál\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Doba otevírání X displeje (v ms): %ld"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Doba otevírání X displeje (v ms): %<PRId64>"
 
 msgid ""
 "\n"
@@ -4045,8 +4045,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Chyba formátu v souboru tagù \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Pøed bajtem %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Pøed bajtem %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -4109,8 +4109,8 @@ msgid "1 change"
 msgstr "poèet zmìn: 1"
 
 #, c-format
-msgid "%ld changes"
-msgstr "poèet zmìn: %ld"
+msgid "%<PRId64> changes"
+msgstr "poèet zmìn: %<PRId64>"
 
 msgid "E439: undo list corrupt"
 msgstr "E439: záznam o zmìnách poškozen"

--- a/src/po/cs.po
+++ b/src/po/cs.po
@@ -60,8 +60,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Seznam bufferù je prázdný"
 
 #, c-format
-msgid "E86: Cannot go to buffer %ld"
-msgstr "E86: Nelze pøeskoèit na buffer %ld"
+msgid "E86: Cannot go to buffer %<PRId64>"
+msgstr "E86: Nelze pøeskoèit na buffer %<PRId64>"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Za poslední buffer nelze pøeskoèit"
@@ -70,8 +70,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Pøed první buffer nelze pøeskoèit"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (use ! to override)"
-msgstr "E89: Zmìny v bufferu %ld nebyly ulo¾eny (! pro vynucení)"
+msgid "E89: No write since last change for buffer %<PRId64> (use ! to override)"
+msgstr "E89: Zmìny v bufferu %<PRId64> nebyly ulo¾eny (! pro vynucení)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Poslední buffer nelze deaktivovat"
@@ -80,8 +80,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varování: pøeteèení seznamu s názvy souborù"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Buffer %ld nenalezen"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Buffer %<PRId64> nenalezen"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -92,8 +92,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Vzoru %s nevyhovuje ¾ádný buffer"
 
 #, c-format
-msgid "line %ld"
-msgstr "øádek %ld"
+msgid "line %<PRId64>"
+msgstr "øádek %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer tohoto jména ji¾ existuje"
@@ -116,11 +116,11 @@ msgstr "[Pouze pro ètení]"
 msgid "1 line --%d%%--"
 msgstr "øádkù: --%d%%--"
 
-msgid "%ld lines --%d%%--"
-msgstr "øádkù: %ld --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "øádkù: %<PRId64> --%d%%--"
 
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "øádek %ld/%ld --%d%%-- sloupec"
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "øádek %<PRId64>/%<PRId64> --%d%%-- sloupec"
 
 msgid "[No file]"
 msgstr "[®ádný soubor]"
@@ -169,12 +169,12 @@ msgid "Signs for %s:"
 msgstr "Znaky pro %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    øádek=%ld id=%d jméno=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    øádek=%<PRId64> id=%d jméno=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Nelze pøekroèit maximální poèet %ld diff bufferù"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Nelze pøekroèit maximální poèet %<PRId64> diff bufferù"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nelze vytvoøit diffy"
@@ -446,8 +446,8 @@ msgid "E133: :return not inside a function"
 msgstr "E133: :return mimo funkci"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "dokonèeno provádìní %s. Návratová hodnota #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "dokonèeno provádìní %s. Návratová hodnota #%<PRId64>"
 
 #, c-format
 msgid "%s returning \"%s\""
@@ -471,12 +471,12 @@ msgid "1 line moved"
 msgstr "poèet pøesunutých øádkù: 1"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "Poèet pøesunutých øádkù: %ld"
+msgid "%<PRId64> lines moved"
+msgstr "Poèet pøesunutých øádkù: %<PRId64>"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "Poèet filtrovaných øádkù: %ld"
+msgid "%<PRId64> lines filtered"
+msgstr "Poèet filtrovaných øádkù: %<PRId64>"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Automatické pøíkazy *Filter* nesmí mìnit aktuální buffer"
@@ -552,8 +552,8 @@ msgid "Overwrite existing file \"%.*s\"?"
 msgstr "Pøepsat soubor \"%.*s\"?"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: ®ádný název souboru pro buffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: ®ádný název souboru pro buffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Soubor nebyl ulo¾en: Ukládání je zakázáno volbou 'write'"
@@ -593,15 +593,15 @@ msgid "1 substitution"
 msgstr "1 nahrazení"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld nahrazení"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> nahrazení"
 
 msgid " on 1 line"
 msgstr " na jednom øádku"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " na %ld øádcích"
+msgid " on %<PRId64> lines"
+msgstr " na %<PRId64> øádcích"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global nelze volat rekurzivnì"
@@ -672,8 +672,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: chybné jméno bufferu: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Chybné ID volby: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Chybné ID volby: %<PRId64>"
 
 msgid "[Deleted]"
 msgstr "[Vymazáno]"
@@ -682,16 +682,16 @@ msgid "Entering Debug mode.  Type \"cont\" to leave."
 msgstr "Spou¹tím ladící re¾im. Pro ukonèení napi¹te \"cont\"."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "øádek %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "øádek %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "pøíkaz: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Bod pøeru¹ení v \"%s%s\" na øádku %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Bod pøeru¹ení v \"%s%s\" na øádku %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -701,8 +701,8 @@ msgid "No breakpoints defined"
 msgstr "Nebyly definovánu ¾ádné body pøeru¹ení"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  øádek %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  øádek %<PRId64>"
 
 #, c-format
 msgid "Save changes to \"%.*s\"?"
@@ -752,16 +752,16 @@ msgid "could not source \"%s\""
 msgstr "nelze interpretovat \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "øádek %ld: nelze interpretovat \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "øádek %<PRId64>: nelze interpretovat \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "interpretuji \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "øádek %ld: interpretuji %s"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "øádek %<PRId64>: interpretuji %s"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -873,8 +873,8 @@ msgid "%d more files to edit.  Quit anyway?"
 msgstr "Je¹tì zbývají soubory k editaci (%d). Chcete pøesto ukonèit editor?"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Je¹tì zbývají soubory k editaci (%ld)."
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Je¹tì zbývají soubory k editaci (%<PRId64>)."
 
 msgid "E174: Command already exists: use ! to redefine"
 msgstr "E174: Pøíkaz ji¾ existuje: pou¾ijte ! pro pøedefinování"
@@ -1262,15 +1262,15 @@ msgid "1 line, "
 msgstr "1 øádek, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld øádkù, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> øádkù, "
 
 msgid "1 character"
 msgstr "1 znak"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld znakù, "
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znakù, "
 
 msgid "[noeol]"
 msgstr "[¾ádný eol]"
@@ -1630,15 +1630,15 @@ msgid "Font%d width is not twice that of font0\n"
 msgstr "©íøka písma%d není dvojnásoblem ¹íøky písma0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "©íøka písma0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "©íøka písma0: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"©íøka písma1: %ld\n"
+"©íøka písma1: %<PRId64>\n"
 "\n"
 
 #, c-format
@@ -2764,12 +2764,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Uchování se nezdaøilo"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: chybné èíslo øádku: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: chybné èíslo øádku: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: nelze nalézt øádek %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: nelze nalézt øádek %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: chybné id ukazatele na blok 3"
@@ -2787,8 +2787,8 @@ msgid "deleted block 1?"
 msgstr "smazán blok 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Nelze nalézt øádek %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Nelze nalézt øádek %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: chybné id ukazatele na blok"
@@ -2797,12 +2797,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count má nulovou hodnotu"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: poèet øádkù mimo rozsah: %ld > celkový poèet øádkù"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: poèet øádkù mimo rozsah: %<PRId64> > celkový poèet øádkù"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: chybný poèet øádkù v bloku %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: chybný poèet øádkù v bloku %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Nárùst velikosti zásobníku"
@@ -3039,12 +3039,12 @@ msgid "1 line less"
 msgstr "poèet smazaných øádkù: 1"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "poèet nových øádkù: %ld"
+msgid "%<PRId64> more lines"
+msgstr "poèet nových øádkù: %<PRId64>"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "poèet smazaných øádkù: %ld"
+msgid "%<PRId64> fewer lines"
+msgstr "poèet smazaných øádkù: %<PRId64>"
 
 msgid " (Interrupted)"
 msgstr "(Pøeru¹eno)"
@@ -3080,8 +3080,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Øádek se stává pøíli¹ dlouhým"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Vnitøní chyba: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Vnitøní chyba: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3163,23 +3163,23 @@ msgid "1 line %sed %d times"
 msgstr "Poèet øádkù posunutých pomocí %s %d-krát : 1"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "Poèet øádkù: %ld (posunutých jednou pomocí %s)"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "Poèet øádkù: %<PRId64> (posunutých jednou pomocí %s)"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "Poèet øádkù: %ld (posunutých pomocí %s %d-krát)"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "Poèet øádkù: %<PRId64> (posunutých pomocí %s %d-krát)"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "poèet øádkù k odsazení: %ld"
+msgid "%<PRId64> lines to indent... "
+msgstr "poèet øádkù k odsazení: %<PRId64>"
 
 msgid "1 line indented "
 msgstr "poèet øádkù k odsazení: 1"
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "poèet odsazených øádkù: %ld"
+msgid "%<PRId64> lines indented "
+msgstr "poèet odsazených øádkù: %<PRId64>"
 
 #. must display the prompt
 msgid "cannot yank; delete anyway"
@@ -3189,19 +3189,19 @@ msgid "1 line changed"
 msgstr "poèet øádek se zmìnìnou velikostí písmen: 1"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "poèet øádek se zmìnìnou velikostí písmen: %ld"
+msgid "%<PRId64> lines changed"
+msgstr "poèet øádek se zmìnìnou velikostí písmen: %<PRId64>"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "poèet uvolòovaných øádkù: %ld"
+msgid "freeing %<PRId64> lines"
+msgstr "poèet uvolòovaných øádkù: %<PRId64>"
 
 msgid "1 line yanked"
 msgstr "poèet zkopírovaných øádkù: 1"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "poèet zkopírovaných øádkù: %ld"
+msgid "%<PRId64> lines yanked"
+msgstr "poèet zkopírovaných øádkù: %<PRId64>"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3234,20 +3234,20 @@ msgid "E354: Invalid register name: '%s'"
 msgstr "E354: '%s' není pøípustné jméno registru"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "øádkù: %ld;"
+msgid "%<PRId64> Cols; "
+msgstr "øádkù: %<PRId64>;"
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Vybráno %s%ld z %ld øádkù; %ld z %ld slov; %ld z %ld Bytù"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Vybráno %s%<PRId64> z %<PRId64> øádkù; %<PRId64> z %<PRId64> slov; %<PRId64> z %<PRId64> Bytù"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Sloupec %s z %s; Øádek %ld z %ld; Slovo %ld z %ld; Byte %ld z %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Sloupec %s z %s; Øádek %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Byte %<PRId64> z %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld pro BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> pro BOM)"
 
 msgid "Thanks for flying Vim"
 msgstr "Dìkuji za pou¾ití Vim"
@@ -3416,8 +3416,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Vy¾aduje Amigados verze 2.04 nebo vy¹¹í\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Vy¾aduje %s verze %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Vy¾aduje %s verze %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Nelze otevøít NIL:\n"
@@ -3507,8 +3507,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Zachycen smrtelný signál\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Doba otevírání X displeje (v ms): %ld"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Doba otevírání X displeje (v ms): %<PRId64>"
 
 msgid ""
 "\n"
@@ -4045,8 +4045,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Chyba formátu v souboru tagù \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Pøed bajtem %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Pøed bajtem %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -4109,8 +4109,8 @@ msgid "1 change"
 msgstr "poèet zmìn: 1"
 
 #, c-format
-msgid "%ld changes"
-msgstr "poèet zmìn: %ld"
+msgid "%<PRId64> changes"
+msgstr "poèet zmìn: %<PRId64>"
 
 msgid "E439: undo list corrupt"
 msgstr "E439: záznam o zmìnách po¹kozen"

--- a/src/po/cs.po
+++ b/src/po/cs.po
@@ -3062,18 +3062,18 @@ msgstr "CHYBA: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bajtù] celkem uvolnìno-alokováno %lu-%lu, vyu¾ito %lu, maximální vyu¾ití "
-"%lu\n"
+"[bajtù] celkem uvolnìno-alokováno %<PRIu64>-%<PRIu64>, vyu¾ito %<PRIu64>, maximální vyu¾ití "
+"%<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[volání] celkem re/malloc(): %lu, celkem free() %lu\n"
+"[volání] celkem re/malloc(): %<PRIu64>, celkem free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3084,8 +3084,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Vnitøní chyba: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Nedostatek pamìti! (potøebuji alokovat bajtù: %lu)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Nedostatek pamìti! (potøebuji alokovat bajtù: %<PRIu64>)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -3671,17 +3671,17 @@ msgstr "FEHLER: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[Bytes] gesamt alloc-frei %lu-%lu, in Verwendung %lu, maximale Verwendung %lu\n"
+"[Bytes] gesamt alloc-frei %<PRIu64>-%<PRIu64>, in Verwendung %<PRIu64>, maximale Verwendung %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[Aufrufe] gesamt re/malloc()s %lu, gesamt free()s %lu\n"
+"[Aufrufe] gesamt re/malloc()s %<PRIu64>, gesamt free()s %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3692,8 +3692,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Interner Fehler: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Kein Speicherplatz mehr vorhanden (%lu Bytes reserviert)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Kein Speicherplatz mehr vorhanden (%<PRIu64> Bytes reserviert)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -62,8 +62,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Es gibt keine angezeigten Puffer"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Puffer %ld existiert nicht"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Puffer %<PRId64> existiert nicht"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kann nicht über den letzten Puffer hinaus gehen"
@@ -72,8 +72,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kann nicht vor den ersten Puffer gehen"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Puffer %ld nicht gesichert seit der letzten Änderung (erzwinge mit !)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Puffer %<PRId64> nicht gesichert seit der letzten Änderung (erzwinge mit !)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Kann letzten Puffer nicht ausladen"
@@ -82,8 +82,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Achtung: Überlauf der Liste der Dateinamen"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Kein Puffer %ld gefunden"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Kein Puffer %<PRId64> gefunden"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -94,8 +94,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Kein übereinstimmender Puffer für %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "Zeile %ld"
+msgid "line %<PRId64>"
+msgstr "Zeile %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Ein Puffer mit diesem Namen existiert bereits"
@@ -120,12 +120,12 @@ msgid "1 line --%d%%--"
 msgstr "1 Zeile --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld Zeilen --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> Zeilen --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "Zeile %ld von %ld --%d%%-- Spalte "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "Zeile %<PRId64> von %<PRId64> --%d%%-- Spalte "
 
 msgid "[No Name]"
 msgstr "[Unbenannt]"
@@ -175,12 +175,12 @@ msgid "Signs for %s:"
 msgstr "Zeichen für %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    Zeile=%ld  id=%d  Name=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    Zeile=%<PRId64>  id=%d  Name=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Keine Differenz für mehr als %ld Puffer"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Keine Differenz für mehr als %<PRId64> Puffer"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kann keine Differenz erstellen"
@@ -318,8 +318,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Unerwartete Zeichen in :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Index der Liste außerhalb des zulässigen Bereichs: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Index der Liste außerhalb des zulässigen Bereichs: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -648,8 +648,8 @@ msgid "%s aborted"
 msgstr "%s abgebrochen"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s lieferte #%ld zurück"
+msgid "%s returning #%<PRId64>"
+msgstr "%s lieferte #%<PRId64> zurück"
 
 #, c-format
 msgid "%s returning %s"
@@ -696,12 +696,12 @@ msgid "1 line moved"
 msgstr "1 Zeile verschoben"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld Zeilen verschoben"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> Zeilen verschoben"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld Zeilen gefiltert"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> Zeilen gefiltert"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter*-Autokommandos dürfen den aktuellen Puffer nicht ändern"
@@ -783,8 +783,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Auslagerungsdatei existiert bereits: %s (mit :silent! erzwingen)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Kein Dateiname für Puffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Kein Dateiname für Puffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Datei wurde nicht geschrieben: Schreiben ist durch die Option 'write' ausgeschaltet"
@@ -827,19 +827,19 @@ msgid "1 substitution"
 msgstr "eine Ersetzung"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld Treffer"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> Treffer"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld Ersetzungen"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> Ersetzungen"
 
 msgid " on 1 line"
 msgstr " auf einer Zeile"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " auf %ld Zeilen"
+msgid " on %<PRId64> lines"
+msgstr " auf %<PRId64> Zeilen"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kann :global nicht rekursiv ausführen"
@@ -922,8 +922,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: ungültige Puffernummer: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Ungültige Zeichen-ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Ungültige Zeichen-ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NICHT GEFUNDEN)"
@@ -938,16 +938,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Debug-Modus. Geben Sie \"cont\" zum Fortsetzen ein."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "Zeile %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "Zeile %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "Befehl: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Haltepunkt in \"%s%s\" Zeile %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Haltepunkt in \"%s%s\" Zeile %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -957,8 +957,8 @@ msgid "No breakpoints defined"
 msgstr "Keine Haltepunkte definiert"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  Zeile %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  Zeile %<PRId64>"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: Erste Verwendung von :profile startet <fname>"
@@ -1014,16 +1014,16 @@ msgid "could not source \"%s\""
 msgstr "\"%s\" konnte nicht gelesen werden"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "Zeile %ld: \"%s\" konnte nicht gelesen werden"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "Zeile %<PRId64>: \"%s\" konnte nicht gelesen werden"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "lese \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "Zeile %ld: lese \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "Zeile %<PRId64>: lese \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1113,8 +1113,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: Eine weitere Datei zum Editieren"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: %ld weitere Dateien zum Editieren"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: %<PRId64> weitere Dateien zum Editieren"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Befehl existiert bereits: ! zum Ersetzen hinzufügen"
@@ -1288,8 +1288,8 @@ msgid "Exception discarded: %s"
 msgstr "Ausnahme verworfen: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, Zeile %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, Zeile %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1481,12 +1481,12 @@ msgid "[crypted]"
 msgstr "[verschlüsselt]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "UMWANDLUNGSFEHLER in Zeile %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "UMWANDLUNGSFEHLER in Zeile %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[UNZULÄSSIGES BYTE in Zeile %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[UNZULÄSSIGES BYTE in Zeile %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[LESE-FEHLER]"
@@ -1625,15 +1625,15 @@ msgid "1 line, "
 msgstr "eine Zeile, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld Zeilen, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> Zeilen, "
 
 msgid "1 character"
 msgstr "ein Zeichen"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld Zeichen"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> Zeichen"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2035,19 +2035,19 @@ msgid "Font1: %s\n"
 msgstr "Schriftart 1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Die Breite der Schriftart %ld ist nicht doppelt so groß wie die der Schriftart 0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Die Breite der Schriftart %<PRId64> ist nicht doppelt so groß wie die der Schriftart 0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Schriftart 0 Breite: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Schriftart 0 Breite: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Schriftart 1 Breite: %ld\n"
+"Schriftart 1 Breite: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2224,8 +2224,8 @@ msgid "Added cscope database %s"
 msgstr "csope Datenbank %s hinzugefügt"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Fehler beim Lesen aus der cscope Verbindung %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Fehler beim Lesen aus der cscope Verbindung %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: Unbekannter cscope Suchtyp"
@@ -3363,12 +3363,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Absicherung fehlgeschlagen"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: unzulässige lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: unzulässige lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: kann Zeile %ld nicht finden"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: kann Zeile %<PRId64> nicht finden"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Zeiger Block id falsch 3"
@@ -3386,8 +3386,8 @@ msgid "deleted block 1?"
 msgstr "Block 1 gelöscht?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Kann Zeile %ld nicht finden"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Kann Zeile %<PRId64> nicht finden"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: Zeiger Block id ist falsch"
@@ -3396,12 +3396,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count ist Null"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: Zeilennummer nicht im zulässigen Bereich: %ld nach dem Ende"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: Zeilennummer nicht im zulässigen Bereich: %<PRId64> nach dem Ende"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: Zeilen Zähler falsch in Block %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: Zeilen Zähler falsch in Block %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Stapel Größe wächst"
@@ -3581,8 +3581,8 @@ msgid "Hit ENTER or type command to continue"
 msgstr "Drücken Sie die EINGABETASTE oder geben Sie einen Befehl ein"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s Zeile %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s Zeile %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Mehr --"
@@ -3645,12 +3645,12 @@ msgid "1 line less"
 msgstr "eine Zeile weniger"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld Zeilen mehr"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> Zeilen mehr"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld Zeilen weniger"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> Zeilen weniger"
 
 msgid " (Interrupted)"
 msgstr " (Unterbrochen)"
@@ -3688,8 +3688,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Zeile wird zu lang"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Interner Fehler: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Interner Fehler: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3762,8 +3762,8 @@ msgid "read from Netbeans socket"
 msgstr "gelesen vom NetBeans Socket"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Verbindung zu NetBeans für Puffer %ld verloren"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Verbindung zu NetBeans für Puffer %<PRId64> verloren"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3808,23 +3808,23 @@ msgid "1 line %sed %d times"
 msgstr "eine Zeile %s %d Mal"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld Zeilen %s ein Mal"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> Zeilen %s ein Mal"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld Zeilen %s %d Mal"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> Zeilen %s %d Mal"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld Zeilen zum Einrücken... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> Zeilen zum Einrücken... "
 
 msgid "1 line indented "
 msgstr "eine Zeile eingerückt... "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld Zeilen eingerückt... "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> Zeilen eingerückt... "
 
 msgid "E748: No previously used register"
 msgstr "E748: Kein bereits verwendetes Register"
@@ -3837,12 +3837,12 @@ msgid "1 line changed"
 msgstr "eine Zeile geändert"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld Zeilen geändert"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> Zeilen geändert"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "gebe %ld Zeilen frei"
+msgid "freeing %<PRId64> lines"
+msgstr "gebe %<PRId64> Zeilen frei"
 
 msgid "block of 1 line yanked"
 msgstr "Block von einer Zeile kopiert"
@@ -3851,12 +3851,12 @@ msgid "1 line yanked"
 msgstr "eine Zeile kopiert"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "Block von %ld Zeilen kopiert"
+msgid "block of %<PRId64> lines yanked"
+msgstr "Block von %<PRId64> Zeilen kopiert"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld Zeilen kopiert"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> Zeilen kopiert"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3885,36 +3885,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Unbekannter Register Typ %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Spalten; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Spalten; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "%s%ld von %ld Zeilen; %ld von %ld Wörtern; %ld von %ld Bytes"
-
-#, c-format
-msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
-"Bytes"
-msgstr ""
-"%s%ld von %ld Zeilen; %ld von %ld Wörtern; %ld von %ld Zeichen; %ld von %ld "
-"Bytes"
-
-#, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Sp %s von %s; Zeile %ld von %ld; Wort %ld von %ld; Byte %ld von %ld"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "%s%<PRId64> von %<PRId64> Zeilen; %<PRId64> von %<PRId64> Wörtern; %<PRId64> von %<PRId64> Bytes"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
+"Bytes"
 msgstr ""
-"Sp %s von %s; Zeile %ld von %ld; Wort %ld von %ld; Zeichen %ld von %ld; Byte %ld von "
-"%ld"
+"%s%<PRId64> von %<PRId64> Zeilen; %<PRId64> von %<PRId64> Wörtern; %<PRId64> von %<PRId64> Zeichen; %<PRId64> von %<PRId64> "
+"Bytes"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld für BOM)"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Sp %s von %s; Zeile %<PRId64> von %<PRId64>; Wort %<PRId64> von %<PRId64>; Byte %<PRId64> von %<PRId64>"
+
+#, c-format
+msgid ""
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
+msgstr ""
+"Sp %s von %s; Zeile %<PRId64> von %<PRId64>; Wort %<PRId64> von %<PRId64>; Zeichen %<PRId64> von %<PRId64>; Byte %<PRId64> von "
+"%<PRId64>"
+
+#, c-format
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> für BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Seite %N"
@@ -4080,8 +4080,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Brauche Amigados Version 2.04 oder neuere\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Benötige %s Version %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Benötige %s Version %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Kann NIL nicht öffnen:\n"
@@ -4165,8 +4165,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Erhielt tödliches Signal\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Öffnen des X-Displays dauerte %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Öffnen des X-Displays dauerte %<PRId64> msec"
 
 msgid ""
 "\n"
@@ -4806,8 +4806,8 @@ msgid "Performing soundfolding..."
 msgstr "Führe 'Soundfolding' durch..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Anzahl der Wörter nach 'Soundfolding': %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Anzahl der Wörter nach 'Soundfolding': %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -4842,8 +4842,8 @@ msgid "Done!"
 msgstr "Fertig!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' hat nicht %ld Einträge"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' hat nicht %<PRId64> Einträge"
 
 #, c-format
 msgid "Word removed from %s"
@@ -4860,8 +4860,8 @@ msgid "Sorry, no suggestions"
 msgstr "Leider keine Vorschläge"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Leider nur %ld Vorschläge"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Leider nur %<PRId64> Vorschläge"
 
 #. avoid more prompt
 #, c-format
@@ -5160,8 +5160,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Format Fehler in Tag-Datei \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Vor byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Vor byte %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5223,8 +5223,8 @@ msgid "Already at newest change"
 msgstr "Bereits bei der jüngsten Änderung"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "Nummer %ld zur Wiederherstellung nicht gefunden"
+msgid "Undo number %<PRId64> not found"
+msgstr "Nummer %<PRId64> zur Wiederherstellung nicht gefunden"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: Zeilennummer falsch"
@@ -5248,8 +5248,8 @@ msgid "changes"
 msgstr "Änderungen"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "vor"
@@ -5975,8 +5975,8 @@ msgstr "Die Länge des Pfads ist zu groß!"
 msgid "Edits the selected file(s) with Vim"
 msgstr "Editiert die ausgewählte(n) Datei(en) mit Vim"
 
-msgid "%ld seconds ago"
-msgstr "vor %ld Sekunden"
+msgid "%<PRId64> seconds ago"
+msgstr "vor %<PRId64> Sekunden"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: 'undojoin' ist nicht erlaubt nach 'undo'"

--- a/src/po/en_GB.po
+++ b/src/po/en_GB.po
@@ -26,8 +26,8 @@ msgstr ""
 "Content-Transfer-Encoding: 7bit\n"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Cannot diff more than %ld buffers"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Cannot diff more than %<PRId64> buffers"
 
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
 msgstr "E101: More than two buffers in diff mode, do not know which one to use"

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -4022,18 +4022,18 @@ msgstr "ERARO: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bajtoj] totalaj disponigitaj/maldisponigitaj %lu-%lu, nun uzataj %lu, "
-"kulmina uzo %lu\n"
+"[bajtoj] totalaj disponigitaj/maldisponigitaj %<PRIu64>-%<PRIu64>, nun uzataj %<PRIu64>, "
+"kulmina uzo %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[alvokoj] totalaj re/malloc() %lu, totalaj free() %lu\n"
+"[alvokoj] totalaj re/malloc() %<PRIu64>, totalaj free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4044,8 +4044,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Interna eraro: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Ne plu restas memoro! (disponigo de %lu bajtoj)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Ne plu restas memoro! (disponigo de %<PRIu64> bajtoj)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -1856,8 +1856,8 @@ msgid "1 character"
 msgstr "1 signo"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld signoj"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> signoj"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -101,8 +101,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Estas neniu listigita bufro"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: La bufro %ld ne ekzistas"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: La bufro %<PRId64> ne ekzistas"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Ne eblas iri preter la lastan bufron"
@@ -111,9 +111,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Ne eblas iri antaŭ la unuan bufron"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Neniu skribo de post la lasta ŝanĝo de la bufro %ld (aldonu ! por "
+"E89: Neniu skribo de post la lasta ŝanĝo de la bufro %<PRId64> (aldonu ! por "
 "transpasi)"
 
 msgid "E90: Cannot unload last buffer"
@@ -123,8 +123,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Averto: Listo de dosiernomoj troas"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Bufro %ld ne trovita"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Bufro %<PRId64> ne trovita"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -135,8 +135,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Neniu bufro kongruas kun %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "linio %ld"
+msgid "line %<PRId64>"
+msgstr "linio %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Bufro kun tiu nomo jam ekzistas"
@@ -161,12 +161,12 @@ msgid "1 line --%d%%--"
 msgstr "1 linio --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld linioj --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> linioj --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "linio %ld de %ld --%d%%-- kol "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "linio %<PRId64> de %<PRId64> --%d%%-- kol "
 
 msgid "[No Name]"
 msgstr "[Neniu nomo]"
@@ -213,12 +213,12 @@ msgid "Signs for %s:"
 msgstr "Emfazaj simbolaĵoj de %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    linio=%ld  id=%d  nomo=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    linio=%<PRId64>  id=%d  nomo=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Ne eblas dosierdiferenci pli ol %ld bufrojn"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Ne eblas dosierdiferenci pli ol %<PRId64> bufrojn"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Ne eblas legi aŭ skribi provizorajn dosierojn"
@@ -377,8 +377,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Neatenditaj signoj en \":let\""
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: indekso de listo ekster limoj: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: indekso de listo ekster limoj: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -790,8 +790,8 @@ msgid "%s aborted"
 msgstr "%s ĉesigita"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s liveras #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s liveras #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -840,12 +840,12 @@ msgid "1 line moved"
 msgstr "1 linio movita"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld linioj movitaj"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> linioj movitaj"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld linioj filtritaj"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> linioj filtritaj"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filtraj* Aŭtokomandoj ne rajtas ŝanĝi aktualan bufron"
@@ -929,8 +929,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Permutodosiero .swp ekzistas: %s (:silent! por transpasi)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Neniu dosiernomo de bufro %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Neniu dosiernomo de bufro %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Dosiero ne skribita: Skribo malŝaltita per la opcio 'write'"
@@ -987,19 +987,19 @@ msgid "1 substitution"
 msgstr "1 anstataŭigo"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld kongruoj"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> kongruoj"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld anstataŭigoj"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> anstataŭigoj"
 
 msgid " on 1 line"
 msgstr " en 1 linio"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " en %ld linioj"
+msgid " on %<PRId64> lines"
+msgstr " en %<PRId64> linioj"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Ne eblas fari \":global\" rekursie"
@@ -1087,8 +1087,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Nevalida nomo de bufro: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Nevalida identigilo de simbolo: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Nevalida identigilo de simbolo: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr "  (NETROVITA)"
@@ -1103,16 +1103,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Eniras sencimigan reĝimon.  Tajpu \"cont\" por daŭrigi."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "linio %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "linio %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "kmd: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Kontrolpunkto en \"%s%s\" linio %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Kontrolpunkto en \"%s%s\" linio %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1122,8 +1122,8 @@ msgid "No breakpoints defined"
 msgstr "Neniu kontrolpunkto estas difinita"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  linio %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  linio %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Uzu unue \":profile start {dosiernomo}\""
@@ -1179,16 +1179,16 @@ msgid "could not source \"%s\""
 msgstr "ne eblis ruli \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "linio %ld: ne eblis ruli \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "linio %<PRId64>: ne eblis ruli \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "rulas \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "linio %ld: rulas \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "linio %<PRId64>: rulas \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1277,8 +1277,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 plia redaktenda dosiero"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: %ld pliaj redaktendaj dosieroj"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: %<PRId64> pliaj redaktendaj dosieroj"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: La komando jam ekzistas: aldonu ! por anstataŭigi ĝin"
@@ -1478,8 +1478,8 @@ msgid "Exception discarded: %s"
 msgstr "Escepto ne konservita: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, linio %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, linio %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1686,12 +1686,12 @@ msgid "[crypted]"
 msgstr "[ĉifrita]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ERARO DE KONVERTO en linio %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ERARO DE KONVERTO en linio %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[NEVALIDA BAJTO en linio %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[NEVALIDA BAJTO en linio %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[ERAROJ DE LEGADO]"
@@ -1774,10 +1774,10 @@ msgstr "E513: skriberaro, konverto fiaskis (igu 'fenc' malplena por transpasi)"
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: skriberaro, konverto fiaskis en linio %ld (igu 'fenc' malplena  por "
+"E513: skriberaro, konverto fiaskis en linio %<PRId64> (igu 'fenc' malplena  por "
 "transpasi)"
 
 msgid "E514: write error (file system full?)"
@@ -1787,8 +1787,8 @@ msgid " CONVERSION ERROR"
 msgstr " ERARO DE KONVERTO"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " en linio %ld;"
+msgid " in line %<PRId64>;"
+msgstr " en linio %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Aparatdosiero]"
@@ -1849,8 +1849,8 @@ msgid "1 line, "
 msgstr "1 linio, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld linioj, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> linioj, "
 
 msgid "1 character"
 msgstr "1 signo"
@@ -1861,8 +1861,8 @@ msgstr "%<PRId64> signoj"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld signoj"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> signoj"
 
 msgid "[noeol]"
 msgstr "[sen EOL]"
@@ -2280,19 +2280,19 @@ msgid "Font1: %s\n"
 msgstr "Font1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Font%ld ne estas duoble pli larĝa ol font0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Font%<PRId64> ne estas duoble pli larĝa ol font0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Larĝo de font0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Larĝo de font0: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Larĝo de Font1: %ld\n"
+"Larĝo de Font1: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2470,8 +2470,8 @@ msgid "Added cscope database %s"
 msgstr "Aldonis datumbazon de cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: eraro dum legado de konekto de cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: eraro dum legado de konekto de cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: nekonata tipo de serĉo de cscope"
@@ -3699,12 +3699,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Konservo fiaskis"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: nevalida lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: nevalida lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: ne eblas trovi linion %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: ne eblas trovi linion %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: nevalida referenco de bloko id 3"
@@ -3722,8 +3722,8 @@ msgid "deleted block 1?"
 msgstr "ĉu forviŝita bloko 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Ne eblas trovi linion %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Ne eblas trovi linion %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: nevalida referenco de bloko id"
@@ -3732,12 +3732,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count estas nul"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: numero de linio ekster limoj: %ld preter la fino"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: numero de linio ekster limoj: %<PRId64> preter la fino"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: nevalida nombro de linioj en bloko %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: nevalida nombro de linioj en bloko %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Stako pligrandiĝas"
@@ -3923,8 +3923,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Premu ENEN-KLAVON aŭ tajpu komandon por daŭrigi"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s linio %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s linio %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Pli --"
@@ -3996,12 +3996,12 @@ msgid "1 line less"
 msgstr "1 malplia linio"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld pliaj linioj"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> pliaj linioj"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld malpliaj linioj"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> malpliaj linioj"
 
 msgid " (Interrupted)"
 msgstr " (Interrompita)"
@@ -4040,8 +4040,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Linio iĝas tro longa"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Interna eraro: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Interna eraro: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4117,8 +4117,8 @@ msgid "read from Netbeans socket"
 msgstr "lego el kontaktoskatolo de Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Konekto de NetBeans perdita por bufro %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Konekto de NetBeans perdita por bufro %<PRId64>"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: netbeans ne estas subtenata kun tiu grafika interfaco"
@@ -4170,23 +4170,23 @@ msgid "1 line %sed %d times"
 msgstr "1 linio %sita %d foje"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld linio %sita 1 foje"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> linio %sita 1 foje"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld linioj %sitaj %d foje"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> linioj %sitaj %d foje"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld krommarĝenendaj linioj... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> krommarĝenendaj linioj... "
 
 msgid "1 line indented "
 msgstr "1 linio krommarĝenita "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld linioj krommarĝenitaj "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> linioj krommarĝenitaj "
 
 msgid "E748: No previously used register"
 msgstr "E748: Neniu reĝistro antaŭe uzata"
@@ -4199,12 +4199,12 @@ msgid "1 line changed"
 msgstr "1 linio ŝanĝita"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld linioj ŝanĝitaj"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> linioj ŝanĝitaj"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "malokupas %ld liniojn"
+msgid "freeing %<PRId64> lines"
+msgstr "malokupas %<PRId64> liniojn"
 
 msgid "block of 1 line yanked"
 msgstr "bloko de 1 linio kopiita"
@@ -4213,12 +4213,12 @@ msgid "1 line yanked"
 msgstr "1 linio kopiita"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "bloko de %ld linioj kopiita"
+msgid "block of %<PRId64> lines yanked"
+msgstr "bloko de %<PRId64> linioj kopiita"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld linioj kopiitaj"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> linioj kopiitaj"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4247,36 +4247,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Nekonata tipo de reĝistro %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Kolumnoj; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Kolumnoj; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Apartigis %s%ld de %ld Linioj; %ld de %ld Vortoj; %ld de %ld Bajtoj"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Apartigis %s%<PRId64> de %<PRId64> Linioj; %<PRId64> de %<PRId64> Vortoj; %<PRId64> de %<PRId64> Bajtoj"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Apartigis %s%ld de %ld Linioj; %ld de %ld Vortoj; %ld de %ld Signoj; %ld de "
-"%ld Bajtoj"
+"Apartigis %s%<PRId64> de %<PRId64> Linioj; %<PRId64> de %<PRId64> Vortoj; %<PRId64> de %<PRId64> Signoj; %<PRId64> de "
+"%<PRId64> Bajtoj"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Kol %s de %s; Linio %ld de %ld; Vorto %ld de %ld; Bajto %ld de %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Kol %s de %s; Linio %<PRId64> de %<PRId64>; Vorto %<PRId64> de %<PRId64>; Bajto %<PRId64> de %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Kol %s de %s; Linio %ld de %ld; Vorto %ld de %ld; Signo %ld de %ld; Bajto "
-"%ld de %ld"
+"Kol %s de %s; Linio %<PRId64> de %<PRId64>; Vorto %<PRId64> de %<PRId64>; Signo %<PRId64> de %<PRId64>; Bajto "
+"%<PRId64> de %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld por BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> por BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Folio %N"
@@ -4458,8 +4458,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Bezonas version 2.04 de Amigados aŭ pli novan\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Bezonas %s-on versio %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Bezonas %s-on versio %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Ne eblas malfermi NIL:\n"
@@ -4541,8 +4541,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Kaptis mortigantan signalon\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Malfermo de vidigo X daŭris %ld msek"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Malfermo de vidigo X daŭris %<PRId64> msek"
 
 msgid ""
 "\n"
@@ -5314,8 +5314,8 @@ msgid "Performing soundfolding..."
 msgstr "Fonetika analizado..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Nombro de vortoj post fonetika analizado: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Nombro de vortoj post fonetika analizado: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5350,8 +5350,8 @@ msgid "Done!"
 msgstr "Farita!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' ne havas %ld rikordojn"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' ne havas %<PRId64> rikordojn"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5368,8 +5368,8 @@ msgid "Sorry, no suggestions"
 msgstr "Bedaŭrinde ne estas sugestoj"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Bedaŭrinde estas nur %ld sugestoj"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Bedaŭrinde estas nur %<PRId64> sugestoj"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5682,8 +5682,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Eraro de formato en etikeda dosiero \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Antaŭ bajto %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Antaŭ bajto %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5827,8 +5827,8 @@ msgid "Already at newest change"
 msgstr "Jam al la plej nova ŝanĝo"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Malfara numero %ld netrovita"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Malfara numero %<PRId64> netrovita"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: nevalidaj numeroj de linioj"
@@ -5852,8 +5852,8 @@ msgid "changes"
 msgstr "ŝanĝoj"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "antaŭ"
@@ -5868,8 +5868,8 @@ msgid "number changes  when               saved"
 msgstr "numero ŝanĝoj   tempo              konservita"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "antaŭ %ld sekundoj"
+msgid "%<PRId64> seconds ago"
+msgstr "antaŭ %<PRId64> sekundoj"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin estas nepermesebla post malfaro"

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -5169,18 +5169,18 @@ msgstr "ERROR: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bytes] total liberados por alloc: %lu-%lu, en uso: %lu, uso máximo: %lu\n"
+"[bytes] total liberados por alloc: %<PRIu64>-%<PRIu64>, en uso: %<PRIu64>, uso máximo: %<PRIu64>\n"
 
 #: misc2.c:740
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[llamadas] total re/malloc(): %lu, total free(): %lu\n"
+"[llamadas] total re/malloc(): %<PRIu64>, total free(): %<PRIu64>\n"
 "\n"
 
 #: misc2.c:795
@@ -5194,8 +5194,8 @@ msgstr "E341: Error interno: lalloc(%<PRId64>, )"
 
 #: misc2.c:953
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: ¡Memoria agotada! (al asignar %lu bytes)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: ¡Memoria agotada! (al asignar %<PRIu64> bytes)"
 
 #: misc2.c:3033
 #, c-format

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -78,8 +78,8 @@ msgstr "E85: No hay búfers en la lista"
 
 #: buffer.c:1016
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: El búfer %ld no existe"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: El búfer %<PRId64> no existe"
 
 #: buffer.c:1019
 msgid "E87: Cannot go beyond last buffer"
@@ -91,9 +91,9 @@ msgstr "E88: No se pudo regresar antes del primer búfer"
 
 #: buffer.c:1063
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: No se guardó el archivo desde el último cambio del búfer %ld (añada \"!"
+"E89: No se guardó el archivo desde el último cambio del búfer %<PRId64> (añada \"!"
 "\" para forzar)"
 
 #: buffer.c:1080
@@ -106,8 +106,8 @@ msgstr "W14: Advertencia: La lista de nombres de archivos es muy larga"
 
 #: buffer.c:1850 quickfix.c:3632
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: No se encontró el búfer %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: No se encontró el búfer %<PRId64>"
 
 #: buffer.c:2125
 #, c-format
@@ -121,8 +121,8 @@ msgstr "E94: No hay un búfer que coincida con %s"
 
 #: buffer.c:2579
 #, c-format
-msgid "line %ld"
-msgstr "línea %ld"
+msgid "line %<PRId64>"
+msgstr "línea %<PRId64>"
 
 #: buffer.c:2666
 msgid "E95: Buffer with this name already exists"
@@ -155,13 +155,13 @@ msgstr "1 línea --%d%%--"
 
 #: buffer.c:3032
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld líneas --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> líneas --%d%%--"
 
 #: buffer.c:3039
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "línea %ld de %ld --%d%%-- col "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "línea %<PRId64> de %<PRId64> --%d%%-- col "
 
 #: buffer.c:3160 buffer.c:5126 memline.c:1727
 msgid "[No Name]"
@@ -229,13 +229,13 @@ msgstr "Signos para %s:"
 
 #: buffer.c:5455
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    línea=%ld id=%d nombre=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    línea=%<PRId64> id=%d nombre=%s"
 
 #: diff.c:141
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: No se puede usar \"diff\" con más de %ld búfers"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: No se puede usar \"diff\" con más de %<PRId64> búfers"
 
 #: diff.c:777
 msgid "E810: Cannot read or write temp files"
@@ -441,8 +441,8 @@ msgstr "E18: Caracteres inesperados en :let"
 
 #: eval.c:97
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: índice de lista fuera de rango: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: índice de lista fuera de rango: %<PRId64>"
 
 #: eval.c:98
 #, c-format
@@ -939,8 +939,8 @@ msgstr "Abortada la ejecución de %s"
 
 #: eval.c:21337
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s devuelve #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s devuelve #%<PRId64>"
 
 #: eval.c:21353
 #, c-format
@@ -1003,13 +1003,13 @@ msgstr "1 línea movida"
 
 #: ex_cmds.c:810
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld líneas movidas"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> líneas movidas"
 
 #: ex_cmds.c:1305
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld líneas filtradas"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> líneas filtradas"
 
 #: ex_cmds.c:1329
 msgid "E135: *Filter* Autocommands must not change current buffer"
@@ -1120,8 +1120,8 @@ msgstr ""
 
 #: ex_cmds.c:2901
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: No existe un nombre de archivo para el búfer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: No existe un nombre de archivo para el búfer %<PRId64>"
 
 #: ex_cmds.c:2940
 msgid "E142: File not written: Writing is disabled by 'write' option"
@@ -1194,13 +1194,13 @@ msgstr "Una (1) sustitución"
 
 #: ex_cmds.c:5174
 #, c-format
-msgid "%ld matches"
-msgstr "%ld coincidencias"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> coincidencias"
 
 #: ex_cmds.c:5174
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld sustituciones"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> sustituciones"
 
 #: ex_cmds.c:5179
 msgid " on 1 line"
@@ -1208,8 +1208,8 @@ msgstr " en una (1) línea"
 
 #: ex_cmds.c:5182
 #, c-format
-msgid " on %ld lines"
-msgstr " en %ld líneas"
+msgid " on %<PRId64> lines"
+msgstr " en %<PRId64> líneas"
 
 #: ex_cmds.c:5229
 msgid "E147: Cannot do :global recursive"
@@ -1314,8 +1314,8 @@ msgstr "E158: El nombre del búfer no es válido: %s"
 
 #: ex_cmds.c:6926
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: La identificación del signo no es válida: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: La identificación del signo no es válida: %<PRId64>"
 
 #: ex_cmds.c:6996
 msgid " (NOT FOUND)"
@@ -1335,8 +1335,8 @@ msgstr "Iniciando modo de depuración. Escriba \"cont\" para continuar."
 
 #: ex_cmds2.c:142 ex_docmd.c:1081
 #, c-format
-msgid "line %ld: %s"
-msgstr "línea %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "línea %<PRId64>: %s"
 
 #: ex_cmds2.c:144
 #, c-format
@@ -1345,8 +1345,8 @@ msgstr "cmd: %s"
 
 #: ex_cmds2.c:344
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "\"Breakpoint\" en \"%s%s\" línea %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "\"Breakpoint\" en \"%s%s\" línea %<PRId64>"
 
 #: ex_cmds2.c:656
 #, c-format
@@ -1359,8 +1359,8 @@ msgstr "No se han definido \"breakpoints\""
 
 #: ex_cmds2.c:697
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  línea %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  línea %<PRId64>"
 
 #: ex_cmds2.c:1095
 msgid "E750: First use :profile start <fname>"
@@ -1434,8 +1434,8 @@ msgstr "No pude ejecutar %s"
 
 #: ex_cmds2.c:2934
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "línea %ld: no se pudo ejecutar %s"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "línea %<PRId64>: no se pudo ejecutar %s"
 
 #: ex_cmds2.c:2950
 #, c-format
@@ -1444,8 +1444,8 @@ msgstr "ejecutando %s"
 
 #: ex_cmds2.c:2952
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "línea %ld: ejecutando %s"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "línea %<PRId64>: ejecutando %s"
 
 #: ex_cmds2.c:3143
 #, c-format
@@ -1566,8 +1566,8 @@ msgstr "E173: Un (1) archivo más para editar"
 
 #: ex_docmd.c:5048
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Hay %ld archivos en edición"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Hay %<PRId64> archivos en edición"
 
 #: ex_docmd.c:5142
 msgid "E174: Command already exists: add ! to replace it"
@@ -1822,8 +1822,8 @@ msgstr "Excepción descartada: %s"
 
 #: ex_eval.c:635 ex_eval.c:687
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, en la línea %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, en la línea %<PRId64>"
 
 # always scroll up, don't overwrite
 #. always scroll up, don't overwrite
@@ -2096,13 +2096,13 @@ msgstr "[cifrado]"
 
 #: fileio.c:2432
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ERROR DE CONVERSIÓN en línea %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ERROR DE CONVERSIÓN en línea %<PRId64>]"
 
 #: fileio.c:2438
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[BYTE ILEGAL en la línea %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[BYTE ILEGAL en la línea %<PRId64>]"
 
 #: fileio.c:2445
 msgid "[READ ERRORS]"
@@ -2226,10 +2226,10 @@ msgstr ""
 #: fileio.c:4501
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Error de escritura, la conversión falló en la línea %ld(vacíe 'fenc' "
+"E513: Error de escritura, la conversión falló en la línea %<PRId64>(vacíe 'fenc' "
 "para forzar)"
 
 #: fileio.c:4510
@@ -2242,8 +2242,8 @@ msgstr " ERROR DE CONVERSIÓN"
 
 #: fileio.c:4583
 #, c-format
-msgid " in line %ld;"
-msgstr "en la línea %ld"
+msgid " in line %<PRId64>;"
+msgstr "en la línea %<PRId64>"
 
 #: fileio.c:4600
 msgid "[Device]"
@@ -2323,8 +2323,8 @@ msgstr "1 línea, "
 
 #: fileio.c:4975
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld líneas, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> líneas, "
 
 #: fileio.c:4978
 msgid "1 character"
@@ -2332,8 +2332,8 @@ msgstr "1 carácter"
 
 #: fileio.c:4980
 #, c-format
-msgid "%ld characters"
-msgstr "%ld caracteres"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> caracteres"
 
 #: fileio.c:4990 netbeans.c:3637
 msgid "[noeol]"
@@ -2886,23 +2886,23 @@ msgstr "Tipo de letra de impresión 1: %s\n"
 
 #: gui_x11.c:2204
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
 msgstr ""
-"La anchura del tipo de letra de impresión %ld no es el doble de la \n"
+"La anchura del tipo de letra de impresión %<PRId64> no es el doble de la \n"
 "de la tipografía de impresión 0\n"
 
 #: gui_x11.c:2205
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Anchura del tipo de letra de impresión 0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Anchura del tipo de letra de impresión 0: %<PRId64>\n"
 
 #: gui_x11.c:2206
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Anchura del tipo de letra de impresión 1: %ld\n"
+"Anchura del tipo de letra de impresión 1: %<PRId64>\n"
 "\n"
 
 #: gui_xmdlg.c:690 gui_xmdlg.c:809
@@ -3135,8 +3135,8 @@ msgstr "Se ha añadido la base de datos \"cscope\" %s"
 
 #: if_cscope.c:695
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Error al leer la conexión %ld con \"cscope\""
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Error al leer la conexión %<PRId64> con \"cscope\""
 
 #: if_cscope.c:802
 msgid "E561: unknown cscope search type"
@@ -4761,13 +4761,13 @@ msgstr "E314: Falló la preservación del archivo"
 
 #: memline.c:2103
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: \"ml_get\": número de línea no válido: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: \"ml_get\": número de línea no válido: %<PRId64>"
 
 #: memline.c:2138
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: \"ml_get\": no se pudo encontrar la línea %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: \"ml_get\": no se pudo encontrar la línea %<PRId64>"
 
 #: memline.c:2552
 msgid "E317: pointer block id wrong 3"
@@ -4791,8 +4791,8 @@ msgstr "¿bloque 1 suprimido?"
 
 #: memline.c:3101
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: No se pudo encontrar la línea %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: No se pudo encontrar la línea %<PRId64>"
 
 #: memline.c:3347
 msgid "E317: pointer block id wrong"
@@ -4804,13 +4804,13 @@ msgstr "\"pe_line_count\" es cero"
 
 #: memline.c:3392
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: número de línea fuera de rango: %ld más allá del final"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: número de línea fuera de rango: %<PRId64> más allá del final"
 
 #: memline.c:3396
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: recuento de líneas erróneo en el bloque %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: recuento de líneas erróneo en el bloque %<PRId64>"
 
 #: memline.c:3445
 msgid "Stack size increases"
@@ -5045,8 +5045,8 @@ msgstr "Pulse INTRO o escriba una orden para continuar"
 
 #: message.c:2139
 #, c-format
-msgid "%s line %ld"
-msgstr "%s, en la línea %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s, en la línea %<PRId64>"
 
 #: message.c:2839
 msgid "-- More --"
@@ -5134,13 +5134,13 @@ msgstr "1 línea menos"
 
 #: misc1.c:3330
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld líneas más"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> líneas más"
 
 #: misc1.c:3332
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld líneas menos"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> líneas menos"
 
 #: misc1.c:3335
 msgid " (Interrupted)"
@@ -5189,8 +5189,8 @@ msgstr "E340: La línea se está haciendo demasiado larga"
 
 #: misc2.c:839
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Error interno: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Error interno: lalloc(%<PRId64>, )"
 
 #: misc2.c:953
 #, c-format
@@ -5284,8 +5284,8 @@ msgstr "leído del socket NetBeans"
 
 #: netbeans.c:1872
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Se perdió la conexión NetBeans para el búfer %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Se perdió la conexión NetBeans para el búfer %<PRId64>"
 
 #: netbeans.c:3692
 msgid "E505: "
@@ -5343,18 +5343,18 @@ msgstr "1 línea %sed %d veces"
 
 #: ops.c:300
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld líneas %sed 1 vez"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> líneas %sed 1 vez"
 
 #: ops.c:303
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld líneas %sed %d veces"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> líneas %sed %d veces"
 
 #: ops.c:691
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld líneas por sangrar..."
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> líneas por sangrar..."
 
 #: ops.c:742
 msgid "1 line indented "
@@ -5362,8 +5362,8 @@ msgstr "1 línea sangrada"
 
 #: ops.c:744
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld líneas sangradas"
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> líneas sangradas"
 
 #: ops.c:1170
 msgid "E748: No previously used register"
@@ -5381,13 +5381,13 @@ msgstr "1 línea cambiada"
 
 #: ops.c:2333
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld líneas cambiadas"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> líneas cambiadas"
 
 #: ops.c:2788
 #, c-format
-msgid "freeing %ld lines"
-msgstr "liberando %ld líneas"
+msgid "freeing %<PRId64> lines"
+msgstr "liberando %<PRId64> líneas"
 
 #: ops.c:3073
 msgid "block of 1 line yanked"
@@ -5399,13 +5399,13 @@ msgstr "1 línea copiada"
 
 #: ops.c:3080
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "bloque de %ld líneas copiadas"
+msgid "block of %<PRId64> lines yanked"
+msgstr "bloque de %<PRId64> líneas copiadas"
 
 #: ops.c:3083
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld líneas copiadas"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> líneas copiadas"
 
 #: ops.c:3378
 #, c-format
@@ -5442,42 +5442,42 @@ msgstr "E574: Registro desconocido de tipo %d"
 
 #: ops.c:6435
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Cols; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Cols; "
 
 #: ops.c:6444
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"Selección %s%ld de %ld Líneas; %ld de %ld Palabras; %ld de %ld Caracteres"
+"Selección %s%<PRId64> de %<PRId64> Líneas; %<PRId64> de %<PRId64> Palabras; %<PRId64> de %<PRId64> Caracteres"
 
 #: ops.c:6451
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Selección %s%ld de %ld Líneas; %ld de %ld Palabras; %ld de %ld Caracteres; %"
-"ld de %ld Bytes"
+"Selección %s%<PRId64> de %<PRId64> Líneas; %<PRId64> de %<PRId64> Palabras; %<PRId64> de %<PRId64> Caracteres; %"
+"ld de %<PRId64> Bytes"
 
 #: ops.c:6470
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Col %s de %s; Línea %ld de %ld; Palabra %ld de %ld; Byte %ld de %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Col %s de %s; Línea %<PRId64> de %<PRId64>; Palabra %<PRId64> de %<PRId64>; Byte %<PRId64> de %<PRId64>"
 
 #: ops.c:6478
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Col %s de %s; Línea %ld de %ld; Palabra %ld de %ld; Carácter %ld de %ld Byte "
-"%ld de %ld"
+"Col %s de %s; Línea %<PRId64> de %<PRId64>; Palabra %<PRId64> de %<PRId64>; Carácter %<PRId64> de %<PRId64> Byte "
+"%<PRId64> de %<PRId64>"
 
 #: ops.c:6490
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld para BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> para BOM)"
 
 #: option.c:1953
 msgid "%<%f%h%m%=Page %N"
@@ -5700,8 +5700,8 @@ msgstr "Necesito Amigados 2.04 o una versión posterior\n"
 
 #: os_amiga.c:346
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Necesito %s versión %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Necesito %s versión %<PRId64>\n"
 
 #: os_amiga.c:419
 msgid "Cannot open NIL:\n"
@@ -5812,8 +5812,8 @@ msgstr "Vim: Capté una señal mortal\n"
 
 #: os_unix.c:1412
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Abrir la pantalla X tomó %ld mseg"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Abrir la pantalla X tomó %<PRId64> mseg"
 
 #: os_unix.c:1439
 msgid ""
@@ -6683,8 +6683,8 @@ msgstr "Ejecutando compresión fonética"
 
 #: spell.c:8754
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Número de palabras después de la compresión fonética: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Número de palabras después de la compresión fonética: %<PRId64>"
 
 #: spell.c:8879
 #, c-format
@@ -6730,8 +6730,8 @@ msgstr "¡Listo!"
 
 #: spell.c:9543
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' no tiene entradas %ld"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' no tiene entradas %<PRId64>"
 
 #: spell.c:9588
 #, c-format
@@ -6754,8 +6754,8 @@ msgstr "Lo siento, no hay sugerencias"
 
 #: spell.c:10325
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Lo siento, solo hay %ld sugerencias"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Lo siento, solo hay %<PRId64> sugerencias"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -7141,8 +7141,8 @@ msgstr "E431: Error de formato en el archivo de etiquetas \"%s\""
 
 #: tag.c:2392
 #, c-format
-msgid "Before byte %ld"
-msgstr "Adelante del byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Adelante del byte %<PRId64>"
 
 #: tag.c:2425
 #, c-format
@@ -7234,8 +7234,8 @@ msgstr "Este es el cambio más nuevo"
 
 #: undo.c:930
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "No se encontró el número de \"deshacer\" %ld"
+msgid "Undo number %<PRId64> not found"
+msgstr "No se encontró el número de \"deshacer\" %<PRId64>"
 
 #: undo.c:1100
 msgid "E438: u_undo: line numbers wrong"
@@ -7267,8 +7267,8 @@ msgstr "cambios"
 
 #: undo.c:1375
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 #: undo.c:1378
 msgid "before"
@@ -7288,8 +7288,8 @@ msgstr "el número modifica el tiempo"
 
 #: undo.c:1525
 #, c-format
-msgid "%ld seconds ago"
-msgstr "hace %ld segundos"
+msgid "%<PRId64> seconds ago"
+msgstr "hace %<PRId64> segundos"
 
 #: undo.c:1541
 msgid "E790: undojoin is not allowed after undo"

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -3961,17 +3961,17 @@ msgstr "VIRHE: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[tavua] yht. alloc-free %lu-%lu, käytössä %lu, käyttöhuippu %lu\n"
+"[tavua] yht. alloc-free %<PRIu64>-%<PRIu64>, käytössä %<PRIu64>, käyttöhuippu %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[kutsut] yht. re/malloc() %lu, yht. free() %lu\n"
+"[kutsut] yht. re/malloc() %<PRIu64>, yht. free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3982,8 +3982,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Sisäinen virhe: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Muisti loppui! (varattaessa %lu tavua)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Muisti loppui! (varattaessa %<PRIu64> tavua)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -1806,8 +1806,8 @@ msgid "1 character"
 msgstr "1 merkki"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld merkkiä"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> merkkiä"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -91,8 +91,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Luetteloitua puskuria ei ole"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Puskuria %ld ei ole"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Puskuria %<PRId64> ei ole"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Viimeisen puskurin ohi ei voi edetä"
@@ -101,9 +101,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Ensimmäisen puskurin ohi ei voi edetä"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Puskurin %ld muutoksia ei ole tallennettu (lisää komentoon ! "
+"E89: Puskurin %<PRId64> muutoksia ei ole tallennettu (lisää komentoon ! "
 "ohittaaksesi)"
 
 msgid "E90: Cannot unload last buffer"
@@ -113,8 +113,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varoitus: Tiedostonimiluettelon ylivuoto"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Puskuria %ld ei löydy"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Puskuria %<PRId64> ei löydy"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -125,8 +125,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: %s ei täsmää yhteenkään puskuriin"
 
 #, c-format
-msgid "line %ld"
-msgstr "rivi %ld"
+msgid "line %<PRId64>"
+msgstr "rivi %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Samanniminen puskuri on jo olemassa"
@@ -151,12 +151,12 @@ msgid "1 line --%d%%--"
 msgstr "1 rivi --%d %%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld riviä --%d %%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> riviä --%d %%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "rivi %ld/%ld --%d %%-- sarake "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "rivi %<PRId64>/%<PRId64> --%d %%-- sarake "
 
 msgid "[No Name]"
 msgstr "[Nimetön]"
@@ -205,12 +205,12 @@ msgid "Signs for %s:"
 msgstr "Merkit kohteelle %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    rivi=%ld  id=%d  nimi=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    rivi=%<PRId64>  id=%d  nimi=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Ei voi diffata enempää kuin %ld puskuria"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Ei voi diffata enempää kuin %<PRId64> puskuria"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Ei voi lukea tai kirjoittaa väliaikaistiedostoja"
@@ -362,8 +362,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Odottamattomia merkkejä komennossa :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Indeksi %ld luettelon rajojen ulkopuolella"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Indeksi %<PRId64> luettelon rajojen ulkopuolella"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -747,8 +747,8 @@ msgid "%s aborted"
 msgstr "%s keskeytettiin"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s palaa kohdassa #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s palaa kohdassa #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -782,16 +782,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Siirrytään vianetsintätilaan, kirjoita cont jatkaaksesi."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "rivi %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "rivi %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "kmnt: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Katkaisukohta %s%s rivillä %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Katkaisukohta %s%s rivillä %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -801,8 +801,8 @@ msgid "No breakpoints defined"
 msgstr "Ei katkaisukohtia"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  rivi %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  rivi %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Aloita käskyllä :profile start {fname}"
@@ -861,16 +861,16 @@ msgid "could not source \"%s\""
 msgstr "ei voitu ladata %s"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "rivi %ld: ei voitu ladata %s"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "rivi %<PRId64>: ei voitu ladata %s"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "ladataan %s"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "rivi %ld: ladataan %s"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "rivi %<PRId64>: ladataan %s"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -928,12 +928,12 @@ msgid "1 line moved"
 msgstr "1 rivi siirretty"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld riviä siirretty"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> riviä siirretty"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld riviä suodatettu"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> riviä suodatettu"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter*-autocommand ei voi vaihtaa puskuria"
@@ -1016,8 +1016,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Swap-tiedosto on jo olemassa: %s (komento :silent! ohittaa)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Ei tiedostonimeä puskurille %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Ei tiedostonimeä puskurille %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr ""
@@ -1075,19 +1075,19 @@ msgid "1 substitution"
 msgstr "1 korvaus"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld täsmäystä"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> täsmäystä"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld korvausta"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> korvausta"
 
 msgid " on 1 line"
 msgstr " 1 rivillä"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " %ld rivillä"
+msgid " on %<PRId64> lines"
+msgstr " %<PRId64> rivillä"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :globalia ei voi suorittaa rekursiivisesti"
@@ -1170,8 +1170,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Virheellinen puskurin nimi: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Virheellinen merkin tunnus: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Virheellinen merkin tunnus: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (EI LÖYTYNYT)"
@@ -1233,8 +1233,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: vielä 1 tiedosto muokattavana"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: vielä %ld tiedostoa muokattavana"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: vielä %<PRId64> tiedostoa muokattavana"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Komento on jo olemassa, käytä !:ä korvataksesi"
@@ -1420,8 +1420,8 @@ msgid "Exception discarded: %s"
 msgstr "Poikkeus poistettu: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, rivi %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, rivi %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1627,12 +1627,12 @@ msgid "[crypted]"
 msgstr "[salattu]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[MUUNNOSVIRHE rivillä %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[MUUNNOSVIRHE rivillä %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[VIRHEELLINEN OKTETTI rivillä %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[VIRHEELLINEN OKTETTI rivillä %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[LUKUVIRHEITÄ]"
@@ -1725,9 +1725,9 @@ msgstr "E513: kirjoitusvirhe, muunnos epäonnistui (tyhjää fenc ohittaaksesi)"
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
-msgstr "E513: kirjoitusvirhe, muunnos epäonnistui rivillä %ld"
+msgstr "E513: kirjoitusvirhe, muunnos epäonnistui rivillä %<PRId64>"
 "(tyhjää fenc ohittaaksesi)"
 
 msgid "E514: write error (file system full?)"
@@ -1737,8 +1737,8 @@ msgid " CONVERSION ERROR"
 msgstr " MUUNNOSVIRHE"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " rivillä %ld"
+msgid " in line %<PRId64>;"
+msgstr " rivillä %<PRId64>"
 
 msgid "[Device]"
 msgstr "[Laite]"
@@ -1799,8 +1799,8 @@ msgid "1 line, "
 msgstr "1 rivi, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld riviä, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> riviä, "
 
 msgid "1 character"
 msgstr "1 merkki"
@@ -1811,8 +1811,8 @@ msgstr "%<PRId64> merkkiä"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld merkkiä"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> merkkiä"
 
 # ei rivinvaihtoja
 msgid "[noeol]"
@@ -2227,19 +2227,19 @@ msgid "Font1: %s\n"
 msgstr "Fontti1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Fontti%ld:n leveys ei ole kaksi kertaa fontti0:n\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Fontti%<PRId64>:n leveys ei ole kaksi kertaa fontti0:n\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Fontti0:n leveys: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Fontti0:n leveys: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Fontti1:n leveys: %ld\n"
+"Fontti1:n leveys: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2416,8 +2416,8 @@ msgid "Added cscope database %s"
 msgstr "Lisätty cscope-tietokanta %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Virhe luettaessa cscope-yhteyttä %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Virhe luettaessa cscope-yhteyttä %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: tuntematon cscope-hakutyyppi"
@@ -3638,12 +3638,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Säilyttäminen epäonnistui"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: virheellinen lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: virheellinen lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: riviä %ld ei löydy"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: riviä %<PRId64> ei löydy"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: osoitinlohkon tunnus väärä 3"
@@ -3661,8 +3661,8 @@ msgid "deleted block 1?"
 msgstr "poistettu lohko 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Riviä %ld ei löydy"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Riviä %<PRId64> ei löydy"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: osoitinlohkon tunnus väärä"
@@ -3671,12 +3671,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count on nolla"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: rivinumero arvoalueen ulkopuoleta: %ld on loppua suurempi"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: rivinumero arvoalueen ulkopuoleta: %<PRId64> on loppua suurempi"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: rivimäärä väärin lohkossa %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: rivimäärä väärin lohkossa %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Pinon koko kasvaa"
@@ -3864,8 +3864,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Paina enteriä tai kirjoita komento aloittaaksesi "
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s rivi %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s rivi %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Lisää --"
@@ -3934,12 +3934,12 @@ msgid "1 line less"
 msgstr "1 rivi vähemmän"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld riviä lisää"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> riviä lisää"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld riviä vähemmän"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> riviä vähemmän"
 
 msgid " (Interrupted)"
 msgstr " (Keskeytetty)"
@@ -3978,8 +3978,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Rivistä tulee liian pitkä"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Sisäinen virhe: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Sisäinen virhe: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4051,8 +4051,8 @@ msgid "read from Netbeans socket"
 msgstr "luettu Netbeans-soketista"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: NetBeans-yhteys katkesi puskurille %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: NetBeans-yhteys katkesi puskurille %<PRId64>"
 
 msgid "E511: netbeans already connected"
 msgstr "E511: netbeans on yhdistetty jo"
@@ -4099,23 +4099,23 @@ msgid "1 line %sed %d times"
 msgstr "1 riviä %s %d kertaa"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld riviä %s kerran"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> riviä %s kerran"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld riviä %s %d kertaa"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> riviä %s %d kertaa"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld riviä sisennettävänä..."
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> riviä sisennettävänä..."
 
 msgid "1 line indented "
 msgstr "1 rivi sisennetty "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld riviä sisennetty "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> riviä sisennetty "
 
 msgid "E748: No previously used register"
 msgstr "E748: Ei aiemmin käytettyjä rekisterejä"
@@ -4128,12 +4128,12 @@ msgid "1 line changed"
 msgstr "1 rivi muuttui"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld riviä muuttui"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> riviä muuttui"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "vapautetaan %ld riviä"
+msgid "freeing %<PRId64> lines"
+msgstr "vapautetaan %<PRId64> riviä"
 
 msgid "block of 1 line yanked"
 msgstr "1 rivin lohko kopioitu"
@@ -4142,12 +4142,12 @@ msgid "1 line yanked"
 msgstr "1 rivi kopioitu"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "lohko %ld riviltä kopioitu"
+msgid "block of %<PRId64> lines yanked"
+msgstr "lohko %<PRId64> riviltä kopioitu"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld riviä kopioitu"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> riviä kopioitu"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4176,33 +4176,33 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Tuntematon rekisterityyppi %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld saraketta, "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> saraketta, "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Valittu %s%ld/%ld riviä, %ld/%ld sanaa, %ld/%ld tavua"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Valittu %s%<PRId64>/%<PRId64> riviä, %<PRId64>/%<PRId64> sanaa, %<PRId64>/%<PRId64> tavua"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
-msgstr "Valittu %s%ld/%ld riviä, %ld/%ld sanaa, %ld/%ld merkkiä, %ld/%ld tavua"
+msgstr "Valittu %s%<PRId64>/%<PRId64> riviä, %<PRId64>/%<PRId64> sanaa, %<PRId64>/%<PRId64> merkkiä, %<PRId64>/%<PRId64> tavua"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Sarake %s/%s, Rivi %ld/%ld, sana %ld/%ld, tavu %ld/%ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Sarake %s/%s, Rivi %<PRId64>/%<PRId64>, sana %<PRId64>/%<PRId64>, tavu %<PRId64>/%<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
-msgstr "Sarake %s/%s, rivi %ld/%ld, sana %ld/%ld, merkki %ld/%ld, tavu %ld/%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
+msgstr "Sarake %s/%s, rivi %<PRId64>/%<PRId64>, sana %<PRId64>/%<PRId64>, merkki %<PRId64>/%<PRId64>, tavu %<PRId64>/%<PRId64>"
 
 # Unicode Byte Order Mark
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld BOMista)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> BOMista)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Sivu %N"
@@ -4381,8 +4381,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Amigados 2.04 tai uudempi tarvitaan\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Tarvitaan %s versio %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Tarvitaan %s versio %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Ei voi avata NILiä:\n"
@@ -4464,8 +4464,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Tappava signaali\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "X-näytön avaus vei %ld millisekuntia"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "X-näytön avaus vei %<PRId64> millisekuntia"
 
 msgid ""
 "\n"
@@ -5154,8 +5154,8 @@ msgid "Performing soundfolding..."
 msgstr "Ääntämyksen mukaan yhdistellään..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Sanoja ääntämysyhdistelyn jälkeen: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Sanoja ääntämysyhdistelyn jälkeen: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5190,8 +5190,8 @@ msgid "Done!"
 msgstr "Valmista."
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: spellfile ei sisällä %ld kohtaa"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: spellfile ei sisällä %<PRId64> kohtaa"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5208,8 +5208,8 @@ msgid "Sorry, no suggestions"
 msgstr "Sori, ei ehdotuksia"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Sori, vain %ld ehdotusta"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Sori, vain %<PRId64> ehdotusta"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5506,8 +5506,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Muotovirh tägitiedostossa %s"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Ennen tavua %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Ennen tavua %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5655,8 +5655,8 @@ msgid "Already at newest change"
 msgstr "Nuorimmassa muutoksessa"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Kumouslukua %ld ei löydy"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Kumouslukua %<PRId64> ei löydy"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: väärät rivinumerot"
@@ -5681,8 +5681,8 @@ msgstr "muutosta"
 
 # eka %s yläpuolelta, toka %s alapuolelta, kolmas %s aika
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s, %s #%ld %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s, %s #%<PRId64> %s"
 
 msgid "before"
 msgstr "ennen muutosta"
@@ -5697,8 +5697,8 @@ msgid "number changes  time            saved"
 msgstr "muutoksia       aika            tallennettu"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld sekuntia sitten"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> sekuntia sitten"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin ei toimi undon jälkeen"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -2058,8 +2058,8 @@ msgid "1 character"
 msgstr "1 caractère"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld caractères"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> caractères"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -99,8 +99,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Aucun tampon n'est listé"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Le tampon %ld n'existe pas"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Le tampon %<PRId64> n'existe pas"
 
 # AB - Je ne suis pas sûr que l'on puisse obtenir ce message.
 msgid "E87: Cannot go beyond last buffer"
@@ -111,9 +111,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Impossible d'aller avant le premier tampon"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Le tampon %ld n'a pas été enregistré (ajoutez ! pour passer outre)"
+"E89: Le tampon %<PRId64> n'a pas été enregistré (ajoutez ! pour passer outre)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Impossible de décharger le dernier tampon"
@@ -124,8 +124,8 @@ msgstr "W14: Alerte : La liste des noms de fichier déborde"
 # AB - Vu le code source, la version française est meilleure que la
 #      version anglaise. Ce message est similaire au message E86.
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Le tampon %ld n'existe pas"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Le tampon %<PRId64> n'existe pas"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
 #, c-format
@@ -137,8 +137,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Aucun tampon ne correspond à %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "ligne %ld"
+msgid "line %<PRId64>"
+msgstr "ligne %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Un tampon porte déjà ce nom"
@@ -166,14 +166,14 @@ msgid "1 line --%d%%--"
 msgstr "1 ligne --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld lignes --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> lignes --%d%%--"
 
 # AB - Faut-il remplacer "sur" par "de" ?
 # DB - Mon avis : oui.
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "ligne %ld sur %ld --%d%%-- col "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "ligne %<PRId64> sur %<PRId64> --%d%%-- col "
 
 # DB - Je trouvais [Aucun fichier] (VO : [No file]) plus naturel
 #      lors du lancement de Vim en mode graphique (ce message
@@ -227,16 +227,16 @@ msgid "Signs for %s:"
 msgstr "Symboles dans %s :"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    ligne=%ld  id=%d  nom=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    ligne=%<PRId64>  id=%d  nom=%s"
 
 # AB - Je n'ai pas trouvé de traduction satisfaisante au verbe "diff". Comme
 #      Vim fait en pratique appel au programme "diff" pour evaluer les
 #      différences entre fichiers, "to diff" a été traduit par "utiliser diff"
 #      et d'autres expressions appropriées.
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Impossible d'utiliser diff sur plus de %ld tampons"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Impossible d'utiliser diff sur plus de %<PRId64> tampons"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Impossible de lire ou écrire des fichiers temporaires"
@@ -430,8 +430,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Caractères inattendus avant '='"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: index de Liste hors limites : %ld au-delà de la fin"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: index de Liste hors limites : %<PRId64> au-delà de la fin"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -877,8 +877,8 @@ msgstr "%s annulée"
 
 # AB - Ce texte fait partie d'un message de débogage.
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s a retourné #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s a retourné #%<PRId64>"
 
 # AB - Ce texte fait partie d'un message de débogage.
 #, c-format
@@ -934,12 +934,12 @@ msgid "1 line moved"
 msgstr "1 ligne déplacée"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld lignes déplacées"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> lignes déplacées"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld lignes filtrées"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> lignes filtrées"
 
 # AB - J'ai volontairement omis l'astérisque initiale car je pense que le
 #      motif "Filter*" décrit plus clairement les quatre autocommandes liées
@@ -1064,8 +1064,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Le fichier d'échange %s existe déjà (:silent! pour passer outre)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Pas de nom de fichier pour le tampon %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Pas de nom de fichier pour le tampon %<PRId64>"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
 msgid "E142: File not written: Writing is disabled by 'write' option"
@@ -1137,19 +1137,19 @@ msgid "1 substitution"
 msgstr "1 substitution"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld correspondances"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> correspondances"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld substitutions"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> substitutions"
 
 msgid " on 1 line"
 msgstr " sur 1 ligne"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " sur %ld lignes"
+msgid " on %<PRId64> lines"
+msgstr " sur %<PRId64> lignes"
 
 # AB - Il faut respecter l'esprit plus que la lettre.
 # AB - Ce message devrait contenir une référence à :vglobal.
@@ -1264,8 +1264,8 @@ msgstr "E158: Le tampon %s est introuvable"
 # AB - Vu le code source, la version française est meilleure que la
 #      version anglaise.
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Le symbole %ld est introuvable"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Le symbole %<PRId64> est introuvable"
 
 msgid " (NOT FOUND)"
 msgstr "  (INTROUVABLE)"
@@ -1282,16 +1282,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Mode débogage activé. Tapez \"cont\" pour continuer."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "ligne %ld : %s"
+msgid "line %<PRId64>: %s"
+msgstr "ligne %<PRId64> : %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "cmde : %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Point d'arrêt dans %s%s ligne %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Point d'arrêt dans %s%s ligne %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1303,8 +1303,8 @@ msgstr "Aucun point d'arrêt n'est défini"
 # AB - Le deuxième %s est remplacé par "func" ou "file" sans que l'on puisse
 #      traduire ces mots.
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  ligne %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  ligne %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Utilisez d'abord \":profile start {nomfichier}\""
@@ -1365,16 +1365,16 @@ msgid "could not source \"%s\""
 msgstr "impossible de sourcer \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "ligne %ld : impossible de sourcer \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "ligne %<PRId64> : impossible de sourcer \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "sourcement \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "ligne %ld : sourcement de \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "ligne %<PRId64> : sourcement de \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1465,8 +1465,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: encore 1 fichier à éditer"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: encore %ld fichiers à éditer"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: encore %<PRId64> fichiers à éditer"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: La commande existe déjà : ajoutez ! pour la redéfinir"
@@ -1661,8 +1661,8 @@ msgid "Exception discarded: %s"
 msgstr "Exception éliminée : %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, ligne %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, ligne %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1878,12 +1878,12 @@ msgid "[crypted]"
 msgstr "[chiffré]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ERREUR DE CONVERSION à la ligne %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ERREUR DE CONVERSION à la ligne %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[OCTET INVALIDE à la ligne %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[OCTET INVALIDE à la ligne %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[ERREURS DE LECTURE]"
@@ -1973,10 +1973,10 @@ msgstr ""
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Erreur d'écriture, échec de conversion à la ligne %ld (videz 'fenc' "
+"E513: Erreur d'écriture, échec de conversion à la ligne %<PRId64> (videz 'fenc' "
 "pour passer outre)"
 
 msgid "E514: write error (file system full?)"
@@ -1986,8 +1986,8 @@ msgid " CONVERSION ERROR"
 msgstr " ERREUR DE CONVERSION"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " à la ligne %ld"
+msgid " in line %<PRId64>;"
+msgstr " à la ligne %<PRId64>"
 
 msgid "[Device]"
 msgstr "[Périph.]"
@@ -2051,8 +2051,8 @@ msgid "1 line, "
 msgstr "1 ligne, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld lignes, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> lignes, "
 
 msgid "1 character"
 msgstr "1 caractère"
@@ -2063,8 +2063,8 @@ msgstr "%<PRId64> caractères"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld caractères"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> caractères"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2502,19 +2502,19 @@ msgid "Font1: %s\n"
 msgstr "Font1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "La largeur de Font%ld n'est pas le double de celle de Font0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "La largeur de Font%<PRId64> n'est pas le double de celle de Font0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Largeur de Font0 : %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Largeur de Font0 : %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Largeur de Font1 : %ld\n"
+"Largeur de Font1 : %<PRId64>\n"
 "\n"
 
 # DB - todo : Pas certain de mon coup, ici...
@@ -2697,8 +2697,8 @@ msgid "Added cscope database %s"
 msgstr "Base de données cscope %s ajoutée"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: erreur lors de la lecture de la connexion cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: erreur lors de la lecture de la connexion cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: type de recherche cscope inconnu"
@@ -3938,12 +3938,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Échec de la préservation"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get : numéro de ligne invalide : %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get : numéro de ligne invalide : %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get : ligne %ld introuvable"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get : ligne %<PRId64> introuvable"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: mauvais id de pointeur de bloc 3"
@@ -3961,8 +3961,8 @@ msgid "deleted block 1?"
 msgstr "bloc 1 effacé ?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Ligne %ld introuvable"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Ligne %<PRId64> introuvable"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: mauvais id de pointeur de bloc"
@@ -3971,12 +3971,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count vaut zéro"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: numéro de ligne hors limites : %ld au-delà de la fin"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: numéro de ligne hors limites : %<PRId64> au-delà de la fin"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: nombre de lignes erroné dans le bloc %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: nombre de lignes erroné dans le bloc %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "La taille de la pile s'accroît"
@@ -4163,8 +4163,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Appuyez sur ENTRÉE ou tapez une commande pour continuer"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s, ligne %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s, ligne %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Plus --"
@@ -4236,12 +4236,12 @@ msgid "1 line less"
 msgstr "1 ligne en moins"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld lignes en plus"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> lignes en plus"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld lignes en moins"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> lignes en moins"
 
 msgid " (Interrupted)"
 msgstr " (Interrompu)"
@@ -4279,8 +4279,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: La ligne devient trop longue"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Erreur interne : lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Erreur interne : lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4358,8 +4358,8 @@ msgid "read from Netbeans socket"
 msgstr "read sur la socket Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Connexion NetBeans perdue pour le tampon %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Connexion NetBeans perdue pour le tampon %<PRId64>"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: netbeans n'est pas supporté avec cette interface graphique"
@@ -4411,23 +4411,23 @@ msgid "1 line %sed %d times"
 msgstr "1 ligne %sée %d fois"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld lignes %sées 1 fois"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> lignes %sées 1 fois"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld lignes %sées %d fois"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> lignes %sées %d fois"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld lignes à indenter... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> lignes à indenter... "
 
 msgid "1 line indented "
 msgstr "1 ligne indentée "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld lignes indentées "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> lignes indentées "
 
 msgid "E748: No previously used register"
 msgstr "E748: Aucun registre n'a été précédemment utilisé"
@@ -4441,12 +4441,12 @@ msgid "1 line changed"
 msgstr "1 ligne modifiée"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld lignes modifiées"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> lignes modifiées"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "libération de %ld lignes"
+msgid "freeing %<PRId64> lines"
+msgstr "libération de %<PRId64> lignes"
 
 msgid "block of 1 line yanked"
 msgstr "bloc de 1 ligne copié"
@@ -4455,12 +4455,12 @@ msgid "1 line yanked"
 msgstr "1 ligne copiée"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "bloc de %ld lignes copié"
+msgid "block of %<PRId64> lines yanked"
+msgstr "bloc de %<PRId64> lignes copié"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld lignes copiées"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> lignes copiées"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4489,38 +4489,38 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Type de registre %d inconnu"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Colonnes ; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Colonnes ; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
 msgstr ""
-"%s%ld sur %ld Lignes ; %ld sur %ld Mots ; %ld sur %ld Octets sélectionnés"
+"%s%<PRId64> sur %<PRId64> Lignes ; %<PRId64> sur %<PRId64> Mots ; %<PRId64> sur %<PRId64> Octets sélectionnés"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"%s%ld sur %ld Lignes ; %ld sur %ld Mots ; %ld sur %ld Caractères ; %ld sur "
-"%ld octets sélectionnés"
+"%s%<PRId64> sur %<PRId64> Lignes ; %<PRId64> sur %<PRId64> Mots ; %<PRId64> sur %<PRId64> Caractères ; %<PRId64> sur "
+"%<PRId64> octets sélectionnés"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
 msgstr ""
-"Colonne %s sur %s ; Ligne %ld sur %ld ; Mot %ld sur %ld ; Octet %ld sur %ld"
+"Colonne %s sur %s ; Ligne %<PRId64> sur %<PRId64> ; Mot %<PRId64> sur %<PRId64> ; Octet %<PRId64> sur %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Colonne %s sur %s ; Ligne %ld sur %ld ; Mot %ld sur %ld ; Caractère %ld sur "
-"%ld ; Octet %ld sur %ld"
+"Colonne %s sur %s ; Ligne %<PRId64> sur %<PRId64> ; Mot %<PRId64> sur %<PRId64> ; Caractère %<PRId64> sur "
+"%<PRId64> ; Octet %<PRId64> sur %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld pour le BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> pour le BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Page %N"
@@ -4705,8 +4705,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Amigados version 2.04 ou ultérieure est nécessaire\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "%s version %ld est nécessaire\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "%s version %<PRId64> est nécessaire\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Impossible d'ouvrir NIL :\n"
@@ -4789,8 +4789,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim : Signal mortel intercepté\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "L'ouverture du display X a pris %ld ms"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "L'ouverture du display X a pris %<PRId64> ms"
 
 msgid ""
 "\n"
@@ -5566,8 +5566,8 @@ msgid "Performing soundfolding..."
 msgstr "Analyse phonétique en cours..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Nombre de mots après l'analyse phonétique : %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Nombre de mots après l'analyse phonétique : %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5603,8 +5603,8 @@ msgstr "Terminé !"
 
 # DB - todo : perfectible.
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' n'a pas %ld entrées"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' n'a pas %<PRId64> entrées"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5622,8 +5622,8 @@ msgid "Sorry, no suggestions"
 msgstr "Désolé, aucune suggestion"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Désolé, seulement %ld suggestions"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Désolé, seulement %<PRId64> suggestions"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5941,8 +5941,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Erreur de format dans le fichier de marqueurs \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Avant l'octet %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Avant l'octet %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -6093,8 +6093,8 @@ msgid "Already at newest change"
 msgstr "Déjà à la modification la plus récente"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Annulation n° %ld introuvable"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Annulation n° %<PRId64> introuvable"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo : numéros de ligne erronés"
@@ -6118,8 +6118,8 @@ msgid "changes"
 msgstr "modifications"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s ; %s #%ld ; %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s ; %s #%<PRId64> ; %s"
 
 msgid "before"
 msgstr "avant"
@@ -6135,8 +6135,8 @@ msgid "number changes  when               saved"
 msgstr "numéro modif.   instant            enregistré"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "il y a %ld secondes"
+msgid "%<PRId64> seconds ago"
+msgstr "il y a %<PRId64> secondes"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin n'est pas autorisé après une annulation"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -4262,17 +4262,17 @@ msgstr "ERREUR : "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[octets] total alloué-libéré %lu-%lu, utilisé %lu, pic %lu\n"
+"[octets] total alloué-libéré %<PRIu64>-%<PRIu64>, utilisé %<PRIu64>, pic %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[appels] total re/malloc() %lu, total free() %lu\n"
+"[appels] total re/malloc() %<PRIu64>, total free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4283,8 +4283,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Erreur interne : lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Mémoire épuisée ! (allocation de %lu octets)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Mémoire épuisée ! (allocation de %<PRIu64> octets)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/ga.po
+++ b/src/po/ga.po
@@ -58,8 +58,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Níl aon mhaolán liostaithe ann"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Níl a leithéid de mhaolán %ld"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Níl a leithéid de mhaolán %<PRId64>"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Ní féidir a dhul thar an maolán deireanach"
@@ -68,9 +68,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Ní féidir a dhul roimh an chéad mhaolán"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Athraíodh maolán %ld ach nach bhfuil sé sábháilte ó shin (cuir ! leis "
+"E89: Athraíodh maolán %<PRId64> ach nach bhfuil sé sábháilte ó shin (cuir ! leis "
 "an ordú chun sárú)"
 
 msgid "E90: Cannot unload last buffer"
@@ -80,8 +80,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Rabhadh: Liosta ainmneacha comhaid thar maoil"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Maolán %ld gan aimsiú"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Maolán %<PRId64> gan aimsiú"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -92,8 +92,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Níl aon mhaolán comhoiriúnaithe le %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "líne %ld:"
+msgid "line %<PRId64>"
+msgstr "líne %<PRId64>:"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Tá maolán ann leis an ainm seo cheana"
@@ -118,12 +118,12 @@ msgid "1 line --%d%%--"
 msgstr "1 líne --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld líne --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> líne --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "líne %ld de %ld --%d%%-- col "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "líne %<PRId64> de %<PRId64> --%d%%-- col "
 
 msgid "[No Name]"
 msgstr "[Gan Ainm]"
@@ -176,12 +176,12 @@ msgid "Signs for %s:"
 msgstr "Comharthaí do %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    líne=%ld  id=%d  ainm=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    líne=%<PRId64>  id=%d  ainm=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Ní féidir diff a dhéanamh ar níos mó ná %ld maolán"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Ní féidir diff a dhéanamh ar níos mó ná %<PRId64> maolán"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Ní féidir comhaid shealadacha a léamh nó a scríobh"
@@ -335,8 +335,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Carachtair gan choinne i :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: innéacs liosta as raon: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: innéacs liosta as raon: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -720,8 +720,8 @@ msgid "%s aborted"
 msgstr "%s tobscortha"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s ag aisfhilleadh #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s ag aisfhilleadh #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -771,12 +771,12 @@ msgid "1 line moved"
 msgstr "Bogadh líne amháin"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "Bogadh %ld líne"
+msgid "%<PRId64> lines moved"
+msgstr "Bogadh %<PRId64> líne"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "Scagadh %ld líne"
+msgid "%<PRId64> lines filtered"
+msgstr "Scagadh %<PRId64> líne"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr ""
@@ -864,8 +864,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Tá comhad babhtála ann cheana: %s (úsáid :silent! chun sárú)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Níl aon ainm ar mhaolán %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Níl aon ainm ar mhaolán %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Níor scríobhadh an comhad: díchumasaithe leis an rogha 'write'"
@@ -923,19 +923,19 @@ msgid "1 substitution"
 msgstr "1 ionadaíocht"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld rud comhoiriúnach"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> rud comhoiriúnach"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld ionadaíocht"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> ionadaíocht"
 
 msgid " on 1 line"
 msgstr " ar líne amháin"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " ar %ld líne"
+msgid " on %<PRId64> lines"
+msgstr " ar %<PRId64> líne"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Ní cheadaítear :global go hathchúrsach"
@@ -1019,8 +1019,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ainm maoláin neamhbhailí: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: ID neamhbhailí comhartha: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: ID neamhbhailí comhartha: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (AR IARRAIDH)"
@@ -1035,16 +1035,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Mód dífhabhtaithe á thosú.  Clóscríobh \"cont\" chun leanúint."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "líne %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "líne %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "ordú: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Brisphointe i \"%s%s\" líne %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Brisphointe i \"%s%s\" líne %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1054,8 +1054,8 @@ msgid "No breakpoints defined"
 msgstr "Níl aon bhrisphointe socraithe"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  líne %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  líne %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Úsáid \":profile start {ainm}\" ar dtús"
@@ -1111,16 +1111,16 @@ msgid "could not source \"%s\""
 msgstr "níorbh fhéidir \"%s\" a léamh"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "líne %ld: níorbh fhéidir \"%s\" a fhoinsiú"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "líne %<PRId64>: níorbh fhéidir \"%s\" a fhoinsiú"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" á fhoinsiú"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "líne %ld: \"%s\" á fhoinsiú"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "líne %<PRId64>: \"%s\" á fhoinsiú"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1211,8 +1211,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 chomhad le heagrú fós"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: %ld comhad le cur in eagar"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: %<PRId64> comhad le cur in eagar"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Tá an t-ordú ann cheana: cuir ! leis chun sárú"
@@ -1401,8 +1401,8 @@ msgid "Exception discarded: %s"
 msgstr "Eisceacht curtha i leataobh: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, líne %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, líne %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1610,12 +1610,12 @@ msgid "[crypted]"
 msgstr "[criptithe]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[EARRÁID TIONTAITHE i líne %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[EARRÁID TIONTAITHE i líne %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[BEART NEAMHCHEADAITHE i líne %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[BEART NEAMHCHEADAITHE i líne %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[EARRÁIDÍ LÉIMH]"
@@ -1701,10 +1701,10 @@ msgstr ""
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: earráid le linn scríofa, theip ar thiontú ar líne %ld (úsáid 'fenc' folamh le "
+"E513: earráid le linn scríofa, theip ar thiontú ar líne %<PRId64> (úsáid 'fenc' folamh le "
 "sárú)"
 
 msgid "E514: write error (file system full?)"
@@ -1714,8 +1714,8 @@ msgid " CONVERSION ERROR"
 msgstr " EARRÁID TIONTAITHE"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " ar líne %ld;"
+msgid " in line %<PRId64>;"
+msgstr " ar líne %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Gléas]"
@@ -1776,15 +1776,15 @@ msgid "1 line, "
 msgstr "1 líne, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld líne, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> líne, "
 
 msgid "1 character"
 msgstr "1 carachtar"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld carachtar"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> carachtar"
 
 msgid "[noeol]"
 msgstr "[ganEOL]"
@@ -2202,19 +2202,19 @@ msgid "Font1: %s\n"
 msgstr "Cló1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Níl Cló%ld níos leithne faoi dhó ná cló0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Níl Cló%<PRId64> níos leithne faoi dhó ná cló0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Leithead Cló0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Leithead Cló0: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Leithead Cló1: %ld\n"
+"Leithead Cló1: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2392,8 +2392,8 @@ msgid "Added cscope database %s"
 msgstr "Bunachar sonraí nua cscope: %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: earráid agus an nasc cscope %ld á léamh"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: earráid agus an nasc cscope %<PRId64> á léamh"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: cineál anaithnid cuardaigh cscope"
@@ -3636,12 +3636,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Theip ar chaomhnú"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: lnum neamhbhailí: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: lnum neamhbhailí: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: líne %ld gan aimsiú"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: líne %<PRId64> gan aimsiú"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: aitheantas mícheart ar an mbloc pointeora 3"
@@ -3659,8 +3659,8 @@ msgid "deleted block 1?"
 msgstr "bloc a haon scriosta?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Líne %ld gan aimsiú"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Líne %<PRId64> gan aimsiú"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: aitheantas mícheart ar an mbloc pointeora"
@@ -3669,12 +3669,12 @@ msgid "pe_line_count is zero"
 msgstr "is 0 pe_line_count\""
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: líne-uimhir as raon: %ld thar dheireadh"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: líne-uimhir as raon: %<PRId64> thar dheireadh"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: líon mícheart na línte i mbloc %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: líon mícheart na línte i mbloc %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Méadaíonn an chruach"
@@ -3866,8 +3866,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Brúigh ENTER nó iontráil ordú le leanúint"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s líne %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s líne %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Tuilleadh --"
@@ -3938,12 +3938,12 @@ msgid "1 line less"
 msgstr "1 líne níos lú"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld líne eile"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> líne eile"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld líne níos lú"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> líne níos lú"
 
 msgid " (Interrupted)"
 msgstr " (Idirbhriste)"
@@ -3982,8 +3982,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Tá an líne ag éirí rófhada"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Earráid inmheánach: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Earráid inmheánach: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4055,8 +4055,8 @@ msgid "read from Netbeans socket"
 msgstr "léadh ó shoicéad Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Cailleadh nasc NetBeans le haghaidh maoláin %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Cailleadh nasc NetBeans le haghaidh maoláin %<PRId64>"
 
 msgid "E505: "
 msgstr "E505: "
@@ -4103,24 +4103,24 @@ msgstr "1 líne %s %d uair"
 
 # ouch - English -ed ?
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld líne %sed uair amháin"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> líne %sed uair amháin"
 
 # ouch - English -ed ?
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld líne %sed %d uair"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> líne %sed %d uair"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld líne le heangú... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> líne le heangú... "
 
 msgid "1 line indented "
 msgstr "eangaíodh líne amháin "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld líne eangaithe "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> líne eangaithe "
 
 msgid "E748: No previously used register"
 msgstr "E748: Níl aon tabhall úsáidte roimhe seo"
@@ -4133,12 +4133,12 @@ msgid "1 line changed"
 msgstr "athraíodh líne amháin"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "athraíodh %ld líne"
+msgid "%<PRId64> lines changed"
+msgstr "athraíodh %<PRId64> líne"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "%ld líne á saoradh"
+msgid "freeing %<PRId64> lines"
+msgstr "%<PRId64> líne á saoradh"
 
 msgid "block of 1 line yanked"
 msgstr "sracadh bloc de líne amháin"
@@ -4147,12 +4147,12 @@ msgid "1 line yanked"
 msgstr "sracadh líne amháin"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "sracadh bloc de %ld líne"
+msgid "block of %<PRId64> lines yanked"
+msgstr "sracadh bloc de %<PRId64> líne"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld líne sractha"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> líne sractha"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4182,36 +4182,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Cineál anaithnid tabhaill %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Colún; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Colún; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Roghnaíodh %s%ld as %ld Líne; %ld as %ld Focal; %ld as %ld Beart"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Roghnaíodh %s%<PRId64> as %<PRId64> Líne; %<PRId64> as %<PRId64> Focal; %<PRId64> as %<PRId64> Beart"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Roghnaíodh %s%ld as %ld Líne; %ld as %ld Focal; %ld as %ld Carachtar; %ld as "
-"%ld Beart"
+"Roghnaíodh %s%<PRId64> as %<PRId64> Líne; %<PRId64> as %<PRId64> Focal; %<PRId64> as %<PRId64> Carachtar; %<PRId64> as "
+"%<PRId64> Beart"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Col %s as %s; Líne %ld as %ld; Focal %ld as %ld; Beart %ld as %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Col %s as %s; Líne %<PRId64> as %<PRId64>; Focal %<PRId64> as %<PRId64>; Beart %<PRId64> as %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Col %s as %s; Líne %ld as %ld; Focal %ld as %ld; Carachtar %ld as %ld; Beart "
-"%ld as %ld"
+"Col %s as %s; Líne %<PRId64> as %<PRId64>; Focal %<PRId64> as %<PRId64>; Carachtar %<PRId64> as %<PRId64>; Beart "
+"%<PRId64> as %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld do BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> do BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Leathanach %N"
@@ -4388,8 +4388,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Tá gá le Amigados leagan 2.04 nó níos déanaí\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Tá gá le %s, leagan %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Tá gá le %s, leagan %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Ní féidir NIL a oscailt:\n"
@@ -4473,8 +4473,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Fuarthas comhartha marfach\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Thóg %ld ms chun an scáileán X a oscailt"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Thóg %<PRId64> ms chun an scáileán X a oscailt"
 
 msgid ""
 "\n"
@@ -5161,8 +5161,8 @@ msgid "Performing soundfolding..."
 msgstr "Fuaimfhilleadh..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Líon na bhfocal tar éis fuaimfhillte: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Líon na bhfocal tar éis fuaimfhillte: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5197,8 +5197,8 @@ msgid "Done!"
 msgstr "Críochnaithe!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: níl %ld iontráil i 'spellfile'"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: níl %<PRId64> iontráil i 'spellfile'"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5215,8 +5215,8 @@ msgid "Sorry, no suggestions"
 msgstr "Tá brón orm, níl aon mholadh ann"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Tá brón orm, níl ach %ld moladh ann"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Tá brón orm, níl ach %<PRId64> moladh ann"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5517,8 +5517,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Earráid fhormáide i gcomhad clibeanna \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Roimh bheart %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Roimh bheart %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5587,8 +5587,8 @@ msgid "Already at newest change"
 msgstr "Ag an athrú is nuaí cheana"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "Níor aimsíodh cealú uimhir a %ld"
+msgid "Undo number %<PRId64> not found"
+msgstr "Níor aimsíodh cealú uimhir a %<PRId64>"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: líne-uimhreacha míchearta"
@@ -5612,8 +5612,8 @@ msgid "changes"
 msgstr "athrú"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "roimh"
@@ -5629,8 +5629,8 @@ msgid "number changes  time"
 msgstr "uimhir athruithe  am"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld soicind ó shin"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> soicind ó shin"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: ní cheadaítear \"undojoin\" tar éis \"undo\""
@@ -6454,8 +6454,8 @@ msgstr "Buaileadh an BUN le linn an chuardaigh, ag leanúint ag an BHARR"
 #~ msgstr ""
 #~ "Ní mór do charachtar a úsáidtear ar SLASH a bheith ASCII; i %s líne %d: %s"
 
-#~ msgid "%ld changes"
-#~ msgstr "%ld athrú"
+#~ msgid "%<PRId64> changes"
+#~ msgstr "%<PRId64> athrú"
 
 #~ msgid "with KDE GUI."
 #~ msgstr "le GUI KDE."

--- a/src/po/ga.po
+++ b/src/po/ga.po
@@ -3965,17 +3965,17 @@ msgstr "EARRÁID: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[beart] iomlán dáilte-saor %lu-%lu, in úsáid %lu, buaic %lu\n"
+"[beart] iomlán dáilte-saor %<PRIu64>-%<PRIu64>, in úsáid %<PRIu64>, buaic %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[glaonna] re/malloc(): %lu, free(): %lu\n"
+"[glaonna] re/malloc(): %<PRIu64>, free(): %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3986,8 +3986,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Earráid inmheánach: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Cuimhne ídithe!  (%lu beart á ndáileadh)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Cuimhne ídithe!  (%<PRIu64> beart á ndáileadh)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -4001,17 +4001,17 @@ msgstr "ERRORE: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[byte] totali alloc-rilasc %lu-%lu, in uso %lu, max uso %lu\n"
+"[byte] totali alloc-rilasc %<PRIu64>-%<PRIu64>, in uso %<PRIu64>, max uso %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[chiamate] totale re/malloc() %lu, totale free() %lu\n"
+"[chiamate] totale re/malloc() %<PRIu64>, totale free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4022,8 +4022,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Errore interno: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Non c'è più memoria! (stavo allocando %lu byte)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Non c'è più memoria! (stavo allocando %<PRIu64> byte)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -1859,8 +1859,8 @@ msgid "1 character"
 msgstr "1 carattere"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld caratteri"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> caratteri"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -92,8 +92,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Non c'è alcun buffer elencato"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Non esiste il buffer %ld"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Non esiste il buffer %<PRId64>"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Non posso oltrepassare l'ultimo buffer"
@@ -102,9 +102,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Non posso andare prima del primo buffer"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Buffer %ld non salvato dopo modifica (aggiungi ! per eseguire comunque)"
+"E89: Buffer %<PRId64> non salvato dopo modifica (aggiungi ! per eseguire comunque)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Non riesco a scaricare l'ultimo buffer"
@@ -113,8 +113,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Attenzione: Superato limite della lista dei nomi di file"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Buffer %ld non trovato"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Buffer %<PRId64> non trovato"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -125,8 +125,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Nessun buffer corrispondente a %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "linea %ld"
+msgid "line %<PRId64>"
+msgstr "linea %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: C'è già un buffer con questo nome"
@@ -152,11 +152,11 @@ msgstr "[in sola lettura]"
 msgid "1 line --%d%%--"
 msgstr "1 linea --%d%%--"
 
-msgid "%ld lines --%d%%--"
-msgstr "%ld linee --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> linee --%d%%--"
 
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "linea %ld di %ld --%d%%-- col "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "linea %<PRId64> di %<PRId64> --%d%%-- col "
 
 msgid "[No Name]"
 msgstr "[Senza nome]"
@@ -202,12 +202,12 @@ msgid "Signs for %s:"
 msgstr "Segni per %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    linea=%ld id=%d, nome=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    linea=%<PRId64> id=%d, nome=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Non supporto differenze fra più di %ld buffer"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Non supporto differenze fra più di %<PRId64> buffer"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Non riesco a leggere o scrivere file temporanei"
@@ -365,8 +365,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Caratteri non previsti in :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: indice lista fuori intervallo: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: indice lista fuori intervallo: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -782,8 +782,8 @@ msgid "%s aborted"
 msgstr "%s non completata"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s ritorno #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s ritorno #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -832,12 +832,12 @@ msgid "1 line moved"
 msgstr "1 linea mossa"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld linee mosse"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> linee mosse"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld linee filtrate"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> linee filtrate"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Gli autocomandi non devono modificare il buffer in uso"
@@ -921,8 +921,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: File swap esistente: %s (:silent! per sovrascriverlo)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Manca nome file per il buffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Manca nome file per il buffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: File non scritto: Scrittura inibita da opzione 'write'"
@@ -980,19 +980,19 @@ msgid "1 substitution"
 msgstr "1 sostituzione"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld corrisp."
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> corrisp."
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld sostituzioni"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> sostituzioni"
 
 msgid " on 1 line"
 msgstr " in 1 linea"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " in %ld linee"
+msgid " on %<PRId64> lines"
+msgstr " in %<PRId64> linee"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global non può essere usato ricorsivamente"
@@ -1078,8 +1078,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Nome buffer non valido: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: ID 'sign' non valido: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: ID 'sign' non valido: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NON TROVATO)"
@@ -1094,16 +1094,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Entro modalità Debug.  Batti \"cont\" per continuare."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "linea %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "linea %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "com: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Pausa in \"%s%s\" linea %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Pausa in \"%s%s\" linea %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1113,8 +1113,8 @@ msgid "No breakpoints defined"
 msgstr "Nessun 'breakpoint' definito"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s linea %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s linea %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Usare prima \":profile start {fname}\""
@@ -1172,16 +1172,16 @@ msgid "could not source \"%s\""
 msgstr "non riesco ad eseguire \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "linea %ld: non riesco ad eseguire \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "linea %<PRId64>: non riesco ad eseguire \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "eseguo \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "linea %ld: eseguo \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "linea %<PRId64>: eseguo \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1270,8 +1270,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: ancora 1 file da elaborare"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: ancora %ld file da elaborare"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: ancora %<PRId64> file da elaborare"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Il comando esiste già: aggiungi ! per sostituirlo"
@@ -1472,8 +1472,8 @@ msgid "Exception discarded: %s"
 msgstr "Eccezione scartata: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, linea %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, linea %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1677,12 +1677,12 @@ msgid "[crypted]"
 msgstr "[cifrato]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ERRORE DI CONVERSIONE alla linea %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ERRORE DI CONVERSIONE alla linea %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[BYTE NON VALIDO alla linea %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[BYTE NON VALIDO alla linea %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[ERRORI IN LETTURA]"
@@ -1777,10 +1777,10 @@ msgstr ""
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: errore in scrittura, conversione fallita alla linea %ld (rendere "
+"E513: errore in scrittura, conversione fallita alla linea %<PRId64> (rendere "
 "'fenc' nullo per eseguire comunque)"
 
 msgid "E514: write error (file system full?)"
@@ -1790,8 +1790,8 @@ msgid " CONVERSION ERROR"
 msgstr " ERRORE DI CONVERSIONE"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " alla linea %ld;"
+msgid " in line %<PRId64>;"
+msgstr " alla linea %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Dispositivo]"
@@ -1852,8 +1852,8 @@ msgid "1 line, "
 msgstr "1 linea, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld linee,"
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> linee,"
 
 msgid "1 character"
 msgstr "1 carattere"
@@ -1864,8 +1864,8 @@ msgstr "%<PRId64> caratteri"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld caratteri"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> caratteri"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2280,16 +2280,16 @@ msgid "Font1: %s"
 msgstr "Font1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "La larghezza di font%ld non è doppia di quella di font0"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "La larghezza di font%<PRId64> non è doppia di quella di font0"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "Larghezza di Font0: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "Larghezza di Font0: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "Larghezza di Font1: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "Larghezza di Font1: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "Specifica di font non valida"
@@ -2464,8 +2464,8 @@ msgid "Added cscope database %s"
 msgstr "Aggiunto database cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: errore leggendo connessione cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: errore leggendo connessione cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: tipo di ricerca cscope sconosciuta"
@@ -3680,12 +3680,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Preservazione fallita"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: numero linea non valido: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: numero linea non valido: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: non riesco a trovare la linea %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: non riesco a trovare la linea %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: ID blocco puntatori errato 3"
@@ -3703,8 +3703,8 @@ msgid "deleted block 1?"
 msgstr "cancellato blocco 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Non riesco a trovare la linea %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Non riesco a trovare la linea %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: ID blocco puntatori errato"
@@ -3713,12 +3713,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count a zero"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: numero linea non ammissibile: %ld dopo la fine"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: numero linea non ammissibile: %<PRId64> dopo la fine"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: contatore linee errato nel blocco %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: contatore linee errato nel blocco %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Dimensione stack aumentata"
@@ -3904,8 +3904,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Premi INVIO o un comando per proseguire"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s linea %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s linea %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Ancora --"
@@ -3975,12 +3975,12 @@ msgid "1 line less"
 msgstr "1 linea in meno"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld linee in più"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> linee in più"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld linee in meno"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> linee in meno"
 
 msgid " (Interrupted)"
 msgstr " (Interrotto)"
@@ -4018,8 +4018,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: La linea sta diventando troppo lunga"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Errore interno: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Errore interno: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4095,8 +4095,8 @@ msgid "read from Netbeans socket"
 msgstr "lettura da socket Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Connessione NetBeans persa per il buffer %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Connessione NetBeans persa per il buffer %<PRId64>"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: netbeans non è supportato con questa GUI"
@@ -4147,23 +4147,23 @@ msgid "1 line %sed %d times"
 msgstr "1 linea %sa %d volte"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld linee %se 1 volta"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> linee %se 1 volta"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld linee %se %d volte"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> linee %se %d volte"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld linee da rientrare... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> linee da rientrare... "
 
 msgid "1 line indented "
 msgstr "1 linea rientrata "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld linee rientrate "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> linee rientrate "
 
 msgid "E748: No previously used register"
 msgstr "E748: Nessun registro usato in precedenza"
@@ -4176,12 +4176,12 @@ msgid "1 line changed"
 msgstr "1 linea cambiata"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld linee cambiate"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> linee cambiate"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "libero %ld linee"
+msgid "freeing %<PRId64> lines"
+msgstr "libero %<PRId64> linee"
 
 msgid "block of 1 line yanked"
 msgstr "blocco di 1 linea messo in registro"
@@ -4190,12 +4190,12 @@ msgid "1 line yanked"
 msgstr "1 linea messa in registro"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "blocco di %ld linee messo in registro"
+msgid "block of %<PRId64> lines yanked"
+msgstr "blocco di %<PRId64> linee messo in registro"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld linee messe in registro"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> linee messe in registro"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4224,36 +4224,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Tipo di registro sconosciuto: %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Col.; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Col.; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Selezionate %s%ld di %ld Linee; %ld di %ld Parole; %ld di %ld Caratt."
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Selezionate %s%<PRId64> di %<PRId64> Linee; %<PRId64> di %<PRId64> Parole; %<PRId64> di %<PRId64> Caratt."
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Selezionate %s%ld di %ld Linee; %ld di %ld Parole; %ld di %ld Caratt.; %ld "
-"di %ld Byte"
+"Selezionate %s%<PRId64> di %<PRId64> Linee; %<PRId64> di %<PRId64> Parole; %<PRId64> di %<PRId64> Caratt.; %<PRId64> "
+"di %<PRId64> Byte"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Col. %s di %s; Linea %ld di %ld; Parola %ld di %ld; Caratt. %ld di %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Col. %s di %s; Linea %<PRId64> di %<PRId64>; Parola %<PRId64> di %<PRId64>; Caratt. %<PRId64> di %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Col. %s di %s; Linea %ld di %ld; Parola %ld di %ld; Caratt. %ld di %ld; Byte "
-"%ld di %ld"
+"Col. %s di %s; Linea %<PRId64> di %<PRId64>; Parola %<PRId64> di %<PRId64>; Caratt. %<PRId64> di %<PRId64>; Byte "
+"%<PRId64> di %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld per BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> per BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Pagina %N"
@@ -4435,8 +4435,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Serve Amigados versione 2.04 o successiva\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Serve %s versione %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Serve %s versione %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Non riesco ad aprire NIL:\n"
@@ -4517,8 +4517,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Intercettato segnale fatale\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Attivazione visualizzazione X ha richiesto %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Attivazione visualizzazione X ha richiesto %<PRId64> msec"
 
 msgid ""
 "\n"
@@ -5269,8 +5269,8 @@ msgid "Performing soundfolding..."
 msgstr "Eseguo soundfolding..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Numero di parole dopo soundfolding: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Numero di parole dopo soundfolding: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5305,8 +5305,8 @@ msgid "Done!"
 msgstr "Fatto!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' non ha %ld elementi"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' non ha %<PRId64> elementi"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5323,8 +5323,8 @@ msgid "Sorry, no suggestions"
 msgstr "Spiacente, nessun suggerimento"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Spiacente, solo %ld suggerimenti"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Spiacente, solo %<PRId64> suggerimenti"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5642,8 +5642,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Errore di formato nel tag file \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Prima del byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Prima del byte %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5787,8 +5787,8 @@ msgid "Already at newest change"
 msgstr "Questa è già l'ultima modifica"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Undo numero %ld non trovato"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Undo numero %<PRId64> non trovato"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: numeri linee errati"
@@ -5812,8 +5812,8 @@ msgid "changes"
 msgstr "modifiche"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "prima"
@@ -5828,8 +5828,8 @@ msgid "number changes  when               saved"
 msgstr "numero modif.   quando             salv."
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld secondi fa"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> secondi fa"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin non è consentito dopo undo"

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -91,8 +91,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: リスト表示されるバッファはありません"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: バッファ %ld はありません"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: バッファ %<PRId64> はありません"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 最後のバッファを越えて移動はできません"
@@ -101,8 +101,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 最初のバッファより前へは移動できません"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: バッファ %ld の変更は保存されていません (! で変更を破棄)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: バッファ %<PRId64> の変更は保存されていません (! で変更を破棄)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: 最後のバッファは解放できません"
@@ -111,8 +111,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: ファイル名のリストが長過ぎます"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: バッファ %ld が見つかりません"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: バッファ %<PRId64> が見つかりません"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -123,8 +123,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: %s に該当するバッファはありませんでした"
 
 #, c-format
-msgid "line %ld"
-msgstr "行 %ld"
+msgid "line %<PRId64>"
+msgstr "行 %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: この名前のバッファは既にあります"
@@ -152,12 +152,12 @@ msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld 行 --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> 行 --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "行 %ld (全体 %ld) --%d%%-- col "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "行 %<PRId64> (全体 %<PRId64>) --%d%%-- col "
 
 msgid "[No Name]"
 msgstr "[無名]"
@@ -203,12 +203,12 @@ msgid "Signs for %s:"
 msgstr "%s のサイン:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    行=%ld  識別子=%d  名前=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    行=%<PRId64>  識別子=%d  名前=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: %ld 以上のバッファはdiffできません"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: %<PRId64> 以上のバッファはdiffできません"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 一時ファイルの読込もしくは書込ができません"
@@ -367,8 +367,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: 予期せぬ文字が :let にありました"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: リストのインデックスが範囲外です: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: リストのインデックスが範囲外です: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -782,8 +782,8 @@ msgid "%s aborted"
 msgstr "%s が中断されました"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s が #%ld を返しました"
+msgid "%s returning #%<PRId64>"
+msgstr "%s が #%<PRId64> を返しました"
 
 #, c-format
 msgid "%s returning %s"
@@ -832,12 +832,12 @@ msgid "1 line moved"
 msgstr "1 行が移動されました"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld 行が移動されました"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> 行が移動されました"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld 行がフィルタ処理されました"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> 行がフィルタ処理されました"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *フィルタ* autocommandは現在のバッファを変更してはいけません"
@@ -921,8 +921,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: スワップファイルが存在します: %s (:silent! を追加で上書)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: バッファ %ld には名前がありません"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: バッファ %<PRId64> には名前がありません"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: ファイルは保存されませんでした: 'write' オプションにより無効です"
@@ -979,19 +979,19 @@ msgid "1 substitution"
 msgstr "1 箇所置換しました"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld 箇所該当しました"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> 箇所該当しました"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld 箇所置換しました"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> 箇所置換しました"
 
 msgid " on 1 line"
 msgstr " (計 1 行内)"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " (計 %ld 行内)"
+msgid " on %<PRId64> lines"
+msgstr " (計 %<PRId64> 行内)"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global を再帰的には使えません"
@@ -1078,8 +1078,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 無効なバッファ名です: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: 無効なsign識別子です: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: 無効なsign識別子です: %<PRId64>"
 
 # Added at 27-Jan-2004.
 msgid " (NOT FOUND)"
@@ -1095,16 +1095,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "デバッグモードに入ります. 続けるには \"cont\" と入力してください."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "行 %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "行 %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "コマンド: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "ブレークポイント \"%s%s\" 行 %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "ブレークポイント \"%s%s\" 行 %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1114,8 +1114,8 @@ msgid "No breakpoints defined"
 msgstr "ブレークポイントが定義されていません"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  行 %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  行 %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 初めに \":profile start {fname}\" を実行してください"
@@ -1171,16 +1171,16 @@ msgid "could not source \"%s\""
 msgstr "\"%s\" を取込めません"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "行 %ld: \"%s\" を取込めません"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "行 %<PRId64>: \"%s\" を取込めません"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" を取込中"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "行 %ld: %s を取込中"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "行 %<PRId64>: %s を取込中"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1269,8 +1269,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 編集すべきファイルが 1 個あります"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 編集すべきファイルがあと %ld 個あります"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 編集すべきファイルがあと %<PRId64> 個あります"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: コマンドが既にあります: 再定義するには ! を追加してください"
@@ -1464,8 +1464,8 @@ msgid "Exception discarded: %s"
 msgstr "例外が破棄されました: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, 行 %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, 行 %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1669,12 +1669,12 @@ msgid "[crypted]"
 msgstr "[暗号化]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[%ld 行目で変換エラー]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[%<PRId64> 行目で変換エラー]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[%ld 行目の不正なバイト]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[%<PRId64> 行目の不正なバイト]"
 
 msgid "[READ ERRORS]"
 msgstr "[読込エラー]"
@@ -1758,10 +1758,10 @@ msgstr "E513: 書込みエラー, 変換失敗 (上書するには 'fenc' を空にしてください)"
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: 書込みエラー, 変換失敗, 行数 %ld (上書するには 'fenc' を空にしてくださ"
+"E513: 書込みエラー, 変換失敗, 行数 %<PRId64> (上書するには 'fenc' を空にしてくださ"
 "い)"
 
 msgid "E514: write error (file system full?)"
@@ -1771,8 +1771,8 @@ msgid " CONVERSION ERROR"
 msgstr " 変換エラー"
 
 #, c-format
-msgid " in line %ld;"
-msgstr "行 %ld;"
+msgid " in line %<PRId64>;"
+msgstr "行 %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[デバイス]"
@@ -1833,8 +1833,8 @@ msgid "1 line, "
 msgstr "1 行, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 行, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 行, "
 
 msgid "1 character"
 msgstr "1 文字"
@@ -1845,8 +1845,8 @@ msgstr "%<PRId64> 文字"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld 文字"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 文字"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2258,16 +2258,16 @@ msgid "Font1: %s"
 msgstr "フォント1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "フォント%ld の幅がフォント0の2倍ではありません"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "フォント%<PRId64> の幅がフォント0の2倍ではありません"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "フォント0の幅: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "フォント0の幅: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "フォント1の幅: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "フォント1の幅: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "無効なフォント指定です"
@@ -2444,8 +2444,8 @@ msgid "Added cscope database %s"
 msgstr "cscopeデータベース %s を追加"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: cscopeの接続 %ld を読込み中のエラーです"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: cscopeの接続 %<PRId64> を読込み中のエラーです"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知のcscope検索型です"
@@ -3661,12 +3661,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 維持に失敗しました"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 無効なlnumです: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 無効なlnumです: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: 行 %ld を見つけられません"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: 行 %<PRId64> を見つけられません"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: ポインタブロックのIDが間違っています 3"
@@ -3684,8 +3684,8 @@ msgid "deleted block 1?"
 msgstr "ブロック 1 は消された?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: 行 %ld が見つかりません"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: 行 %<PRId64> が見つかりません"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: ポインタブロックのIDが間違っています"
@@ -3694,12 +3694,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count がゼロです"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 行番号が範囲外です: %ld 超えています"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 行番号が範囲外です: %<PRId64> 超えています"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: ブロック %ld の行カウントが間違っています"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: ブロック %<PRId64> の行カウントが間違っています"
 
 msgid "Stack size increases"
 msgstr "スタックサイズが増えます"
@@ -3883,8 +3883,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "続けるにはENTERを押すかコマンドを入力してください"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s 行 %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s 行 %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- 継続 --"
@@ -3954,12 +3954,12 @@ msgid "1 line less"
 msgstr "1 行 削除しました"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld 行 追加しました"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> 行 追加しました"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld 行 削除しました"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> 行 削除しました"
 
 msgid " (Interrupted)"
 msgstr " (割込まれました)"
@@ -3997,8 +3997,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 行が長くなり過ぎました"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 内部エラー: lalloc(%ld,)"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4074,8 +4074,8 @@ msgid "read from Netbeans socket"
 msgstr "Netbeans のソケットを読込み"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: バッファ %ld の NetBeans 接続が失われました"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: バッファ %<PRId64> の NetBeans 接続が失われました"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: NetBeansはこのGUIには対応していません"
@@ -4126,23 +4126,23 @@ msgid "1 line %sed %d times"
 msgstr "1 行が %s で %d 回処理されました"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld 行が %s で 1 回処理されました"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> 行が %s で 1 回処理されました"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld 行が %s で %d 回処理されました"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> 行が %s で %d 回処理されました"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld 行がインデントされます... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> 行がインデントされます... "
 
 msgid "1 line indented "
 msgstr "1 行をインデントしました "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld 行をインデントしました "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> 行をインデントしました "
 
 msgid "E748: No previously used register"
 msgstr "E748: まだレジスタを使用していません"
@@ -4155,12 +4155,12 @@ msgid "1 line changed"
 msgstr "1 行が変更されました"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld 行が変更されました"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> 行が変更されました"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "%ld 行を解放中"
+msgid "freeing %<PRId64> lines"
+msgstr "%<PRId64> 行を解放中"
 
 msgid "block of 1 line yanked"
 msgstr "1 行のブロックがヤンクされました"
@@ -4169,12 +4169,12 @@ msgid "1 line yanked"
 msgstr "1 行がヤンクされました"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "%ld 行のブロックがヤンクされました"
+msgid "block of %<PRId64> lines yanked"
+msgstr "%<PRId64> 行のブロックがヤンクされました"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld 行がヤンクされました"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> 行がヤンクされました"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4203,33 +4203,33 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: 未知のレジスタ型 %d です"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 列; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 列; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "選択 %s%ld / %ld 行; %ld / %ld 単語; %ld / %ld バイト"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> バイト"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
-msgstr "選択 %s%ld / %ld 行; %ld / %ld 単語; %ld / %ld 文字; %ld / %ld バイト"
+msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> 文字; %<PRId64> / %<PRId64> バイト"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "列 %s / %s; 行 %ld of %ld; 単語 %ld / %ld; バイト %ld / %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "列 %s / %s; 行 %<PRId64> of %<PRId64>; 単語 %<PRId64> / %<PRId64>; バイト %<PRId64> / %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"列 %s / %s; 行 %ld / %ld; 単語 %ld / %ld; 文字 %ld / %ld; バイト %ld of %ld"
+"列 %s / %s; 行 %<PRId64> / %<PRId64>; 単語 %<PRId64> / %<PRId64>; 文字 %<PRId64> / %<PRId64>; バイト %<PRId64> of %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld for BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=%N ページ"
@@ -4412,8 +4412,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Amigadosのバージョン 2.04かそれ以降が必要です\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "%s のバージョン %ld が必要です\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "%s のバージョン %<PRId64> が必要です\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "NILを開けません:\n"
@@ -4495,8 +4495,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: 致命的シグナルを検知しました\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Xサーバへの接続に %ld ミリ秒かかりました"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Xサーバへの接続に %<PRId64> ミリ秒かかりました"
 
 msgid ""
 "\n"
@@ -5277,8 +5277,8 @@ msgid "Performing soundfolding..."
 msgstr "音声畳込みを実行中..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "音声畳込み後の総単語数: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "音声畳込み後の総単語数: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5313,8 +5313,8 @@ msgid "Done!"
 msgstr "実行しました!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' には %ld 個のエントリはありません"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' には %<PRId64> 個のエントリはありません"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5331,8 +5331,8 @@ msgid "Sorry, no suggestions"
 msgstr "残念ですが, 修正候補はありません"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "残念ですが, 修正候補は %ld 個しかありません"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "残念ですが, 修正候補は %<PRId64> 個しかありません"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5649,8 +5649,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: タグファイル \"%s\" のフォーマットにエラーがあります"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "直前の %ld バイト"
+msgid "Before byte %<PRId64>"
+msgstr "直前の %<PRId64> バイト"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5794,8 +5794,8 @@ msgid "Already at newest change"
 msgstr "既に一番新しい変更です"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: アンドゥ番号 %ld は見つかりません"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: アンドゥ番号 %<PRId64> は見つかりません"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行番号が間違っています"
@@ -5819,8 +5819,8 @@ msgid "changes"
 msgstr "箇所変更しました"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "前方"
@@ -5835,8 +5835,8 @@ msgid "number changes  when               saved"
 msgstr "通番   変更数   変更時期           保存済"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld 秒経過しています"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> 秒経過しています"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo の直後に undojoin はできません"

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -1840,8 +1840,8 @@ msgid "1 character"
 msgstr "1 文字"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld 文字"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 文字"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -3980,17 +3980,17 @@ msgstr "エラー: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[メモリ(バイト)] 総割当-解放量 %lu-%lu, 使用量 %lu, ピーク時 %lu\n"
+"[メモリ(バイト)] 総割当-解放量 %<PRIu64>-%<PRIu64>, 使用量 %<PRIu64>, ピーク時 %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[呼出] 総 re/malloc() 回数 %lu, 総 free() 回数 %lu\n"
+"[呼出] 総 re/malloc() 回数 %<PRIu64>, 総 free() 回数 %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4001,8 +4001,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: メモリが足りません!  (%lu バイトを割当要求)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: メモリが足りません!  (%<PRIu64> バイトを割当要求)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -1840,8 +1840,8 @@ msgid "1 character"
 msgstr "1 文字"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld 文字"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 文字"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -3980,17 +3980,17 @@ msgstr "エラー: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[メモリ(バイト)] 総割当-解放量 %lu-%lu, 使用量 %lu, ピーク時 %lu\n"
+"[メモリ(バイト)] 総割当-解放量 %<PRIu64>-%<PRIu64>, 使用量 %<PRIu64>, ピーク時 %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[呼出] 総 re/malloc() 回数 %lu, 総 free() 回数 %lu\n"
+"[呼出] 総 re/malloc() 回数 %<PRIu64>, 総 free() 回数 %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4001,8 +4001,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: メモリが足りません!  (%lu バイトを割当要求)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: メモリが足りません!  (%<PRIu64> バイトを割当要求)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -91,8 +91,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: リスト表示されるバッファはありません"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: バッファ %ld はありません"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: バッファ %<PRId64> はありません"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 最後のバッファを越えて移動はできません"
@@ -101,8 +101,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 最初のバッファより前へは移動できません"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: バッファ %ld の変更は保存されていません (! で変更を破棄)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: バッファ %<PRId64> の変更は保存されていません (! で変更を破棄)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: 最後のバッファは解放できません"
@@ -111,8 +111,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: ファイル名のリストが長過ぎます"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: バッファ %ld が見つかりません"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: バッファ %<PRId64> が見つかりません"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -123,8 +123,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: %s に該当するバッファはありませんでした"
 
 #, c-format
-msgid "line %ld"
-msgstr "行 %ld"
+msgid "line %<PRId64>"
+msgstr "行 %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: この名前のバッファは既にあります"
@@ -152,12 +152,12 @@ msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld 行 --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> 行 --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "行 %ld (全体 %ld) --%d%%-- col "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "行 %<PRId64> (全体 %<PRId64>) --%d%%-- col "
 
 msgid "[No Name]"
 msgstr "[無名]"
@@ -203,12 +203,12 @@ msgid "Signs for %s:"
 msgstr "%s のサイン:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    行=%ld  識別子=%d  名前=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    行=%<PRId64>  識別子=%d  名前=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: %ld 以上のバッファはdiffできません"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: %<PRId64> 以上のバッファはdiffできません"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 一時ファイルの読込もしくは書込ができません"
@@ -367,8 +367,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: 予期せぬ文字が :let にありました"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: リストのインデックスが範囲外です: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: リストのインデックスが範囲外です: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -782,8 +782,8 @@ msgid "%s aborted"
 msgstr "%s が中断されました"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s が #%ld を返しました"
+msgid "%s returning #%<PRId64>"
+msgstr "%s が #%<PRId64> を返しました"
 
 #, c-format
 msgid "%s returning %s"
@@ -832,12 +832,12 @@ msgid "1 line moved"
 msgstr "1 行が移動されました"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld 行が移動されました"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> 行が移動されました"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld 行がフィルタ処理されました"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> 行がフィルタ処理されました"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *フィルタ* autocommandは現在のバッファを変更してはいけません"
@@ -921,8 +921,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: スワップファイルが存在します: %s (:silent! を追加で上書)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: バッファ %ld には名前がありません"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: バッファ %<PRId64> には名前がありません"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: ファイルは保存されませんでした: 'write' オプションにより無効です"
@@ -979,19 +979,19 @@ msgid "1 substitution"
 msgstr "1 箇所置換しました"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld 箇所該当しました"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> 箇所該当しました"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld 箇所置換しました"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> 箇所置換しました"
 
 msgid " on 1 line"
 msgstr " (計 1 行内)"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " (計 %ld 行内)"
+msgid " on %<PRId64> lines"
+msgstr " (計 %<PRId64> 行内)"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global を再帰的には使えません"
@@ -1078,8 +1078,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 無効なバッファ名です: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: 無効なsign識別子です: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: 無効なsign識別子です: %<PRId64>"
 
 # Added at 27-Jan-2004.
 msgid " (NOT FOUND)"
@@ -1095,16 +1095,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "デバッグモードに入ります. 続けるには \"cont\" と入力してください."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "行 %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "行 %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "コマンド: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "ブレークポイント \"%s%s\" 行 %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "ブレークポイント \"%s%s\" 行 %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1114,8 +1114,8 @@ msgid "No breakpoints defined"
 msgstr "ブレークポイントが定義されていません"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  行 %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  行 %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 初めに \":profile start {fname}\" を実行してください"
@@ -1171,16 +1171,16 @@ msgid "could not source \"%s\""
 msgstr "\"%s\" を取込めません"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "行 %ld: \"%s\" を取込めません"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "行 %<PRId64>: \"%s\" を取込めません"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" を取込中"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "行 %ld: %s を取込中"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "行 %<PRId64>: %s を取込中"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1269,8 +1269,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 編集すべきファイルが 1 個あります"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 編集すべきファイルがあと %ld 個あります"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 編集すべきファイルがあと %<PRId64> 個あります"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: コマンドが既にあります: 再定義するには ! を追加してください"
@@ -1464,8 +1464,8 @@ msgid "Exception discarded: %s"
 msgstr "例外が破棄されました: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, 行 %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, 行 %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1669,12 +1669,12 @@ msgid "[crypted]"
 msgstr "[暗号化]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[%ld 行目で変換エラー]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[%<PRId64> 行目で変換エラー]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[%ld 行目の不正なバイト]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[%<PRId64> 行目の不正なバイト]"
 
 msgid "[READ ERRORS]"
 msgstr "[読込エラー]"
@@ -1758,10 +1758,10 @@ msgstr "E513: 書込みエラー, 変換失敗 (上書するには 'fenc' を空
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: 書込みエラー, 変換失敗, 行数 %ld (上書するには 'fenc' を空にしてくださ"
+"E513: 書込みエラー, 変換失敗, 行数 %<PRId64> (上書するには 'fenc' を空にしてくださ"
 "い)"
 
 msgid "E514: write error (file system full?)"
@@ -1771,8 +1771,8 @@ msgid " CONVERSION ERROR"
 msgstr " 変換エラー"
 
 #, c-format
-msgid " in line %ld;"
-msgstr "行 %ld;"
+msgid " in line %<PRId64>;"
+msgstr "行 %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[デバイス]"
@@ -1833,8 +1833,8 @@ msgid "1 line, "
 msgstr "1 行, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 行, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 行, "
 
 msgid "1 character"
 msgstr "1 文字"
@@ -1845,8 +1845,8 @@ msgstr "%<PRId64> 文字"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld 文字"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 文字"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2258,16 +2258,16 @@ msgid "Font1: %s"
 msgstr "フォント1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "フォント%ld の幅がフォント0の2倍ではありません"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "フォント%<PRId64> の幅がフォント0の2倍ではありません"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "フォント0の幅: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "フォント0の幅: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "フォント1の幅: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "フォント1の幅: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "無効なフォント指定です"
@@ -2444,8 +2444,8 @@ msgid "Added cscope database %s"
 msgstr "cscopeデータベース %s を追加"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: cscopeの接続 %ld を読込み中のエラーです"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: cscopeの接続 %<PRId64> を読込み中のエラーです"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知のcscope検索型です"
@@ -3661,12 +3661,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 維持に失敗しました"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 無効なlnumです: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 無効なlnumです: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: 行 %ld を見つけられません"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: 行 %<PRId64> を見つけられません"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: ポインタブロックのIDが間違っています 3"
@@ -3684,8 +3684,8 @@ msgid "deleted block 1?"
 msgstr "ブロック 1 は消された?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: 行 %ld が見つかりません"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: 行 %<PRId64> が見つかりません"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: ポインタブロックのIDが間違っています"
@@ -3694,12 +3694,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count がゼロです"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 行番号が範囲外です: %ld 超えています"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 行番号が範囲外です: %<PRId64> 超えています"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: ブロック %ld の行カウントが間違っています"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: ブロック %<PRId64> の行カウントが間違っています"
 
 msgid "Stack size increases"
 msgstr "スタックサイズが増えます"
@@ -3883,8 +3883,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "続けるにはENTERを押すかコマンドを入力してください"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s 行 %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s 行 %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- 継続 --"
@@ -3954,12 +3954,12 @@ msgid "1 line less"
 msgstr "1 行 削除しました"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld 行 追加しました"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> 行 追加しました"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld 行 削除しました"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> 行 削除しました"
 
 msgid " (Interrupted)"
 msgstr " (割込まれました)"
@@ -3997,8 +3997,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 行が長くなり過ぎました"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 内部エラー: lalloc(%ld,)"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4074,8 +4074,8 @@ msgid "read from Netbeans socket"
 msgstr "Netbeans のソケットを読込み"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: バッファ %ld の NetBeans 接続が失われました"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: バッファ %<PRId64> の NetBeans 接続が失われました"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: NetBeansはこのGUIには対応していません"
@@ -4126,23 +4126,23 @@ msgid "1 line %sed %d times"
 msgstr "1 行が %s で %d 回処理されました"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld 行が %s で 1 回処理されました"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> 行が %s で 1 回処理されました"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld 行が %s で %d 回処理されました"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> 行が %s で %d 回処理されました"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld 行がインデントされます... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> 行がインデントされます... "
 
 msgid "1 line indented "
 msgstr "1 行をインデントしました "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld 行をインデントしました "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> 行をインデントしました "
 
 msgid "E748: No previously used register"
 msgstr "E748: まだレジスタを使用していません"
@@ -4155,12 +4155,12 @@ msgid "1 line changed"
 msgstr "1 行が変更されました"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld 行が変更されました"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> 行が変更されました"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "%ld 行を解放中"
+msgid "freeing %<PRId64> lines"
+msgstr "%<PRId64> 行を解放中"
 
 msgid "block of 1 line yanked"
 msgstr "1 行のブロックがヤンクされました"
@@ -4169,12 +4169,12 @@ msgid "1 line yanked"
 msgstr "1 行がヤンクされました"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "%ld 行のブロックがヤンクされました"
+msgid "block of %<PRId64> lines yanked"
+msgstr "%<PRId64> 行のブロックがヤンクされました"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld 行がヤンクされました"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> 行がヤンクされました"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4203,33 +4203,33 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: 未知のレジスタ型 %d です"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 列; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 列; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "選択 %s%ld / %ld 行; %ld / %ld 単語; %ld / %ld バイト"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> バイト"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
-msgstr "選択 %s%ld / %ld 行; %ld / %ld 単語; %ld / %ld 文字; %ld / %ld バイト"
+msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> 文字; %<PRId64> / %<PRId64> バイト"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "列 %s / %s; 行 %ld of %ld; 単語 %ld / %ld; バイト %ld / %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "列 %s / %s; 行 %<PRId64> of %<PRId64>; 単語 %<PRId64> / %<PRId64>; バイト %<PRId64> / %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"列 %s / %s; 行 %ld / %ld; 単語 %ld / %ld; 文字 %ld / %ld; バイト %ld of %ld"
+"列 %s / %s; 行 %<PRId64> / %<PRId64>; 単語 %<PRId64> / %<PRId64>; 文字 %<PRId64> / %<PRId64>; バイト %<PRId64> of %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld for BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=%N ページ"
@@ -4412,8 +4412,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Amigadosのバージョン 2.04かそれ以降が必要です\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "%s のバージョン %ld が必要です\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "%s のバージョン %<PRId64> が必要です\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "NILを開けません:\n"
@@ -4495,8 +4495,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: 致命的シグナルを検知しました\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Xサーバへの接続に %ld ミリ秒かかりました"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Xサーバへの接続に %<PRId64> ミリ秒かかりました"
 
 msgid ""
 "\n"
@@ -5277,8 +5277,8 @@ msgid "Performing soundfolding..."
 msgstr "音声畳込みを実行中..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "音声畳込み後の総単語数: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "音声畳込み後の総単語数: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5313,8 +5313,8 @@ msgid "Done!"
 msgstr "実行しました!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' には %ld 個のエントリはありません"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' には %<PRId64> 個のエントリはありません"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5331,8 +5331,8 @@ msgid "Sorry, no suggestions"
 msgstr "残念ですが, 修正候補はありません"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "残念ですが, 修正候補は %ld 個しかありません"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "残念ですが, 修正候補は %<PRId64> 個しかありません"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5649,8 +5649,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: タグファイル \"%s\" のフォーマットにエラーがあります"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "直前の %ld バイト"
+msgid "Before byte %<PRId64>"
+msgstr "直前の %<PRId64> バイト"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5794,8 +5794,8 @@ msgid "Already at newest change"
 msgstr "既に一番新しい変更です"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: アンドゥ番号 %ld は見つかりません"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: アンドゥ番号 %<PRId64> は見つかりません"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行番号が間違っています"
@@ -5819,8 +5819,8 @@ msgid "changes"
 msgstr "箇所変更しました"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "前方"
@@ -5835,8 +5835,8 @@ msgid "number changes  when               saved"
 msgstr "通番   変更数   変更時期           保存済"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld 秒経過しています"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> 秒経過しています"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo の直後に undojoin はできません"

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -91,8 +91,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: リスト表\示されるバッファはありません"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: バッファ %ld はありません"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: バッファ %<PRId64> はありません"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 最後のバッファを越えて移動はできません"
@@ -101,8 +101,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 最初のバッファより前へは移動できません"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: バッファ %ld の変更は保存されていません (! で変更を破棄)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: バッファ %<PRId64> の変更は保存されていません (! で変更を破棄)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: 最後のバッファは解放できません"
@@ -111,8 +111,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: ファイル名のリストが長過ぎます"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: バッファ %ld が見つかりません"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: バッファ %<PRId64> が見つかりません"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -123,8 +123,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: %s に該当するバッファはありませんでした"
 
 #, c-format
-msgid "line %ld"
-msgstr "行 %ld"
+msgid "line %<PRId64>"
+msgstr "行 %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: この名前のバッファは既にあります"
@@ -152,12 +152,12 @@ msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld 行 --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> 行 --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "行 %ld (全体 %ld) --%d%%-- col "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "行 %<PRId64> (全体 %<PRId64>) --%d%%-- col "
 
 msgid "[No Name]"
 msgstr "[無名]"
@@ -203,12 +203,12 @@ msgid "Signs for %s:"
 msgstr "%s のサイン:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    行=%ld  識別子=%d  名前=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    行=%<PRId64>  識別子=%d  名前=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: %ld 以上のバッファはdiffできません"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: %<PRId64> 以上のバッファはdiffできません"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 一時ファイルの読込もしくは書込ができません"
@@ -367,8 +367,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: 予\期せぬ文字が :let にありました"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: リストのインデックスが範囲外です: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: リストのインデックスが範囲外です: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -782,8 +782,8 @@ msgid "%s aborted"
 msgstr "%s が中断されました"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s が #%ld を返しました"
+msgid "%s returning #%<PRId64>"
+msgstr "%s が #%<PRId64> を返しました"
 
 #, c-format
 msgid "%s returning %s"
@@ -832,12 +832,12 @@ msgid "1 line moved"
 msgstr "1 行が移動されました"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld 行が移動されました"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> 行が移動されました"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld 行がフィルタ処理されました"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> 行がフィルタ処理されました"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *フィルタ* autocommandは現在のバッファを変更してはいけません"
@@ -921,8 +921,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: スワップファイルが存在します: %s (:silent! を追加で上書)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: バッファ %ld には名前がありません"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: バッファ %<PRId64> には名前がありません"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: ファイルは保存されませんでした: 'write' オプションにより無効です"
@@ -979,19 +979,19 @@ msgid "1 substitution"
 msgstr "1 箇所置換しました"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld 箇所該当しました"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> 箇所該当しました"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld 箇所置換しました"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> 箇所置換しました"
 
 msgid " on 1 line"
 msgstr " (計 1 行内)"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " (計 %ld 行内)"
+msgid " on %<PRId64> lines"
+msgstr " (計 %<PRId64> 行内)"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global を再帰的には使えません"
@@ -1078,8 +1078,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 無効なバッファ名です: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: 無効なsign識別子です: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: 無効なsign識別子です: %<PRId64>"
 
 # Added at 27-Jan-2004.
 msgid " (NOT FOUND)"
@@ -1095,16 +1095,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "デバッグモードに入ります. 続けるには \"cont\" と入力してください."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "行 %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "行 %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "コマンド: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "ブレークポイント \"%s%s\" 行 %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "ブレークポイント \"%s%s\" 行 %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1114,8 +1114,8 @@ msgid "No breakpoints defined"
 msgstr "ブレークポイントが定義されていません"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  行 %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  行 %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 初めに \":profile start {fname}\" を実行してください"
@@ -1171,16 +1171,16 @@ msgid "could not source \"%s\""
 msgstr "\"%s\" を取込めません"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "行 %ld: \"%s\" を取込めません"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "行 %<PRId64>: \"%s\" を取込めません"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" を取込中"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "行 %ld: %s を取込中"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "行 %<PRId64>: %s を取込中"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1269,8 +1269,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 編集すべきファイルが 1 個あります"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 編集すべきファイルがあと %ld 個あります"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 編集すべきファイルがあと %<PRId64> 個あります"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: コマンドが既にあります: 再定義するには ! を追加してください"
@@ -1464,8 +1464,8 @@ msgid "Exception discarded: %s"
 msgstr "例外が破棄されました: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, 行 %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, 行 %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1669,12 +1669,12 @@ msgid "[crypted]"
 msgstr "[暗号化]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[%ld 行目で変換エラー]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[%<PRId64> 行目で変換エラー]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[%ld 行目の不正なバイト]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[%<PRId64> 行目の不正なバイト]"
 
 msgid "[READ ERRORS]"
 msgstr "[読込エラー]"
@@ -1758,10 +1758,10 @@ msgstr "E513: 書込みエラー, 変換失敗 (上書するには 'fenc' を空にしてください)"
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: 書込みエラー, 変換失敗, 行数 %ld (上書するには 'fenc' を空にしてくださ"
+"E513: 書込みエラー, 変換失敗, 行数 %<PRId64> (上書するには 'fenc' を空にしてくださ"
 "い)"
 
 msgid "E514: write error (file system full?)"
@@ -1771,8 +1771,8 @@ msgid " CONVERSION ERROR"
 msgstr " 変換エラー"
 
 #, c-format
-msgid " in line %ld;"
-msgstr "行 %ld;"
+msgid " in line %<PRId64>;"
+msgstr "行 %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[デバイス]"
@@ -1833,8 +1833,8 @@ msgid "1 line, "
 msgstr "1 行, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 行, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 行, "
 
 msgid "1 character"
 msgstr "1 文字"
@@ -1845,8 +1845,8 @@ msgstr "%<PRId64> 文字"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld 文字"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 文字"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2258,16 +2258,16 @@ msgid "Font1: %s"
 msgstr "フォント1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "フォント%ld の幅がフォント0の2倍ではありません"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "フォント%<PRId64> の幅がフォント0の2倍ではありません"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "フォント0の幅: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "フォント0の幅: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "フォント1の幅: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "フォント1の幅: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "無効なフォント指定です"
@@ -2444,8 +2444,8 @@ msgid "Added cscope database %s"
 msgstr "cscopeデータベース %s を追加"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: cscopeの接続 %ld を読込み中のエラーです"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: cscopeの接続 %<PRId64> を読込み中のエラーです"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知のcscope検索型です"
@@ -3661,12 +3661,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 維持に失敗しました"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 無効なlnumです: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 無効なlnumです: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: 行 %ld を見つけられません"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: 行 %<PRId64> を見つけられません"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: ポインタブロックのIDが間違っています 3"
@@ -3684,8 +3684,8 @@ msgid "deleted block 1?"
 msgstr "ブロック 1 は消された?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: 行 %ld が見つかりません"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: 行 %<PRId64> が見つかりません"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: ポインタブロックのIDが間違っています"
@@ -3694,12 +3694,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count がゼロです"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 行番号が範囲外です: %ld 超えています"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 行番号が範囲外です: %<PRId64> 超えています"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: ブロック %ld の行カウントが間違っています"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: ブロック %<PRId64> の行カウントが間違っています"
 
 msgid "Stack size increases"
 msgstr "スタックサイズが増えます"
@@ -3883,8 +3883,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "続けるにはENTERを押すかコマンドを入力してください"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s 行 %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s 行 %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- 継続 --"
@@ -3954,12 +3954,12 @@ msgid "1 line less"
 msgstr "1 行 削除しました"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld 行 追加しました"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> 行 追加しました"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld 行 削除しました"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> 行 削除しました"
 
 msgid " (Interrupted)"
 msgstr " (割込まれました)"
@@ -3997,8 +3997,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 行が長くなり過ぎました"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 内部エラー: lalloc(%ld,)"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4074,8 +4074,8 @@ msgid "read from Netbeans socket"
 msgstr "Netbeans のソ\ケットを読込み"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: バッファ %ld の NetBeans 接続が失われました"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: バッファ %<PRId64> の NetBeans 接続が失われました"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: NetBeansはこのGUIには対応していません"
@@ -4126,23 +4126,23 @@ msgid "1 line %sed %d times"
 msgstr "1 行が %s で %d 回処理されました"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld 行が %s で 1 回処理されました"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> 行が %s で 1 回処理されました"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld 行が %s で %d 回処理されました"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> 行が %s で %d 回処理されました"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld 行がインデントされます... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> 行がインデントされます... "
 
 msgid "1 line indented "
 msgstr "1 行をインデントしました "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld 行をインデントしました "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> 行をインデントしました "
 
 msgid "E748: No previously used register"
 msgstr "E748: まだレジスタを使用していません"
@@ -4155,12 +4155,12 @@ msgid "1 line changed"
 msgstr "1 行が変更されました"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld 行が変更されました"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> 行が変更されました"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "%ld 行を解放中"
+msgid "freeing %<PRId64> lines"
+msgstr "%<PRId64> 行を解放中"
 
 msgid "block of 1 line yanked"
 msgstr "1 行のブロックがヤンクされました"
@@ -4169,12 +4169,12 @@ msgid "1 line yanked"
 msgstr "1 行がヤンクされました"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "%ld 行のブロックがヤンクされました"
+msgid "block of %<PRId64> lines yanked"
+msgstr "%<PRId64> 行のブロックがヤンクされました"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld 行がヤンクされました"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> 行がヤンクされました"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4203,33 +4203,33 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: 未知のレジスタ型 %d です"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 列; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 列; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "選択 %s%ld / %ld 行; %ld / %ld 単語; %ld / %ld バイト"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> バイト"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
-msgstr "選択 %s%ld / %ld 行; %ld / %ld 単語; %ld / %ld 文字; %ld / %ld バイト"
+msgstr "選択 %s%<PRId64> / %<PRId64> 行; %<PRId64> / %<PRId64> 単語; %<PRId64> / %<PRId64> 文字; %<PRId64> / %<PRId64> バイト"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "列 %s / %s; 行 %ld of %ld; 単語 %ld / %ld; バイト %ld / %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "列 %s / %s; 行 %<PRId64> of %<PRId64>; 単語 %<PRId64> / %<PRId64>; バイト %<PRId64> / %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"列 %s / %s; 行 %ld / %ld; 単語 %ld / %ld; 文字 %ld / %ld; バイト %ld of %ld"
+"列 %s / %s; 行 %<PRId64> / %<PRId64>; 単語 %<PRId64> / %<PRId64>; 文字 %<PRId64> / %<PRId64>; バイト %<PRId64> of %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld for BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=%N ページ"
@@ -4412,8 +4412,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Amigadosのバージョン 2.04かそれ以降が必要です\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "%s のバージョン %ld が必要です\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "%s のバージョン %<PRId64> が必要です\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "NILを開けません:\n"
@@ -4495,8 +4495,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: 致命的シグナルを検知しました\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Xサーバへの接続に %ld ミリ秒かかりました"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Xサーバへの接続に %<PRId64> ミリ秒かかりました"
 
 msgid ""
 "\n"
@@ -5277,8 +5277,8 @@ msgid "Performing soundfolding..."
 msgstr "音声畳込みを実行中..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "音声畳込み後の総単語数: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "音声畳込み後の総単語数: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5313,8 +5313,8 @@ msgid "Done!"
 msgstr "実行しました!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' には %ld 個のエントリはありません"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' には %<PRId64> 個のエントリはありません"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5331,8 +5331,8 @@ msgid "Sorry, no suggestions"
 msgstr "残念ですが, 修正候補はありません"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "残念ですが, 修正候補は %ld 個しかありません"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "残念ですが, 修正候補は %<PRId64> 個しかありません"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5649,8 +5649,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: タグファイル \"%s\" のフォーマットにエラーがあります"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "直前の %ld バイト"
+msgid "Before byte %<PRId64>"
+msgstr "直前の %<PRId64> バイト"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5794,8 +5794,8 @@ msgid "Already at newest change"
 msgstr "既に一番新しい変更です"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: アンドゥ番号 %ld は見つかりません"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: アンドゥ番号 %<PRId64> は見つかりません"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行番号が間違っています"
@@ -5819,8 +5819,8 @@ msgid "changes"
 msgstr "箇所変更しました"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "前方"
@@ -5835,8 +5835,8 @@ msgid "number changes  when               saved"
 msgstr "通番   変更数   変更時期           保存済"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld 秒経過しています"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> 秒経過しています"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo の直後に undojoin はできません"

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -3980,17 +3980,17 @@ msgstr "エラー: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[メモリ(バイト)] 総割当-解放量 %lu-%lu, 使用量 %lu, ピーク時 %lu\n"
+"[メモリ(バイト)] 総割当-解放量 %<PRIu64>-%<PRIu64>, 使用量 %<PRIu64>, ピーク時 %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[呼出] 総 re/malloc() 回数 %lu, 総 free() 回数 %lu\n"
+"[呼出] 総 re/malloc() 回数 %<PRIu64>, 総 free() 回数 %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4001,8 +4001,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 内部エラー: lalloc(%<PRId64>,)"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: メモリが足りません!  (%lu バイトを割当要求)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: メモリが足りません!  (%<PRIu64> バイトを割当要求)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -1840,8 +1840,8 @@ msgid "1 character"
 msgstr "1 •¶Žš"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld •¶Žš"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> •¶Žš"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/ko.UTF-8.po
+++ b/src/po/ko.UTF-8.po
@@ -79,8 +79,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: 나열된 버퍼가 없습니다"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: 버퍼 %ld이(가) 존재하지 않습니다"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: 버퍼 %<PRId64>이(가) 존재하지 않습니다"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 마지막 버퍼입니다"
@@ -89,9 +89,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 첫 번째 버퍼입니다"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: 버퍼 %ld을(를) 마지막으로 고친 뒤 저장하지 않았습니다 (덮어쓰려면 ! 더하"
+"E89: 버퍼 %<PRId64>을(를) 마지막으로 고친 뒤 저장하지 않았습니다 (덮어쓰려면 ! 더하"
 "기)"
 
 msgid "E90: Cannot unload last buffer"
@@ -101,8 +101,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 경고: 파일 이름 목록이 넘쳤습니다"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: 버퍼 %ld을(를) 찾을 수 없습니다"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: 버퍼 %<PRId64>을(를) 찾을 수 없습니다"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -113,8 +113,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: %s와 맞는 버퍼가 없습니다"
 
 #, c-format
-msgid "line %ld"
-msgstr "%ld 줄"
+msgid "line %<PRId64>"
+msgstr "%<PRId64> 줄"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 이 이름을 가진 버퍼가 이미 있습니다"
@@ -139,12 +139,12 @@ msgid "1 line --%d%%--"
 msgstr "1 줄 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld 줄 --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> 줄 --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "%ld / %ld 줄 --%d%%-- 칸 "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "%<PRId64> / %<PRId64> 줄 --%d%%-- 칸 "
 
 msgid "[No Name]"
 msgstr "[이름 없음]"
@@ -190,12 +190,12 @@ msgid "Signs for %s:"
 msgstr "%s에 대한 기호:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    줄=%ld  id=%d  이름=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    줄=%<PRId64>  id=%d  이름=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: %ld개 이상의 버퍼에 대해서는 diff를 할 수 없습니다"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: %<PRId64>개 이상의 버퍼에 대해서는 diff를 할 수 없습니다"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 임시 파일을 읽거나 쓸 수 없습니다"
@@ -354,8 +354,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: ':let'에 모르는 글자"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: 목록 번호가 범위를 벗어남: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: 목록 번호가 범위를 벗어남: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -736,8 +736,8 @@ msgid "%s aborted"
 msgstr "%s이(가) 중지되었습니다"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s이(가) #%ld을(를) 돌려주었습니다"
+msgid "%s returning #%<PRId64>"
+msgstr "%s이(가) #%<PRId64>을(를) 돌려주었습니다"
 
 #, c-format
 msgid "%s returning %s"
@@ -786,12 +786,12 @@ msgid "1 line moved"
 msgstr "1 줄 옮겨졌습니다"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld 줄 옮겨졌습니다"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> 줄 옮겨졌습니다"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld 줄을 걸렀습니다"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> 줄을 걸렀습니다"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 자동명령은 현재 버퍼를 바꾸어서는 안 됩니다"
@@ -875,8 +875,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 스왑 파일 있음: %s (덮어쓰려면 :silent! 사용)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: 버퍼 %ld의 파일 이름이 없습니다"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: 버퍼 %<PRId64>의 파일 이름이 없습니다"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 파일이 써지지 않음: 'write' 옵션에 의해 쓸 수가 없습니다"
@@ -933,19 +933,19 @@ msgid "1 substitution"
 msgstr "1개 바꿨음"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld개 찾아짐"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64>개 찾아짐"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld개 바꿨음"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64>개 바꿨음"
 
 msgid " on 1 line"
 msgstr " 한 줄에서"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " %ld 줄에서"
+msgid " on %<PRId64> lines"
+msgstr " %<PRId64> 줄에서"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global은 재귀 호출 될 수 없습니다"
@@ -1027,8 +1027,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 잘못된 버퍼 이름: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: 잘못된 sign ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: 잘못된 sign ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (못 찾았음)"
@@ -1043,16 +1043,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "디버그 상태로 들어감.  계속하려면 \"cont\"를 입력하십시오."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "%ld 줄: %s"
+msgid "line %<PRId64>: %s"
+msgstr "%<PRId64> 줄: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "명령: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "중지점: \"%s%s\" %ld 줄"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "중지점: \"%s%s\" %<PRId64> 줄"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1062,8 +1062,8 @@ msgid "No breakpoints defined"
 msgstr "중지점이 정의되어 있지 않습니다"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  %ld 줄"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  %<PRId64> 줄"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 먼저 \":profile start {fname}\"을 사용하세요"
@@ -1119,16 +1119,16 @@ msgid "could not source \"%s\""
 msgstr "\"%s\"을(를) 불러 들일 수 없습니다"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "%ld 줄: \"%s\"을(를) 불러 들일 수 없습니다"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "%<PRId64> 줄: \"%s\"을(를) 불러 들일 수 없습니다"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\"을(를) 불러들이는 중"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "%ld 줄: \"%s\" 불러들이는 중"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "%<PRId64> 줄: \"%s\" 불러들이는 중"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1217,8 +1217,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 고칠 파일이 한 개 더 있습니다"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 고칠 파일이 %ld 개 더 있습니다"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 고칠 파일이 %<PRId64> 개 더 있습니다"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 명령이 이미 존재합니다: 바꾸려면 !을 더하세요"
@@ -1408,8 +1408,8 @@ msgid "Exception discarded: %s"
 msgstr "예외 버려짐: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, %ld 줄"
+msgid "%s, line %<PRId64>"
+msgstr "%s, %<PRId64> 줄"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1613,12 +1613,12 @@ msgid "[crypted]"
 msgstr "[암호화 되었습니다]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[%ld 줄에서 변환 에러]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[%<PRId64> 줄에서 변환 에러]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[%ld 줄에 잘못된 바이트]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[%<PRId64> 줄에 잘못된 바이트]"
 
 msgid "[READ ERRORS]"
 msgstr "[읽기 에러]"
@@ -1700,9 +1700,9 @@ msgstr "E513: 쓰기 에러, 변환 실패 (무시하려면 'fenc'를 비우면 
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
-msgstr "E513: 쓰기 에러, %ld 줄에서 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
+msgstr "E513: 쓰기 에러, %<PRId64> 줄에서 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
 
 msgid "E514: write error (file system full?)"
 msgstr "E514: 쓰기 에러 (파일 시스템이 꽉찼나요?)"
@@ -1711,8 +1711,8 @@ msgid " CONVERSION ERROR"
 msgstr " 변환 에러"
 
 #, c-format
-msgid " in line %ld;"
-msgstr "%ld 줄에서;"
+msgid " in line %<PRId64>;"
+msgstr "%<PRId64> 줄에서;"
 
 msgid "[Device]"
 msgstr "[장치]"
@@ -1773,8 +1773,8 @@ msgid "1 line, "
 msgstr "1 줄, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 줄, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 줄, "
 
 msgid "1 character"
 msgstr "1 글자"
@@ -1785,8 +1785,8 @@ msgstr "%<PRId64> 글자"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld 글자"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 글자"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2194,19 +2194,19 @@ msgid "Font1: %s\n"
 msgstr "글꼴1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "글꼴%ld 너비가 글꼴0의 두배가 아닙니다\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "글꼴%<PRId64> 너비가 글꼴0의 두배가 아닙니다\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "글꼴0 너비: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "글꼴0 너비: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"글꼴1 너비: %ld\n"
+"글꼴1 너비: %<PRId64>\n"
 "\n"
 
 #~ msgid "Invalid font specification"
@@ -2383,8 +2383,8 @@ msgid "Added cscope database %s"
 msgstr "cscope 데이터베이스 %s에 더했습니다."
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: cscope 연결 %ld 읽기 에러"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: cscope 연결 %<PRId64> 읽기 에러"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 모르는 cscope 찾기 형식"
@@ -3596,12 +3596,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 파일 보존을 실패했습니다"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 잘못된 lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 잘못된 lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: %ld 줄을 찾을 수 없습니다"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: %<PRId64> 줄을 찾을 수 없습니다"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 잘못된 포인터 구역 id 3"
@@ -3619,8 +3619,8 @@ msgid "deleted block 1?"
 msgstr "구역 1이 지워졌나요?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: %ld 줄을 찾을 수 없습니다"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: %<PRId64> 줄을 찾을 수 없습니다"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: 잘못된 포인터 구역 id"
@@ -3629,12 +3629,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count가 0입니다"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 줄 번호가 범위를 벗어났습니다: 마지막에서 %ld 만큼"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 줄 번호가 범위를 벗어났습니다: 마지막에서 %<PRId64> 만큼"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: 구역 %ld의 줄 갯수가 틀렸습니다"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: 구역 %<PRId64>의 줄 갯수가 틀렸습니다"
 
 msgid "Stack size increases"
 msgstr "스택 크기 증가"
@@ -3822,8 +3822,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "계속하려면 엔터 혹은 명령을 입력하십시오"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s 줄 %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s 줄 %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- 더 --"
@@ -3892,12 +3892,12 @@ msgid "1 line less"
 msgstr "한 줄 이하"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld 보다 많은 줄"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> 보다 많은 줄"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld 보다 적은 줄"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> 보다 적은 줄"
 
 msgid " (Interrupted)"
 msgstr " (중단되었습니다)"
@@ -3931,8 +3931,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 줄이 너무 길어졌습니다"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 내부 에러: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 내부 에러: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4004,8 +4004,8 @@ msgid "read from Netbeans socket"
 msgstr "Netbeans 소켓에서 읽기"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: 버퍼 %ld에 대한 NetBeans 연결을 잃어버렸습니다"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: 버퍼 %<PRId64>에 대한 NetBeans 연결을 잃어버렸습니다"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: 이 GUI는 netbeans를 지원하지 않습니다"
@@ -4055,23 +4055,23 @@ msgid "1 line %sed %d times"
 msgstr "1 line %sed %d times"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld lines %sed 1 time"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> lines %sed 1 time"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld lines %sed %d times"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> lines %sed %d times"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld lines to indent... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> lines to indent... "
 
 msgid "1 line indented "
 msgstr "1 line indented "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld lines indented "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> lines indented "
 
 #~ msgid "E748: No previously used register"
 #~ msgstr ""
@@ -4084,12 +4084,12 @@ msgid "1 line changed"
 msgstr "1 line changed"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld lines changed"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> lines changed"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "freeing %ld lines"
+msgid "freeing %<PRId64> lines"
+msgstr "freeing %<PRId64> lines"
 
 msgid "block of 1 line yanked"
 msgstr "block of 1 line yanked"
@@ -4098,12 +4098,12 @@ msgid "1 line yanked"
 msgstr "1 line yanked"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "block of %ld lines yanked"
+msgid "block of %<PRId64> lines yanked"
+msgstr "block of %<PRId64> lines yanked"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld lines yanked"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> lines yanked"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4132,36 +4132,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: 모르는 레지스터 형식 %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 열; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 열; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Selected %s%ld of %ld 라인; %ld of %ld 단어; %ld of %ld 바이트"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; %<PRId64> of %<PRId64> 바이트"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Selected %s%ld of %ld 라인; %ld of %ld 단어; %ld of %ld 문자; %ld of %ld 바이"
+"Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; %<PRId64> of %<PRId64> 문자; %<PRId64> of %<PRId64> 바이"
 "트"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Col %s of %s; 라인 %ld of %ld; 단어 %ld of %ld; 바이트 %ld of %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 바이트 %<PRId64> of %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Col %s of %s; 라인 %ld of %ld; 단어 %ld of %ld; 문자 %ld of %ld; 바이트 %ld "
-"of %ld"
+"Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 문자 %<PRId64> of %<PRId64>; 바이트 %<PRId64> "
+"of %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld for BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=페이지 %N"
@@ -4340,8 +4340,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "아미가도스 2.04나 더 높은 판이 필요합니다\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Need %s version %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Need %s version %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "NIL을 열 수 없음:\n"
@@ -4423,8 +4423,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "빔: 죽을 시그널을 잡았습니다\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "X 디스플레이를 여는 데 %ld msec이 걸렸습니다"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "X 디스플레이를 여는 데 %<PRId64> msec이 걸렸습니다"
 
 msgid ""
 "\n"
@@ -5117,8 +5117,8 @@ msgid "Performing soundfolding..."
 msgstr "soundfold 수행중..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "soundfold 수행 후의 단어 수: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "soundfold 수행 후의 단어 수: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5153,8 +5153,8 @@ msgid "Done!"
 msgstr "끝!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile'에 %ld 항목이 없습니다"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile'에 %<PRId64> 항목이 없습니다"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5171,8 +5171,8 @@ msgid "Sorry, no suggestions"
 msgstr "죄송, 제안할 게 없습니다"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "죄송, %ld개만 제안"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "죄송, %<PRId64>개만 제안"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5472,8 +5472,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: 태그 파일 \"%s\"에 형식 에러가 있습니다"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Before byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Before byte %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5620,8 +5620,8 @@ msgid "Already at newest change"
 msgstr "더 이상의 수정은 없었습니다"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Undo 번호 %ld를 찾을 수 없습니다"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Undo 번호 %<PRId64>를 찾을 수 없습니다"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 잘못된 줄 번호"
@@ -5645,8 +5645,8 @@ msgid "changes"
 msgstr "changes"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "before"
@@ -5661,8 +5661,8 @@ msgstr "취소할 게 없습니다"
 #~ msgstr ""
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld seconds ago"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> seconds ago"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo 뒤에 undojoin은 할 수 없습니다"

--- a/src/po/ko.UTF-8.po
+++ b/src/po/ko.UTF-8.po
@@ -1780,8 +1780,8 @@ msgid "1 character"
 msgstr "1 글자"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld 글자"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 글자"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/ko.UTF-8.po
+++ b/src/po/ko.UTF-8.po
@@ -3918,12 +3918,12 @@ msgstr "에러: "
 #, c-format
 #~ msgid ""
 #~ "\n"
-#~ "[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 #~ msgstr ""
 
 #, c-format
 #~ msgid ""
-#~ "[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 #~ "\n"
 #~ msgstr ""
 
@@ -3935,8 +3935,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 내부 에러: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: 메모리 부족!  (%lu 바이트를 할당)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 메모리 부족!  (%<PRIu64> 바이트를 할당)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -79,8 +79,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: 나열된 버퍼가 없습니다"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: 버퍼 %ld이(가) 존재하지 않습니다"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: 버퍼 %<PRId64>이(가) 존재하지 않습니다"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 마지막 버퍼입니다"
@@ -89,9 +89,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 첫 번째 버퍼입니다"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: 버퍼 %ld을(를) 마지막으로 고친 뒤 저장하지 않았습니다 (덮어쓰려면 ! 더하"
+"E89: 버퍼 %<PRId64>을(를) 마지막으로 고친 뒤 저장하지 않았습니다 (덮어쓰려면 ! 더하"
 "기)"
 
 msgid "E90: Cannot unload last buffer"
@@ -101,8 +101,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 경고: 파일 이름 목록이 넘쳤습니다"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: 버퍼 %ld을(를) 찾을 수 없습니다"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: 버퍼 %<PRId64>을(를) 찾을 수 없습니다"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -113,8 +113,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: %s와 맞는 버퍼가 없습니다"
 
 #, c-format
-msgid "line %ld"
-msgstr "%ld 줄"
+msgid "line %<PRId64>"
+msgstr "%<PRId64> 줄"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 이 이름을 가진 버퍼가 이미 있습니다"
@@ -139,12 +139,12 @@ msgid "1 line --%d%%--"
 msgstr "1 줄 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld 줄 --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> 줄 --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "%ld / %ld 줄 --%d%%-- 칸 "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "%<PRId64> / %<PRId64> 줄 --%d%%-- 칸 "
 
 msgid "[No Name]"
 msgstr "[이름 없음]"
@@ -190,12 +190,12 @@ msgid "Signs for %s:"
 msgstr "%s에 대한 기호:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    줄=%ld  id=%d  이름=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    줄=%<PRId64>  id=%d  이름=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: %ld개 이상의 버퍼에 대해서는 diff를 할 수 없습니다"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: %<PRId64>개 이상의 버퍼에 대해서는 diff를 할 수 없습니다"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: 임시 파일을 읽거나 쓸 수 없습니다"
@@ -354,8 +354,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: ':let'에 모르는 글자"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: 목록 번호가 범위를 벗어남: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: 목록 번호가 범위를 벗어남: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -736,8 +736,8 @@ msgid "%s aborted"
 msgstr "%s이(가) 중지되었습니다"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s이(가) #%ld을(를) 돌려주었습니다"
+msgid "%s returning #%<PRId64>"
+msgstr "%s이(가) #%<PRId64>을(를) 돌려주었습니다"
 
 #, c-format
 msgid "%s returning %s"
@@ -786,12 +786,12 @@ msgid "1 line moved"
 msgstr "1 줄 옮겨졌습니다"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld 줄 옮겨졌습니다"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> 줄 옮겨졌습니다"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld 줄을 걸렀습니다"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> 줄을 걸렀습니다"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 자동명령은 현재 버퍼를 바꾸어서는 안 됩니다"
@@ -875,8 +875,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 스왑 파일 있음: %s (덮어쓰려면 :silent! 사용)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: 버퍼 %ld의 파일 이름이 없습니다"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: 버퍼 %<PRId64>의 파일 이름이 없습니다"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 파일이 써지지 않음: 'write' 옵션에 의해 쓸 수가 없습니다"
@@ -933,19 +933,19 @@ msgid "1 substitution"
 msgstr "1개 바꿨음"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld개 찾아짐"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64>개 찾아짐"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld개 바꿨음"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64>개 바꿨음"
 
 msgid " on 1 line"
 msgstr " 한 줄에서"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " %ld 줄에서"
+msgid " on %<PRId64> lines"
+msgstr " %<PRId64> 줄에서"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global은 재귀 호출 될 수 없습니다"
@@ -1027,8 +1027,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 잘못된 버퍼 이름: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: 잘못된 sign ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: 잘못된 sign ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (못 찾았음)"
@@ -1043,16 +1043,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "디버그 상태로 들어감.  계속하려면 \"cont\"를 입력하십시오."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "%ld 줄: %s"
+msgid "line %<PRId64>: %s"
+msgstr "%<PRId64> 줄: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "명령: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "중지점: \"%s%s\" %ld 줄"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "중지점: \"%s%s\" %<PRId64> 줄"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1062,8 +1062,8 @@ msgid "No breakpoints defined"
 msgstr "중지점이 정의되어 있지 않습니다"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  %ld 줄"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  %<PRId64> 줄"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: 먼저 \":profile start {fname}\"을 사용하세요"
@@ -1119,16 +1119,16 @@ msgid "could not source \"%s\""
 msgstr "\"%s\"을(를) 불러 들일 수 없습니다"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "%ld 줄: \"%s\"을(를) 불러 들일 수 없습니다"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "%<PRId64> 줄: \"%s\"을(를) 불러 들일 수 없습니다"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\"을(를) 불러들이는 중"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "%ld 줄: \"%s\" 불러들이는 중"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "%<PRId64> 줄: \"%s\" 불러들이는 중"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1217,8 +1217,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 고칠 파일이 한 개 더 있습니다"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 고칠 파일이 %ld 개 더 있습니다"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 고칠 파일이 %<PRId64> 개 더 있습니다"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 명령이 이미 존재합니다: 바꾸려면 !을 더하세요"
@@ -1408,8 +1408,8 @@ msgid "Exception discarded: %s"
 msgstr "예외 버려짐: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, %ld 줄"
+msgid "%s, line %<PRId64>"
+msgstr "%s, %<PRId64> 줄"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1613,12 +1613,12 @@ msgid "[crypted]"
 msgstr "[암호화 되었습니다]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[%ld 줄에서 변환 에러]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[%<PRId64> 줄에서 변환 에러]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[%ld 줄에 잘못된 바이트]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[%<PRId64> 줄에 잘못된 바이트]"
 
 msgid "[READ ERRORS]"
 msgstr "[읽기 에러]"
@@ -1700,9 +1700,9 @@ msgstr "E513: 쓰기 에러, 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
-msgstr "E513: 쓰기 에러, %ld 줄에서 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
+msgstr "E513: 쓰기 에러, %<PRId64> 줄에서 변환 실패 (무시하려면 'fenc'를 비우면 됨)"
 
 msgid "E514: write error (file system full?)"
 msgstr "E514: 쓰기 에러 (파일 시스템이 꽉찼나요?)"
@@ -1711,8 +1711,8 @@ msgid " CONVERSION ERROR"
 msgstr " 변환 에러"
 
 #, c-format
-msgid " in line %ld;"
-msgstr "%ld 줄에서;"
+msgid " in line %<PRId64>;"
+msgstr "%<PRId64> 줄에서;"
 
 msgid "[Device]"
 msgstr "[장치]"
@@ -1773,8 +1773,8 @@ msgid "1 line, "
 msgstr "1 줄, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 줄, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 줄, "
 
 msgid "1 character"
 msgstr "1 글자"
@@ -1785,8 +1785,8 @@ msgstr "%<PRId64> 글자"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld 글자"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 글자"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2194,19 +2194,19 @@ msgid "Font1: %s\n"
 msgstr "글꼴1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "글꼴%ld 너비가 글꼴0의 두배가 아닙니다\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "글꼴%<PRId64> 너비가 글꼴0의 두배가 아닙니다\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "글꼴0 너비: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "글꼴0 너비: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"글꼴1 너비: %ld\n"
+"글꼴1 너비: %<PRId64>\n"
 "\n"
 
 #~ msgid "Invalid font specification"
@@ -2383,8 +2383,8 @@ msgid "Added cscope database %s"
 msgstr "cscope 데이터베이스 %s에 더했습니다."
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: cscope 연결 %ld 읽기 에러"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: cscope 연결 %<PRId64> 읽기 에러"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 모르는 cscope 찾기 형식"
@@ -3596,12 +3596,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 파일 보존을 실패했습니다"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 잘못된 lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 잘못된 lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: %ld 줄을 찾을 수 없습니다"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: %<PRId64> 줄을 찾을 수 없습니다"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 잘못된 포인터 구역 id 3"
@@ -3619,8 +3619,8 @@ msgid "deleted block 1?"
 msgstr "구역 1이 지워졌나요?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: %ld 줄을 찾을 수 없습니다"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: %<PRId64> 줄을 찾을 수 없습니다"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: 잘못된 포인터 구역 id"
@@ -3629,12 +3629,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count가 0입니다"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 줄 번호가 범위를 벗어났습니다: 마지막에서 %ld 만큼"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 줄 번호가 범위를 벗어났습니다: 마지막에서 %<PRId64> 만큼"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: 구역 %ld의 줄 갯수가 틀렸습니다"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: 구역 %<PRId64>의 줄 갯수가 틀렸습니다"
 
 msgid "Stack size increases"
 msgstr "스택 크기 증가"
@@ -3822,8 +3822,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "계속하려면 엔터 혹은 명령을 입력하십시오"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s 줄 %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s 줄 %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- 더 --"
@@ -3892,12 +3892,12 @@ msgid "1 line less"
 msgstr "한 줄 이하"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld 보다 많은 줄"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> 보다 많은 줄"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld 보다 적은 줄"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> 보다 적은 줄"
 
 msgid " (Interrupted)"
 msgstr " (중단되었습니다)"
@@ -3931,8 +3931,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 줄이 너무 길어졌습니다"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 내부 에러: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 내부 에러: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4004,8 +4004,8 @@ msgid "read from Netbeans socket"
 msgstr "Netbeans 소켓에서 읽기"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: 버퍼 %ld에 대한 NetBeans 연결을 잃어버렸습니다"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: 버퍼 %<PRId64>에 대한 NetBeans 연결을 잃어버렸습니다"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: 이 GUI는 netbeans를 지원하지 않습니다"
@@ -4055,23 +4055,23 @@ msgid "1 line %sed %d times"
 msgstr "1 line %sed %d times"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld lines %sed 1 time"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> lines %sed 1 time"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld lines %sed %d times"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> lines %sed %d times"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld lines to indent... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> lines to indent... "
 
 msgid "1 line indented "
 msgstr "1 line indented "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld lines indented "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> lines indented "
 
 #~ msgid "E748: No previously used register"
 #~ msgstr ""
@@ -4084,12 +4084,12 @@ msgid "1 line changed"
 msgstr "1 line changed"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld lines changed"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> lines changed"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "freeing %ld lines"
+msgid "freeing %<PRId64> lines"
+msgstr "freeing %<PRId64> lines"
 
 msgid "block of 1 line yanked"
 msgstr "block of 1 line yanked"
@@ -4098,12 +4098,12 @@ msgid "1 line yanked"
 msgstr "1 line yanked"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "block of %ld lines yanked"
+msgid "block of %<PRId64> lines yanked"
+msgstr "block of %<PRId64> lines yanked"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld lines yanked"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> lines yanked"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4132,36 +4132,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: 모르는 레지스터 형식 %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 열; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 열; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Selected %s%ld of %ld 라인; %ld of %ld 단어; %ld of %ld 바이트"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; %<PRId64> of %<PRId64> 바이트"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Selected %s%ld of %ld 라인; %ld of %ld 단어; %ld of %ld 문자; %ld of %ld 바이"
+"Selected %s%<PRId64> of %<PRId64> 라인; %<PRId64> of %<PRId64> 단어; %<PRId64> of %<PRId64> 문자; %<PRId64> of %<PRId64> 바이"
 "트"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Col %s of %s; 라인 %ld of %ld; 단어 %ld of %ld; 바이트 %ld of %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 바이트 %<PRId64> of %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Col %s of %s; 라인 %ld of %ld; 단어 %ld of %ld; 문자 %ld of %ld; 바이트 %ld "
-"of %ld"
+"Col %s of %s; 라인 %<PRId64> of %<PRId64>; 단어 %<PRId64> of %<PRId64>; 문자 %<PRId64> of %<PRId64>; 바이트 %<PRId64> "
+"of %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld for BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=페이지 %N"
@@ -4340,8 +4340,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "아미가도스 2.04나 더 높은 판이 필요합니다\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Need %s version %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Need %s version %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "NIL을 열 수 없음:\n"
@@ -4423,8 +4423,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "빔: 죽을 시그널을 잡았습니다\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "X 디스플레이를 여는 데 %ld msec이 걸렸습니다"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "X 디스플레이를 여는 데 %<PRId64> msec이 걸렸습니다"
 
 msgid ""
 "\n"
@@ -5117,8 +5117,8 @@ msgid "Performing soundfolding..."
 msgstr "soundfold 수행중..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "soundfold 수행 후의 단어 수: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "soundfold 수행 후의 단어 수: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5153,8 +5153,8 @@ msgid "Done!"
 msgstr "끝!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile'에 %ld 항목이 없습니다"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile'에 %<PRId64> 항목이 없습니다"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5171,8 +5171,8 @@ msgid "Sorry, no suggestions"
 msgstr "죄송, 제안할 게 없습니다"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "죄송, %ld개만 제안"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "죄송, %<PRId64>개만 제안"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5472,8 +5472,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: 태그 파일 \"%s\"에 형식 에러가 있습니다"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Before byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Before byte %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5620,8 +5620,8 @@ msgid "Already at newest change"
 msgstr "더 이상의 수정은 없었습니다"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Undo 번호 %ld를 찾을 수 없습니다"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Undo 번호 %<PRId64>를 찾을 수 없습니다"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 잘못된 줄 번호"
@@ -5645,8 +5645,8 @@ msgid "changes"
 msgstr "changes"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "before"
@@ -5661,8 +5661,8 @@ msgstr "취소할 게 없습니다"
 #~ msgstr ""
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld seconds ago"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> seconds ago"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undo 뒤에 undojoin은 할 수 없습니다"

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -3918,12 +3918,12 @@ msgstr "에러: "
 #, c-format
 #~ msgid ""
 #~ "\n"
-#~ "[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 #~ msgstr ""
 
 #, c-format
 #~ msgid ""
-#~ "[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 #~ "\n"
 #~ msgstr ""
 
@@ -3935,8 +3935,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 내부 에러: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: 메모리 부족!  (%lu 바이트를 할당)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 메모리 부족!  (%<PRIu64> 바이트를 할당)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -1780,8 +1780,8 @@ msgid "1 character"
 msgstr "1 글자"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld 글자"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 글자"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/nb.po
+++ b/src/po/nb.po
@@ -3829,17 +3829,17 @@ msgstr "FEIL: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bytes] totalt alloc-frigjort %lu-%lu, i bruk %lu, topp-bruk %lu\n"
+"[bytes] totalt alloc-frigjort %<PRIu64>-%<PRIu64>, i bruk %<PRIu64>, topp-bruk %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[kall] totale \"re/malloc()\"-er %lu, totale \"free()\"-er %lu\n"
+"[kall] totale \"re/malloc()\"-er %<PRIu64>, totale \"free()\"-er %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3850,8 +3850,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Intern feil: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Ikke mer ledig hukommelse! (Reserverer %lu bytes)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Ikke mer ledig hukommelse! (Reserverer %<PRIu64> bytes)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/nb.po
+++ b/src/po/nb.po
@@ -78,8 +78,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Det finnes ingen listede buffere"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Bufferen %ld finnes ikke"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Bufferen %<PRId64> finnes ikke"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kan ikke gå forbi siste buffer"
@@ -88,9 +88,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kan ikke gå forbi første buffer"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Ikke lagret siden forrige forandring av bufferen %ld (legg til ! for å "
+"E89: Ikke lagret siden forrige forandring av bufferen %<PRId64> (legg til ! for å "
 "overstyre)"
 
 msgid "E90: Cannot unload last buffer"
@@ -100,8 +100,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Advarsel: Listen med filnavn er overfylt"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Fant ikke bufferen %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Fant ikke bufferen %<PRId64>"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -112,8 +112,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Ingen samsvarende buffer for %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "linje %ld"
+msgid "line %<PRId64>"
+msgstr "linje %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: En buffer med dette navnet finnes allerede"
@@ -138,12 +138,12 @@ msgid "1 line --%d%%--"
 msgstr "1 linje --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld linjer --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> linjer --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "linje %ld av %ld --%d%%-- kol "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "linje %<PRId64> av %<PRId64> --%d%%-- kol "
 
 msgid "[No Name]"
 msgstr "[Uten navn]"
@@ -193,12 +193,12 @@ msgid "Signs for %s:"
 msgstr "Skilt for %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    linje=%ld  id=%d  navn=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    linje=%<PRId64>  id=%d  navn=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Kan ikke sammenligne flere enn %ld buffere"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Kan ikke sammenligne flere enn %<PRId64> buffere"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kan ikke lage differansefiler"
@@ -348,8 +348,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Uventede tegn i :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Listeindeks utenfor område: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Listeindeks utenfor område: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -698,8 +698,8 @@ msgid "%s aborted"
 msgstr "%s avbrutt"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s returnerer #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s returnerer #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -746,12 +746,12 @@ msgid "1 line moved"
 msgstr "1 linje flyttet"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld linjer flyttet"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> linjer flyttet"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld linjer filtrert"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> linjer filtrert"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autokommandoer må ikke forandre nåværende buffer"
@@ -834,8 +834,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Swapfilen finnes: %s (:silent! overstyrer)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Mangler filnavn for buffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Mangler filnavn for buffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Filen ble ikke lagret: Lagring er deaktivert med 'write'-valget"
@@ -878,19 +878,19 @@ msgid "1 substitution"
 msgstr "1 erstatning"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld treff"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> treff"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld erstatninger"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> erstatninger"
 
 msgid " on 1 line"
 msgstr " i 1 linje"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " i %ld linjer"
+msgid " on %<PRId64> lines"
+msgstr " i %<PRId64> linjer"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kan ikke gjøre :global rekursiv"
@@ -973,8 +973,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ugyldig buffernavn: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Ulovlig skilt-ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Ulovlig skilt-ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (IKKE FUNNET)"
@@ -989,16 +989,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Går inn i debuggingsmodus. Skriv \"cont\" for å fortsette."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "linje %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "linje %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "kommando: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Stoppunkt i \"%s%s\" linje %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Stoppunkt i \"%s%s\" linje %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1008,8 +1008,8 @@ msgid "No breakpoints defined"
 msgstr "Ingen stoppunkt definert"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  linje %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  linje %<PRId64>"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: Bruk først :profile start <filnavn>"
@@ -1065,16 +1065,16 @@ msgid "could not source \"%s\""
 msgstr "kunne ikke kjøre \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "linje %ld: Kunne ikke kjøre \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "linje %<PRId64>: Kunne ikke kjøre \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "kjører \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "linje %ld: kjører \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "linje %<PRId64>: kjører \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1166,8 +1166,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 annen fil å redigere"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: %ld andre filer å redigere"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: %<PRId64> andre filer å redigere"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Kommandoen finnes allerede: Legg til ! for å erstatte den"
@@ -1355,8 +1355,8 @@ msgid "Exception discarded: %s"
 msgstr "Unntak forkastet: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, linje %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, linje %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1554,12 +1554,12 @@ msgid "[crypted]"
 msgstr "[kryptert]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[KONVERTERINGSFEIL i linje %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[KONVERTERINGSFEIL i linje %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[ULOVLIG BYTE i linje %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[ULOVLIG BYTE i linje %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[LESEFEIL]"
@@ -1703,15 +1703,15 @@ msgid "1 line, "
 msgstr "1 linje, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld linjer, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> linjer, "
 
 msgid "1 character"
 msgstr "1 tegn"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld tegn"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> tegn"
 
 msgid "[noeol]"
 msgstr "[ingenlinjeslutt]"
@@ -2128,19 +2128,19 @@ msgid "Font1: %s\n"
 msgstr "Font1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Font%ld-bredde er ikke to ganger bredden av font0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Font%<PRId64>-bredde er ikke to ganger bredden av font0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Font0-bredde: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Font0-bredde: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Font1-bredde: %ld\n"
+"Font1-bredde: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2317,8 +2317,8 @@ msgid "Added cscope database %s"
 msgstr "La til cscope-database %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Feil under lesing av cscope-forbindelse %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Feil under lesing av cscope-forbindelse %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: Ukjent cscope-søketype"
@@ -3508,12 +3508,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Bevaring feilet"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: Ugyldig lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: Ugyldig lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: Kan ikke finne linje %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: Kan ikke finne linje %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Pekerblokk-id feil 3"
@@ -3531,8 +3531,8 @@ msgid "deleted block 1?"
 msgstr "slettet blokk 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Kan ikke finne linje %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Kan ikke finne linje %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: Pekerblokk-id feil"
@@ -3541,12 +3541,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count er null"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: Linjenummer utenfor område: %ld forbi slutten"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: Linjenummer utenfor område: %<PRId64> forbi slutten"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: Linjeantall feil i blokk %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: Linjeantall feil i blokk %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Stackstørrelse øker"
@@ -3735,8 +3735,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Trykk ENTER eller skriv kommando for å fortsette"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s linje %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s linje %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Mer --"
@@ -3802,12 +3802,12 @@ msgid "1 line less"
 msgstr "1 linje fjernet"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld linjer lagt til"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> linjer lagt til"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld linjer fjernet"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> linjer fjernet"
 
 msgid " (Interrupted)"
 msgstr " (Avbrutt)"
@@ -3846,8 +3846,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Linjen blir for lang"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Intern feil: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Intern feil: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3921,8 +3921,8 @@ msgid "read from Netbeans socket"
 msgstr "les fra Netbeans-socket"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Mistet NetBeans-forbindelse for buffer %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Mistet NetBeans-forbindelse for buffer %<PRId64>"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3966,23 +3966,23 @@ msgid "1 line %sed %d times"
 msgstr "1 linje \"%s\"-et %d ganger"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld linjer \"%s\"-et 1 gang"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> linjer \"%s\"-et 1 gang"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld linjer \"%s\"-et %d ganger"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> linjer \"%s\"-et %d ganger"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld linjer å rykke inn ... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> linjer å rykke inn ... "
 
 msgid "1 line indented "
 msgstr "1 linje rykket inn "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld linjer rykket inn "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> linjer rykket inn "
 
 msgid "E748: No previously used register"
 msgstr "E748: Register ikke tidligere brukt"
@@ -3995,12 +3995,12 @@ msgid "1 line changed"
 msgstr "1 linje forandret"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld linjer forandret"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> linjer forandret"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "frigjør %ld linjer"
+msgid "freeing %<PRId64> lines"
+msgstr "frigjør %<PRId64> linjer"
 
 msgid "block of 1 line yanked"
 msgstr "blokk med 1 linje kopiert til utklippstavlen"
@@ -4009,12 +4009,12 @@ msgid "1 line yanked"
 msgstr "1 linje kopiert til utklippstavlen"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "blokk med %ld linjer kopiert til utklippstavlen"
+msgid "block of %<PRId64> lines yanked"
+msgstr "blokk med %<PRId64> linjer kopiert til utklippstavlen"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld linjer kopiert til utklippstavlen"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> linjer kopiert til utklippstavlen"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4044,35 +4044,35 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Ukjent registertype %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Kol; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Kol; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Valgte %s%ld av %ld linjer; %ld av %ld ord; %ld av %ld bytes"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> bytes"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Valgte %s%ld av %ld linjer; %ld av %ld ord; %ld av %ld tegn; %ld av %ld bytes"
+"Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> tegn; %<PRId64> av %<PRId64> bytes"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Kol %s av %s; Linje %ld av %ld; Ord %ld av %ld; Byte %ld av %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Kol %s av %s; Linje %<PRId64> av %<PRId64>; Ord %<PRId64> av %<PRId64>; Byte %<PRId64> av %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Kol %s av %s; linje %ld av %ld; ord %ld av %ld; tegn %ld av %ld; byte %ld av "
-"%ld"
+"Kol %s av %s; linje %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; tegn %<PRId64> av %<PRId64>; byte %<PRId64> av "
+"%<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld for BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Side %N"
@@ -4238,8 +4238,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Trenger Amigados versjon 2.04 eller nyere\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Trenger %s versjon %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Trenger %s versjon %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Kan ikke åpne NIL:\n"
@@ -4321,8 +4321,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Mottok dødelig signal\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Åpning av X-display tok %ld millisekunder"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Åpning av X-display tok %<PRId64> millisekunder"
 
 msgid ""
 "\n"
@@ -4979,7 +4979,7 @@ msgstr "Pakket %d av %d noder; %d (%d%%) igjen"
 #~ msgstr ""
 
 #, c-format
-#~ msgid "Number of words after soundfolding: %ld"
+#~ msgid "Number of words after soundfolding: %<PRId64>"
 #~ msgstr ""
 
 #, c-format
@@ -5015,8 +5015,8 @@ msgid "Done!"
 msgstr "Ferdig!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' har ikke %ld poster"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' har ikke %<PRId64> poster"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5033,8 +5033,8 @@ msgid "Sorry, no suggestions"
 msgstr "Dessverre, ingen forslag"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Dessverre bare %ld forslag"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Dessverre bare %<PRId64> forslag"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5335,8 +5335,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Formatfeil i tagfil \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Før byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Før byte %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5399,8 +5399,8 @@ msgid "Already at newest change"
 msgstr "Allerede ved nyeste forandring"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "Angrenummer %ld ikke funnet"
+msgid "Undo number %<PRId64> not found"
+msgstr "Angrenummer %<PRId64> ikke funnet"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: Gale linjenummer"
@@ -5424,8 +5424,8 @@ msgid "changes"
 msgstr "forandringer"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "før"
@@ -5440,8 +5440,8 @@ msgid "number changes  time"
 msgstr "nummer forandringer tidspunkt"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld sekunder siden"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> sekunder siden"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin er ikke tillatt etter undo"

--- a/src/po/nl.po
+++ b/src/po/nl.po
@@ -3432,12 +3432,12 @@ msgstr "biep!"
 #, c-format
 #~ msgid ""
 #~ "\n"
-#~ "[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 #~ msgstr ""
 
 #, c-format
 #~ msgid ""
-#~ "[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 #~ "\n"
 #~ msgstr ""
 
@@ -3449,7 +3449,7 @@ msgstr "biep!"
 #~ msgstr ""
 
 #, c-format
-#~ msgid "E342: Out of memory!  (allocating %lu bytes)"
+#~ msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
 #~ msgstr ""
 
 #, c-format

--- a/src/po/nl.po
+++ b/src/po/nl.po
@@ -1771,8 +1771,8 @@ msgid "1 character"
 msgstr "1 teken"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld tekens"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> tekens"
 
 #, c-format
 msgid "%ld characters"

--- a/src/po/nl.po
+++ b/src/po/nl.po
@@ -77,8 +77,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: er is geen vermelde buffer"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Buffer %ld bestaat niet"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Buffer %<PRId64> bestaat niet"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: kan niet voorbij het laatste buffer komen"
@@ -87,8 +87,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: kan niet vóór het eerste buffer komen"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: niets opgeslagen sinds laatste wijziging van buffer %ld (voeg ! toe om te forceren)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: niets opgeslagen sinds laatste wijziging van buffer %<PRId64> (voeg ! toe om te forceren)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: kan laatste buffer niet legen"
@@ -97,8 +97,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: waarschuwing: lijst met bestandsnamen is vol"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: buffer %ld niet gevonden"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: buffer %<PRId64> niet gevonden"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -109,8 +109,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: geen overeenkomstig buffer voor %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "regel %ld"
+msgid "line %<PRId64>"
+msgstr "regel %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: buffer met deze naam bestaat al"
@@ -135,12 +135,12 @@ msgid "1 line --%d%%--"
 msgstr "1 regel --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld regels --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> regels --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "regel %ld van %ld --%d%%-- kol "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "regel %<PRId64> van %<PRId64> --%d%%-- kol "
 
 msgid "[No Name]"
 msgstr "[Geen naam]"
@@ -193,12 +193,12 @@ msgid "Signs for %s:"
 msgstr "Tekens voor %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    regel=%ld  id=%d  naam=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    regel=%<PRId64>  id=%d  naam=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: kan niet meer dan %ld buffers vergelijken"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: kan niet meer dan %<PRId64> buffers vergelijken"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: kan tijdelijke bestand niet lezen of opslaan"
@@ -350,8 +350,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: onverwachte tekens in :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: lijstindex buiten bereik: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: lijstindex buiten bereik: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -732,8 +732,8 @@ msgid "%s aborted"
 msgstr "%s afgebroken"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s komt terug met de waarde #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s komt terug met de waarde #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -782,12 +782,12 @@ msgid "1 line moved"
 msgstr "1 regel verplaatst"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld regels verplaatst"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> regels verplaatst"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld regels gefilterd"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> regels gefilterd"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autocommands mogen huidige buffer niet wijzigen"
@@ -873,8 +873,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: wisselbestand bestaat: %s (:silent! overschrijft)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: buffer %ld heeft geen bestandsnaam"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: buffer %<PRId64> heeft geen bestandsnaam"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: bestand is niet opgeslagen: opslaan is uitgeschakeld door 'write'-optie"
@@ -931,19 +931,19 @@ msgid "1 substitution"
 msgstr "1 vervanging"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld overeenkomsten"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> overeenkomsten"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld vervangingen"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> vervangingen"
 
 msgid " on 1 line"
 msgstr " op 1 regel"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " op %ld regels"
+msgid " on %<PRId64> lines"
+msgstr " op %<PRId64> regels"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: kan :global niet recursief uitvoeren"
@@ -1026,8 +1026,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: ongeldige buffernaam: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: ongeldige id margeteken: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: ongeldige id margeteken: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NIET GEVONDEN)"
@@ -1042,16 +1042,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Debug-modus gestart.  Typ \"cont\" om verder te gaan."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "regel %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "regel %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "'Breakpoint' in \"%s%s\" regel %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "'Breakpoint' in \"%s%s\" regel %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1061,8 +1061,8 @@ msgid "No breakpoints defined"
 msgstr "Geen 'breakpoints' opgegeven"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  regel %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  regel %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: gebruik eerst \":profile start {fname}\""
@@ -1118,16 +1118,16 @@ msgid "could not source \"%s\""
 msgstr "kan \"%s\" niet laden"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "regel %ld: kan \"%s\" niet laden"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "regel %<PRId64>: kan \"%s\" niet laden"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "\"%s\" laden"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "regel %ld: \"%s\" laden"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "regel %<PRId64>: \"%s\" laden"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1216,8 +1216,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 bestand wacht op bewerking"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: %ld bestanden wachten op bewerking"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: %<PRId64> bestanden wachten op bewerking"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: opdracht bestaat al: voeg ! toe om het te vervangen"
@@ -1401,8 +1401,8 @@ msgid "Exception discarded: %s"
 msgstr "Afgedankte uitzondering: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, regel %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, regel %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1606,12 +1606,12 @@ msgid "[crypted]"
 msgstr "[versleuteld]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[OMZETFOUT in regel %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[OMZETFOUT in regel %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[ONGELDIGE BYTE in regel %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[ONGELDIGE BYTE in regel %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[LEESFOUTEN]"
@@ -1692,8 +1692,8 @@ msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: schrijffout waarbij omzetting is mislukt (leeg 'fenc' om te overschrijven)"
 
 #, c-format
-msgid "E513: write error, conversion failed in line %ld (make 'fenc' empty to override)"
-msgstr "E513: schrijffout waarbij omzetting in regel %ld is mislukt (leeg 'fenc' om te overschrijven)"
+msgid "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to override)"
+msgstr "E513: schrijffout waarbij omzetting in regel %<PRId64> is mislukt (leeg 'fenc' om te overschrijven)"
 
 msgid "E514: write error (file system full?)"
 msgstr "E514: schrijffout (is bestandssysteem vol?)"
@@ -1702,8 +1702,8 @@ msgid " CONVERSION ERROR"
 msgstr " OMZETTINGFOUT"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " in regel %ld;"
+msgid " in line %<PRId64>;"
+msgstr " in regel %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Apparaat]"
@@ -1764,8 +1764,8 @@ msgid "1 line, "
 msgstr "1 regel, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld regels, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> regels, "
 
 msgid "1 character"
 msgstr "1 teken"
@@ -1775,8 +1775,8 @@ msgid "%<PRId64> characters"
 msgstr "%<PRId64> tekens"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld tekens"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> tekens"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2198,19 +2198,19 @@ msgid "Font1: %s\n"
 msgstr "Font1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Breedte font%ld is niet het dubbele van font0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Breedte font%<PRId64> is niet het dubbele van font0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Font0-breedte: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Font0-breedte: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Font1-breedte: %ld\n"
+"Font1-breedte: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2387,8 +2387,8 @@ msgid "Added cscope database %s"
 msgstr "cscope-databank %s toegevoegd"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: lezen van cscope-verbinding %ld is mislukt"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: lezen van cscope-verbinding %<PRId64> is mislukt"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: soort cscope-zoekopdracht is onbekend"
@@ -3342,8 +3342,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Toets ENTER of typ een opdracht om verder te gaan"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s regel %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s regel %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- meer --"
@@ -3405,12 +3405,12 @@ msgid "1 line less"
 msgstr "1 regel minder"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld regels meer"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> regels meer"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld regels minder"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> regels minder"
 
 msgid " (Interrupted)"
 msgstr " (onderbroken)"
@@ -3445,7 +3445,7 @@ msgstr "biep!"
 #~ msgstr ""
 
 #, c-format
-#~ msgid "E341: Internal error: lalloc(%ld, )"
+#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 #~ msgstr ""
 
 #, c-format
@@ -3514,7 +3514,7 @@ msgstr "biep!"
 #~ msgstr ""
 
 #, c-format
-#~ msgid "E658: NetBeans connection lost for buffer %ld"
+#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
 #~ msgstr ""
 
 #~ msgid "E511: netbeans already connected"
@@ -3562,23 +3562,23 @@ msgid "1 line %sed %d times"
 msgstr "1 regel %sed %d maal"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld regels %sed 1 maal"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> regels %sed 1 maal"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld regels %sed %d maal"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> regels %sed %d maal"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld in te springen regels... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> in te springen regels... "
 
 msgid "1 line indented "
 msgstr "1 regel ingesprongen "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld regels ingesprongen "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> regels ingesprongen "
 
 #~ msgid "E748: No previously used register"
 #~ msgstr ""
@@ -3591,11 +3591,11 @@ msgid "1 line changed"
 msgstr "1 regel gewijzigd"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld regels gewijzigd"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> regels gewijzigd"
 
 #, c-format
-#~ msgid "freeing %ld lines"
+#~ msgid "freeing %<PRId64> lines"
 #~ msgstr ""
 
 msgid "block of 1 line yanked"
@@ -3605,12 +3605,12 @@ msgid "1 line yanked"
 msgstr "1 regel gekopieerd"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "blok van %ld regels gekopieerd"
+msgid "block of %<PRId64> lines yanked"
+msgstr "blok van %<PRId64> regels gekopieerd"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld regels gekopieerd"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> regels gekopieerd"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3640,28 +3640,28 @@ msgstr ""
 #~ msgstr ""
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld koln; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> koln; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "geselecteerd %s%ld van %ld regels; %ld van %ld woorden; %ld van %ld bytes"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "geselecteerd %s%<PRId64> van %<PRId64> regels; %<PRId64> van %<PRId64> woorden; %<PRId64> van %<PRId64> bytes"
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld Bytes"
-msgstr "geselecteerd %s%ld van %ld regels; %ld van %ld woorden; %ld van %ld rekens; %ld van %ld bytes"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr "geselecteerd %s%<PRId64> van %<PRId64> regels; %<PRId64> van %<PRId64> woorden; %<PRId64> van %<PRId64> rekens; %<PRId64> van %<PRId64> bytes"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "kol %s van %s; regel %ld van %ld; woord %ld van %ld; byte %ld van %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "kol %s van %s; regel %<PRId64> van %<PRId64>; woord %<PRId64> van %<PRId64>; byte %<PRId64> van %<PRId64>"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of %ld"
-msgstr "kol %s van %s; regel %ld van %ld; woord %ld van %ld; teken %ld van %ld; byte %ld van %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "kol %s van %s; regel %<PRId64> van %<PRId64>; woord %<PRId64> van %<PRId64>; teken %<PRId64> van %<PRId64>; byte %<PRId64> van %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld voor BOD)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> voor BOD)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=pagina %N"
@@ -3834,8 +3834,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Vereist Amigados versie 2.04 of nieuwer\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Vereist %s versie %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Vereist %s versie %<PRId64>\n"
 
 #~ msgid "Cannot open NIL:\n"
 #~ msgstr ""
@@ -3920,8 +3920,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: fataal signaal gevangen\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Openen van X-display vereiste %ld ms"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Openen van X-display vereiste %<PRId64> ms"
 
 #~ msgid ""
 #~ "\n"
@@ -4571,7 +4571,7 @@ msgstr ""
 #~ msgstr ""
 
 #, c-format
-#~ msgid "Number of words after soundfolding: %ld"
+#~ msgid "Number of words after soundfolding: %<PRId64>"
 #~ msgstr ""
 
 #, c-format
@@ -4607,7 +4607,7 @@ msgstr ""
 #~ msgstr ""
 
 #, c-format
-#~ msgid "E765: 'spellfile' does not have %ld entries"
+#~ msgid "E765: 'spellfile' does not have %<PRId64> entries"
 #~ msgstr ""
 
 #, c-format
@@ -4625,7 +4625,7 @@ msgstr ""
 #~ msgstr ""
 
 #, c-format
-#~ msgid "Sorry, only %ld suggestions"
+#~ msgid "Sorry, only %<PRId64> suggestions"
 #~ msgstr ""
 
 #. for when 'cmdheight' > 1
@@ -4918,7 +4918,7 @@ msgstr "E426: tag niet gevonden: %s"
 #~ msgstr ""
 
 #, c-format
-#~ msgid "Before byte %ld"
+#~ msgid "Before byte %<PRId64>"
 #~ msgstr ""
 
 #, c-format
@@ -5061,8 +5061,8 @@ msgid "Already at newest change"
 msgstr "Reeds de nieuwste wijziging"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Ongedaan-nummer %ld niet gevonden"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Ongedaan-nummer %<PRId64> niet gevonden"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: regelnummers onjuist"
@@ -5086,8 +5086,8 @@ msgid "changes"
 msgstr "wijzigingen"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "voor"
@@ -5102,8 +5102,8 @@ msgid "number changes  time"
 msgstr "aantal wijzign  tijd"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld seconden geleden"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> seconden geleden"
 
 #~ msgid "E790: undojoin is not allowed after undo"
 #~ msgstr ""

--- a/src/po/no.po
+++ b/src/po/no.po
@@ -3829,17 +3829,17 @@ msgstr "FEIL: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bytes] totalt alloc-frigjort %lu-%lu, i bruk %lu, topp-bruk %lu\n"
+"[bytes] totalt alloc-frigjort %<PRIu64>-%<PRIu64>, i bruk %<PRIu64>, topp-bruk %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[kall] totale \"re/malloc()\"-er %lu, totale \"free()\"-er %lu\n"
+"[kall] totale \"re/malloc()\"-er %<PRIu64>, totale \"free()\"-er %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3850,8 +3850,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Intern feil: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Ikke mer ledig hukommelse! (Reserverer %lu bytes)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Ikke mer ledig hukommelse! (Reserverer %<PRIu64> bytes)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/no.po
+++ b/src/po/no.po
@@ -78,8 +78,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Det finnes ingen listede buffere"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Bufferen %ld finnes ikke"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Bufferen %<PRId64> finnes ikke"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kan ikke gå forbi siste buffer"
@@ -88,9 +88,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kan ikke gå forbi første buffer"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Ikke lagret siden forrige forandring av bufferen %ld (legg til ! for å "
+"E89: Ikke lagret siden forrige forandring av bufferen %<PRId64> (legg til ! for å "
 "overstyre)"
 
 msgid "E90: Cannot unload last buffer"
@@ -100,8 +100,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Advarsel: Listen med filnavn er overfylt"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Fant ikke bufferen %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Fant ikke bufferen %<PRId64>"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -112,8 +112,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Ingen samsvarende buffer for %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "linje %ld"
+msgid "line %<PRId64>"
+msgstr "linje %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: En buffer med dette navnet finnes allerede"
@@ -138,12 +138,12 @@ msgid "1 line --%d%%--"
 msgstr "1 linje --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld linjer --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> linjer --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "linje %ld av %ld --%d%%-- kol "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "linje %<PRId64> av %<PRId64> --%d%%-- kol "
 
 msgid "[No Name]"
 msgstr "[Uten navn]"
@@ -193,12 +193,12 @@ msgid "Signs for %s:"
 msgstr "Skilt for %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    linje=%ld  id=%d  navn=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    linje=%<PRId64>  id=%d  navn=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Kan ikke sammenligne flere enn %ld buffere"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Kan ikke sammenligne flere enn %<PRId64> buffere"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kan ikke lage differansefiler"
@@ -348,8 +348,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Uventede tegn i :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Listeindeks utenfor område: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Listeindeks utenfor område: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -698,8 +698,8 @@ msgid "%s aborted"
 msgstr "%s avbrutt"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s returnerer #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s returnerer #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -746,12 +746,12 @@ msgid "1 line moved"
 msgstr "1 linje flyttet"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld linjer flyttet"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> linjer flyttet"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld linjer filtrert"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> linjer filtrert"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autokommandoer må ikke forandre nåværende buffer"
@@ -834,8 +834,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Swapfilen finnes: %s (:silent! overstyrer)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Mangler filnavn for buffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Mangler filnavn for buffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Filen ble ikke lagret: Lagring er deaktivert med 'write'-valget"
@@ -878,19 +878,19 @@ msgid "1 substitution"
 msgstr "1 erstatning"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld treff"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> treff"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld erstatninger"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> erstatninger"
 
 msgid " on 1 line"
 msgstr " i 1 linje"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " i %ld linjer"
+msgid " on %<PRId64> lines"
+msgstr " i %<PRId64> linjer"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kan ikke gjøre :global rekursiv"
@@ -973,8 +973,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ugyldig buffernavn: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Ulovlig skilt-ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Ulovlig skilt-ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (IKKE FUNNET)"
@@ -989,16 +989,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Går inn i debuggingsmodus. Skriv \"cont\" for å fortsette."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "linje %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "linje %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "kommando: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Stoppunkt i \"%s%s\" linje %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Stoppunkt i \"%s%s\" linje %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1008,8 +1008,8 @@ msgid "No breakpoints defined"
 msgstr "Ingen stoppunkt definert"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  linje %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  linje %<PRId64>"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: Bruk først :profile start <filnavn>"
@@ -1065,16 +1065,16 @@ msgid "could not source \"%s\""
 msgstr "kunne ikke kjøre \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "linje %ld: Kunne ikke kjøre \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "linje %<PRId64>: Kunne ikke kjøre \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "kjører \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "linje %ld: kjører \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "linje %<PRId64>: kjører \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1166,8 +1166,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 annen fil å redigere"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: %ld andre filer å redigere"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: %<PRId64> andre filer å redigere"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Kommandoen finnes allerede: Legg til ! for å erstatte den"
@@ -1355,8 +1355,8 @@ msgid "Exception discarded: %s"
 msgstr "Unntak forkastet: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, linje %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, linje %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1554,12 +1554,12 @@ msgid "[crypted]"
 msgstr "[kryptert]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[KONVERTERINGSFEIL i linje %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[KONVERTERINGSFEIL i linje %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[ULOVLIG BYTE i linje %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[ULOVLIG BYTE i linje %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[LESEFEIL]"
@@ -1703,15 +1703,15 @@ msgid "1 line, "
 msgstr "1 linje, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld linjer, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> linjer, "
 
 msgid "1 character"
 msgstr "1 tegn"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld tegn"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> tegn"
 
 msgid "[noeol]"
 msgstr "[ingenlinjeslutt]"
@@ -2128,19 +2128,19 @@ msgid "Font1: %s\n"
 msgstr "Font1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Font%ld-bredde er ikke to ganger bredden av font0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Font%<PRId64>-bredde er ikke to ganger bredden av font0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Font0-bredde: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Font0-bredde: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Font1-bredde: %ld\n"
+"Font1-bredde: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2317,8 +2317,8 @@ msgid "Added cscope database %s"
 msgstr "La til cscope-database %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Feil under lesing av cscope-forbindelse %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Feil under lesing av cscope-forbindelse %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: Ukjent cscope-søketype"
@@ -3508,12 +3508,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Bevaring feilet"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: Ugyldig lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: Ugyldig lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: Kan ikke finne linje %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: Kan ikke finne linje %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Pekerblokk-id feil 3"
@@ -3531,8 +3531,8 @@ msgid "deleted block 1?"
 msgstr "slettet blokk 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Kan ikke finne linje %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Kan ikke finne linje %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: Pekerblokk-id feil"
@@ -3541,12 +3541,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count er null"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: Linjenummer utenfor område: %ld forbi slutten"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: Linjenummer utenfor område: %<PRId64> forbi slutten"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: Linjeantall feil i blokk %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: Linjeantall feil i blokk %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Stackstørrelse øker"
@@ -3735,8 +3735,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Trykk ENTER eller skriv kommando for å fortsette"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s linje %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s linje %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Mer --"
@@ -3802,12 +3802,12 @@ msgid "1 line less"
 msgstr "1 linje fjernet"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld linjer lagt til"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> linjer lagt til"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld linjer fjernet"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> linjer fjernet"
 
 msgid " (Interrupted)"
 msgstr " (Avbrutt)"
@@ -3846,8 +3846,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Linjen blir for lang"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Intern feil: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Intern feil: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3921,8 +3921,8 @@ msgid "read from Netbeans socket"
 msgstr "les fra Netbeans-socket"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Mistet NetBeans-forbindelse for buffer %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Mistet NetBeans-forbindelse for buffer %<PRId64>"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3966,23 +3966,23 @@ msgid "1 line %sed %d times"
 msgstr "1 linje \"%s\"-et %d ganger"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld linjer \"%s\"-et 1 gang"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> linjer \"%s\"-et 1 gang"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld linjer \"%s\"-et %d ganger"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> linjer \"%s\"-et %d ganger"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld linjer å rykke inn ... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> linjer å rykke inn ... "
 
 msgid "1 line indented "
 msgstr "1 linje rykket inn "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld linjer rykket inn "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> linjer rykket inn "
 
 msgid "E748: No previously used register"
 msgstr "E748: Register ikke tidligere brukt"
@@ -3995,12 +3995,12 @@ msgid "1 line changed"
 msgstr "1 linje forandret"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld linjer forandret"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> linjer forandret"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "frigjør %ld linjer"
+msgid "freeing %<PRId64> lines"
+msgstr "frigjør %<PRId64> linjer"
 
 msgid "block of 1 line yanked"
 msgstr "blokk med 1 linje kopiert til utklippstavlen"
@@ -4009,12 +4009,12 @@ msgid "1 line yanked"
 msgstr "1 linje kopiert til utklippstavlen"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "blokk med %ld linjer kopiert til utklippstavlen"
+msgid "block of %<PRId64> lines yanked"
+msgstr "blokk med %<PRId64> linjer kopiert til utklippstavlen"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld linjer kopiert til utklippstavlen"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> linjer kopiert til utklippstavlen"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4044,35 +4044,35 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Ukjent registertype %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Kol; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Kol; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Valgte %s%ld av %ld linjer; %ld av %ld ord; %ld av %ld bytes"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> bytes"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Valgte %s%ld av %ld linjer; %ld av %ld ord; %ld av %ld tegn; %ld av %ld bytes"
+"Valgte %s%<PRId64> av %<PRId64> linjer; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> tegn; %<PRId64> av %<PRId64> bytes"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Kol %s av %s; Linje %ld av %ld; Ord %ld av %ld; Byte %ld av %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Kol %s av %s; Linje %<PRId64> av %<PRId64>; Ord %<PRId64> av %<PRId64>; Byte %<PRId64> av %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Kol %s av %s; linje %ld av %ld; ord %ld av %ld; tegn %ld av %ld; byte %ld av "
-"%ld"
+"Kol %s av %s; linje %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; tegn %<PRId64> av %<PRId64>; byte %<PRId64> av "
+"%<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld for BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Side %N"
@@ -4238,8 +4238,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Trenger Amigados versjon 2.04 eller nyere\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Trenger %s versjon %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Trenger %s versjon %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Kan ikke åpne NIL:\n"
@@ -4321,8 +4321,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Mottok dødelig signal\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Åpning av X-display tok %ld millisekunder"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Åpning av X-display tok %<PRId64> millisekunder"
 
 msgid ""
 "\n"
@@ -4979,7 +4979,7 @@ msgstr "Pakket %d av %d noder; %d (%d%%) igjen"
 #~ msgstr ""
 
 #, c-format
-#~ msgid "Number of words after soundfolding: %ld"
+#~ msgid "Number of words after soundfolding: %<PRId64>"
 #~ msgstr ""
 
 #, c-format
@@ -5015,8 +5015,8 @@ msgid "Done!"
 msgstr "Ferdig!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' har ikke %ld poster"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' har ikke %<PRId64> poster"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5033,8 +5033,8 @@ msgid "Sorry, no suggestions"
 msgstr "Dessverre, ingen forslag"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Dessverre bare %ld forslag"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Dessverre bare %<PRId64> forslag"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5335,8 +5335,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Formatfeil i tagfil \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Før byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Før byte %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5399,8 +5399,8 @@ msgid "Already at newest change"
 msgstr "Allerede ved nyeste forandring"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "Angrenummer %ld ikke funnet"
+msgid "Undo number %<PRId64> not found"
+msgstr "Angrenummer %<PRId64> ikke funnet"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: Gale linjenummer"
@@ -5424,8 +5424,8 @@ msgid "changes"
 msgstr "forandringer"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "før"
@@ -5440,8 +5440,8 @@ msgid "number changes  time"
 msgstr "nummer forandringer tidspunkt"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld sekunder siden"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> sekunder siden"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin er ikke tillatt etter undo"

--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -1840,8 +1840,8 @@ msgid "1 character"
 msgstr "1 znak"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld znaków"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znaków"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -3988,18 +3988,18 @@ msgstr "BŁĄD: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bajtów] totalne alokacje-zwolnienia %lu-%lu, w użytku %lu, maksymalne "
-"użycie %lu\n"
+"[bajtów] totalne alokacje-zwolnienia %<PRIu64>-%<PRIu64>, w użytku %<PRIu64>, maksymalne "
+"użycie %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[wywołania] wszystkich re/malloc()-ów %lu, wszystkich free()-ów %lu\n"
+"[wywołania] wszystkich re/malloc()-ów %<PRIu64>, wszystkich free()-ów %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4010,8 +4010,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Wewnętrzny błąd: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Brak pamięci!  (rezerwacja %lu bajtów)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Brak pamięci!  (rezerwacja %<PRIu64> bajtów)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -88,8 +88,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Nie ma wylistowanych buforów"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Bufor \"%ld\" nie istnieje"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Bufor \"%<PRId64>\" nie istnieje"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Nie mogę przejść poza ostatni bufor"
@@ -98,8 +98,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Nie mogę przejść przed pierwszy bufor"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Nie zapisano zmian w buforze %ld (wymuś przez !)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Nie zapisano zmian w buforze %<PRId64> (wymuś przez !)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Nie mogę wyładować ostatniego bufora"
@@ -108,8 +108,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: OSTRZEŻENIE: Przepełnienie listy nazw plików"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Nie znaleziono bufora %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Nie znaleziono bufora %<PRId64>"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -120,8 +120,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Żaden bufor nie pasuje do %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "wiersz %ld"
+msgid "line %<PRId64>"
+msgstr "wiersz %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Bufor o tej nazwie już istnieje"
@@ -149,12 +149,12 @@ msgid "1 line --%d%%--"
 msgstr "1 wiersz --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld wiersze --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> wiersze --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "wiersz %ld z %ld --%d%%-- kol "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "wiersz %<PRId64> z %<PRId64> --%d%%-- kol "
 
 msgid "[No Name]"
 msgstr "[Bez nazwy]"
@@ -200,12 +200,12 @@ msgid "Signs for %s:"
 msgstr "Znaki dla %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    wiersz=%ld  id=%d  nazwa=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    wiersz=%<PRId64>  id=%d  nazwa=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Nie mogę zróżnicować więcej niż %ld buforów"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Nie mogę zróżnicować więcej niż %<PRId64> buforów"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Nie mogę otworzyć lub zapisać plików tymczasowych"
@@ -364,8 +364,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Nieoczekiwane znaki w :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Indeks listy poza zakresem: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Indeks listy poza zakresem: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -779,8 +779,8 @@ msgid "%s aborted"
 msgstr "porzucono %s"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s zwraca #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s zwraca #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -814,16 +814,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Wchodzę w tryb odpluskwiania. Wprowadź \"cont\" aby kontynuować."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "wiersz %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "wiersz %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Punkt kontrolny w \"%s%s\" wiersz %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Punkt kontrolny w \"%s%s\" wiersz %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -833,8 +833,8 @@ msgid "No breakpoints defined"
 msgstr "Nie określono żadnych punktów kontrolnych"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  wiersz %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  wiersz %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Pierwsze użycie \":profile start {fname}\""
@@ -893,16 +893,16 @@ msgid "could not source \"%s\""
 msgstr "nie mogłem wczytać \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "wiersz: %ld nie mogłem wczytać \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "wiersz: %<PRId64> nie mogłem wczytać \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "wczytywanie \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "wiersz %ld: wczytywanie \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "wiersz %<PRId64>: wczytywanie \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -959,12 +959,12 @@ msgid "1 line moved"
 msgstr "1 wiersz przeniesiony"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld wiersze przeniesione"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> wiersze przeniesione"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld wierszy przefiltrowanych"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> wierszy przefiltrowanych"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Autokomendy *Filter* nie mogą zmieniać bieżącego bufora"
@@ -1045,8 +1045,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Plik wymiany istnieje: %s (wymuś poprzez :silent!)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Brak nazwy pliku dla bufora %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Brak nazwy pliku dla bufora %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Plik niezapisany: Zapis jest wyłączony opcją 'write'"
@@ -1103,19 +1103,19 @@ msgid "1 substitution"
 msgstr "1 podstawienie "
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld dopasowań"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> dopasowań"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld podstawień"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> podstawień"
 
 msgid " on 1 line"
 msgstr " w 1 wierszu"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " w %ld wierszach"
+msgid " on %<PRId64> lines"
+msgstr " w %<PRId64> wierszach"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Nie mogę wykonać :global rekursywnie"
@@ -1202,8 +1202,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Niewłaściwa nazwa bufora: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Niewłaściwe ID znaku: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Niewłaściwe ID znaku: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NIE ZNALEZIONO)"
@@ -1266,8 +1266,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 więcej plik do edycji"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: jeszcze %ld plików do edycji"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: jeszcze %<PRId64> plików do edycji"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Komenda już istnieje; aby ją przedefiniować stosuj !"
@@ -1464,8 +1464,8 @@ msgid "Exception discarded: %s"
 msgstr "Wyjątek odrzucony: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, wiersz %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, wiersz %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1669,12 +1669,12 @@ msgid "[crypted]"
 msgstr "[zakodowane]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[BŁĄD W PRZEMIANIE w linii %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[BŁĄD W PRZEMIANIE w linii %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[NIEDOZWOLONY BAJT w wierszu %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[NIEDOZWOLONY BAJT w wierszu %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[BŁĘDY W ODCZYCIE]"
@@ -1758,10 +1758,10 @@ msgstr ""
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Błąd zapisu, przemiana się nie powiodła w wierszu %ld (opróżnij 'fenc' "
+"E513: Błąd zapisu, przemiana się nie powiodła w wierszu %<PRId64> (opróżnij 'fenc' "
 "by wymusić)"
 
 msgid "E514: write error (file system full?)"
@@ -1771,8 +1771,8 @@ msgid " CONVERSION ERROR"
 msgstr " BŁĄD W PRZEMIANIE"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " w wierszu %ld;"
+msgid " in line %<PRId64>;"
+msgstr " w wierszu %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Urządzenie]"
@@ -1833,8 +1833,8 @@ msgid "1 line, "
 msgstr "1 wiersz, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld wierszy, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> wierszy, "
 
 msgid "1 character"
 msgstr "1 znak"
@@ -1845,8 +1845,8 @@ msgstr "%<PRId64> znaków"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld znaków"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znaków"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2264,16 +2264,16 @@ msgid "Font1: %s"
 msgstr "Font1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "Szerokość font%ld nie jest podwójną szerokością font0"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "Szerokość font%<PRId64> nie jest podwójną szerokością font0"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "Szerokość font0: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "Szerokość font0: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "Szerokość font1: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "Szerokość font1: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "Nieprawidłowy opis czcionki"
@@ -2449,8 +2449,8 @@ msgid "Added cscope database %s"
 msgstr "Dodano bazę danych cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: błąd odczytu połączenia z cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: błąd odczytu połączenia z cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: nieznany typ szukania cscope"
@@ -3670,12 +3670,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Nieudane zabezpieczenie"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: niewłaściwy lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: niewłaściwy lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: nie znaleziono wiersza %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: nie znaleziono wiersza %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: niepoprawne id wskaźnika bloku 3"
@@ -3693,8 +3693,8 @@ msgid "deleted block 1?"
 msgstr "blok nr 1 skasowany?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Nie mogę znaleźć wiersza %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Nie mogę znaleźć wiersza %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: niepoprawne id bloku odniesienia"
@@ -3703,12 +3703,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count wynosi zero"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: numer wiersza poza zakresem: %ld jest poza końcem"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: numer wiersza poza zakresem: %<PRId64> jest poza końcem"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: liczba wierszy niepoprawna w bloku %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: liczba wierszy niepoprawna w bloku %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Wielkość stosu wzrasta"
@@ -3892,8 +3892,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Naciśnij ENTER lub wprowadź komendę aby kontynuować"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s wiersz %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s wiersz %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Więcej --"
@@ -3962,12 +3962,12 @@ msgid "1 line less"
 msgstr "1 wiersz mniej"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "dodano %ld wierszy"
+msgid "%<PRId64> more lines"
+msgstr "dodano %<PRId64> wierszy"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "usunięto %ld wierszy"
+msgid "%<PRId64> fewer lines"
+msgstr "usunięto %<PRId64> wierszy"
 
 msgid " (Interrupted)"
 msgstr " (Przerwane)"
@@ -4006,8 +4006,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Wiersz staje się zbyt długi"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Wewnętrzny błąd: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Wewnętrzny błąd: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4082,8 +4082,8 @@ msgid "read from Netbeans socket"
 msgstr "odczyt z gniazda Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Bufor %ld utracił połączenie z NetBeans"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Bufor %<PRId64> utracił połączenie z NetBeans"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: netbeans nie są obsługiwane przez to GUI"
@@ -4134,23 +4134,23 @@ msgid "1 line %sed %d times"
 msgstr "1 wiersz %sed %d razy"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld wierszy %sed 1 raz"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> wierszy %sed 1 raz"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld wierszy %sed %d razy"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> wierszy %sed %d razy"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld wierszy do wcięcia... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> wierszy do wcięcia... "
 
 msgid "1 line indented "
 msgstr "1 wiersz wcięty "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld wierszy wciętych "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> wierszy wciętych "
 
 msgid "E748: No previously used register"
 msgstr "E748: Brak poprzednio użytego rejestru"
@@ -4163,12 +4163,12 @@ msgid "1 line changed"
 msgstr "1 wiersz zmieniono"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld wierszy zmieniono"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> wierszy zmieniono"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "zwalniam %ld wierszy"
+msgid "freeing %<PRId64> lines"
+msgstr "zwalniam %<PRId64> wierszy"
 
 msgid "block of 1 line yanked"
 msgstr "skopiowano blok 1 wiersza"
@@ -4177,12 +4177,12 @@ msgid "1 line yanked"
 msgstr "1 wiersz skopiowano"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "%ld wierszy skopiowanych"
+msgid "block of %<PRId64> lines yanked"
+msgstr "%<PRId64> wierszy skopiowanych"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld wierszy skopiowanych"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> wierszy skopiowanych"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4211,36 +4211,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Nieznany typ rejestru %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Kolumn; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Kolumn; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Wybrano %s%ld z %ld Wierszy; %ld z %ld Słów; %ld z %ld Bajtów"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> Słów; %<PRId64> z %<PRId64> Bajtów"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Wybrano %s%ld z %ld Wierszy; %ld z %ld Słów; %ld z %ld Znaków; %ld z %ld "
+"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> Słów; %<PRId64> z %<PRId64> Znaków; %<PRId64> z %<PRId64> "
 "Bajtów"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Kol %s z %s; Wiersz %ld z %ld; Słowo %ld z %ld; Bajt %ld z %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; Słowo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Kol %s z %s; Wiersz %ld z %ld; Słowo %ld z %ld; Znak %ld z %ld; Bajt %ld z "
-"%ld"
+"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; Słowo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z "
+"%<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld dla BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> dla BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strona %N"
@@ -4422,8 +4422,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Potrzebuję Amigados w wersji 2.04 lub późniejszą\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Potrzebuję %s w wersji %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Potrzebuję %s w wersji %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Nie mogę otworzyć NIL:\n"
@@ -4506,8 +4506,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Załapał śmiertelny sygnał\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Otwieranie ekranu X trwało %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Otwieranie ekranu X trwało %<PRId64> msec"
 
 msgid ""
 "\n"
@@ -5275,8 +5275,8 @@ msgid "Performing soundfolding..."
 msgstr "Wykonuję kompresję dźwiękową..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Liczba słów po kompresji dźwiękowej: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Liczba słów po kompresji dźwiękowej: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5311,8 +5311,8 @@ msgid "Done!"
 msgstr "Zrobione!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' nie posiada wpisów %ld"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' nie posiada wpisów %<PRId64>"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5329,8 +5329,8 @@ msgid "Sorry, no suggestions"
 msgstr "Przykro mi, brak podpowiedzi"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Przykro mi, tylko %ld podpowiedzi"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Przykro mi, tylko %<PRId64> podpowiedzi"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5647,8 +5647,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Błąd formatu w pliku znaczników \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Przed bajtem %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Przed bajtem %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5792,8 +5792,8 @@ msgid "Already at newest change"
 msgstr "Już w miejscu najnowszej zmiany"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Nie znaleziono numeru cofnięcia %ld"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Nie znaleziono numeru cofnięcia %<PRId64>"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: niewłaściwe numery wierszy"
@@ -5817,8 +5817,8 @@ msgid "changes"
 msgstr "zmiany"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "przed"
@@ -5833,8 +5833,8 @@ msgid "number changes  when               saved"
 msgstr "liczba zmiany   kiedy              zapisano"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld sekund temu"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> sekund temu"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin nie jest dozwolone po undo"

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -3988,18 +3988,18 @@ msgstr "B£¥D: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bajtów] totalne alokacje-zwolnienia %lu-%lu, w u¿ytku %lu, maksymalne "
-"u¿ycie %lu\n"
+"[bajtów] totalne alokacje-zwolnienia %<PRIu64>-%<PRIu64>, w u¿ytku %<PRIu64>, maksymalne "
+"u¿ycie %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[wywo³ania] wszystkich re/malloc()-ów %lu, wszystkich free()-ów %lu\n"
+"[wywo³ania] wszystkich re/malloc()-ów %<PRIu64>, wszystkich free()-ów %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4010,8 +4010,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Wewnêtrzny b³¹d: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Brak pamiêci!  (rezerwacja %lu bajtów)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Brak pamiêci!  (rezerwacja %<PRIu64> bajtów)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -88,8 +88,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Nie ma wylistowanych buforów"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Bufor \"%ld\" nie istnieje"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Bufor \"%<PRId64>\" nie istnieje"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Nie mogê przejœæ poza ostatni bufor"
@@ -98,8 +98,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Nie mogê przejœæ przed pierwszy bufor"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Nie zapisano zmian w buforze %ld (wymuœ przez !)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Nie zapisano zmian w buforze %<PRId64> (wymuœ przez !)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Nie mogê wy³adowaæ ostatniego bufora"
@@ -108,8 +108,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: OSTRZE¯ENIE: Przepe³nienie listy nazw plików"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Nie znaleziono bufora %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Nie znaleziono bufora %<PRId64>"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -120,8 +120,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: ¯aden bufor nie pasuje do %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "wiersz %ld"
+msgid "line %<PRId64>"
+msgstr "wiersz %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Bufor o tej nazwie ju¿ istnieje"
@@ -149,12 +149,12 @@ msgid "1 line --%d%%--"
 msgstr "1 wiersz --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld wiersze --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> wiersze --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "wiersz %ld z %ld --%d%%-- kol "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "wiersz %<PRId64> z %<PRId64> --%d%%-- kol "
 
 msgid "[No Name]"
 msgstr "[Bez nazwy]"
@@ -200,12 +200,12 @@ msgid "Signs for %s:"
 msgstr "Znaki dla %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    wiersz=%ld  id=%d  nazwa=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    wiersz=%<PRId64>  id=%d  nazwa=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Nie mogê zró¿nicowaæ wiêcej ni¿ %ld buforów"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Nie mogê zró¿nicowaæ wiêcej ni¿ %<PRId64> buforów"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Nie mogê otworzyæ lub zapisaæ plików tymczasowych"
@@ -364,8 +364,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Nieoczekiwane znaki w :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Indeks listy poza zakresem: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Indeks listy poza zakresem: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -779,8 +779,8 @@ msgid "%s aborted"
 msgstr "porzucono %s"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s zwraca #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s zwraca #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -814,16 +814,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Wchodzê w tryb odpluskwiania. WprowadŸ \"cont\" aby kontynuowaæ."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "wiersz %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "wiersz %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Punkt kontrolny w \"%s%s\" wiersz %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Punkt kontrolny w \"%s%s\" wiersz %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -833,8 +833,8 @@ msgid "No breakpoints defined"
 msgstr "Nie okreœlono ¿adnych punktów kontrolnych"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  wiersz %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  wiersz %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Pierwsze u¿ycie \":profile start {fname}\""
@@ -893,16 +893,16 @@ msgid "could not source \"%s\""
 msgstr "nie mog³em wczytaæ \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "wiersz: %ld nie mog³em wczytaæ \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "wiersz: %<PRId64> nie mog³em wczytaæ \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "wczytywanie \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "wiersz %ld: wczytywanie \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "wiersz %<PRId64>: wczytywanie \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -959,12 +959,12 @@ msgid "1 line moved"
 msgstr "1 wiersz przeniesiony"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld wiersze przeniesione"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> wiersze przeniesione"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld wierszy przefiltrowanych"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> wierszy przefiltrowanych"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Autokomendy *Filter* nie mog¹ zmieniaæ bie¿¹cego bufora"
@@ -1045,8 +1045,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Plik wymiany istnieje: %s (wymuœ poprzez :silent!)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Brak nazwy pliku dla bufora %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Brak nazwy pliku dla bufora %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Plik niezapisany: Zapis jest wy³¹czony opcj¹ 'write'"
@@ -1103,19 +1103,19 @@ msgid "1 substitution"
 msgstr "1 podstawienie "
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld dopasowañ"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> dopasowañ"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld podstawieñ"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> podstawieñ"
 
 msgid " on 1 line"
 msgstr " w 1 wierszu"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " w %ld wierszach"
+msgid " on %<PRId64> lines"
+msgstr " w %<PRId64> wierszach"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Nie mogê wykonaæ :global rekursywnie"
@@ -1202,8 +1202,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Niew³aœciwa nazwa bufora: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Niew³aœciwe ID znaku: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Niew³aœciwe ID znaku: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NIE ZNALEZIONO)"
@@ -1266,8 +1266,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 wiêcej plik do edycji"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: jeszcze %ld plików do edycji"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: jeszcze %<PRId64> plików do edycji"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Komenda ju¿ istnieje; aby j¹ przedefiniowaæ stosuj !"
@@ -1464,8 +1464,8 @@ msgid "Exception discarded: %s"
 msgstr "Wyj¹tek odrzucony: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, wiersz %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, wiersz %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1669,12 +1669,12 @@ msgid "[crypted]"
 msgstr "[zakodowane]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[B£¥D W PRZEMIANIE w linii %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[B£¥D W PRZEMIANIE w linii %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[NIEDOZWOLONY BAJT w wierszu %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[NIEDOZWOLONY BAJT w wierszu %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[B£ÊDY W ODCZYCIE]"
@@ -1758,10 +1758,10 @@ msgstr ""
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: B³¹d zapisu, przemiana siê nie powiod³a w wierszu %ld (opró¿nij 'fenc' "
+"E513: B³¹d zapisu, przemiana siê nie powiod³a w wierszu %<PRId64> (opró¿nij 'fenc' "
 "by wymusiæ)"
 
 msgid "E514: write error (file system full?)"
@@ -1771,8 +1771,8 @@ msgid " CONVERSION ERROR"
 msgstr " B£¥D W PRZEMIANIE"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " w wierszu %ld;"
+msgid " in line %<PRId64>;"
+msgstr " w wierszu %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Urz¹dzenie]"
@@ -1833,8 +1833,8 @@ msgid "1 line, "
 msgstr "1 wiersz, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld wierszy, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> wierszy, "
 
 msgid "1 character"
 msgstr "1 znak"
@@ -1845,8 +1845,8 @@ msgstr "%<PRId64> znaków"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld znaków"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znaków"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2264,16 +2264,16 @@ msgid "Font1: %s"
 msgstr "Font1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "Szerokoœæ font%ld nie jest podwójn¹ szerokoœci¹ font0"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "Szerokoœæ font%<PRId64> nie jest podwójn¹ szerokoœci¹ font0"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "Szerokoœæ font0: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "Szerokoœæ font0: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "Szerokoœæ font1: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "Szerokoœæ font1: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "Nieprawid³owy opis czcionki"
@@ -2449,8 +2449,8 @@ msgid "Added cscope database %s"
 msgstr "Dodano bazê danych cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: b³¹d odczytu po³¹czenia z cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: b³¹d odczytu po³¹czenia z cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: nieznany typ szukania cscope"
@@ -3670,12 +3670,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Nieudane zabezpieczenie"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: niew³aœciwy lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: niew³aœciwy lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: nie znaleziono wiersza %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: nie znaleziono wiersza %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: niepoprawne id wskaŸnika bloku 3"
@@ -3693,8 +3693,8 @@ msgid "deleted block 1?"
 msgstr "blok nr 1 skasowany?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Nie mogê znaleŸæ wiersza %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Nie mogê znaleŸæ wiersza %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: niepoprawne id bloku odniesienia"
@@ -3703,12 +3703,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count wynosi zero"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: numer wiersza poza zakresem: %ld jest poza koñcem"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: numer wiersza poza zakresem: %<PRId64> jest poza koñcem"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: liczba wierszy niepoprawna w bloku %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: liczba wierszy niepoprawna w bloku %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Wielkoœæ stosu wzrasta"
@@ -3892,8 +3892,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Naciœnij ENTER lub wprowadŸ komendê aby kontynuowaæ"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s wiersz %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s wiersz %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Wiêcej --"
@@ -3962,12 +3962,12 @@ msgid "1 line less"
 msgstr "1 wiersz mniej"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "dodano %ld wierszy"
+msgid "%<PRId64> more lines"
+msgstr "dodano %<PRId64> wierszy"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "usuniêto %ld wierszy"
+msgid "%<PRId64> fewer lines"
+msgstr "usuniêto %<PRId64> wierszy"
 
 msgid " (Interrupted)"
 msgstr " (Przerwane)"
@@ -4006,8 +4006,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Wiersz staje siê zbyt d³ugi"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Wewnêtrzny b³¹d: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Wewnêtrzny b³¹d: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4082,8 +4082,8 @@ msgid "read from Netbeans socket"
 msgstr "odczyt z gniazda Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Bufor %ld utraci³ po³¹czenie z NetBeans"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Bufor %<PRId64> utraci³ po³¹czenie z NetBeans"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: netbeans nie s¹ obs³ugiwane przez to GUI"
@@ -4134,23 +4134,23 @@ msgid "1 line %sed %d times"
 msgstr "1 wiersz %sed %d razy"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld wierszy %sed 1 raz"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> wierszy %sed 1 raz"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld wierszy %sed %d razy"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> wierszy %sed %d razy"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld wierszy do wciêcia... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> wierszy do wciêcia... "
 
 msgid "1 line indented "
 msgstr "1 wiersz wciêty "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld wierszy wciêtych "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> wierszy wciêtych "
 
 msgid "E748: No previously used register"
 msgstr "E748: Brak poprzednio u¿ytego rejestru"
@@ -4163,12 +4163,12 @@ msgid "1 line changed"
 msgstr "1 wiersz zmieniono"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld wierszy zmieniono"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> wierszy zmieniono"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "zwalniam %ld wierszy"
+msgid "freeing %<PRId64> lines"
+msgstr "zwalniam %<PRId64> wierszy"
 
 msgid "block of 1 line yanked"
 msgstr "skopiowano blok 1 wiersza"
@@ -4177,12 +4177,12 @@ msgid "1 line yanked"
 msgstr "1 wiersz skopiowano"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "%ld wierszy skopiowanych"
+msgid "block of %<PRId64> lines yanked"
+msgstr "%<PRId64> wierszy skopiowanych"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld wierszy skopiowanych"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> wierszy skopiowanych"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4211,36 +4211,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Nieznany typ rejestru %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Kolumn; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Kolumn; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Wybrano %s%ld z %ld Wierszy; %ld z %ld S³ów; %ld z %ld Bajtów"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; %<PRId64> z %<PRId64> Bajtów"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Wybrano %s%ld z %ld Wierszy; %ld z %ld S³ów; %ld z %ld Znaków; %ld z %ld "
+"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; %<PRId64> z %<PRId64> Znaków; %<PRId64> z %<PRId64> "
 "Bajtów"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Kol %s z %s; Wiersz %ld z %ld; S³owo %ld z %ld; Bajt %ld z %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Kol %s z %s; Wiersz %ld z %ld; S³owo %ld z %ld; Znak %ld z %ld; Bajt %ld z "
-"%ld"
+"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z "
+"%<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld dla BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> dla BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strona %N"
@@ -4422,8 +4422,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Potrzebujê Amigados w wersji 2.04 lub póŸniejsz¹\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Potrzebujê %s w wersji %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Potrzebujê %s w wersji %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Nie mogê otworzyæ NIL:\n"
@@ -4506,8 +4506,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Za³apa³ œmiertelny sygna³\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Otwieranie ekranu X trwa³o %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Otwieranie ekranu X trwa³o %<PRId64> msec"
 
 msgid ""
 "\n"
@@ -5275,8 +5275,8 @@ msgid "Performing soundfolding..."
 msgstr "Wykonujê kompresjê dŸwiêkow¹..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Liczba s³ów po kompresji dŸwiêkowej: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Liczba s³ów po kompresji dŸwiêkowej: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5311,8 +5311,8 @@ msgid "Done!"
 msgstr "Zrobione!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' nie posiada wpisów %ld"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' nie posiada wpisów %<PRId64>"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5329,8 +5329,8 @@ msgid "Sorry, no suggestions"
 msgstr "Przykro mi, brak podpowiedzi"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Przykro mi, tylko %ld podpowiedzi"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Przykro mi, tylko %<PRId64> podpowiedzi"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5647,8 +5647,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: B³¹d formatu w pliku znaczników \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Przed bajtem %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Przed bajtem %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5792,8 +5792,8 @@ msgid "Already at newest change"
 msgstr "Ju¿ w miejscu najnowszej zmiany"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Nie znaleziono numeru cofniêcia %ld"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Nie znaleziono numeru cofniêcia %<PRId64>"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: niew³aœciwe numery wierszy"
@@ -5817,8 +5817,8 @@ msgid "changes"
 msgstr "zmiany"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "przed"
@@ -5833,8 +5833,8 @@ msgid "number changes  when               saved"
 msgstr "liczba zmiany   kiedy              zapisano"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld sekund temu"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> sekund temu"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin nie jest dozwolone po undo"

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -1840,8 +1840,8 @@ msgid "1 character"
 msgstr "1 znak"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld znaków"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znaków"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -88,8 +88,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Nie ma wylistowanych buforów"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Bufor \"%ld\" nie istnieje"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Bufor \"%<PRId64>\" nie istnieje"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Nie mogê przej¶æ poza ostatni bufor"
@@ -98,8 +98,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Nie mogê przej¶æ przed pierwszy bufor"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Nie zapisano zmian w buforze %ld (wymu¶ przez !)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Nie zapisano zmian w buforze %<PRId64> (wymu¶ przez !)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Nie mogê wy³adowaæ ostatniego bufora"
@@ -108,8 +108,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: OSTRZE¯ENIE: Przepe³nienie listy nazw plików"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Nie znaleziono bufora %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Nie znaleziono bufora %<PRId64>"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -120,8 +120,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: ¯aden bufor nie pasuje do %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "wiersz %ld"
+msgid "line %<PRId64>"
+msgstr "wiersz %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Bufor o tej nazwie ju¿ istnieje"
@@ -149,12 +149,12 @@ msgid "1 line --%d%%--"
 msgstr "1 wiersz --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld wiersze --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> wiersze --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "wiersz %ld z %ld --%d%%-- kol "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "wiersz %<PRId64> z %<PRId64> --%d%%-- kol "
 
 msgid "[No Name]"
 msgstr "[Bez nazwy]"
@@ -200,12 +200,12 @@ msgid "Signs for %s:"
 msgstr "Znaki dla %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    wiersz=%ld  id=%d  nazwa=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    wiersz=%<PRId64>  id=%d  nazwa=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Nie mogê zró¿nicowaæ wiêcej ni¿ %ld buforów"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Nie mogê zró¿nicowaæ wiêcej ni¿ %<PRId64> buforów"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Nie mogê otworzyæ lub zapisaæ plików tymczasowych"
@@ -364,8 +364,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Nieoczekiwane znaki w :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Indeks listy poza zakresem: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Indeks listy poza zakresem: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -779,8 +779,8 @@ msgid "%s aborted"
 msgstr "porzucono %s"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s zwraca #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s zwraca #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -814,16 +814,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Wchodzê w tryb odpluskwiania. Wprowad¼ \"cont\" aby kontynuowaæ."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "wiersz %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "wiersz %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Punkt kontrolny w \"%s%s\" wiersz %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Punkt kontrolny w \"%s%s\" wiersz %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -833,8 +833,8 @@ msgid "No breakpoints defined"
 msgstr "Nie okre¶lono ¿adnych punktów kontrolnych"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  wiersz %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  wiersz %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Pierwsze u¿ycie \":profile start {fname}\""
@@ -893,16 +893,16 @@ msgid "could not source \"%s\""
 msgstr "nie mog³em wczytaæ \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "wiersz: %ld nie mog³em wczytaæ \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "wiersz: %<PRId64> nie mog³em wczytaæ \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "wczytywanie \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "wiersz %ld: wczytywanie \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "wiersz %<PRId64>: wczytywanie \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -959,12 +959,12 @@ msgid "1 line moved"
 msgstr "1 wiersz przeniesiony"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld wiersze przeniesione"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> wiersze przeniesione"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld wierszy przefiltrowanych"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> wierszy przefiltrowanych"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Autokomendy *Filter* nie mog± zmieniaæ bie¿±cego bufora"
@@ -1045,8 +1045,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Plik wymiany istnieje: %s (wymu¶ poprzez :silent!)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Brak nazwy pliku dla bufora %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Brak nazwy pliku dla bufora %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Plik niezapisany: Zapis jest wy³±czony opcj± 'write'"
@@ -1103,19 +1103,19 @@ msgid "1 substitution"
 msgstr "1 podstawienie "
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld dopasowañ"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> dopasowañ"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld podstawieñ"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> podstawieñ"
 
 msgid " on 1 line"
 msgstr " w 1 wierszu"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " w %ld wierszach"
+msgid " on %<PRId64> lines"
+msgstr " w %<PRId64> wierszach"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Nie mogê wykonaæ :global rekursywnie"
@@ -1202,8 +1202,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Niew³a¶ciwa nazwa bufora: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Niew³a¶ciwe ID znaku: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Niew³a¶ciwe ID znaku: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NIE ZNALEZIONO)"
@@ -1266,8 +1266,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 wiêcej plik do edycji"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: jeszcze %ld plików do edycji"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: jeszcze %<PRId64> plików do edycji"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Komenda ju¿ istnieje; aby j± przedefiniowaæ stosuj !"
@@ -1464,8 +1464,8 @@ msgid "Exception discarded: %s"
 msgstr "Wyj±tek odrzucony: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, wiersz %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, wiersz %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1669,12 +1669,12 @@ msgid "[crypted]"
 msgstr "[zakodowane]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[B£¡D W PRZEMIANIE w linii %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[B£¡D W PRZEMIANIE w linii %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[NIEDOZWOLONY BAJT w wierszu %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[NIEDOZWOLONY BAJT w wierszu %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[B£ÊDY W ODCZYCIE]"
@@ -1758,10 +1758,10 @@ msgstr ""
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: B³±d zapisu, przemiana siê nie powiod³a w wierszu %ld (opró¿nij 'fenc' "
+"E513: B³±d zapisu, przemiana siê nie powiod³a w wierszu %<PRId64> (opró¿nij 'fenc' "
 "by wymusiæ)"
 
 msgid "E514: write error (file system full?)"
@@ -1771,8 +1771,8 @@ msgid " CONVERSION ERROR"
 msgstr " B£¡D W PRZEMIANIE"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " w wierszu %ld;"
+msgid " in line %<PRId64>;"
+msgstr " w wierszu %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Urz±dzenie]"
@@ -1833,8 +1833,8 @@ msgid "1 line, "
 msgstr "1 wiersz, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld wierszy, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> wierszy, "
 
 msgid "1 character"
 msgstr "1 znak"
@@ -1845,8 +1845,8 @@ msgstr "%<PRId64> znaków"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld znaków"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znaków"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2264,16 +2264,16 @@ msgid "Font1: %s"
 msgstr "Font1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "Szeroko¶æ font%ld nie jest podwójn± szeroko¶ci± font0"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "Szeroko¶æ font%<PRId64> nie jest podwójn± szeroko¶ci± font0"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "Szeroko¶æ font0: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "Szeroko¶æ font0: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "Szeroko¶æ font1: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "Szeroko¶æ font1: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "Nieprawid³owy opis czcionki"
@@ -2449,8 +2449,8 @@ msgid "Added cscope database %s"
 msgstr "Dodano bazê danych cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: b³±d odczytu po³±czenia z cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: b³±d odczytu po³±czenia z cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: nieznany typ szukania cscope"
@@ -3670,12 +3670,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Nieudane zabezpieczenie"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: niew³a¶ciwy lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: niew³a¶ciwy lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: nie znaleziono wiersza %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: nie znaleziono wiersza %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: niepoprawne id wska¼nika bloku 3"
@@ -3693,8 +3693,8 @@ msgid "deleted block 1?"
 msgstr "blok nr 1 skasowany?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Nie mogê znale¼æ wiersza %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Nie mogê znale¼æ wiersza %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: niepoprawne id bloku odniesienia"
@@ -3703,12 +3703,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count wynosi zero"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: numer wiersza poza zakresem: %ld jest poza koñcem"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: numer wiersza poza zakresem: %<PRId64> jest poza koñcem"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: liczba wierszy niepoprawna w bloku %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: liczba wierszy niepoprawna w bloku %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Wielko¶æ stosu wzrasta"
@@ -3892,8 +3892,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Naci¶nij ENTER lub wprowad¼ komendê aby kontynuowaæ"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s wiersz %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s wiersz %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Wiêcej --"
@@ -3962,12 +3962,12 @@ msgid "1 line less"
 msgstr "1 wiersz mniej"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "dodano %ld wierszy"
+msgid "%<PRId64> more lines"
+msgstr "dodano %<PRId64> wierszy"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "usuniêto %ld wierszy"
+msgid "%<PRId64> fewer lines"
+msgstr "usuniêto %<PRId64> wierszy"
 
 msgid " (Interrupted)"
 msgstr " (Przerwane)"
@@ -4006,8 +4006,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Wiersz staje siê zbyt d³ugi"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Wewnêtrzny b³±d: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Wewnêtrzny b³±d: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4082,8 +4082,8 @@ msgid "read from Netbeans socket"
 msgstr "odczyt z gniazda Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Bufor %ld utraci³ po³±czenie z NetBeans"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Bufor %<PRId64> utraci³ po³±czenie z NetBeans"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: netbeans nie s± obs³ugiwane przez to GUI"
@@ -4134,23 +4134,23 @@ msgid "1 line %sed %d times"
 msgstr "1 wiersz %sed %d razy"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld wierszy %sed 1 raz"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> wierszy %sed 1 raz"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld wierszy %sed %d razy"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> wierszy %sed %d razy"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld wierszy do wciêcia... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> wierszy do wciêcia... "
 
 msgid "1 line indented "
 msgstr "1 wiersz wciêty "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld wierszy wciêtych "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> wierszy wciêtych "
 
 msgid "E748: No previously used register"
 msgstr "E748: Brak poprzednio u¿ytego rejestru"
@@ -4163,12 +4163,12 @@ msgid "1 line changed"
 msgstr "1 wiersz zmieniono"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld wierszy zmieniono"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> wierszy zmieniono"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "zwalniam %ld wierszy"
+msgid "freeing %<PRId64> lines"
+msgstr "zwalniam %<PRId64> wierszy"
 
 msgid "block of 1 line yanked"
 msgstr "skopiowano blok 1 wiersza"
@@ -4177,12 +4177,12 @@ msgid "1 line yanked"
 msgstr "1 wiersz skopiowano"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "%ld wierszy skopiowanych"
+msgid "block of %<PRId64> lines yanked"
+msgstr "%<PRId64> wierszy skopiowanych"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld wierszy skopiowanych"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> wierszy skopiowanych"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4211,36 +4211,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Nieznany typ rejestru %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Kolumn; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Kolumn; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Wybrano %s%ld z %ld Wierszy; %ld z %ld S³ów; %ld z %ld Bajtów"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; %<PRId64> z %<PRId64> Bajtów"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Wybrano %s%ld z %ld Wierszy; %ld z %ld S³ów; %ld z %ld Znaków; %ld z %ld "
+"Wybrano %s%<PRId64> z %<PRId64> Wierszy; %<PRId64> z %<PRId64> S³ów; %<PRId64> z %<PRId64> Znaków; %<PRId64> z %<PRId64> "
 "Bajtów"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Kol %s z %s; Wiersz %ld z %ld; S³owo %ld z %ld; Bajt %ld z %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Kol %s z %s; Wiersz %ld z %ld; S³owo %ld z %ld; Znak %ld z %ld; Bajt %ld z "
-"%ld"
+"Kol %s z %s; Wiersz %<PRId64> z %<PRId64>; S³owo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z "
+"%<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld dla BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> dla BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strona %N"
@@ -4422,8 +4422,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Potrzebujê Amigados w wersji 2.04 lub pó¼niejsz±\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Potrzebujê %s w wersji %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Potrzebujê %s w wersji %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Nie mogê otworzyæ NIL:\n"
@@ -4506,8 +4506,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Za³apa³ ¶miertelny sygna³\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Otwieranie ekranu X trwa³o %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Otwieranie ekranu X trwa³o %<PRId64> msec"
 
 msgid ""
 "\n"
@@ -5275,8 +5275,8 @@ msgid "Performing soundfolding..."
 msgstr "Wykonujê kompresjê d¼wiêkow±..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Liczba s³ów po kompresji d¼wiêkowej: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Liczba s³ów po kompresji d¼wiêkowej: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5311,8 +5311,8 @@ msgid "Done!"
 msgstr "Zrobione!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' nie posiada wpisów %ld"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' nie posiada wpisów %<PRId64>"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5329,8 +5329,8 @@ msgid "Sorry, no suggestions"
 msgstr "Przykro mi, brak podpowiedzi"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Przykro mi, tylko %ld podpowiedzi"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Przykro mi, tylko %<PRId64> podpowiedzi"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5647,8 +5647,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: B³±d formatu w pliku znaczników \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Przed bajtem %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Przed bajtem %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5792,8 +5792,8 @@ msgid "Already at newest change"
 msgstr "Ju¿ w miejscu najnowszej zmiany"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Nie znaleziono numeru cofniêcia %ld"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Nie znaleziono numeru cofniêcia %<PRId64>"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: niew³a¶ciwe numery wierszy"
@@ -5817,8 +5817,8 @@ msgid "changes"
 msgstr "zmiany"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "przed"
@@ -5833,8 +5833,8 @@ msgid "number changes  when               saved"
 msgstr "liczba zmiany   kiedy              zapisano"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld sekund temu"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> sekund temu"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin nie jest dozwolone po undo"

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -3988,18 +3988,18 @@ msgstr "B£¡D: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bajtów] totalne alokacje-zwolnienia %lu-%lu, w u¿ytku %lu, maksymalne "
-"u¿ycie %lu\n"
+"[bajtów] totalne alokacje-zwolnienia %<PRIu64>-%<PRIu64>, w u¿ytku %<PRIu64>, maksymalne "
+"u¿ycie %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[wywo³ania] wszystkich re/malloc()-ów %lu, wszystkich free()-ów %lu\n"
+"[wywo³ania] wszystkich re/malloc()-ów %<PRIu64>, wszystkich free()-ów %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4010,8 +4010,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Wewnêtrzny b³±d: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Brak pamiêci!  (rezerwacja %lu bajtów)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Brak pamiêci!  (rezerwacja %<PRIu64> bajtów)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -1840,8 +1840,8 @@ msgid "1 character"
 msgstr "1 znak"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld znaków"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znaków"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -3853,17 +3853,17 @@ msgstr "ERRO: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bytes] total alocado-liberado %lu-%lu, em uso %lu, pico %lu\n"
+"[bytes] total alocado-liberado %<PRIu64>-%<PRIu64>, em uso %<PRIu64>, pico %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[total de chamadas] re/malloc() %lu, free() %lu\n"
+"[total de chamadas] re/malloc() %<PRIu64>, free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3874,8 +3874,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Erro interno: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Memória esgotada!  (ao alocar %lu bytes)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Memória esgotada!  (ao alocar %<PRIu64> bytes)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -57,8 +57,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Não há buffers listados"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Buffer %ld não existe"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Buffer %<PRId64> não existe"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Não é possível ir além do último buffer"
@@ -67,8 +67,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Não é possível ir para antes do primeiro buffer"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Alterações no buffer %ld não foram gravadas (adicione ! para forçar)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Alterações no buffer %<PRId64> não foram gravadas (adicione ! para forçar)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Impossível descarregar último buffer"
@@ -77,8 +77,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Aviso: Estouro da lista de nomes de arquivos"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Buffer %ld não encontrado"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Buffer %<PRId64> não encontrado"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -89,8 +89,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Nenhum buffer coincide com %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "linha %ld"
+msgid "line %<PRId64>"
+msgstr "linha %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Já existe um buffer com esse nome"
@@ -115,12 +115,12 @@ msgid "1 line --%d%%--"
 msgstr "1 linha --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld linhas --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> linhas --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "linha %ld de %ld --%d%%-- col "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "linha %<PRId64> de %<PRId64> --%d%%-- col "
 
 msgid "[No Name]"
 msgstr "[Sem nome]"
@@ -173,12 +173,12 @@ msgid "Signs for %s:"
 msgstr "Sinais para %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    linha=%ld  id=%d  nome=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    linha=%<PRId64>  id=%d  nome=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Não é possível usar diff com mais de %ld buffers"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Não é possível usar diff com mais de %<PRId64> buffers"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Não foi possível ler ou gravar arquivos temporários"
@@ -330,8 +330,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Caracteres inesperados em :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: índice da lista fora dos limites: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: índice da lista fora dos limites: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -712,8 +712,8 @@ msgid "%s aborted"
 msgstr "%s cancelada"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s devolveu #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s devolveu #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -747,16 +747,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Entrando modo de depuração.  Digite \"cont\" para continuar."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "linha %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "linha %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "cmdo: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Ponto de interrupção em \"%s%s\", linha %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Ponto de interrupção em \"%s%s\", linha %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -766,8 +766,8 @@ msgid "No breakpoints defined"
 msgstr "Nenhum ponto de interrupção definido"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  linha %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  linha %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Primeiro digite \":profile start {nome_arquivo}\""
@@ -826,16 +826,16 @@ msgid "could not source \"%s\""
 msgstr "não foi possível executar \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "linha %ld: não foi possível executar \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "linha %<PRId64>: não foi possível executar \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "executando \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "linha %ld: executando \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "linha %<PRId64>: executando \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -892,12 +892,12 @@ msgid "1 line moved"
 msgstr "1 linha movida"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld linhas movidas"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> linhas movidas"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld linhas filtradas"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> linhas filtradas"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Os autocomandos *Filter* não devem modificar o buffer atual"
@@ -980,8 +980,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Arquivo de troca existe: %s (:silent! para forçar)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Sem nome de arquivo para o buffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Sem nome de arquivo para o buffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Arquivo não gravado: gravação desativada pela opção 'write'"
@@ -1038,19 +1038,19 @@ msgid "1 substitution"
 msgstr "1 substituição"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld correspondências"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> correspondências"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld substituições"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> substituições"
 
 msgid " on 1 line"
 msgstr " em 1 linha"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " em %ld linhas"
+msgid " on %<PRId64> lines"
+msgstr " em %<PRId64> linhas"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global não pode ser executado recursivamente"
@@ -1133,8 +1133,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Nome de buffer inválido: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: ID de sinal inválido: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: ID de sinal inválido: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NÃO ENCONTRADO)"
@@ -1196,8 +1196,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: Mais 1 arquivo para editar"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Mais %ld arquivos para editar"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Mais %<PRId64> arquivos para editar"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Comando já existe; adicione ! para substituí-lo"
@@ -1381,8 +1381,8 @@ msgid "Exception discarded: %s"
 msgstr "Exceção descartada: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, linha %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, linha %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1586,12 +1586,12 @@ msgid "[crypted]"
 msgstr "[criptografado]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ERRO DE CONVERSÃO na linha %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ERRO DE CONVERSÃO na linha %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[BYTE INVÁLIDO na linha %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[BYTE INVÁLIDO na linha %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[ERROS DE LEITURA]"
@@ -1669,8 +1669,8 @@ msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
 msgstr "E513: erro de gravação, conversão falhou (torne 'fenc' vazio para forçar)"
 
 #, c-format
-msgid "E513: write error, conversion failed in line %ld (make 'fenc' empty to override)"
-msgstr "E513: erro de gravação, conversão falhou na linha %ld (deixe 'fenc' vazio para forçar)"
+msgid "E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to override)"
+msgstr "E513: erro de gravação, conversão falhou na linha %<PRId64> (deixe 'fenc' vazio para forçar)"
 
 msgid "E514: write error (file system full?)"
 msgstr "E514: erro de gravação (sistema de arquivos cheio?)"
@@ -1679,8 +1679,8 @@ msgid " CONVERSION ERROR"
 msgstr " ERRO DE CONVERSÃO"
 
 #, c-format
-msgid " in line %ld;"
-msgstr "na linha %ld;"
+msgid " in line %<PRId64>;"
+msgstr "na linha %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Dispositivo]"
@@ -1741,15 +1741,15 @@ msgid "1 line, "
 msgstr "1 linha, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld linhas, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> linhas, "
 
 msgid "1 character"
 msgstr "1 caractere"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld caracteres"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> caracteres"
 
 msgid "[noeol]"
 msgstr "[sem fim de linha]"
@@ -2156,19 +2156,19 @@ msgid "Font1: %s\n"
 msgstr "Fonte1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "O tamanho da Fonte%ld não é o dobro do da Fonte0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "O tamanho da Fonte%<PRId64> não é o dobro do da Fonte0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Tamanho da Fonte0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Tamanho da Fonte0: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Tamanho da Fonte1: %ld\n"
+"Tamanho da Fonte1: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2345,8 +2345,8 @@ msgid "Added cscope database %s"
 msgstr "Adicionado banco de dados do cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: erro ao ler a conexão %ld do cscope"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: erro ao ler a conexão %<PRId64> do cscope"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: tipo desconhecido de busca do cscope"
@@ -3530,12 +3530,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Preservação falhou"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: número de linha inválido: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: número de linha inválido: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: linha %ld não encontrada"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: linha %<PRId64> não encontrada"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: id do bloco de ponteiros incorreto: 3"
@@ -3553,8 +3553,8 @@ msgid "deleted block 1?"
 msgstr "bloco 1 apagado?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Linha %ld não encontrada"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Linha %<PRId64> não encontrada"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: id do bloco de ponteiros incorreto"
@@ -3563,12 +3563,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count é zero"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: número da linha fora dos limites: %ld além do fim"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: número da linha fora dos limites: %<PRId64> além do fim"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: número de linhas incorreto no bloco %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: número de linhas incorreto no bloco %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Aumenta o tamanho da pilha"
@@ -3756,8 +3756,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Aperte ENTER ou digite um comando para continuar"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s, linha %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s, linha %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Mais --"
@@ -3826,12 +3826,12 @@ msgid "1 line less"
 msgstr "1 linha a menos"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld linhas a mais"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> linhas a mais"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld linhas a menos"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> linhas a menos"
 
 msgid " (Interrupted)"
 msgstr " (Interrompido)"
@@ -3870,8 +3870,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: A linha está tornando-se muito longa"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Erro interno: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Erro interno: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3939,8 +3939,8 @@ msgid "read from Netbeans socket"
 msgstr "lido do socket do NetBeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Conexão com o NetBeans perdida para o buffer %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Conexão com o NetBeans perdida para o buffer %<PRId64>"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3984,23 +3984,23 @@ msgid "1 line %sed %d times"
 msgstr "1 linha %sada %d vezes"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld linhas %sadas 1 vez"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> linhas %sadas 1 vez"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld linhas %sadas %d vezes"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> linhas %sadas %d vezes"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld linhas para indentar... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> linhas para indentar... "
 
 msgid "1 line indented "
 msgstr "1 linha indentada "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld linhas indentadas "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> linhas indentadas "
 
 msgid "E748: No previously used register"
 msgstr "E748: Nenhum registrador foi anteriormente utilizado"
@@ -4013,12 +4013,12 @@ msgid "1 line changed"
 msgstr "1 linha alterada"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld linhas alteradas"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> linhas alteradas"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "liberando %ld linhas"
+msgid "freeing %<PRId64> lines"
+msgstr "liberando %<PRId64> linhas"
 
 msgid "block of 1 line yanked"
 msgstr "bloco de uma linha copiado"
@@ -4027,12 +4027,12 @@ msgid "1 line yanked"
 msgstr "1 linha copiada"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "bloco de %ld linhas copiado"
+msgid "block of %<PRId64> lines yanked"
+msgstr "bloco de %<PRId64> linhas copiado"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld linhas copiadas"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> linhas copiadas"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4062,28 +4062,28 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Registrador de tipo desconhecido %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld colunas; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> colunas; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Selecionadas %s%ld de %ld linhas; %ld de %ld palavras; %ld de %ld bytes"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Selecionadas %s%<PRId64> de %<PRId64> linhas; %<PRId64> de %<PRId64> palavras; %<PRId64> de %<PRId64> bytes"
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld Bytes"
-msgstr "Selecionadas %s%ld de %ld linhas; %ld de %ld palavras; %ld de %ld caracteres; %ld de %ld bytes"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
+msgstr "Selecionadas %s%<PRId64> de %<PRId64> linhas; %<PRId64> de %<PRId64> palavras; %<PRId64> de %<PRId64> caracteres; %<PRId64> de %<PRId64> bytes"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Coluna %s de %s; linha %ld de %ld; palavra %ld de %ld; byte %ld de %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Coluna %s de %s; linha %<PRId64> de %<PRId64>; palavra %<PRId64> de %<PRId64>; byte %<PRId64> de %<PRId64>"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of %ld"
-msgstr "Coluna %s de %s; linha %ld de %ld; palavra %ld de %ld; caractere %ld de %ld; byte %ld de %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Coluna %s de %s; linha %<PRId64> de %<PRId64>; palavra %<PRId64> de %<PRId64>; caractere %<PRId64> de %<PRId64>; byte %<PRId64> de %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld para BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> para BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Página %N"
@@ -4256,8 +4256,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Necessário Amigados versão 2.04 ou mais nova\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Necessário %s versão %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Necessário %s versão %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Impossível abrir NIL:\n"
@@ -4339,8 +4339,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Sinal mortal interceptado\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Abertura do display X demorou %ld ms"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Abertura do display X demorou %<PRId64> ms"
 
 msgid ""
 "\n"
@@ -5016,8 +5016,8 @@ msgid "Performing soundfolding..."
 msgstr "Realizando análise fonética..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Número de palavras após análise fonética: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Número de palavras após análise fonética: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5052,8 +5052,8 @@ msgid "Done!"
 msgstr "Concluído!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' não contém %ld elementos"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' não contém %<PRId64> elementos"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5070,8 +5070,8 @@ msgid "Sorry, no suggestions"
 msgstr "Desculpe, não há sugestões"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Desculpe, apenas %ld sugestões"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Desculpe, apenas %<PRId64> sugestões"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5371,8 +5371,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Erro de formato no arquivo de marcadores \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Antes do byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Antes do byte %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5445,8 +5445,8 @@ msgid "Already at newest change"
 msgstr "Já está na alteração mais nova"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "Desfazimento nº %ld não encontrado"
+msgid "Undo number %<PRId64> not found"
+msgstr "Desfazimento nº %<PRId64> não encontrado"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: números de linha errados"
@@ -5470,8 +5470,8 @@ msgid "changes"
 msgstr "alterações"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "antes de"
@@ -5486,8 +5486,8 @@ msgid "number changes  time"
 msgstr "número alteraç. hora"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld segundos atrás"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> segundos atrás"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin não é permitido depois de desfazer"

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -1859,8 +1859,8 @@ msgid "1 character"
 msgstr "1 символ"
 
 #, c-format
-msgid "%lld characters"
-msgstr "символов: %lld"
+msgid "%<PRId64> characters"
+msgstr "символов: %<PRId64>"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -4042,17 +4042,17 @@ msgstr "ОШИБКА: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[байт] всего выдел.-освоб. %lu-%lu, использ. %lu, макс. использ. %lu\n"
+"[байт] всего выдел.-освоб. %<PRIu64>-%<PRIu64>, использ. %<PRIu64>, макс. использ. %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[вызовы] re/malloc() всего %lu, free() всего %lu\n"
+"[вызовы] re/malloc() всего %<PRIu64>, free() всего %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4063,8 +4063,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Внутренняя ошибка: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Не хватает памяти! (выделяется %lu байт)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Не хватает памяти! (выделяется %<PRIu64> байт)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -87,8 +87,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Буферы в списке отсутствуют"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Буфер %ld не существует"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Буфер %<PRId64> не существует"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Это последний буфер"
@@ -97,9 +97,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Это первый буфер"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Изменения в буфере %ld не сохранены (добавьте !, чтобы обойти проверку)"
+"E89: Изменения в буфере %<PRId64> не сохранены (добавьте !, чтобы обойти проверку)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Невозможно выгрузить из памяти последний буфер"
@@ -108,8 +108,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Предупреждение: переполнение списка имён файлов"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Буфер %ld не найден"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Буфер %<PRId64> не найден"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -120,8 +120,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Нет соответствующего %s буфера"
 
 #, c-format
-msgid "line %ld"
-msgstr "строка %ld"
+msgid "line %<PRId64>"
+msgstr "строка %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Буфер с таким именем уже существует"
@@ -149,12 +149,12 @@ msgid "1 line --%d%%--"
 msgstr "Одна строка --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld стр. --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> стр. --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "стр. %ld из %ld --%d%%-- кол. "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "стр. %<PRId64> из %<PRId64> --%d%%-- кол. "
 
 msgid "[No Name]"
 msgstr "[Нет имени]"
@@ -200,12 +200,12 @@ msgid "Signs for %s:"
 msgstr "Значки для %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    строка=%ld  id=%d  имя=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    строка=%<PRId64>  id=%d  имя=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Следить за отличиями можно не более чем в %ld буферах"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Следить за отличиями можно не более чем в %<PRId64> буферах"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Невозможно прочитать или записать временные файлы"
@@ -363,8 +363,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Неожиданные символы в :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Индекс списка за пределами диапазона: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Индекс списка за пределами диапазона: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -790,8 +790,8 @@ msgid "%s aborted"
 msgstr "%s прервана"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s возвращает #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s возвращает #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -840,12 +840,12 @@ msgid "1 line moved"
 msgstr "Перемещена одна строка"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "Перемещено строк: %ld"
+msgid "%<PRId64> lines moved"
+msgstr "Перемещено строк: %<PRId64>"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "Пропущено через фильтр строк: %ld"
+msgid "%<PRId64> lines filtered"
+msgstr "Пропущено через фильтр строк: %<PRId64>"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Автокоманды *Filter* не должны изменять активный буфер"
@@ -930,8 +930,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Своп-файл существует: %s (:silent! чтобы обойти проверку)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Буфер %ld не связан с именем файла"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Буфер %<PRId64> не связан с именем файла"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Файл не сохранён: запись отключена опцией 'write'"
@@ -989,19 +989,19 @@ msgid "1 substitution"
 msgstr "Одна замена"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld соответствий"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> соответствий"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld замен"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> замен"
 
 msgid " on 1 line"
 msgstr " в одной строке"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " в %ld стр."
+msgid " on %<PRId64> lines"
+msgstr " в %<PRId64> стр."
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Команда :global не может быть рекурсивной"
@@ -1087,8 +1087,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Неправильное имя буфера: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Неправильный ID значка: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Неправильный ID значка: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (НЕ НАЙДЕНО)"
@@ -1103,16 +1103,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Включён режим отладки. Для продолжения наберите \"cont\""
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "строка %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "строка %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "команда: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Точка остановки в \"%s%s\" стр. %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Точка остановки в \"%s%s\" стр. %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1122,8 +1122,8 @@ msgid "No breakpoints defined"
 msgstr "Точки остановки не определены"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s стр. %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s стр. %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Первое использование \":profile start {имя-файла}\""
@@ -1180,16 +1180,16 @@ msgid "could not source \"%s\""
 msgstr "невозможно считать \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "строка %ld: невозможно считать \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "строка %<PRId64>: невозможно считать \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "считывание сценария \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "строка %ld: считывание \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "строка %<PRId64>: считывание \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1279,8 +1279,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 файл ожидает редактирования."
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Есть неотредактированные файлы (%ld)."
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Есть неотредактированные файлы (%<PRId64>)."
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Команда уже существует. Добавьте ! для замены."
@@ -1475,8 +1475,8 @@ msgid "Exception discarded: %s"
 msgstr "Исключительная ситуация проигнорирована: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, строка %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, строка %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1680,12 +1680,12 @@ msgid "[crypted]"
 msgstr "[зашифровано]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ОШИБКА ПРЕОБРАЗОВАНИЯ в строке %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ОШИБКА ПРЕОБРАЗОВАНИЯ в строке %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[НЕДОПУСТИМЫЙ БАЙТ в строке %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[НЕДОПУСТИМЫЙ БАЙТ в строке %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[ОШИБКИ ЧТЕНИЯ]"
@@ -1776,10 +1776,10 @@ msgstr ""
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Ошибка записи, преобразование не удалось на строке %ld (очистите "
+"E513: Ошибка записи, преобразование не удалось на строке %<PRId64> (очистите "
 "'fenc', чтобы обойти)"
 
 msgid "E514: write error (file system full?)"
@@ -1789,8 +1789,8 @@ msgid " CONVERSION ERROR"
 msgstr " ОШИБКА ПРЕОБРАЗОВАНИЯ"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " на строке %ld;"
+msgid " in line %<PRId64>;"
+msgstr " на строке %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Устройство]"
@@ -1852,8 +1852,8 @@ msgid "1 line, "
 msgstr "1 строка, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "строк: %ld, "
+msgid "%<PRId64> lines, "
+msgstr "строк: %<PRId64>, "
 
 msgid "1 character"
 msgstr "1 символ"
@@ -1864,8 +1864,8 @@ msgstr "символов: %<PRId64>"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "символов: %ld"
+msgid "%<PRId64> characters"
+msgstr "символов: %<PRId64>"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2290,16 +2290,16 @@ msgid "Font1: %s"
 msgstr "Font1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "Ширина шрифта font%ld должна быть вдвое больше ширины шрифта font0"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "Ширина шрифта font%<PRId64> должна быть вдвое больше ширины шрифта font0"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "Ширина шрифта font0: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "Ширина шрифта font0: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "Ширина шрифта font1: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "Ширина шрифта font1: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "Неправильное определение шрифта"
@@ -2475,8 +2475,8 @@ msgid "Added cscope database %s"
 msgstr "Добавлена база данных cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Ошибка получения информации от соединения cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Ошибка получения информации от соединения cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: Неизвестный тип поиска cscope"
@@ -3717,12 +3717,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Неудачная попытка обновления своп-файла"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: неправильное значение lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: неправильное значение lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: невозможно найти строку %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: невозможно найти строку %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Неправильное значение указателя блока 3"
@@ -3740,8 +3740,8 @@ msgid "deleted block 1?"
 msgstr "удалён блок 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Строка %ld не обнаружена"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Строка %<PRId64> не обнаружена"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: Неправильное значение указателя блока"
@@ -3750,12 +3750,12 @@ msgid "pe_line_count is zero"
 msgstr "значение pe_line_count равно нулю"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: Номер строки за пределами диапазона: %ld"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: Номер строки за пределами диапазона: %<PRId64>"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: Неправильное значение счётчика строк в блоке %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: Неправильное значение счётчика строк в блоке %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Размер стека увеличен"
@@ -3945,8 +3945,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Нажмите ENTER или введите команду для продолжения"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s строка %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s строка %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Продолжение следует --"
@@ -4016,12 +4016,12 @@ msgid "1 line less"
 msgstr "Убрана одна строка"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "Добавлено строк: %ld"
+msgid "%<PRId64> more lines"
+msgstr "Добавлено строк: %<PRId64>"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "Убрано строк: %ld"
+msgid "%<PRId64> fewer lines"
+msgstr "Убрано строк: %<PRId64>"
 
 msgid " (Interrupted)"
 msgstr " (Прервано)"
@@ -4059,8 +4059,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Строка становится слишком длинной"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Внутренняя ошибка: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Внутренняя ошибка: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4136,8 +4136,8 @@ msgid "read from Netbeans socket"
 msgstr "чтение из гнезда NetBeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Потеряно соединение с NetBeans для буфера %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Потеряно соединение с NetBeans для буфера %<PRId64>"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: NetBeans не поддерживается с этим графическим интерфейсом"
@@ -4189,23 +4189,23 @@ msgid "1 line %sed %d times"
 msgstr "Изменены отступы в 1 строке (%s %d раз)"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "Изменены отступы, %ld строк (%s 1 раз)"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "Изменены отступы, %<PRId64> строк (%s 1 раз)"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "Изменены отступы, %ld строк (%s %d раз)"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "Изменены отступы, %<PRId64> строк (%s %d раз)"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "Изменяются отступы строках (%ld)..."
+msgid "%<PRId64> lines to indent... "
+msgstr "Изменяются отступы строках (%<PRId64>)..."
 
 msgid "1 line indented "
 msgstr "Изменён отступ в одной строке "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "Изменены отступы в строках (%ld) "
+msgid "%<PRId64> lines indented "
+msgstr "Изменены отступы в строках (%<PRId64>) "
 
 msgid "E748: No previously used register"
 msgstr "E748: Нет предыдущего использованного регистра"
@@ -4218,12 +4218,12 @@ msgid "1 line changed"
 msgstr "изменена 1 строка"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "изменено строк: %ld"
+msgid "%<PRId64> lines changed"
+msgstr "изменено строк: %<PRId64>"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "очищено строк: %ld"
+msgid "freeing %<PRId64> lines"
+msgstr "очищено строк: %<PRId64>"
 
 msgid "block of 1 line yanked"
 msgstr "скопирован блок из одной строки"
@@ -4232,12 +4232,12 @@ msgid "1 line yanked"
 msgstr "скопирована одна строка"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "скопирован блок из строк: %ld"
+msgid "block of %<PRId64> lines yanked"
+msgstr "скопирован блок из строк: %<PRId64>"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "скопировано строк: %ld"
+msgid "%<PRId64> lines yanked"
+msgstr "скопировано строк: %<PRId64>"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4266,36 +4266,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Неизвестный тип регистра %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "Колонок: %ld; "
+msgid "%<PRId64> Cols; "
+msgstr "Колонок: %<PRId64>; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Выделено %s%ld из %ld строк; %ld из %ld слов; %ld из %ld байт"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Выделено %s%<PRId64> из %<PRId64> строк; %<PRId64> из %<PRId64> слов; %<PRId64> из %<PRId64> байт"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Выделено %s%ld из %ld стр.; %ld из %ld слов; %ld из %ld симв.; %ld из %ld "
+"Выделено %s%<PRId64> из %<PRId64> стр.; %<PRId64> из %<PRId64> слов; %<PRId64> из %<PRId64> симв.; %<PRId64> из %<PRId64> "
 "байт"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Кол. %s из %s; стр. %ld из %ld; сл. %ld из %ld; байт %ld из %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; байт %<PRId64> из %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Кол. %s из %s; стр. %ld из %ld; сл. %ld из %ld; симв. %ld из %ld; байт %ld "
-"из %ld"
+"Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; симв. %<PRId64> из %<PRId64>; байт %<PRId64> "
+"из %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld с учётом BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> с учётом BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Стр. %N"
@@ -4480,8 +4480,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Необходима Amigados версии 2.04 или более поздней\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Необходима %s версии %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Необходима %s версии %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Невозможно открыть NIL:\n"
@@ -4563,8 +4563,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Получен убийственный сигнал\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Открытие дисплея X заняло %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Открытие дисплея X заняло %<PRId64> msec"
 
 msgid ""
 "\n"
@@ -5338,8 +5338,8 @@ msgid "Performing soundfolding..."
 msgstr "Выполнение звуковой свёртки..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Количество слов после звуковой свёртки: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Количество слов после звуковой свёртки: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5374,8 +5374,8 @@ msgid "Done!"
 msgstr "Завершено!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' не содержит %ld элементов"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' не содержит %<PRId64> элементов"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5392,8 +5392,8 @@ msgid "Sorry, no suggestions"
 msgstr "Извините, нет предположений"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Извините, только %ld предположений"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Извините, только %<PRId64> предположений"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5711,8 +5711,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Ошибка формата в файле меток \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Перед байтом %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Перед байтом %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5856,8 +5856,8 @@ msgid "Already at newest change"
 msgstr "Уже на самом последнем изменении"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Не найдена отмена номер %ld"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Не найдена отмена номер %<PRId64>"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: неправильные номера строк"
@@ -5881,8 +5881,8 @@ msgid "changes"
 msgstr "изм."
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "перед"
@@ -5898,8 +5898,8 @@ msgid "number changes  when               saved"
 msgstr " номер  измен.  когда              сохранено"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld с назад"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> с назад"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: Объединение отмен не допускается после отмены"

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -1859,8 +1859,8 @@ msgid "1 character"
 msgstr "1 символ"
 
 #, c-format
-msgid "%lld characters"
-msgstr "символов: %lld"
+msgid "%<PRId64> characters"
+msgstr "символов: %<PRId64>"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -87,8 +87,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Буферы в списке отсутствуют"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Буфер %ld не существует"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Буфер %<PRId64> не существует"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Это последний буфер"
@@ -97,9 +97,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Это первый буфер"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Изменения в буфере %ld не сохранены (добавьте !, чтобы обойти проверку)"
+"E89: Изменения в буфере %<PRId64> не сохранены (добавьте !, чтобы обойти проверку)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Невозможно выгрузить из памяти последний буфер"
@@ -108,8 +108,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Предупреждение: переполнение списка имён файлов"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Буфер %ld не найден"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Буфер %<PRId64> не найден"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -120,8 +120,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Нет соответствующего %s буфера"
 
 #, c-format
-msgid "line %ld"
-msgstr "строка %ld"
+msgid "line %<PRId64>"
+msgstr "строка %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Буфер с таким именем уже существует"
@@ -149,12 +149,12 @@ msgid "1 line --%d%%--"
 msgstr "Одна строка --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld стр. --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> стр. --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "стр. %ld из %ld --%d%%-- кол. "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "стр. %<PRId64> из %<PRId64> --%d%%-- кол. "
 
 msgid "[No Name]"
 msgstr "[Нет имени]"
@@ -200,12 +200,12 @@ msgid "Signs for %s:"
 msgstr "Значки для %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    строка=%ld  id=%d  имя=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    строка=%<PRId64>  id=%d  имя=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Следить за отличиями можно не более чем в %ld буферах"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Следить за отличиями можно не более чем в %<PRId64> буферах"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Невозможно прочитать или записать временные файлы"
@@ -363,8 +363,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Неожиданные символы в :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Индекс списка за пределами диапазона: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Индекс списка за пределами диапазона: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -790,8 +790,8 @@ msgid "%s aborted"
 msgstr "%s прервана"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s возвращает #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s возвращает #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -840,12 +840,12 @@ msgid "1 line moved"
 msgstr "Перемещена одна строка"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "Перемещено строк: %ld"
+msgid "%<PRId64> lines moved"
+msgstr "Перемещено строк: %<PRId64>"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "Пропущено через фильтр строк: %ld"
+msgid "%<PRId64> lines filtered"
+msgstr "Пропущено через фильтр строк: %<PRId64>"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Автокоманды *Filter* не должны изменять активный буфер"
@@ -930,8 +930,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Своп-файл существует: %s (:silent! чтобы обойти проверку)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Буфер %ld не связан с именем файла"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Буфер %<PRId64> не связан с именем файла"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Файл не сохранён: запись отключена опцией 'write'"
@@ -989,19 +989,19 @@ msgid "1 substitution"
 msgstr "Одна замена"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld соответствий"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> соответствий"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld замен"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> замен"
 
 msgid " on 1 line"
 msgstr " в одной строке"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " в %ld стр."
+msgid " on %<PRId64> lines"
+msgstr " в %<PRId64> стр."
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Команда :global не может быть рекурсивной"
@@ -1087,8 +1087,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Неправильное имя буфера: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Неправильный ID значка: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Неправильный ID значка: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (НЕ НАЙДЕНО)"
@@ -1103,16 +1103,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Включён режим отладки. Для продолжения наберите \"cont\""
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "строка %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "строка %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "команда: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Точка остановки в \"%s%s\" стр. %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Точка остановки в \"%s%s\" стр. %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -1122,8 +1122,8 @@ msgid "No breakpoints defined"
 msgstr "Точки остановки не определены"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s стр. %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s стр. %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Первое использование \":profile start {имя-файла}\""
@@ -1180,16 +1180,16 @@ msgid "could not source \"%s\""
 msgstr "невозможно считать \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "строка %ld: невозможно считать \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "строка %<PRId64>: невозможно считать \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "считывание сценария \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "строка %ld: считывание \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "строка %<PRId64>: считывание \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1279,8 +1279,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 файл ожидает редактирования."
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Есть неотредактированные файлы (%ld)."
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Есть неотредактированные файлы (%<PRId64>)."
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Команда уже существует. Добавьте ! для замены."
@@ -1475,8 +1475,8 @@ msgid "Exception discarded: %s"
 msgstr "Исключительная ситуация проигнорирована: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, строка %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, строка %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1680,12 +1680,12 @@ msgid "[crypted]"
 msgstr "[зашифровано]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ОШИБКА ПРЕОБРАЗОВАНИЯ в строке %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ОШИБКА ПРЕОБРАЗОВАНИЯ в строке %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[НЕДОПУСТИМЫЙ БАЙТ в строке %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[НЕДОПУСТИМЫЙ БАЙТ в строке %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[ОШИБКИ ЧТЕНИЯ]"
@@ -1776,10 +1776,10 @@ msgstr ""
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Ошибка записи, преобразование не удалось на строке %ld (очистите "
+"E513: Ошибка записи, преобразование не удалось на строке %<PRId64> (очистите "
 "'fenc', чтобы обойти)"
 
 msgid "E514: write error (file system full?)"
@@ -1789,8 +1789,8 @@ msgid " CONVERSION ERROR"
 msgstr " ОШИБКА ПРЕОБРАЗОВАНИЯ"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " на строке %ld;"
+msgid " in line %<PRId64>;"
+msgstr " на строке %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Устройство]"
@@ -1852,8 +1852,8 @@ msgid "1 line, "
 msgstr "1 строка, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "строк: %ld, "
+msgid "%<PRId64> lines, "
+msgstr "строк: %<PRId64>, "
 
 msgid "1 character"
 msgstr "1 символ"
@@ -1864,8 +1864,8 @@ msgstr "символов: %<PRId64>"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "символов: %ld"
+msgid "%<PRId64> characters"
+msgstr "символов: %<PRId64>"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2290,16 +2290,16 @@ msgid "Font1: %s"
 msgstr "Font1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "Ширина шрифта font%ld должна быть вдвое больше ширины шрифта font0"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "Ширина шрифта font%<PRId64> должна быть вдвое больше ширины шрифта font0"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "Ширина шрифта font0: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "Ширина шрифта font0: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "Ширина шрифта font1: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "Ширина шрифта font1: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "Неправильное определение шрифта"
@@ -2475,8 +2475,8 @@ msgid "Added cscope database %s"
 msgstr "Добавлена база данных cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Ошибка получения информации от соединения cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Ошибка получения информации от соединения cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: Неизвестный тип поиска cscope"
@@ -3717,12 +3717,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Неудачная попытка обновления своп-файла"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: неправильное значение lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: неправильное значение lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: невозможно найти строку %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: невозможно найти строку %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Неправильное значение указателя блока 3"
@@ -3740,8 +3740,8 @@ msgid "deleted block 1?"
 msgstr "удалён блок 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Строка %ld не обнаружена"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Строка %<PRId64> не обнаружена"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: Неправильное значение указателя блока"
@@ -3750,12 +3750,12 @@ msgid "pe_line_count is zero"
 msgstr "значение pe_line_count равно нулю"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: Номер строки за пределами диапазона: %ld"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: Номер строки за пределами диапазона: %<PRId64>"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: Неправильное значение счётчика строк в блоке %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: Неправильное значение счётчика строк в блоке %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Размер стека увеличен"
@@ -3945,8 +3945,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Нажмите ENTER или введите команду для продолжения"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s строка %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s строка %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Продолжение следует --"
@@ -4016,12 +4016,12 @@ msgid "1 line less"
 msgstr "Убрана одна строка"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "Добавлено строк: %ld"
+msgid "%<PRId64> more lines"
+msgstr "Добавлено строк: %<PRId64>"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "Убрано строк: %ld"
+msgid "%<PRId64> fewer lines"
+msgstr "Убрано строк: %<PRId64>"
 
 msgid " (Interrupted)"
 msgstr " (Прервано)"
@@ -4059,8 +4059,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Строка становится слишком длинной"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Внутренняя ошибка: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Внутренняя ошибка: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -4136,8 +4136,8 @@ msgid "read from Netbeans socket"
 msgstr "чтение из гнезда NetBeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Потеряно соединение с NetBeans для буфера %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Потеряно соединение с NetBeans для буфера %<PRId64>"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: NetBeans не поддерживается с этим графическим интерфейсом"
@@ -4189,23 +4189,23 @@ msgid "1 line %sed %d times"
 msgstr "Изменены отступы в 1 строке (%s %d раз)"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "Изменены отступы, %ld строк (%s 1 раз)"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "Изменены отступы, %<PRId64> строк (%s 1 раз)"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "Изменены отступы, %ld строк (%s %d раз)"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "Изменены отступы, %<PRId64> строк (%s %d раз)"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "Изменяются отступы строках (%ld)..."
+msgid "%<PRId64> lines to indent... "
+msgstr "Изменяются отступы строках (%<PRId64>)..."
 
 msgid "1 line indented "
 msgstr "Изменён отступ в одной строке "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "Изменены отступы в строках (%ld) "
+msgid "%<PRId64> lines indented "
+msgstr "Изменены отступы в строках (%<PRId64>) "
 
 msgid "E748: No previously used register"
 msgstr "E748: Нет предыдущего использованного регистра"
@@ -4218,12 +4218,12 @@ msgid "1 line changed"
 msgstr "изменена 1 строка"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "изменено строк: %ld"
+msgid "%<PRId64> lines changed"
+msgstr "изменено строк: %<PRId64>"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "очищено строк: %ld"
+msgid "freeing %<PRId64> lines"
+msgstr "очищено строк: %<PRId64>"
 
 msgid "block of 1 line yanked"
 msgstr "скопирован блок из одной строки"
@@ -4232,12 +4232,12 @@ msgid "1 line yanked"
 msgstr "скопирована одна строка"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "скопирован блок из строк: %ld"
+msgid "block of %<PRId64> lines yanked"
+msgstr "скопирован блок из строк: %<PRId64>"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "скопировано строк: %ld"
+msgid "%<PRId64> lines yanked"
+msgstr "скопировано строк: %<PRId64>"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4266,36 +4266,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Неизвестный тип регистра %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "Колонок: %ld; "
+msgid "%<PRId64> Cols; "
+msgstr "Колонок: %<PRId64>; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Выделено %s%ld из %ld строк; %ld из %ld слов; %ld из %ld байт"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Выделено %s%<PRId64> из %<PRId64> строк; %<PRId64> из %<PRId64> слов; %<PRId64> из %<PRId64> байт"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Выделено %s%ld из %ld стр.; %ld из %ld слов; %ld из %ld симв.; %ld из %ld "
+"Выделено %s%<PRId64> из %<PRId64> стр.; %<PRId64> из %<PRId64> слов; %<PRId64> из %<PRId64> симв.; %<PRId64> из %<PRId64> "
 "байт"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Кол. %s из %s; стр. %ld из %ld; сл. %ld из %ld; байт %ld из %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; байт %<PRId64> из %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Кол. %s из %s; стр. %ld из %ld; сл. %ld из %ld; симв. %ld из %ld; байт %ld "
-"из %ld"
+"Кол. %s из %s; стр. %<PRId64> из %<PRId64>; сл. %<PRId64> из %<PRId64>; симв. %<PRId64> из %<PRId64>; байт %<PRId64> "
+"из %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld с учётом BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> с учётом BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Стр. %N"
@@ -4480,8 +4480,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Необходима Amigados версии 2.04 или более поздней\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Необходима %s версии %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Необходима %s версии %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Невозможно открыть NIL:\n"
@@ -4563,8 +4563,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Получен убийственный сигнал\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Открытие дисплея X заняло %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Открытие дисплея X заняло %<PRId64> msec"
 
 msgid ""
 "\n"
@@ -5338,8 +5338,8 @@ msgid "Performing soundfolding..."
 msgstr "Выполнение звуковой свёртки..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Количество слов после звуковой свёртки: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Количество слов после звуковой свёртки: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5374,8 +5374,8 @@ msgid "Done!"
 msgstr "Завершено!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' не содержит %ld элементов"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' не содержит %<PRId64> элементов"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5392,8 +5392,8 @@ msgid "Sorry, no suggestions"
 msgstr "Извините, нет предположений"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Извините, только %ld предположений"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Извините, только %<PRId64> предположений"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5711,8 +5711,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Ошибка формата в файле меток \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Перед байтом %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Перед байтом %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5856,8 +5856,8 @@ msgid "Already at newest change"
 msgstr "Уже на самом последнем изменении"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Не найдена отмена номер %ld"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Не найдена отмена номер %<PRId64>"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: неправильные номера строк"
@@ -5881,8 +5881,8 @@ msgid "changes"
 msgstr "изм."
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "перед"
@@ -5898,8 +5898,8 @@ msgid "number changes  when               saved"
 msgstr " номер  измен.  когда              сохранено"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld с назад"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> с назад"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: Объединение отмен не допускается после отмены"

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -4042,17 +4042,17 @@ msgstr "ОШИБКА: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[байт] всего выдел.-освоб. %lu-%lu, использ. %lu, макс. использ. %lu\n"
+"[байт] всего выдел.-освоб. %<PRIu64>-%<PRIu64>, использ. %<PRIu64>, макс. использ. %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[вызовы] re/malloc() всего %lu, free() всего %lu\n"
+"[вызовы] re/malloc() всего %<PRIu64>, free() всего %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4063,8 +4063,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Внутренняя ошибка: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Не хватает памяти! (выделяется %lu байт)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Не хватает памяти! (выделяется %<PRIu64> байт)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/sk.cp1250.po
+++ b/src/po/sk.cp1250.po
@@ -59,8 +59,8 @@ msgstr "E84: Nebol nájdenı iadny zmenenı buffer"
 msgid "E85: There is no listed buffer"
 msgstr "E85: Nenašiel som iadny buffer"
 
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Buffer %ld neexistuje"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Buffer %<PRId64> neexistuje"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Za poslednı buffer sa nedá preskoèi"
@@ -68,8 +68,8 @@ msgstr "E87: Za poslednı buffer sa nedá preskoèi"
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Pred prvı buffer sa nedá preskoèi"
 
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Zmeny v bufferi %ld neboli uloené (! pre vynútenie)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Zmeny v bufferi %<PRId64> neboli uloené (! pre vynútenie)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Poslednı buffer sa nedá odstráni"
@@ -78,8 +78,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varovanie: preteèenie zoznamu s názvami súborov"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: buffer %ld nenájdenı"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: buffer %<PRId64> nenájdenı"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -90,8 +90,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Vzoru %s nevyhovuje iadny buffer"
 
 #, c-format
-msgid "line %ld"
-msgstr "riadok %ld"
+msgid "line %<PRId64>"
+msgstr "riadok %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer takéhoto mena u existuje"
@@ -116,12 +116,12 @@ msgid "1 line --%d%%--"
 msgstr "1 riadok --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld riadkov --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> riadkov --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "riadok %ld z %ld --%d%%-- ståpec"
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "riadok %<PRId64> z %<PRId64> --%d%%-- ståpec"
 
 msgid "[No Name]"
 msgstr "[Bez mena]"
@@ -168,12 +168,12 @@ msgid "Signs for %s:"
 msgstr "Znaky pre %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    riadok=%ld  id=%d  meno=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    riadok=%<PRId64>  id=%d  meno=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Nemôem porovna viac ako %ld bufferov"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Nemôem porovna viac ako %<PRId64> bufferov"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nedajú sa vytvori porovnania"
@@ -311,8 +311,8 @@ msgstr "zhoda %d"
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Neoèekávané znaky v :let"
 
-msgid "E684: list index out of range: %ld"
-msgstr "E684: index v zozname je mimo rozsah: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: index v zozname je mimo rozsah: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -620,8 +620,8 @@ msgid "%s aborted"
 msgstr "%s zrušenı"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s vrátilo #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s vrátilo #%<PRId64>"
 
 msgid "%s returning %s"
 msgstr "%s vrátilo %s"
@@ -665,12 +665,12 @@ msgid "1 line moved"
 msgstr "1 riadok presunutı"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld riadkov presunutıch"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> riadkov presunutıch"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld riadkov filtrovanıch"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> riadkov filtrovanıch"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Automatické príkazy *Filter* nesmú meni aktuálny buffer"
@@ -749,8 +749,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Odkladací súbor existuje: %s (pouite :silent! pre prepísanie)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: iadny názov súboru pre buffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: iadny názov súboru pre buffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Súbor nebol uloenı: ukladanie je zakázané vo¾bou 'write'"
@@ -791,19 +791,19 @@ msgstr "1 zhoda"
 msgid "1 substitution"
 msgstr "1 nahradenie"
 
-msgid "%ld matches"
-msgstr "%ld zhôd"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> zhôd"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld nahradení"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> nahradení"
 
 msgid " on 1 line"
 msgstr " na 1 riadku"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " na %ld riadkov"
+msgid " on %<PRId64> lines"
+msgstr " na %<PRId64> riadkov"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global sa nedá vola rekurzívne"
@@ -884,8 +884,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Chybné meno bufferu: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Chybné ID znaèky: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Chybné ID znaèky: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NENÁJDENÉ)"
@@ -900,16 +900,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Spúšam reim ladenia. Pre ukonèenie napíšte \"cont\"."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "riadok %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "riadok %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "príkaz: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Bod prerušenia v \"%s%s\" na riadku %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Bod prerušenia v \"%s%s\" na riadku %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -919,8 +919,8 @@ msgid "No breakpoints defined"
 msgstr "Neboli definovné iadne body prerušenia"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  riadok %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  riadok %<PRId64>"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: Najprv pouite príkaz :profile start <meno_suboru>"
@@ -975,16 +975,16 @@ msgid "could not source \"%s\""
 msgstr "nedá sa interpretova \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "riadok %ld: nemôno interpretova \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "riadok %<PRId64>: nemôno interpretova \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "interpretujem \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "riadok %ld: interpretujem \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "riadok %<PRId64>: interpretujem \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1057,8 +1057,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: Ešte zostáva 1 súbor k úprave."
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Ešte zostáva %ld súborov k úprave."
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Ešte zostáva %<PRId64> súborov k úprave."
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Príkaz u existuje: pouite ! pre predefinovanie"
@@ -1225,8 +1225,8 @@ msgstr "Vınimka ukonèená: %s"
 msgid "Exception discarded: %s"
 msgstr "Vınimka zahodená: %s"
 
-msgid "%s, line %ld"
-msgstr "%s, riadok %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, riadok %<PRId64>"
 
 #. always scroll up, don't overwrite
 msgid "Exception caught: %s"
@@ -1413,8 +1413,8 @@ msgid "[CONVERSION ERROR]"
 msgstr "[CHYBA PREVODU]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[NEPRÍPUSTNİ BAJT na riadku %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[NEPRÍPUSTNİ BAJT na riadku %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[CHYBY ÈÍTANIA]"
@@ -1556,15 +1556,15 @@ msgid "1 line, "
 msgstr "1 riadok, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld riadkov, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> riadkov, "
 
 msgid "1 character"
 msgstr "1 znak"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld znakov"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znakov"
 
 msgid "[noeol]"
 msgstr "[bez znaku konca riadku]"
@@ -1964,19 +1964,19 @@ msgstr "Písmo0: %s\n"
 msgid "Font1: %s\n"
 msgstr "Písmo1: %s\n"
 
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Písmo%ld nie je dvakrát širšie ako písmo0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Písmo%<PRId64> nie je dvakrát širšie ako písmo0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Šírka písma0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Šírka písma0: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Šírka písma1: %ld\n"
+"Šírka písma1: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2145,8 +2145,8 @@ msgstr "E564: %s nie je ani adresárom ani správnou cscope databázou"
 msgid "Added cscope database %s"
 msgstr "Pridaná cscope databáza %s"
 
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: chyba pri èítaní cscope spojenia %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: chyba pri èítaní cscope spojenia %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: neznámy typ cscope h¾adania"
@@ -3308,12 +3308,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Uchovanie sa nepodarilo"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: chybné èíslo riadku: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: chybné èíslo riadku: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: nedá sa nájs riadok %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: nedá sa nájs riadok %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: chybné èíslo ukazovate¾a na blok 3"
@@ -3331,8 +3331,8 @@ msgid "deleted block 1?"
 msgstr "vymazanı blok 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Nedá sa nájs riadok %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Nedá sa nájs riadok %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: chybné èíslo ukazovate¾a na blok"
@@ -3341,12 +3341,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count má nulovú hodnotu"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: èíslo riadku je mimo rozsah: %ld (za koncom)"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: èíslo riadku je mimo rozsah: %<PRId64> (za koncom)"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: chybnı poèet riadkov v bloku %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: chybnı poèet riadkov v bloku %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Nárast ve¾kosti zásobníku"
@@ -3589,12 +3589,12 @@ msgid "1 line less"
 msgstr "1 vymazanı riadok"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld novıch riadkov"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> novıch riadkov"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld vymazanıch riadkov"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> vymazanıch riadkov"
 
 msgid " (Interrupted)"
 msgstr " (Prerušené)"
@@ -3633,8 +3633,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Riadok sa stáva príliš dlhım"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Vnútorná chyba: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Vnútorná chyba: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3706,8 +3706,8 @@ msgstr "E668: Zlé prístupové práva pre súbor s informáciami pre NetBeans spojeni
 msgid "read from Netbeans socket"
 msgstr "èítanie z Netbeans soketu"
 
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Stratené NetBeans spojenie pre buffer %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Stratené NetBeans spojenie pre buffer %<PRId64>"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3745,23 +3745,23 @@ msgid "1 line %sed %d times"
 msgstr "1 riadok upravenı pomocou %s %d krát"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld riadkov upravenıch naraz pomocou %s"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> riadkov upravenıch naraz pomocou %s"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld riadkov upravenıch pomocou %s %d krát"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> riadkov upravenıch pomocou %s %d krát"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld riadkov pre odsadenie..."
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> riadkov pre odsadenie..."
 
 msgid "1 line indented "
 msgstr "1 riadok odsadenı "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld riadkov odsadenıch "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> riadkov odsadenıch "
 
 msgid "E748: No previously used register"
 msgstr "E748: iadny predtım pouívanı register"
@@ -3774,12 +3774,12 @@ msgid "1 line changed"
 msgstr "1 riadok zmenenı"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld zmenenıch riadkov"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> zmenenıch riadkov"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "uvolòujem %ld riadkov"
+msgid "freeing %<PRId64> lines"
+msgstr "uvolòujem %<PRId64> riadkov"
 
 msgid "block of 1 line yanked"
 msgstr "skopírovanı blok 1 riadku"
@@ -3787,12 +3787,12 @@ msgstr "skopírovanı blok 1 riadku"
 msgid "1 line yanked"
 msgstr "1 riadok skopírovanı"
 
-msgid "block of %ld lines yanked"
-msgstr "skopírovanı blok %ld riadkov"
+msgid "block of %<PRId64> lines yanked"
+msgstr "skopírovanı blok %<PRId64> riadkov"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld skopírovanıch riadkov"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> skopírovanıch riadkov"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3821,31 +3821,31 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Neznámy typ registra %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Ståpcov; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Ståpcov; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Vybranıch %s%ld z %ld Riadkov; %ld zo %ld Slov; %ld z %ld Bajtov"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Vybranıch %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; %<PRId64> z %<PRId64> Bajtov"
 
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
-msgstr "Vybranıch %s%ld z %ld Riadkov; %ld zo %ld Slov; %ld z %ld Znakov; %ld z %ld Bajtov"
+msgstr "Vybranıch %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; %<PRId64> z %<PRId64> Znakov; %<PRId64> z %<PRId64> Bajtov"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Ståpec %s z %s; Riadok %ld z %ld; Slovo %ld z %ld; Bajt %ld z %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
-msgstr "Ståpec %s z %s; Riadok %ld z %ld; Slovo %ld z %ld; Znak %ld z %ld; Bajt %ld z %ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
+msgstr "Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld pre BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> pre BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strana %N"
@@ -4011,8 +4011,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Je potrebná Amigados verzia 2.04 alebo novšia\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Potrebná %s verzia %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Potrebná %s verzia %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Nedá sa otvori NIL:\n"
@@ -4094,8 +4094,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Zachytenı smrtiaci signál\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Otvorenie X displej zabralo %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Otvorenie X displej zabralo %<PRId64> msec"
 
 #. KDE sometimes produces X error that we want to ignore
 msgid ""
@@ -4744,8 +4744,8 @@ msgid "Estimated runtime memory use: %d bytes"
 msgstr "Ve¾kos pouívanej pamäte: %d bajtov"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' nemá %ld poloiek"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' nemá %<PRId64> poloiek"
 
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Znaky slov sa odlišujú medzi slovníkovımi súbormi"
@@ -4754,8 +4754,8 @@ msgid "Sorry, no suggestions"
 msgstr "Prepáète, iadne návrhy"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Prepáète, iba %ld návrhov"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Prepáète, iba %<PRId64> návrhov"
 
 #. avoid more prompt
 #, c-format
@@ -5034,8 +5034,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Chyba formátovania v súbore tagov \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Pred bajtom %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Pred bajtom %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5098,8 +5098,8 @@ msgid "1 change"
 msgstr "1 zmena"
 
 #, c-format
-msgid "%ld changes"
-msgstr "%ld zmien"
+msgid "%<PRId64> changes"
+msgstr "%<PRId64> zmien"
 
 msgid "E439: undo list corrupt"
 msgstr "E439: záznam o zmenách poškodenı"

--- a/src/po/sk.cp1250.po
+++ b/src/po/sk.cp1250.po
@@ -3616,17 +3616,17 @@ msgstr "CHYBA: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bajtov] celkom uvolnené-alokované %lu-%lu, využité %lu, maximálne využitie %lu\n"
+"[bajtov] celkom uvolnené-alokované %<PRIu64>-%<PRIu64>, využité %<PRIu64>, maximálne využitie %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[volanie] celkom re/malloc(): %lu, celkom free() %lu\n"
+"[volanie] celkom re/malloc(): %<PRIu64>, celkom free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3637,8 +3637,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Vnútorná chyba: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Nedostatok pamäte! (alokujem %lu bajtov)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Nedostatok pamäte! (alokujem %<PRIu64> bajtov)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/sk.po
+++ b/src/po/sk.po
@@ -59,8 +59,8 @@ msgstr "E84: Nebol nájdený ¾iadny zmenený buffer"
 msgid "E85: There is no listed buffer"
 msgstr "E85: Nena¹iel som ¾iadny buffer"
 
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Buffer %ld neexistuje"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Buffer %<PRId64> neexistuje"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Za posledný buffer sa nedá preskoèi»"
@@ -68,8 +68,8 @@ msgstr "E87: Za posledný buffer sa nedá preskoèi»"
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Pred prvý buffer sa nedá preskoèi»"
 
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Zmeny v bufferi %ld neboli ulo¾ené (! pre vynútenie)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Zmeny v bufferi %<PRId64> neboli ulo¾ené (! pre vynútenie)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Posledný buffer sa nedá odstráni»"
@@ -78,8 +78,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varovanie: preteèenie zoznamu s názvami súborov"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: buffer %ld nenájdený"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: buffer %<PRId64> nenájdený"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -90,8 +90,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Vzoru %s nevyhovuje ¾iadny buffer"
 
 #, c-format
-msgid "line %ld"
-msgstr "riadok %ld"
+msgid "line %<PRId64>"
+msgstr "riadok %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer takéhoto mena u¾ existuje"
@@ -116,12 +116,12 @@ msgid "1 line --%d%%--"
 msgstr "1 riadok --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld riadkov --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> riadkov --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "riadok %ld z %ld --%d%%-- ståpec"
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "riadok %<PRId64> z %<PRId64> --%d%%-- ståpec"
 
 msgid "[No Name]"
 msgstr "[Bez mena]"
@@ -168,12 +168,12 @@ msgid "Signs for %s:"
 msgstr "Znaky pre %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    riadok=%ld  id=%d  meno=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    riadok=%<PRId64>  id=%d  meno=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Nemô¾em porovna» viac ako %ld bufferov"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Nemô¾em porovna» viac ako %<PRId64> bufferov"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Nedajú sa vytvori» porovnania"
@@ -311,8 +311,8 @@ msgstr "zhoda %d"
 msgid "E18: Unexpected characters in :let"
 msgstr "E18: Neoèekávané znaky v :let"
 
-msgid "E684: list index out of range: %ld"
-msgstr "E684: index v zozname je mimo rozsah: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: index v zozname je mimo rozsah: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -620,8 +620,8 @@ msgid "%s aborted"
 msgstr "%s zru¹ený"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s vrátilo #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s vrátilo #%<PRId64>"
 
 msgid "%s returning %s"
 msgstr "%s vrátilo %s"
@@ -665,12 +665,12 @@ msgid "1 line moved"
 msgstr "1 riadok presunutý"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld riadkov presunutých"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> riadkov presunutých"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld riadkov filtrovaných"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> riadkov filtrovaných"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Automatické príkazy *Filter* nesmú meni» aktuálny buffer"
@@ -749,8 +749,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Odkladací súbor existuje: %s (pou¾ite :silent! pre prepísanie)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: ®iadny názov súboru pre buffer %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: ®iadny názov súboru pre buffer %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Súbor nebol ulo¾ený: ukladanie je zakázané voµbou 'write'"
@@ -791,19 +791,19 @@ msgstr "1 zhoda"
 msgid "1 substitution"
 msgstr "1 nahradenie"
 
-msgid "%ld matches"
-msgstr "%ld zhôd"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> zhôd"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld nahradení"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> nahradení"
 
 msgid " on 1 line"
 msgstr " na 1 riadku"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " na %ld riadkov"
+msgid " on %<PRId64> lines"
+msgstr " na %<PRId64> riadkov"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global sa nedá vola» rekurzívne"
@@ -884,8 +884,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Chybné meno bufferu: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Chybné ID znaèky: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Chybné ID znaèky: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (NENÁJDENÉ)"
@@ -900,16 +900,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Spú¹»am re¾im ladenia. Pre ukonèenie napí¹te \"cont\"."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "riadok %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "riadok %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "príkaz: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Bod preru¹enia v \"%s%s\" na riadku %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Bod preru¹enia v \"%s%s\" na riadku %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -919,8 +919,8 @@ msgid "No breakpoints defined"
 msgstr "Neboli definovné ¾iadne body preru¹enia"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  riadok %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  riadok %<PRId64>"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: Najprv pou¾ite príkaz :profile start <meno_suboru>"
@@ -975,16 +975,16 @@ msgid "could not source \"%s\""
 msgstr "nedá sa interpretova» \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "riadok %ld: nemô¾no interpretova» \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "riadok %<PRId64>: nemô¾no interpretova» \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "interpretujem \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "riadok %ld: interpretujem \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "riadok %<PRId64>: interpretujem \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1057,8 +1057,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: E¹te zostáva 1 súbor k úprave."
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: E¹te zostáva %ld súborov k úprave."
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: E¹te zostáva %<PRId64> súborov k úprave."
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Príkaz u¾ existuje: pou¾ite ! pre predefinovanie"
@@ -1225,8 +1225,8 @@ msgstr "Výnimka ukonèená: %s"
 msgid "Exception discarded: %s"
 msgstr "Výnimka zahodená: %s"
 
-msgid "%s, line %ld"
-msgstr "%s, riadok %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, riadok %<PRId64>"
 
 #. always scroll up, don't overwrite
 msgid "Exception caught: %s"
@@ -1413,8 +1413,8 @@ msgid "[CONVERSION ERROR]"
 msgstr "[CHYBA PREVODU]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[NEPRÍPUSTNÝ BAJT na riadku %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[NEPRÍPUSTNÝ BAJT na riadku %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[CHYBY ÈÍTANIA]"
@@ -1556,15 +1556,15 @@ msgid "1 line, "
 msgstr "1 riadok, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld riadkov, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> riadkov, "
 
 msgid "1 character"
 msgstr "1 znak"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld znakov"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> znakov"
 
 msgid "[noeol]"
 msgstr "[bez znaku konca riadku]"
@@ -1964,19 +1964,19 @@ msgstr "Písmo0: %s\n"
 msgid "Font1: %s\n"
 msgstr "Písmo1: %s\n"
 
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Písmo%ld nie je dvakrát ¹ir¹ie ako písmo0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Písmo%<PRId64> nie je dvakrát ¹ir¹ie ako písmo0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "©írka písma0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "©írka písma0: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"©írka písma1: %ld\n"
+"©írka písma1: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2145,8 +2145,8 @@ msgstr "E564: %s nie je ani adresárom ani správnou cscope databázou"
 msgid "Added cscope database %s"
 msgstr "Pridaná cscope databáza %s"
 
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: chyba pri èítaní cscope spojenia %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: chyba pri èítaní cscope spojenia %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: neznámy typ cscope hµadania"
@@ -3308,12 +3308,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Uchovanie sa nepodarilo"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: chybné èíslo riadku: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: chybné èíslo riadku: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: nedá sa nájs» riadok %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: nedá sa nájs» riadok %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: chybné èíslo ukazovateµa na blok 3"
@@ -3331,8 +3331,8 @@ msgid "deleted block 1?"
 msgstr "vymazaný blok 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Nedá sa nájs» riadok %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Nedá sa nájs» riadok %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: chybné èíslo ukazovateµa na blok"
@@ -3341,12 +3341,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count má nulovú hodnotu"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: èíslo riadku je mimo rozsah: %ld (za koncom)"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: èíslo riadku je mimo rozsah: %<PRId64> (za koncom)"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: chybný poèet riadkov v bloku %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: chybný poèet riadkov v bloku %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Nárast veµkosti zásobníku"
@@ -3589,12 +3589,12 @@ msgid "1 line less"
 msgstr "1 vymazaný riadok"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld nových riadkov"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> nových riadkov"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld vymazaných riadkov"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> vymazaných riadkov"
 
 msgid " (Interrupted)"
 msgstr " (Preru¹ené)"
@@ -3633,8 +3633,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Riadok sa stáva príli¹ dlhým"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Vnútorná chyba: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Vnútorná chyba: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3706,8 +3706,8 @@ msgstr "E668: Zlé prístupové práva pre súbor s informáciami pre NetBeans spojeni
 msgid "read from Netbeans socket"
 msgstr "èítanie z Netbeans soketu"
 
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Stratené NetBeans spojenie pre buffer %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Stratené NetBeans spojenie pre buffer %<PRId64>"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3745,23 +3745,23 @@ msgid "1 line %sed %d times"
 msgstr "1 riadok upravený pomocou %s %d krát"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld riadkov upravených naraz pomocou %s"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> riadkov upravených naraz pomocou %s"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld riadkov upravených pomocou %s %d krát"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> riadkov upravených pomocou %s %d krát"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld riadkov pre odsadenie..."
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> riadkov pre odsadenie..."
 
 msgid "1 line indented "
 msgstr "1 riadok odsadený "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld riadkov odsadených "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> riadkov odsadených "
 
 msgid "E748: No previously used register"
 msgstr "E748: ®iadny predtým pou¾ívaný register"
@@ -3774,12 +3774,12 @@ msgid "1 line changed"
 msgstr "1 riadok zmenený"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld zmenených riadkov"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> zmenených riadkov"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "uvolòujem %ld riadkov"
+msgid "freeing %<PRId64> lines"
+msgstr "uvolòujem %<PRId64> riadkov"
 
 msgid "block of 1 line yanked"
 msgstr "skopírovaný blok 1 riadku"
@@ -3787,12 +3787,12 @@ msgstr "skopírovaný blok 1 riadku"
 msgid "1 line yanked"
 msgstr "1 riadok skopírovaný"
 
-msgid "block of %ld lines yanked"
-msgstr "skopírovaný blok %ld riadkov"
+msgid "block of %<PRId64> lines yanked"
+msgstr "skopírovaný blok %<PRId64> riadkov"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld skopírovaných riadkov"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> skopírovaných riadkov"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3821,31 +3821,31 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Neznámy typ registra %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Ståpcov; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Ståpcov; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Vybraných %s%ld z %ld Riadkov; %ld zo %ld Slov; %ld z %ld Bajtov"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Vybraných %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; %<PRId64> z %<PRId64> Bajtov"
 
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
-msgstr "Vybraných %s%ld z %ld Riadkov; %ld zo %ld Slov; %ld z %ld Znakov; %ld z %ld Bajtov"
+msgstr "Vybraných %s%<PRId64> z %<PRId64> Riadkov; %<PRId64> zo %<PRId64> Slov; %<PRId64> z %<PRId64> Znakov; %<PRId64> z %<PRId64> Bajtov"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Ståpec %s z %s; Riadok %ld z %ld; Slovo %ld z %ld; Bajt %ld z %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
-msgstr "Ståpec %s z %s; Riadok %ld z %ld; Slovo %ld z %ld; Znak %ld z %ld; Bajt %ld z %ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
+msgstr "Ståpec %s z %s; Riadok %<PRId64> z %<PRId64>; Slovo %<PRId64> z %<PRId64>; Znak %<PRId64> z %<PRId64>; Bajt %<PRId64> z %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld pre BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> pre BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Strana %N"
@@ -4011,8 +4011,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Je potrebná Amigados verzia 2.04 alebo nov¹ia\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Potrebná %s verzia %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Potrebná %s verzia %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Nedá sa otvori» NIL:\n"
@@ -4094,8 +4094,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Zachytený smrtiaci signál\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Otvorenie X displej zabralo %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Otvorenie X displej zabralo %<PRId64> msec"
 
 #. KDE sometimes produces X error that we want to ignore
 msgid ""
@@ -4744,8 +4744,8 @@ msgid "Estimated runtime memory use: %d bytes"
 msgstr "Veµkos» pou¾ívanej pamäte: %d bajtov"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' nemá %ld polo¾iek"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' nemá %<PRId64> polo¾iek"
 
 msgid "E763: Word characters differ between spell files"
 msgstr "E763: Znaky slov sa odli¹ujú medzi slovníkovými súbormi"
@@ -4754,8 +4754,8 @@ msgid "Sorry, no suggestions"
 msgstr "Prepáète, ¾iadne návrhy"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Prepáète, iba %ld návrhov"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Prepáète, iba %<PRId64> návrhov"
 
 #. avoid more prompt
 #, c-format
@@ -5034,8 +5034,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Chyba formátovania v súbore tagov \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Pred bajtom %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Pred bajtom %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5098,8 +5098,8 @@ msgid "1 change"
 msgstr "1 zmena"
 
 #, c-format
-msgid "%ld changes"
-msgstr "%ld zmien"
+msgid "%<PRId64> changes"
+msgstr "%<PRId64> zmien"
 
 msgid "E439: undo list corrupt"
 msgstr "E439: záznam o zmenách po¹kodený"

--- a/src/po/sk.po
+++ b/src/po/sk.po
@@ -3616,17 +3616,17 @@ msgstr "CHYBA: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bajtov] celkom uvolnené-alokované %lu-%lu, vyu¾ité %lu, maximálne vyu¾itie %lu\n"
+"[bajtov] celkom uvolnené-alokované %<PRIu64>-%<PRIu64>, vyu¾ité %<PRIu64>, maximálne vyu¾itie %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[volanie] celkom re/malloc(): %lu, celkom free() %lu\n"
+"[volanie] celkom re/malloc(): %<PRIu64>, celkom free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3637,8 +3637,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Vnútorná chyba: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Nedostatok pamäte! (alokujem %lu bajtov)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Nedostatok pamäte! (alokujem %<PRIu64> bajtov)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -57,8 +57,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Det finns inga listade buffertar"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Buffert %ld existerar inte"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Buffert %<PRId64> existerar inte"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Kan inte gå bortom sista buffert"
@@ -67,9 +67,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Kan inte gå före första buffert"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Ingen skrivning sedan senaste ändring för buffert %ld (lägg till ! för "
+"E89: Ingen skrivning sedan senaste ändring för buffert %<PRId64> (lägg till ! för "
 "att tvinga)"
 
 msgid "E90: Cannot unload last buffer"
@@ -79,8 +79,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Varning: Lista över filnamn flödar över"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Buffer %ld hittades inte"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Buffer %<PRId64> hittades inte"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -91,8 +91,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Ingen matchande buffert för %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "rad %ld"
+msgid "line %<PRId64>"
+msgstr "rad %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Buffer med det här namnet existerar redan"
@@ -117,12 +117,12 @@ msgid "1 line --%d%%--"
 msgstr "1 rad --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld rader --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> rader --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "rad %ld av %ld --%d%%-- kol "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "rad %<PRId64> av %<PRId64> --%d%%-- kol "
 
 msgid "[No Name]"
 msgstr "[Inget Namn]"
@@ -172,12 +172,12 @@ msgid "Signs for %s:"
 msgstr "Tecken för %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    line=%ld  id=%d  namn=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    line=%<PRId64>  id=%d  namn=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Kan inte skilja fler än %ld buffertar"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Kan inte skilja fler än %<PRId64> buffertar"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Kan inte skapa skiljare"
@@ -325,8 +325,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Oväntade tecken i :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: listindex utanför område: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: listindex utanför område: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -676,8 +676,8 @@ msgid "%s aborted"
 msgstr "%s avbröts"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s returnerar #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s returnerar #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -709,16 +709,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Går in i felsökningsläge.  Skriv \"cont\" för att fortsätta."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "rad %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "rad %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "kommando: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Brytpunkt i \"%s%s\" rad %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Brytpunkt i \"%s%s\" rad %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -728,8 +728,8 @@ msgid "No breakpoints defined"
 msgstr "Inga brytpunkter definierade"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  rad %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  rad %<PRId64>"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: Använd :profile start <fnamn> först"
@@ -788,16 +788,16 @@ msgid "could not source \"%s\""
 msgstr "kunde inte läsa \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "rad %ld: kunde inte läsa \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "rad %<PRId64>: kunde inte läsa \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "läser \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "rad %ld: läser \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "rad %<PRId64>: läser \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -854,12 +854,12 @@ msgid "1 line moved"
 msgstr "1 rad flyttad"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "%ld rader flyttade"
+msgid "%<PRId64> lines moved"
+msgstr "%<PRId64> rader flyttade"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "%ld rader filtrerade"
+msgid "%<PRId64> lines filtered"
+msgstr "%<PRId64> rader filtrerade"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter*-Autokommandon får inte ändra aktuell buffert"
@@ -939,8 +939,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Växlingsfil existerar: %s (:silent! tvingar)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Inget filnamn för buffert %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Inget filnamn för buffert %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Filen skrevs inte: Skrivning är inaktiverat med 'write'-flaggan"
@@ -983,19 +983,19 @@ msgid "1 substitution"
 msgstr "1 ersättning"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld träffar"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> träffar"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld ersättningar"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> ersättningar"
 
 msgid " on 1 line"
 msgstr " på 1 rad"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " på %ld rader"
+msgid " on %<PRId64> lines"
+msgstr " på %<PRId64> rader"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Kan inte göra :global rekursivt"
@@ -1078,8 +1078,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Ogiltigt buffertnamn: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Ogiltigt signatur-ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Ogiltigt signatur-ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (INTE HITTADE)"
@@ -1141,8 +1141,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 fil till att redigera"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: %ld filer till att redigera"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: %<PRId64> filer till att redigera"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Kommando existerar redan: lägg till ! för att ersätta det"
@@ -1323,8 +1323,8 @@ msgid "Exception discarded: %s"
 msgstr "Undantag förkastade: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, rad %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, rad %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1522,12 +1522,12 @@ msgid "[crypted]"
 msgstr "[krypterad]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[KONVERTERINGSFEL på rad %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[KONVERTERINGSFEL på rad %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[OTILLÅTEN BIT på rad %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[OTILLÅTEN BIT på rad %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[LÄSFEL]"
@@ -1673,15 +1673,15 @@ msgid "1 line, "
 msgstr "1 rad, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld rader, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> rader, "
 
 msgid "1 character"
 msgstr "1 tecken"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld tecken"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> tecken"
 
 msgid "[noeol]"
 msgstr "[inget radslut]"
@@ -2098,19 +2098,19 @@ msgid "Font1: %s\n"
 msgstr "Typsnitt1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "Typsnitt%ld är inte dubbelt så bred som font0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "Typsnitt%<PRId64> är inte dubbelt så bred som font0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Typsnitt0 bredd: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Typsnitt0 bredd: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Typsnitt1 bredd: %ld\n"
+"Typsnitt1 bredd: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2287,8 +2287,8 @@ msgid "Added cscope database %s"
 msgstr "Lade till cscope-databas %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: fel vid läsning av cscope-anslutning %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: fel vid läsning av cscope-anslutning %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: okänd cscope-söktyp"
@@ -3487,12 +3487,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Bevaring misslyckades"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: ogiltigt lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: ogiltigt lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: kan inte hitta rad %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: kan inte hitta rad %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: pekarblock-id fel 3"
@@ -3510,8 +3510,8 @@ msgid "deleted block 1?"
 msgstr "tagit bort block 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Kan inte hitta rad %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Kan inte hitta rad %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: pekarblock-id fel"
@@ -3520,12 +3520,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count är noll"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: radnummer utanför område: %ld bakom slutet"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: radnummer utanför område: %<PRId64> bakom slutet"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: radantal fel i block %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: radantal fel i block %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Stackstorlek ökar"
@@ -3713,8 +3713,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Tryck RETUR eller skriv kommando för att fortsätta"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s rad %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s rad %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Mer --"
@@ -3780,12 +3780,12 @@ msgid "1 line less"
 msgstr "1 rad mindre"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "%ld rad till"
+msgid "%<PRId64> more lines"
+msgstr "%<PRId64> rad till"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "%ld färre rader"
+msgid "%<PRId64> fewer lines"
+msgstr "%<PRId64> färre rader"
 
 msgid " (Interrupted)"
 msgstr " (Avbruten)"
@@ -3825,8 +3825,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Rad börjar bli för lång"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Internt fel: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Internt fel: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3899,8 +3899,8 @@ msgid "read from Netbeans socket"
 msgstr "läs från Netbeans-uttag"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: NetBeans-anslutning tappad för buffert %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: NetBeans-anslutning tappad för buffert %<PRId64>"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3944,23 +3944,23 @@ msgid "1 line %sed %d times"
 msgstr "1 rad %sade %d gånger"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld rader %sad 1 gång"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> rader %sad 1 gång"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld rader %sade %d gånger"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> rader %sade %d gånger"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "%ld rader att indentera... "
+msgid "%<PRId64> lines to indent... "
+msgstr "%<PRId64> rader att indentera... "
 
 msgid "1 line indented "
 msgstr "1 rad indenterad "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld rader indenterade "
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> rader indenterade "
 
 msgid "E748: No previously used register"
 msgstr "E748: Inget tidigare använt register"
@@ -3973,12 +3973,12 @@ msgid "1 line changed"
 msgstr "1 rad ändrad"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld rader ändrade"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> rader ändrade"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "frigör %ld rader"
+msgid "freeing %<PRId64> lines"
+msgstr "frigör %<PRId64> rader"
 
 msgid "block of 1 line yanked"
 msgstr "block om 1 rad kopierat"
@@ -3987,12 +3987,12 @@ msgid "1 line yanked"
 msgstr "1 rad kopierad"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "block om %ld rader kopierade"
+msgid "block of %<PRId64> lines yanked"
+msgstr "block om %<PRId64> rader kopierade"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "%ld rader kopierade"
+msgid "%<PRId64> lines yanked"
+msgstr "%<PRId64> rader kopierade"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4022,36 +4022,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Okänd registertyp %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld kolumner; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> kolumner; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Markerade %s%ld av %ld rader; %ld av %ld ord; %ld av %ld bitar"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Markerade %s%<PRId64> av %<PRId64> rader; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> bitar"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Markerade %s%ld av %ld rader; %ld av %ld ord; %ld av %ld tecken; %ld av %ld "
+"Markerade %s%<PRId64> av %<PRId64> rader; %<PRId64> av %<PRId64> ord; %<PRId64> av %<PRId64> tecken; %<PRId64> av %<PRId64> "
 "bitar"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Kol %s av %s; rad %ld av %ld; ord %ld av %ld; bit %ld av %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Kol %s av %s; rad %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; bit %<PRId64> av %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Kol %s av %s; rad %ld av %ld; ord %ld av %ld; tecken %ld av %ld; bit %ld av %"
+"Kol %s av %s; rad %<PRId64> av %<PRId64>; ord %<PRId64> av %<PRId64>; tecken %<PRId64> av %<PRId64>; bit %<PRId64> av %"
 "ld"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld för BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> för BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Sida %N"
@@ -4217,8 +4217,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Behöver Amigados version 2.04 eller senare\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Behöver %s version %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Behöver %s version %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Kan inte öppna NIL:\n"
@@ -4300,8 +4300,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Fångade dödlig signal\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Öppning av X-display tog %ld ms"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Öppning av X-display tog %<PRId64> ms"
 
 msgid ""
 "\n"
@@ -4961,8 +4961,8 @@ msgid "Performing soundfolding..."
 msgstr "Utför ljudvikning..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Antal ord efter ljudvikning: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Antal ord efter ljudvikning: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -4997,8 +4997,8 @@ msgid "Done!"
 msgstr "Klar!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' har inte %ld poster"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' har inte %<PRId64> poster"
 
 #, c-format
 msgid "Word removed from %s"
@@ -5015,8 +5015,8 @@ msgid "Sorry, no suggestions"
 msgstr "Tyvärr, inga föreslag"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Tyvärr, bara %ld föreslag"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Tyvärr, bara %<PRId64> föreslag"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5316,8 +5316,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Formateringsfel i tagg-fil \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Före byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Före byte %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5380,8 +5380,8 @@ msgid "Already at newest change"
 msgstr "Redan vid nyaste ändring"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "Ångra-nummer %ld hittades inte"
+msgid "Undo number %<PRId64> not found"
+msgstr "Ångra-nummer %<PRId64> hittades inte"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: radnummer fel"
@@ -5405,8 +5405,8 @@ msgid "changes"
 msgstr "ändringar"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "före"
@@ -5421,8 +5421,8 @@ msgid "number changes  time"
 msgstr "antal ändringar  tid"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld sekunder sedan"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> sekunder sedan"
 
 msgid "E790: undojoin is not allowed after undo"
 msgstr "E790: undojoin är inte tillåtet efter undo"

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -3807,18 +3807,18 @@ msgstr "FEL: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[byte] sammanlagd allok-frigjord %lu-%lu, i användning %lu, toppanvändning %"
+"[byte] sammanlagd allok-frigjord %<PRIu64>-%<PRIu64>, i användning %<PRIu64>, toppanvändning %"
 "lu\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[anrop] sammanlagda om/malloc()'s %lu, sammanlagda free()'s %lu\n"
+"[anrop] sammanlagda om/malloc()'s %<PRIu64>, sammanlagda free()'s %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3829,8 +3829,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Internt fel: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Slut på minne!  (allokerar %lu byte)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Slut på minne!  (allokerar %<PRIu64> byte)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -1886,8 +1886,8 @@ msgid "1 character"
 msgstr "один символ"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld символів"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> символів"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -89,8 +89,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: У списку немає буферів"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Буфера %ld немає"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Буфера %<PRId64> немає"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Це вже останній буфер"
@@ -99,8 +99,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Це вже найперший буфер"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Буфер %ld має зміни (! щоб не зважати)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Буфер %<PRId64> має зміни (! щоб не зважати)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Не можу вивантажити останній буфер"
@@ -109,8 +109,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Обережно: Список назв файлів переповнено"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Буфер %ld не знайдено"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Буфер %<PRId64> не знайдено"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -121,8 +121,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Не знайдено буфер, схожий на %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "рядок %ld"
+msgid "line %<PRId64>"
+msgstr "рядок %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Буфер з такою назвою вже існує"
@@ -150,12 +150,12 @@ msgid "1 line --%d%%--"
 msgstr "один рядок --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld рядки(ів) --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> рядки(ів) --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "рядок %ld з %ld --%d%%-- колонка "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "рядок %<PRId64> з %<PRId64> --%d%%-- колонка "
 
 msgid "[No Name]"
 msgstr "[Без назви]"
@@ -201,12 +201,12 @@ msgid "Signs for %s:"
 msgstr "Позначки для %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    рядок=%ld  id=%d назва=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    рядок=%<PRId64>  id=%d назва=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Не можна порівнювати понад %ld буфери(ів)"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Не можна порівнювати понад %<PRId64> буфери(ів)"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Не можна читати чи записувати тимчасові файли"
@@ -368,8 +368,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Неочікувані символи у :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Індекс списку поза межами: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Індекс списку поза межами: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -803,8 +803,8 @@ msgid "%s aborted"
 msgstr "%s припинено"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s повертає #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s повертає #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -838,16 +838,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Режим налагодження.  Щоб продовжити введіть «cont»."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "рядок %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "рядок %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "команда: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Точка зупинки в «%s%s» рядок %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Точка зупинки в «%s%s» рядок %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -857,8 +857,8 @@ msgid "No breakpoints defined"
 msgstr "Не визначено жодної точки зупинки"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d %s %s   рядок %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d %s %s   рядок %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Спочатку зробіть «:profile start {файл}»"
@@ -919,16 +919,16 @@ msgid "could not source \"%s\""
 msgstr "Не вдалося виконати «%s»"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "рядок %ld: не вдалося виконати «%s»"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "рядок %<PRId64>: не вдалося виконати «%s»"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "виконується «%s»"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "рядок %ld: виконується «%s»"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "рядок %<PRId64>: виконується «%s»"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -987,12 +987,12 @@ msgid "1 line moved"
 msgstr "Переміщено один рядок"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "Переміщено %ld рядки(ів)"
+msgid "%<PRId64> lines moved"
+msgstr "Переміщено %<PRId64> рядки(ів)"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "Відфільтровано %ld рядки(ів)"
+msgid "%<PRId64> lines filtered"
+msgstr "Відфільтровано %<PRId64> рядки(ів)"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Автокоманди *Filter* не повинні змінювати поточний буфер"
@@ -1073,8 +1073,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Файл обміну існує: %s (:silent! переважує)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Немає вхідного файлу для буфера %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Немає вхідного файлу для буфера %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Файл не записано: запис заборонено опцією 'write'"
@@ -1132,19 +1132,19 @@ msgid "1 substitution"
 msgstr "Одна заміна"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld збіги(ів)"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> збіги(ів)"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld замін(и)"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> замін(и)"
 
 msgid " on 1 line"
 msgstr " в одному рядку"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " в %ld рядках"
+msgid " on %<PRId64> lines"
+msgstr " в %<PRId64> рядках"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global не можна вживати рекурсивно"
@@ -1230,8 +1230,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Некоректна назва буфера: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Неправильний ID надпису: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Неправильний ID надпису: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (НЕ ЗНАЙДЕНО)"
@@ -1293,8 +1293,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: Залишилося відредагувати ще один файл"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Залишилося %ld не редагованих файлів"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Залишилося %<PRId64> не редагованих файлів"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Команда вже існує, ! щоб замінити її"
@@ -1503,8 +1503,8 @@ msgid "Exception discarded: %s"
 msgstr "Виняток скинуто: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, рядок %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, рядок %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1714,12 +1714,12 @@ msgid "[crypted]"
 msgstr "[зашифровано]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ПОМИЛКА КОНВЕРТАЦІЇ у рядку %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ПОМИЛКА КОНВЕРТАЦІЇ у рядку %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[НЕКОРЕКТНИЙ БАЙТ у рядку %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[НЕКОРЕКТНИЙ БАЙТ у рядку %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[ПОМИЛКА ЧИТАННЯ]"
@@ -1805,10 +1805,10 @@ msgstr "E513: Помилка запису, конвертація не вдалася (скиньте 'fenc')"
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Помилка запису, конвертація не вдалася у рядку %ld (скиньте 'fenc')"
+"E513: Помилка запису, конвертація не вдалася у рядку %<PRId64> (скиньте 'fenc')"
 
 msgid "E514: write error (file system full?)"
 msgstr "E514: Помилка запису (скінчилось вільне місце?)"
@@ -1817,8 +1817,8 @@ msgid " CONVERSION ERROR"
 msgstr " ПОМИЛКА КОНВЕРТАЦІЇ"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " у рядку %ld;"
+msgid " in line %<PRId64>;"
+msgstr " у рядку %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Пристрій]"
@@ -1879,8 +1879,8 @@ msgid "1 line, "
 msgstr "один рядок, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld рядків, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> рядків, "
 
 msgid "1 character"
 msgstr "один символ"
@@ -1891,8 +1891,8 @@ msgstr "%<PRId64> символів"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld символів"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> символів"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2325,16 +2325,16 @@ msgid "Font1: %s"
 msgstr "Шрифт1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "Ширина шрифту%ld не більша удвічі за ширину шрифту0"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "Ширина шрифту%<PRId64> не більша удвічі за ширину шрифту0"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "Ширина шрифту0: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "Ширина шрифту0: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "Ширина шрифту1: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "Ширина шрифту1: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "Некоректна специфікація шрифту"
@@ -2515,8 +2515,8 @@ msgid "Added cscope database %s"
 msgstr "Додано базу даних cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Помилка читання зі з'єднання cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Помилка читання зі з'єднання cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: Невідомий тип пошуку cscope"
@@ -3752,13 +3752,13 @@ msgstr "E314: Збереження не вдалося"
 
 # msgstr "E314: "
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: неправильний lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: неправильний lnum: %<PRId64>"
 
 # msgstr "E315: "
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: не знайшов рядок %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: не знайшов рядок %<PRId64>"
 
 # msgstr "E316: "
 msgid "E317: pointer block id wrong 3"
@@ -3778,8 +3778,8 @@ msgid "deleted block 1?"
 msgstr "блок 1 знищено?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Не вдалося знайти рядок %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Не вдалося знайти рядок %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: Вказівник блоку помилковий"
@@ -3789,13 +3789,13 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count дорівнює 0"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: Номер рядка вийшов за межі: %ld за кінцем"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: Номер рядка вийшов за межі: %<PRId64> за кінцем"
 
 # msgstr "E322: "
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: Кількість рядків у блоці %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: Кількість рядків у блоці %<PRId64>"
 
 # msgstr "E323: "
 msgid "Stack size increases"
@@ -3994,8 +3994,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Натисніть ENTER або введіть команду для продовження"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s рядок %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s рядок %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Ще --"
@@ -4065,12 +4065,12 @@ msgid "1 line less"
 msgstr "знищено один рядок"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "додано рядків: %ld"
+msgid "%<PRId64> more lines"
+msgstr "додано рядків: %<PRId64>"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "знищено рядків: %ld"
+msgid "%<PRId64> fewer lines"
+msgstr "знищено рядків: %<PRId64>"
 
 msgid " (Interrupted)"
 msgstr " (Перервано)"
@@ -4102,8 +4102,8 @@ msgstr "E340: Рядок стає занадто довгим"
 
 # msgstr "E340: "
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Внутрішня помилка: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Внутрішня помилка: lalloc(%<PRId64>, )"
 
 # msgstr "E341: "
 #, c-format
@@ -4186,8 +4186,8 @@ msgid "read from Netbeans socket"
 msgstr "читається з сокета Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Втрачено зв'язок із NetBeans для буфера %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Втрачено зв'язок із NetBeans для буфера %<PRId64>"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: netbeans не підтримується з цим GUI"
@@ -4239,23 +4239,23 @@ msgid "1 line %sed %d times"
 msgstr "Один рядок %s-но %d разів"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld рядків %s-но"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> рядків %s-но"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld рядків %s-но %d разів"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> рядків %s-но %d разів"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "Залишилося вирівняти %ld рядків..."
+msgid "%<PRId64> lines to indent... "
+msgstr "Залишилося вирівняти %<PRId64> рядків..."
 
 msgid "1 line indented "
 msgstr "Вирівняно один рядок"
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "Вирівняно рядків: %ld"
+msgid "%<PRId64> lines indented "
+msgstr "Вирівняно рядків: %<PRId64>"
 
 msgid "E748: No previously used register"
 msgstr "E748: Регістри перед цим не вживались"
@@ -4268,12 +4268,12 @@ msgid "1 line changed"
 msgstr "Один рядок змінено"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "Змінено рядків: %ld"
+msgid "%<PRId64> lines changed"
+msgstr "Змінено рядків: %<PRId64>"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "Звільнено рядків: %ld"
+msgid "freeing %<PRId64> lines"
+msgstr "Звільнено рядків: %<PRId64>"
 
 msgid "block of 1 line yanked"
 msgstr "Запам'ятав блок з одного рядка"
@@ -4282,12 +4282,12 @@ msgid "1 line yanked"
 msgstr "Запам'ятав один рядок"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "Запам'ятав блок із %ld рядків"
+msgid "block of %<PRId64> lines yanked"
+msgstr "Запам'ятав блок із %<PRId64> рядків"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "Запам'ятав рядків: %ld"
+msgid "%<PRId64> lines yanked"
+msgstr "Запам'ятав рядків: %<PRId64>"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4317,36 +4317,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Невідомий тип регістру %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "довж.: %ld; "
+msgid "%<PRId64> Cols; "
+msgstr "довж.: %<PRId64>; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Вибрано %s%ld з %ld рядків; %ld з %ld слів; %ld з %ld байтів"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; %<PRId64> з %<PRId64> байтів"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Вибрано %s%ld з %ld рядків; %ld з %ld слів; %ld of %ld символів; %ld з %ld "
+"Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; %<PRId64> of %<PRId64> символів; %<PRId64> з %<PRId64> "
 "байтів"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Колонка %s з %s; рядок %ld з %ld; слово %ld з %ld; байт %ld з %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; байт %<PRId64> з %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Колонка %s з %s; рядок %ld з %ld; слово %ld з %ld; символ %ld of %ld; байт "
-"%ld з %ld"
+"Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; символ %<PRId64> of %<PRId64>; байт "
+"%<PRId64> з %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld для BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> для BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Стор. %N"
@@ -4533,8 +4533,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Потрібна Amigados 2.04 або пізніша\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Потрібно %s версії %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Потрібно %s версії %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Не вдалося відкрити NIL:\n"
@@ -4608,8 +4608,8 @@ msgid "E245: Illegal char '%c' in font name \"%s\""
 msgstr "E245: Помилковий символ %c в назві шрифту «%s»"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "На відкриття дисплею X пішло %ld мілісекунд"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "На відкриття дисплею X пішло %<PRId64> мілісекунд"
 
 msgid ""
 "\n"
@@ -5399,8 +5399,8 @@ msgid "Performing soundfolding..."
 msgstr "Виконується згортання звуків..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Кількість слів після згортання звуків: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Кількість слів після згортання звуків: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5435,8 +5435,8 @@ msgid "Done!"
 msgstr "Зроблено!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' не містить %ld елементів"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' не містить %<PRId64> елементів"
 
 #, c-format
 msgid "Word '%.*s' removed from %s"
@@ -5453,8 +5453,8 @@ msgid "Sorry, no suggestions"
 msgstr "Пробачте, немає пропозицій"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Пробачте, тільки %ld пропозицій"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Пробачте, тільки %<PRId64> пропозицій"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5804,8 +5804,8 @@ msgstr "E431: Помилка формату у файлі теґів «%s»"
 
 # msgstr "E431: "
 #, c-format
-msgid "Before byte %ld"
-msgstr "Перед байтом %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Перед байтом %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5955,8 +5955,8 @@ msgid "Already at newest change"
 msgstr "Вже на найновішій зміні"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Зміну %ld не знайдено в історії"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Зміну %<PRId64> не знайдено в історії"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: неправильні номери рядків"
@@ -5982,8 +5982,8 @@ msgid "changes"
 msgstr "змін"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "перед"
@@ -5998,8 +5998,8 @@ msgid "number changes  when               saved"
 msgstr "номер  зміни    час             збережено"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld секунд тому"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> секунд тому"
 
 # msgstr "E406: "
 msgid "E790: undojoin is not allowed after undo"

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -4084,17 +4084,17 @@ msgstr "ПОМИЛКА: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[байт]  всього розм/знищ. %lu/%lu, викор. %lu, макс. %lu\n"
+"[байт]  всього розм/знищ. %<PRIu64>/%<PRIu64>, викор. %<PRIu64>, макс. %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[виклики] усього re/malloc() - %lu, усього free() - %lu\n"
+"[виклики] усього re/malloc() - %<PRIu64>, усього free() - %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4107,8 +4107,8 @@ msgstr "E341: Внутрішня помилка: lalloc(%<PRId64>, )"
 
 # msgstr "E341: "
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Забракло пам'яті!  (потрібно було %lu байтів)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Забракло пам'яті!  (потрібно було %<PRIu64> байтів)"
 
 # msgstr "E342: "
 #, c-format

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -4084,17 +4084,17 @@ msgstr "ПОМИЛКА: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[байт]  всього розм/знищ. %lu/%lu, викор. %lu, макс. %lu\n"
+"[байт]  всього розм/знищ. %<PRIu64>/%<PRIu64>, викор. %<PRIu64>, макс. %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[виклики] усього re/malloc() - %lu, усього free() - %lu\n"
+"[виклики] усього re/malloc() - %<PRIu64>, усього free() - %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -4107,8 +4107,8 @@ msgstr "E341: Внутрішня помилка: lalloc(%<PRId64>, )"
 
 # msgstr "E341: "
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Забракло пам'яті!  (потрібно було %lu байтів)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Забракло пам'яті!  (потрібно було %<PRIu64> байтів)"
 
 # msgstr "E342: "
 #, c-format

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -1886,8 +1886,8 @@ msgid "1 character"
 msgstr "один символ"
 
 #, c-format
-msgid "%lld characters"
-msgstr "%lld символів"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> символів"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -89,8 +89,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: У списку немає буферів"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Буфера %ld немає"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Буфера %<PRId64> немає"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Це вже останній буфер"
@@ -99,8 +99,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Це вже найперший буфер"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: Буфер %ld має зміни (! щоб не зважати)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: Буфер %<PRId64> має зміни (! щоб не зважати)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: Не можу вивантажити останній буфер"
@@ -109,8 +109,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Обережно: Список назв файлів переповнено"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Буфер %ld не знайдено"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Буфер %<PRId64> не знайдено"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -121,8 +121,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Не знайдено буфер, схожий на %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "рядок %ld"
+msgid "line %<PRId64>"
+msgstr "рядок %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Буфер з такою назвою вже існує"
@@ -150,12 +150,12 @@ msgid "1 line --%d%%--"
 msgstr "один рядок --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld рядки(ів) --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> рядки(ів) --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "рядок %ld з %ld --%d%%-- колонка "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "рядок %<PRId64> з %<PRId64> --%d%%-- колонка "
 
 msgid "[No Name]"
 msgstr "[Без назви]"
@@ -201,12 +201,12 @@ msgid "Signs for %s:"
 msgstr "Позначки для %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    рядок=%ld  id=%d назва=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    рядок=%<PRId64>  id=%d назва=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Не можна порівнювати понад %ld буфери(ів)"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Не можна порівнювати понад %<PRId64> буфери(ів)"
 
 msgid "E810: Cannot read or write temp files"
 msgstr "E810: Не можна читати чи записувати тимчасові файли"
@@ -368,8 +368,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: Неочікувані символи у :let"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: Індекс списку поза межами: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: Індекс списку поза межами: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -803,8 +803,8 @@ msgid "%s aborted"
 msgstr "%s припинено"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s повертає #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s повертає #%<PRId64>"
 
 #, c-format
 msgid "%s returning %s"
@@ -838,16 +838,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Режим налагодження.  Щоб продовжити введіть «cont»."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "рядок %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "рядок %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "команда: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Точка зупинки в «%s%s» рядок %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Точка зупинки в «%s%s» рядок %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -857,8 +857,8 @@ msgid "No breakpoints defined"
 msgstr "Не визначено жодної точки зупинки"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d %s %s   рядок %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d %s %s   рядок %<PRId64>"
 
 msgid "E750: First use \":profile start {fname}\""
 msgstr "E750: Спочатку зробіть «:profile start {файл}»"
@@ -919,16 +919,16 @@ msgid "could not source \"%s\""
 msgstr "Не вдалося виконати «%s»"
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "рядок %ld: не вдалося виконати «%s»"
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "рядок %<PRId64>: не вдалося виконати «%s»"
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "виконується «%s»"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "рядок %ld: виконується «%s»"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "рядок %<PRId64>: виконується «%s»"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -987,12 +987,12 @@ msgid "1 line moved"
 msgstr "Переміщено один рядок"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "Переміщено %ld рядки(ів)"
+msgid "%<PRId64> lines moved"
+msgstr "Переміщено %<PRId64> рядки(ів)"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "Відфільтровано %ld рядки(ів)"
+msgid "%<PRId64> lines filtered"
+msgstr "Відфільтровано %<PRId64> рядки(ів)"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Автокоманди *Filter* не повинні змінювати поточний буфер"
@@ -1073,8 +1073,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: Файл обміну існує: %s (:silent! переважує)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Немає вхідного файлу для буфера %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Немає вхідного файлу для буфера %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Файл не записано: запис заборонено опцією 'write'"
@@ -1132,19 +1132,19 @@ msgid "1 substitution"
 msgstr "Одна заміна"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld збіги(ів)"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> збіги(ів)"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld замін(и)"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> замін(и)"
 
 msgid " on 1 line"
 msgstr " в одному рядку"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " в %ld рядках"
+msgid " on %<PRId64> lines"
+msgstr " в %<PRId64> рядках"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global не можна вживати рекурсивно"
@@ -1230,8 +1230,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Некоректна назва буфера: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Неправильний ID надпису: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Неправильний ID надпису: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (НЕ ЗНАЙДЕНО)"
@@ -1293,8 +1293,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: Залишилося відредагувати ще один файл"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: Залишилося %ld не редагованих файлів"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: Залишилося %<PRId64> не редагованих файлів"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Команда вже існує, ! щоб замінити її"
@@ -1503,8 +1503,8 @@ msgid "Exception discarded: %s"
 msgstr "Виняток скинуто: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, рядок %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, рядок %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1714,12 +1714,12 @@ msgid "[crypted]"
 msgstr "[зашифровано]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[ПОМИЛКА КОНВЕРТАЦІЇ у рядку %ld]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[ПОМИЛКА КОНВЕРТАЦІЇ у рядку %<PRId64>]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[НЕКОРЕКТНИЙ БАЙТ у рядку %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[НЕКОРЕКТНИЙ БАЙТ у рядку %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[ПОМИЛКА ЧИТАННЯ]"
@@ -1805,10 +1805,10 @@ msgstr "E513: Помилка запису, конвертація не вдал�
 
 #, c-format
 msgid ""
-"E513: write error, conversion failed in line %ld (make 'fenc' empty to "
+"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
 "override)"
 msgstr ""
-"E513: Помилка запису, конвертація не вдалася у рядку %ld (скиньте 'fenc')"
+"E513: Помилка запису, конвертація не вдалася у рядку %<PRId64> (скиньте 'fenc')"
 
 msgid "E514: write error (file system full?)"
 msgstr "E514: Помилка запису (скінчилось вільне місце?)"
@@ -1817,8 +1817,8 @@ msgid " CONVERSION ERROR"
 msgstr " ПОМИЛКА КОНВЕРТАЦІЇ"
 
 #, c-format
-msgid " in line %ld;"
-msgstr " у рядку %ld;"
+msgid " in line %<PRId64>;"
+msgstr " у рядку %<PRId64>;"
 
 msgid "[Device]"
 msgstr "[Пристрій]"
@@ -1879,8 +1879,8 @@ msgid "1 line, "
 msgstr "один рядок, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld рядків, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> рядків, "
 
 msgid "1 character"
 msgstr "один символ"
@@ -1891,8 +1891,8 @@ msgstr "%<PRId64> символів"
 
 #. Explicit typecast avoids warning on Mac OS X 10.6
 #, c-format
-msgid "%ld characters"
-msgstr "%ld символів"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> символів"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2325,16 +2325,16 @@ msgid "Font1: %s"
 msgstr "Шрифт1: %s"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0"
-msgstr "Ширина шрифту%ld не більша удвічі за ширину шрифту0"
+msgid "Font%<PRId64> width is not twice that of font0"
+msgstr "Ширина шрифту%<PRId64> не більша удвічі за ширину шрифту0"
 
 #, c-format
-msgid "Font0 width: %ld"
-msgstr "Ширина шрифту0: %ld"
+msgid "Font0 width: %<PRId64>"
+msgstr "Ширина шрифту0: %<PRId64>"
 
 #, c-format
-msgid "Font1 width: %ld"
-msgstr "Ширина шрифту1: %ld"
+msgid "Font1 width: %<PRId64>"
+msgstr "Ширина шрифту1: %<PRId64>"
 
 msgid "Invalid font specification"
 msgstr "Некоректна специфікація шрифту"
@@ -2515,8 +2515,8 @@ msgid "Added cscope database %s"
 msgstr "Додано базу даних cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: Помилка читання зі з'єднання cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: Помилка читання зі з'єднання cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: Невідомий тип пошуку cscope"
@@ -3752,13 +3752,13 @@ msgstr "E314: Збереження не вдалося"
 
 # msgstr "E314: "
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: неправильний lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: неправильний lnum: %<PRId64>"
 
 # msgstr "E315: "
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: не знайшов рядок %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: не знайшов рядок %<PRId64>"
 
 # msgstr "E316: "
 msgid "E317: pointer block id wrong 3"
@@ -3778,8 +3778,8 @@ msgid "deleted block 1?"
 msgstr "блок 1 знищено?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Не вдалося знайти рядок %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Не вдалося знайти рядок %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: Вказівник блоку помилковий"
@@ -3789,13 +3789,13 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count дорівнює 0"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: Номер рядка вийшов за межі: %ld за кінцем"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: Номер рядка вийшов за межі: %<PRId64> за кінцем"
 
 # msgstr "E322: "
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: Кількість рядків у блоці %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: Кількість рядків у блоці %<PRId64>"
 
 # msgstr "E323: "
 msgid "Stack size increases"
@@ -3994,8 +3994,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "Натисніть ENTER або введіть команду для продовження"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s рядок %ld"
+msgid "%s line %<PRId64>"
+msgstr "%s рядок %<PRId64>"
 
 msgid "-- More --"
 msgstr "-- Ще --"
@@ -4065,12 +4065,12 @@ msgid "1 line less"
 msgstr "знищено один рядок"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "додано рядків: %ld"
+msgid "%<PRId64> more lines"
+msgstr "додано рядків: %<PRId64>"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "знищено рядків: %ld"
+msgid "%<PRId64> fewer lines"
+msgstr "знищено рядків: %<PRId64>"
 
 msgid " (Interrupted)"
 msgstr " (Перервано)"
@@ -4102,8 +4102,8 @@ msgstr "E340: Рядок стає занадто довгим"
 
 # msgstr "E340: "
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Внутрішня помилка: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Внутрішня помилка: lalloc(%<PRId64>, )"
 
 # msgstr "E341: "
 #, c-format
@@ -4186,8 +4186,8 @@ msgid "read from Netbeans socket"
 msgstr "читається з сокета Netbeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Втрачено зв'язок із NetBeans для буфера %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Втрачено зв'язок із NetBeans для буфера %<PRId64>"
 
 msgid "E838: netbeans is not supported with this GUI"
 msgstr "E838: netbeans не підтримується з цим GUI"
@@ -4239,23 +4239,23 @@ msgid "1 line %sed %d times"
 msgstr "Один рядок %s-но %d разів"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld рядків %s-но"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> рядків %s-но"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld рядків %s-но %d разів"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> рядків %s-но %d разів"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "Залишилося вирівняти %ld рядків..."
+msgid "%<PRId64> lines to indent... "
+msgstr "Залишилося вирівняти %<PRId64> рядків..."
 
 msgid "1 line indented "
 msgstr "Вирівняно один рядок"
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "Вирівняно рядків: %ld"
+msgid "%<PRId64> lines indented "
+msgstr "Вирівняно рядків: %<PRId64>"
 
 msgid "E748: No previously used register"
 msgstr "E748: Регістри перед цим не вживались"
@@ -4268,12 +4268,12 @@ msgid "1 line changed"
 msgstr "Один рядок змінено"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "Змінено рядків: %ld"
+msgid "%<PRId64> lines changed"
+msgstr "Змінено рядків: %<PRId64>"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "Звільнено рядків: %ld"
+msgid "freeing %<PRId64> lines"
+msgstr "Звільнено рядків: %<PRId64>"
 
 msgid "block of 1 line yanked"
 msgstr "Запам'ятав блок з одного рядка"
@@ -4282,12 +4282,12 @@ msgid "1 line yanked"
 msgstr "Запам'ятав один рядок"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "Запам'ятав блок із %ld рядків"
+msgid "block of %<PRId64> lines yanked"
+msgstr "Запам'ятав блок із %<PRId64> рядків"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "Запам'ятав рядків: %ld"
+msgid "%<PRId64> lines yanked"
+msgstr "Запам'ятав рядків: %<PRId64>"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -4317,36 +4317,36 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: Невідомий тип регістру %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "довж.: %ld; "
+msgid "%<PRId64> Cols; "
+msgstr "довж.: %<PRId64>; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Вибрано %s%ld з %ld рядків; %ld з %ld слів; %ld з %ld байтів"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; %<PRId64> з %<PRId64> байтів"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
 msgstr ""
-"Вибрано %s%ld з %ld рядків; %ld з %ld слів; %ld of %ld символів; %ld з %ld "
+"Вибрано %s%<PRId64> з %<PRId64> рядків; %<PRId64> з %<PRId64> слів; %<PRId64> of %<PRId64> символів; %<PRId64> з %<PRId64> "
 "байтів"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Колонка %s з %s; рядок %ld з %ld; слово %ld з %ld; байт %ld з %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; байт %<PRId64> з %<PRId64>"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"Колонка %s з %s; рядок %ld з %ld; слово %ld з %ld; символ %ld of %ld; байт "
-"%ld з %ld"
+"Колонка %s з %s; рядок %<PRId64> з %<PRId64>; слово %<PRId64> з %<PRId64>; символ %<PRId64> of %<PRId64>; байт "
+"%<PRId64> з %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld для BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> для BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Стор. %N"
@@ -4533,8 +4533,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Потрібна Amigados 2.04 або пізніша\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Потрібно %s версії %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Потрібно %s версії %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Не вдалося відкрити NIL:\n"
@@ -4608,8 +4608,8 @@ msgid "E245: Illegal char '%c' in font name \"%s\""
 msgstr "E245: Помилковий символ %c в назві шрифту «%s»"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "На відкриття дисплею X пішло %ld мілісекунд"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "На відкриття дисплею X пішло %<PRId64> мілісекунд"
 
 msgid ""
 "\n"
@@ -5399,8 +5399,8 @@ msgid "Performing soundfolding..."
 msgstr "Виконується згортання звуків..."
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "Кількість слів після згортання звуків: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "Кількість слів після згортання звуків: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -5435,8 +5435,8 @@ msgid "Done!"
 msgstr "Зроблено!"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' не містить %ld елементів"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' не містить %<PRId64> елементів"
 
 #, c-format
 msgid "Word '%.*s' removed from %s"
@@ -5453,8 +5453,8 @@ msgid "Sorry, no suggestions"
 msgstr "Пробачте, немає пропозицій"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "Пробачте, тільки %ld пропозицій"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "Пробачте, тільки %<PRId64> пропозицій"
 
 #. for when 'cmdheight' > 1
 #. avoid more prompt
@@ -5804,8 +5804,8 @@ msgstr "E431: Помилка формату у файлі теґів «%s»"
 
 # msgstr "E431: "
 #, c-format
-msgid "Before byte %ld"
-msgstr "Перед байтом %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Перед байтом %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5955,8 +5955,8 @@ msgid "Already at newest change"
 msgstr "Вже на найновішій зміні"
 
 #, c-format
-msgid "E830: Undo number %ld not found"
-msgstr "E830: Зміну %ld не знайдено в історії"
+msgid "E830: Undo number %<PRId64> not found"
+msgstr "E830: Зміну %<PRId64> не знайдено в історії"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: неправильні номери рядків"
@@ -5982,8 +5982,8 @@ msgid "changes"
 msgstr "змін"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s; %s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s; %s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "перед"
@@ -5998,8 +5998,8 @@ msgid "number changes  when               saved"
 msgstr "номер  зміни    час             збережено"
 
 #, c-format
-msgid "%ld seconds ago"
-msgstr "%ld секунд тому"
+msgid "%<PRId64> seconds ago"
+msgstr "%<PRId64> секунд тому"
 
 # msgstr "E406: "
 msgid "E790: undojoin is not allowed after undo"

--- a/src/po/vi.po
+++ b/src/po/vi.po
@@ -58,8 +58,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: Không có bộ đệm được liệt kê"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: Bộ đệm %ld không tồn tại"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: Bộ đệm %<PRId64> không tồn tại"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Đây là bộ đệm cuối cùng"
@@ -68,9 +68,9 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: Đây là bộ đệm đầu tiên"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
 msgstr ""
-"E89: Thay đổi trong bộ đệm %ld chưa được ghi lại (thêm ! để thoát ra bằng "
+"E89: Thay đổi trong bộ đệm %<PRId64> chưa được ghi lại (thêm ! để thoát ra bằng "
 "mọi giá)"
 
 msgid "E90: Cannot unload last buffer"
@@ -80,8 +80,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Cảnh báo: Danh sách tên tập tin quá đầy"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: Bộ đệm %ld không được tìm thấy"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: Bộ đệm %<PRId64> không được tìm thấy"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -92,8 +92,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: Không có bộ đệm tương ứng với %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "dòng %ld"
+msgid "line %<PRId64>"
+msgstr "dòng %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Đã có bộ đệm với tên như vậy"
@@ -118,12 +118,12 @@ msgid "1 line --%d%%--"
 msgstr "1 dòng --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld dòng --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> dòng --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "dòng %ld của %ld --%d%%-- cột "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "dòng %<PRId64> của %<PRId64> --%d%%-- cột "
 
 msgid "[No file]"
 msgstr "[Không có tập tin]"
@@ -172,12 +172,12 @@ msgid "Signs for %s:"
 msgstr "Ký hiệu cho %s:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    dòng=%ld  id=%d  tên=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    dòng=%<PRId64>  id=%d  tên=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: Chỉ có thể theo dõi sự khác nhau trong nhiều nhất %ld bộ đệm"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: Chỉ có thể theo dõi sự khác nhau trong nhiều nhất %<PRId64> bộ đệm"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: Không thể tạo tập tin khác biệt (diff)"
@@ -463,8 +463,8 @@ msgid "%s aborted"
 msgstr "%s dừng"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s trả lại #%ld"
+msgid "%s returning #%<PRId64>"
+msgstr "%s trả lại #%<PRId64>"
 
 #, c-format
 msgid "%s returning \"%s\""
@@ -489,16 +489,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "Bật chế độ sửa lỗi (Debug). Gõ \"cont\" để tiếp tục."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "dòng %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "dòng %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "câu lệnh: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "Điểm dừng trên \"%s%s\" dòng %ld"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "Điểm dừng trên \"%s%s\" dòng %<PRId64>"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -508,8 +508,8 @@ msgid "No breakpoints defined"
 msgstr "Điểm dừng không được xác định"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s dòng %ld"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s dòng %<PRId64>"
 
 msgid "Save As"
 msgstr "Ghi nhớ như"
@@ -567,16 +567,16 @@ msgid "could not source \"%s\""
 msgstr "không thực hiện được \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "dòng %ld: không thực hiện được \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "dòng %<PRId64>: không thực hiện được \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "thực hiện \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "dòng %ld: thực hiện \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "dòng %<PRId64>: thực hiện \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -690,12 +690,12 @@ msgid "1 line moved"
 msgstr "Đã di chuyển 1 dòng"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "Đã di chuyển %ld dòng"
+msgid "%<PRId64> lines moved"
+msgstr "Đã di chuyển %<PRId64> dòng"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "Đã lọc %ld dòng"
+msgid "%<PRId64> lines filtered"
+msgstr "Đã lọc %<PRId64> dòng"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Các lệnh tự động *Filter* không được thay đổi bộ đệm hiện thời"
@@ -769,8 +769,8 @@ msgid "Overwrite existing file \"%.*s\"?"
 msgstr "Ghi đè lên tập tin đã có \"%.*s\"?"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: Không có tên tập tin cho bộ đệm %ld"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: Không có tên tập tin cho bộ đệm %<PRId64>"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Tập tin chưa được ghi nhớ: Ghi nhớ bị tắt bởi tùy chọn 'write'"
@@ -810,15 +810,15 @@ msgid "1 substitution"
 msgstr "1 thay thế"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld thay thế"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> thay thế"
 
 msgid " on 1 line"
 msgstr " trên 1 dòng"
 
 #, c-format
-msgid " on %ld lines"
-msgstr " trên %ld dòng"
+msgid " on %<PRId64> lines"
+msgstr " trên %<PRId64> dòng"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Không thực hiện được lệnh :global đệ qui"
@@ -901,8 +901,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Tên bộ đệm không đúng: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: ID của ký hiệu không đúng: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: ID của ký hiệu không đúng: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (KHÔNG TÌM THẤY)"
@@ -966,8 +966,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 1 tập tin nữa chờ soạn thảo."
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: %ld tập tin nữa chưa soạn thảo."
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: %<PRId64> tập tin nữa chưa soạn thảo."
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Đã có câu lệnh: Thêm ! để thay thế"
@@ -1131,8 +1131,8 @@ msgid "Exception discarded: %s"
 msgstr "Trường hợp ngoại lệ bị bỏ qua: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, dòng %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, dòng %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1316,8 +1316,8 @@ msgid "[CONVERSION ERROR]"
 msgstr "[LỖI CHUYỂN BẢNG MÃ]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[BYTE KHÔNG CHO PHÉP trên dòng %ld]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[BYTE KHÔNG CHO PHÉP trên dòng %<PRId64>]"
 
 msgid "[READ ERRORS]"
 msgstr "[LỖI ĐỌC]"
@@ -1461,15 +1461,15 @@ msgid "1 line, "
 msgstr "1 dòng, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld dòng, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> dòng, "
 
 msgid "1 character"
 msgstr "1 ký tự"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld ký tự"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> ký tự"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -1831,20 +1831,20 @@ msgid "Font1: %s\n"
 msgstr "Font1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
 msgstr ""
-"Chiều rộng phông chữ font%ld phải lớn hơn hai lần so với chiều rộng font0\n"
+"Chiều rộng phông chữ font%<PRId64> phải lớn hơn hai lần so với chiều rộng font0\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "Chiều rộng font0: %ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "Chiều rộng font0: %<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"Chiều rộng font1: %ld\n"
+"Chiều rộng font1: %<PRId64>\n"
 "\n"
 
 msgid "E256: Hangul automata ERROR"
@@ -1898,8 +1898,8 @@ msgid "Added cscope database %s"
 msgstr "Đã thêm cơ sở dữ liệu cscope %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: lỗi lấy thông tin từ kết nối cscope %ld"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: lỗi lấy thông tin từ kết nối cscope %<PRId64>"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: không rõ loại tìm kiếm cscope"
@@ -3017,12 +3017,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: Cập nhật không thành công"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: giá trị lnum không đúng: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: giá trị lnum không đúng: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: không tìm được dòng %ld"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: không tìm được dòng %<PRId64>"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: Giá trị của pointer khối số 3 không đúng"
@@ -3040,8 +3040,8 @@ msgid "deleted block 1?"
 msgstr "đã xóa khối số 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: Không tìm được dòng %ld"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: Không tìm được dòng %<PRId64>"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: giá trị của pointer khối không đúng"
@@ -3050,12 +3050,12 @@ msgid "pe_line_count is zero"
 msgstr "giá trị pe_line_count bằng không"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: số thứ tự dòng vượt quá giới hạn : %ld"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: số thứ tự dòng vượt quá giới hạn : %<PRId64>"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: giá trị đếm dòng không đúng trong khối %ld"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: giá trị đếm dòng không đúng trong khối %<PRId64>"
 
 msgid "Stack size increases"
 msgstr "Kích thước của đống tăng lên"
@@ -3293,12 +3293,12 @@ msgid "1 line less"
 msgstr "Bớt 1 dòng"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "Thêm %ld dòng"
+msgid "%<PRId64> more lines"
+msgstr "Thêm %<PRId64> dòng"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "Bớt %ld dòng"
+msgid "%<PRId64> fewer lines"
+msgstr "Bớt %<PRId64> dòng"
 
 msgid " (Interrupted)"
 msgstr " (Bị gián đoạn)"
@@ -3333,8 +3333,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: Dòng đang trở thành quá dài"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: Lỗi nội bộ: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: Lỗi nội bộ: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3417,8 +3417,8 @@ msgid "read from Netbeans socket"
 msgstr "đọc từ socket NetBeans"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: Bị mất liên kết với NetBeans cho bộ đệm %ld"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: Bị mất liên kết với NetBeans cho bộ đệm %<PRId64>"
 
 msgid "Warning: terminal cannot highlight"
 msgstr "Cảnh báo: terminal không thực hiện được sự chiếu sáng"
@@ -3455,23 +3455,23 @@ msgid "1 line %sed %d times"
 msgstr "Trên 1 dòng %s %d lần"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "Trên %ld dòng %s 1 lần"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "Trên %<PRId64> dòng %s 1 lần"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "Trên %ld dòng %s %d lần"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "Trên %<PRId64> dòng %s %d lần"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "Thụt đầu %ld dòng..."
+msgid "%<PRId64> lines to indent... "
+msgstr "Thụt đầu %<PRId64> dòng..."
 
 msgid "1 line indented "
 msgstr "Đã thụt đầu 1 dòng"
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "%ld dòng đã thụt đầu"
+msgid "%<PRId64> lines indented "
+msgstr "%<PRId64> dòng đã thụt đầu"
 
 #. must display the prompt
 msgid "cannot yank; delete anyway"
@@ -3481,19 +3481,19 @@ msgid "1 line changed"
 msgstr "1 dòng đã thay đổi"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "%ld đã thay đổi"
+msgid "%<PRId64> lines changed"
+msgstr "%<PRId64> đã thay đổi"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "đã làm sạch %ld dòng"
+msgid "freeing %<PRId64> lines"
+msgstr "đã làm sạch %<PRId64> dòng"
 
 msgid "1 line yanked"
 msgstr "đã sao chép 1 dòng"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "đã sao chép %ld dòng"
+msgid "%<PRId64> lines yanked"
+msgstr "đã sao chép %<PRId64> dòng"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3526,20 +3526,20 @@ msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Tên sổ đăng ký không cho phép: '%s'"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld Cột; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> Cột; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "Chọn %s%ld của %ld Dòng; %ld của %ld Từ; %ld của %ld Byte"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "Chọn %s%<PRId64> của %<PRId64> Dòng; %<PRId64> của %<PRId64> Từ; %<PRId64> của %<PRId64> Byte"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "Cột %s của %s;  Dòng %ld của %ld; Từ %ld của %ld; Byte %ld của %ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "Cột %s của %s;  Dòng %<PRId64> của %<PRId64>; Từ %<PRId64> của %<PRId64>; Byte %<PRId64> của %<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld cho BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> cho BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Trang %N"
@@ -3712,8 +3712,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "Cần Amigados phiên bản 2.04 hoặc mới hơn\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "Cần %s phiên bản %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "Cần %s phiên bản %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "Không mở được NIL:\n"
@@ -3797,8 +3797,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: Nhận được tín hiệu chết\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "Mở màn hình X mất %ld mili giây"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "Mở màn hình X mất %<PRId64> mili giây"
 
 msgid ""
 "\n"
@@ -4449,8 +4449,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Lỗi định dạng trong tập tin thẻ ghi \"%s\""
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "Trước byte %ld"
+msgid "Before byte %<PRId64>"
+msgstr "Trước byte %<PRId64>"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -4513,8 +4513,8 @@ msgid "1 change"
 msgstr "duy nhất 1 thay đổi"
 
 #, c-format
-msgid "%ld changes"
-msgstr "%ld thay đổi"
+msgid "%<PRId64> changes"
+msgstr "%<PRId64> thay đổi"
 
 msgid "E439: undo list corrupt"
 msgstr "E439: danh sách hủy thao tác (undo) bị hỏng"

--- a/src/po/vi.po
+++ b/src/po/vi.po
@@ -3316,17 +3316,17 @@ msgstr "LỖI: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[byte] tổng phân phối-còn trống %lu-%lu, sử dụng %lu, píc sử dụng %lu\n"
+"[byte] tổng phân phối-còn trống %<PRIu64>-%<PRIu64>, sử dụng %<PRIu64>, píc sử dụng %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[gọi] tổng re/malloc() %lu, tổng free() %lu\n"
+"[gọi] tổng re/malloc() %<PRIu64>, tổng free() %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3337,8 +3337,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: Lỗi nội bộ: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: Không đủ bộ nhớ! (phân chia %lu byte)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: Không đủ bộ nhớ! (phân chia %<PRIu64> byte)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -67,8 +67,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: 没有可列出的缓冲区"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: 缓冲区 %ld 不存在"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: 缓冲区 %<PRId64> 不存在"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 无法切换，已是最后一个缓冲区"
@@ -77,8 +77,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 无法切换，已是第一个缓冲区"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: 缓冲区 %ld 已修改但尚未保存 (请加 ! 强制执行)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: 缓冲区 %<PRId64> 已修改但尚未保存 (请加 ! 强制执行)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: 无法释放最后一个缓冲区"
@@ -87,8 +87,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: 文件名过多"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: 找不到缓冲区 %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: 找不到缓冲区 %<PRId64>"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -99,8 +99,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: 没有匹配的缓冲区 %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "第 %ld 行"
+msgid "line %<PRId64>"
+msgstr "第 %<PRId64> 行"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 已有缓冲区使用该名称"
@@ -125,12 +125,12 @@ msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld 行 --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> 行 --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "行 %ld / %ld --%d%%-- 列 "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "行 %<PRId64> / %<PRId64> --%d%%-- 列 "
 
 msgid "[No Name]"
 msgstr "[未命名]"
@@ -180,12 +180,12 @@ msgid "Signs for %s:"
 msgstr "%s 的 Signs:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    行=%ld  id=%d  名称=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    行=%<PRId64>  id=%d  名称=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: 不能比较(diff) %ld 个以上的缓冲区"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: 不能比较(diff) %<PRId64> 个以上的缓冲区"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: 无法创建 diff"
@@ -326,8 +326,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: :let 中出现异常字符"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: List 索引超出范围: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: List 索引超出范围: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -656,8 +656,8 @@ msgid "%s aborted"
 msgstr "%s 已中止"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s 返回 #%ld "
+msgid "%s returning #%<PRId64>"
+msgstr "%s 返回 #%<PRId64> "
 
 #, c-format
 msgid "%s returning %s"
@@ -704,12 +704,12 @@ msgid "1 line moved"
 msgstr "移动了 1 行"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "移动了 %ld 行"
+msgid "%<PRId64> lines moved"
+msgstr "移动了 %<PRId64> 行"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "过滤了 %ld 行"
+msgid "%<PRId64> lines filtered"
+msgstr "过滤了 %<PRId64> 行"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 自动命令不可以改变当前缓冲区"
@@ -795,8 +795,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 交换文件已存在: %s (:silent! 强制执行)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: 缓冲区 %ld 没有文件名"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: 缓冲区 %<PRId64> 没有文件名"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 文件未写入: 写入被 'write' 选项禁用"
@@ -839,19 +839,19 @@ msgid "1 substitution"
 msgstr "1 次替换，"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld 个匹配，"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> 个匹配，"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld 次替换，"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> 次替换，"
 
 msgid " on 1 line"
 msgstr "共 1 行"
 
 #, c-format
-msgid " on %ld lines"
-msgstr "共 %ld 行"
+msgid " on %<PRId64> lines"
+msgstr "共 %<PRId64> 行"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global 不能递归执行"
@@ -935,8 +935,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 无效的缓冲区名: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: 无效的 sign ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: 无效的 sign ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (找不到)"
@@ -951,16 +951,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "进入调试模式。输入 \"cont\" 继续运行。"
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "第 %ld 行: %s"
+msgid "line %<PRId64>: %s"
+msgstr "第 %<PRId64> 行: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "命令: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "断点 \"%s%s\" 第 %ld 行"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "断点 \"%s%s\" 第 %<PRId64> 行"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -970,8 +970,8 @@ msgid "No breakpoints defined"
 msgstr "没有定义断点"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  第 %ld 行"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  第 %<PRId64> 行"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: 请先使用 :profile start <fname>"
@@ -1027,16 +1027,16 @@ msgid "could not source \"%s\""
 msgstr "不能执行 \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "第 %ld 行: 不能执行 \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "第 %<PRId64> 行: 不能执行 \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "执行 \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "第 %ld 行: 执行 \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "第 %<PRId64> 行: 执行 \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1125,8 +1125,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 还有 1 个文件未编辑"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 还有 %ld 个文件未编辑"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 还有 %<PRId64> 个文件未编辑"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 命令已存在: 请加 ! 强制替换"
@@ -1304,8 +1304,8 @@ msgid "Exception discarded: %s"
 msgstr "丢弃异常: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s，第 %ld 行"
+msgid "%s, line %<PRId64>"
+msgstr "%s，第 %<PRId64> 行"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1509,12 +1509,12 @@ msgid "[crypted]"
 msgstr "[已加密]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[第 %ld 行转换错误]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[第 %<PRId64> 行转换错误]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[第 %ld 行无效字符]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[第 %<PRId64> 行无效字符]"
 
 msgid "[READ ERRORS]"
 msgstr "[读错误]"
@@ -1653,15 +1653,15 @@ msgid "1 line, "
 msgstr "1 行，"
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 行，"
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 行，"
 
 msgid "1 character"
 msgstr "1 个字符"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld 个字符"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 个字符"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2073,19 +2073,19 @@ msgid "Font1: %s\n"
 msgstr "字体1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "字体%ld的宽度不是字体0的两倍\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "字体%<PRId64>的宽度不是字体0的两倍\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "字体0的宽度：%ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "字体0的宽度：%<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"字体1的宽度: %ld\n"
+"字体1的宽度: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2262,8 +2262,8 @@ msgid "Added cscope database %s"
 msgstr "添加了 cscope 数据库 %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: 读取 cscope 连接 %ld 出错"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: 读取 cscope 连接 %<PRId64> 出错"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知的 cscope 查找类型"
@@ -3418,12 +3418,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 保留失败"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 无效的 lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 无效的 lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: 找不到第 %ld 行"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: 找不到第 %<PRId64> 行"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 指针块 id 错误 3"
@@ -3441,8 +3441,8 @@ msgid "deleted block 1?"
 msgstr "删除了块 1？"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: 找不到第 %ld 行"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: 找不到第 %<PRId64> 行"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: 指针块 id 错误"
@@ -3451,12 +3451,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count 为零"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 行号超出范围: %ld 超出结尾"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 行号超出范围: %<PRId64> 超出结尾"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: 块 %ld 行数错误"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: 块 %<PRId64> 行数错误"
 
 msgid "Stack size increases"
 msgstr "堆栈大小增加"
@@ -3640,8 +3640,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "请按 ENTER 或其它命令继续"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s 第 %ld 行"
+msgid "%s line %<PRId64>"
+msgstr "%s 第 %<PRId64> 行"
 
 msgid "-- More --"
 msgstr "-- 更多 --"
@@ -3707,12 +3707,12 @@ msgid "1 line less"
 msgstr "少了 1 行"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "多了 %ld 行"
+msgid "%<PRId64> more lines"
+msgstr "多了 %<PRId64> 行"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "少了 %ld 行"
+msgid "%<PRId64> fewer lines"
+msgstr "少了 %<PRId64> 行"
 
 msgid " (Interrupted)"
 msgstr " (已中断)"
@@ -3751,8 +3751,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 此行过长"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 内部错误: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3823,8 +3823,8 @@ msgid "read from Netbeans socket"
 msgstr "从 Netbeans 套接字读取"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: 缓冲区 %ld 丢失 NetBeans 连接"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: 缓冲区 %<PRId64> 丢失 NetBeans 连接"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3868,23 +3868,23 @@ msgid "1 line %sed %d times"
 msgstr "1 行 %s 了 %d 次"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld 行 %s 了 1 次"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> 行 %s 了 1 次"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld 行 %s 了 %d 次"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> 行 %s 了 %d 次"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "缩进 %ld 行…… "
+msgid "%<PRId64> lines to indent... "
+msgstr "缩进 %<PRId64> 行…… "
 
 msgid "1 line indented "
 msgstr "缩进了 1 行 "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "缩进了 %ld 行 "
+msgid "%<PRId64> lines indented "
+msgstr "缩进了 %<PRId64> 行 "
 
 msgid "E748: No previously used register"
 msgstr "E748: 没有前一个使用的寄存器"
@@ -3897,12 +3897,12 @@ msgid "1 line changed"
 msgstr "改变了 1 行"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "改变了 %ld 行"
+msgid "%<PRId64> lines changed"
+msgstr "改变了 %<PRId64> 行"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "释放了 %ld 行"
+msgid "freeing %<PRId64> lines"
+msgstr "释放了 %<PRId64> 行"
 
 msgid "block of 1 line yanked"
 msgstr "复制了 1 行的块"
@@ -3911,12 +3911,12 @@ msgid "1 line yanked"
 msgstr "复制了 1 行"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "复制了 %ld 行的块"
+msgid "block of %<PRId64> lines yanked"
+msgstr "复制了 %<PRId64> 行的块"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "复制了 %ld 行"
+msgid "%<PRId64> lines yanked"
+msgstr "复制了 %<PRId64> 行"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3946,33 +3946,33 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: 未知的寄存器类型 %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 列; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 列; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "选择了 %s%ld/%ld 行; %ld/%ld 个词; %ld/%ld 个字节"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字节"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
-msgstr "选择了 %s%ld/%ld 行; %ld/%ld 个词; %ld/%ld 个字符; %ld/%ld 个字节"
+msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字符; %<PRId64>/%<PRId64> 个字节"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "第 %s/%s 列; 第 %ld/%ld 行; 第 %ld/%ld 个词; 第 %ld/%ld 个字节"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字节"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"第 %s/%s 列; 第 %ld/%ld 行; 第 %ld/%ld 个词; 第 %ld/%ld 个字符; 第 %ld/%ld 个"
+"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字符; 第 %<PRId64>/%<PRId64> 个"
 "字节"
 
 #, c-format
-#~ msgid "(+%ld for BOM)"
+#~ msgid "(+%<PRId64> for BOM)"
 #~ msgstr ""
 
 #~ msgid "%<%f%h%m%=Page %N"
@@ -4139,8 +4139,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "需要 Amigados 版本 2.04 以上\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "需要 %s 版本 %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "需要 %s 版本 %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "不能打开 NIL:\n"
@@ -4222,8 +4222,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: 拦截到致命信号(deadly signal)\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "打开 X display 用时 %ld 秒"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "打开 X display 用时 %<PRId64> 秒"
 
 msgid ""
 "\n"
@@ -4872,8 +4872,8 @@ msgid "Performing soundfolding..."
 msgstr "正在 soundfolding……"
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "soundfolding 后的单词数: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "soundfolding 后的单词数: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -4908,8 +4908,8 @@ msgid "Done!"
 msgstr "完成！"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' 没有 %ld 项"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' 没有 %<PRId64> 项"
 
 #, c-format
 msgid "Word removed from %s"
@@ -4926,8 +4926,8 @@ msgid "Sorry, no suggestions"
 msgstr "抱歉，没有建议"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "抱歉，只有 %ld 条建议"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "抱歉，只有 %<PRId64> 条建议"
 
 #. avoid more prompt
 #, c-format
@@ -5228,8 +5228,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag 文件 \"%s\" 格式错误"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "在第 %ld 字节之前"
+msgid "Before byte %<PRId64>"
+msgstr "在第 %<PRId64> 字节之前"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5292,8 +5292,8 @@ msgid "Already at newest change"
 msgstr "已位于最新的改变"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "找不到撤销号 %ld"
+msgid "Undo number %<PRId64> not found"
+msgstr "找不到撤销号 %<PRId64>"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行号错误"
@@ -5317,8 +5317,8 @@ msgid "changes"
 msgstr "行发生改变"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s；%s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s；%s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "before"

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -3734,17 +3734,17 @@ msgstr "错误: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[字节] 总共 alloc-free %lu-%lu，使用中 %lu，高峰使用 %lu\n"
+"[字节] 总共 alloc-free %<PRIu64>-%<PRIu64>，使用中 %<PRIu64>，高峰使用 %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[调用] 总共 re/malloc(): %lu，总共 free()': %lu\n"
+"[调用] 总共 re/malloc(): %<PRIu64>，总共 free()': %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3755,8 +3755,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: 内存不足！(分配 %lu 字节)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 内存不足！(分配 %<PRIu64> 字节)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -67,8 +67,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: 没有可列出的缓冲区"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: 缓冲区 %ld 不存在"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: 缓冲区 %<PRId64> 不存在"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 无法切换，已是最后一个缓冲区"
@@ -77,8 +77,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 无法切换，已是第一个缓冲区"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: 缓冲区 %ld 已修改但尚未保存 (请加 ! 强制执行)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: 缓冲区 %<PRId64> 已修改但尚未保存 (请加 ! 强制执行)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: 无法释放最后一个缓冲区"
@@ -87,8 +87,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: 文件名过多"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: 找不到缓冲区 %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: 找不到缓冲区 %<PRId64>"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -99,8 +99,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: 没有匹配的缓冲区 %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "第 %ld 行"
+msgid "line %<PRId64>"
+msgstr "第 %<PRId64> 行"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 已有缓冲区使用该名称"
@@ -125,12 +125,12 @@ msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld 行 --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> 行 --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "行 %ld / %ld --%d%%-- 列 "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "行 %<PRId64> / %<PRId64> --%d%%-- 列 "
 
 msgid "[No Name]"
 msgstr "[未命名]"
@@ -180,12 +180,12 @@ msgid "Signs for %s:"
 msgstr "%s 的 Signs:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    行=%ld  id=%d  名称=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    行=%<PRId64>  id=%d  名称=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: 不能比较(diff) %ld 个以上的缓冲区"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: 不能比较(diff) %<PRId64> 个以上的缓冲区"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: 无法创建 diff"
@@ -327,8 +327,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: :let 中出现异常字符"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: List 索引超出范围: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: List 索引超出范围: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -657,8 +657,8 @@ msgid "%s aborted"
 msgstr "%s 已中止"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s 返回 #%ld "
+msgid "%s returning #%<PRId64>"
+msgstr "%s 返回 #%<PRId64> "
 
 #, c-format
 msgid "%s returning %s"
@@ -705,12 +705,12 @@ msgid "1 line moved"
 msgstr "移动了 1 行"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "移动了 %ld 行"
+msgid "%<PRId64> lines moved"
+msgstr "移动了 %<PRId64> 行"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "过滤了 %ld 行"
+msgid "%<PRId64> lines filtered"
+msgstr "过滤了 %<PRId64> 行"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 自动命令不可以改变当前缓冲区"
@@ -796,8 +796,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 交换文件已存在: %s (:silent! 强制执行)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: 缓冲区 %ld 没有文件名"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: 缓冲区 %<PRId64> 没有文件名"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 文件未写入: 写入被 'write' 选项禁用"
@@ -840,19 +840,19 @@ msgid "1 substitution"
 msgstr "1 次替换，"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld 个匹配，"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> 个匹配，"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld 次替换，"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> 次替换，"
 
 msgid " on 1 line"
 msgstr "共 1 行"
 
 #, c-format
-msgid " on %ld lines"
-msgstr "共 %ld 行"
+msgid " on %<PRId64> lines"
+msgstr "共 %<PRId64> 行"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global 不能递归执行"
@@ -936,8 +936,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 无效的缓冲区名: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: 无效的 sign ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: 无效的 sign ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (找不到)"
@@ -952,16 +952,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "进入调试模式。输入 \"cont\" 继续运行。"
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "第 %ld 行: %s"
+msgid "line %<PRId64>: %s"
+msgstr "第 %<PRId64> 行: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "命令: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "断点 \"%s%s\" 第 %ld 行"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "断点 \"%s%s\" 第 %<PRId64> 行"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -971,8 +971,8 @@ msgid "No breakpoints defined"
 msgstr "没有定义断点"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  第 %ld 行"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  第 %<PRId64> 行"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: 请先使用 :profile start <fname>"
@@ -1028,16 +1028,16 @@ msgid "could not source \"%s\""
 msgstr "不能执行 \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "第 %ld 行: 不能执行 \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "第 %<PRId64> 行: 不能执行 \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "执行 \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "第 %ld 行: 执行 \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "第 %<PRId64> 行: 执行 \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1126,8 +1126,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 还有 1 个文件未编辑"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 还有 %ld 个文件未编辑"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 还有 %<PRId64> 个文件未编辑"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 命令已存在: 请加 ! 强制替换"
@@ -1305,8 +1305,8 @@ msgid "Exception discarded: %s"
 msgstr "丢弃异常: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s，第 %ld 行"
+msgid "%s, line %<PRId64>"
+msgstr "%s，第 %<PRId64> 行"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1510,12 +1510,12 @@ msgid "[crypted]"
 msgstr "[已加密]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[第 %ld 行转换错误]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[第 %<PRId64> 行转换错误]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[第 %ld 行无效字符]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[第 %<PRId64> 行无效字符]"
 
 msgid "[READ ERRORS]"
 msgstr "[读错误]"
@@ -1654,15 +1654,15 @@ msgid "1 line, "
 msgstr "1 行，"
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 行，"
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 行，"
 
 msgid "1 character"
 msgstr "1 个字符"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld 个字符"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 个字符"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2074,19 +2074,19 @@ msgid "Font1: %s\n"
 msgstr "字体1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "字体%ld的宽度不是字体0的两倍\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "字体%<PRId64>的宽度不是字体0的两倍\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "字体0的宽度：%ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "字体0的宽度：%<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"字体1的宽度: %ld\n"
+"字体1的宽度: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2263,8 +2263,8 @@ msgid "Added cscope database %s"
 msgstr "添加了 cscope 数据库 %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: 读取 cscope 连接 %ld 出错"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: 读取 cscope 连接 %<PRId64> 出错"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知的 cscope 查找类型"
@@ -3419,12 +3419,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 保留失败"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 无效的 lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 无效的 lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: 找不到第 %ld 行"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: 找不到第 %<PRId64> 行"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 指针块 id 错误 3"
@@ -3442,8 +3442,8 @@ msgid "deleted block 1?"
 msgstr "删除了块 1？"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: 找不到第 %ld 行"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: 找不到第 %<PRId64> 行"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: 指针块 id 错误"
@@ -3452,12 +3452,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count 为零"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 行号超出范围: %ld 超出结尾"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 行号超出范围: %<PRId64> 超出结尾"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: 块 %ld 行数错误"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: 块 %<PRId64> 行数错误"
 
 msgid "Stack size increases"
 msgstr "堆栈大小增加"
@@ -3641,8 +3641,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "请按 ENTER 或其它命令继续"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s 第 %ld 行"
+msgid "%s line %<PRId64>"
+msgstr "%s 第 %<PRId64> 行"
 
 msgid "-- More --"
 msgstr "-- 更多 --"
@@ -3708,12 +3708,12 @@ msgid "1 line less"
 msgstr "少了 1 行"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "多了 %ld 行"
+msgid "%<PRId64> more lines"
+msgstr "多了 %<PRId64> 行"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "少了 %ld 行"
+msgid "%<PRId64> fewer lines"
+msgstr "少了 %<PRId64> 行"
 
 msgid " (Interrupted)"
 msgstr " (已中断)"
@@ -3752,8 +3752,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 此行过长"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 内部错误: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3824,8 +3824,8 @@ msgid "read from Netbeans socket"
 msgstr "从 Netbeans 套接字读取"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: 缓冲区 %ld 丢失 NetBeans 连接"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: 缓冲区 %<PRId64> 丢失 NetBeans 连接"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3869,23 +3869,23 @@ msgid "1 line %sed %d times"
 msgstr "1 行 %s 了 %d 次"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld 行 %s 了 1 次"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> 行 %s 了 1 次"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld 行 %s 了 %d 次"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> 行 %s 了 %d 次"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "缩进 %ld 行…… "
+msgid "%<PRId64> lines to indent... "
+msgstr "缩进 %<PRId64> 行…… "
 
 msgid "1 line indented "
 msgstr "缩进了 1 行 "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "缩进了 %ld 行 "
+msgid "%<PRId64> lines indented "
+msgstr "缩进了 %<PRId64> 行 "
 
 msgid "E748: No previously used register"
 msgstr "E748: 没有前一个使用的寄存器"
@@ -3898,12 +3898,12 @@ msgid "1 line changed"
 msgstr "改变了 1 行"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "改变了 %ld 行"
+msgid "%<PRId64> lines changed"
+msgstr "改变了 %<PRId64> 行"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "释放了 %ld 行"
+msgid "freeing %<PRId64> lines"
+msgstr "释放了 %<PRId64> 行"
 
 msgid "block of 1 line yanked"
 msgstr "复制了 1 行的块"
@@ -3912,12 +3912,12 @@ msgid "1 line yanked"
 msgstr "复制了 1 行"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "复制了 %ld 行的块"
+msgid "block of %<PRId64> lines yanked"
+msgstr "复制了 %<PRId64> 行的块"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "复制了 %ld 行"
+msgid "%<PRId64> lines yanked"
+msgstr "复制了 %<PRId64> 行"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3947,33 +3947,33 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: 未知的寄存器类型 %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 列; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 列; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "选择了 %s%ld/%ld 行; %ld/%ld 个词; %ld/%ld 个字节"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字节"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
-msgstr "选择了 %s%ld/%ld 行; %ld/%ld 个词; %ld/%ld 个字符; %ld/%ld 个字节"
+msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字符; %<PRId64>/%<PRId64> 个字节"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "第 %s/%s 列; 第 %ld/%ld 行; 第 %ld/%ld 个词; 第 %ld/%ld 个字节"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字节"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"第 %s/%s 列; 第 %ld/%ld 行; 第 %ld/%ld 个词; 第 %ld/%ld 个字符; 第 %ld/%ld 个"
+"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字符; 第 %<PRId64>/%<PRId64> 个"
 "字节"
 
 #, c-format
-#~ msgid "(+%ld for BOM)"
+#~ msgid "(+%<PRId64> for BOM)"
 #~ msgstr ""
 
 #~ msgid "%<%f%h%m%=Page %N"
@@ -4140,8 +4140,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "需要 Amigados 版本 2.04 以上\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "需要 %s 版本 %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "需要 %s 版本 %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "不能打开 NIL:\n"
@@ -4223,8 +4223,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: 拦截到致命信号(deadly signal)\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "打开 X display 用时 %ld 秒"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "打开 X display 用时 %<PRId64> 秒"
 
 msgid ""
 "\n"
@@ -4873,8 +4873,8 @@ msgid "Performing soundfolding..."
 msgstr "正在 soundfolding……"
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "soundfolding 后的单词数: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "soundfolding 后的单词数: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -4909,8 +4909,8 @@ msgid "Done!"
 msgstr "完成！"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' 没有 %ld 项"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' 没有 %<PRId64> 项"
 
 #, c-format
 msgid "Word removed from %s"
@@ -4927,8 +4927,8 @@ msgid "Sorry, no suggestions"
 msgstr "抱歉，没有建议"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "抱歉，只有 %ld 条建议"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "抱歉，只有 %<PRId64> 条建议"
 
 #. avoid more prompt
 #, c-format
@@ -5229,8 +5229,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag 文件 \"%s\" 格式错误"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "在第 %ld 字节之前"
+msgid "Before byte %<PRId64>"
+msgstr "在第 %<PRId64> 字节之前"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5293,8 +5293,8 @@ msgid "Already at newest change"
 msgstr "已位于最新的改变"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "找不到撤销号 %ld"
+msgid "Undo number %<PRId64> not found"
+msgstr "找不到撤销号 %<PRId64>"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行号错误"
@@ -5318,8 +5318,8 @@ msgid "changes"
 msgstr "行发生改变"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s；%s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s；%s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "before"

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -3735,17 +3735,17 @@ msgstr "错误: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[字节] 总共 alloc-free %lu-%lu，使用中 %lu，高峰使用 %lu\n"
+"[字节] 总共 alloc-free %<PRIu64>-%<PRIu64>，使用中 %<PRIu64>，高峰使用 %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[调用] 总共 re/malloc(): %lu，总共 free()': %lu\n"
+"[调用] 总共 re/malloc(): %<PRIu64>，总共 free()': %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3756,8 +3756,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: 内存不足！(分配 %lu 字节)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 内存不足！(分配 %<PRIu64> 字节)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -67,8 +67,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: 没有可列出的缓冲区"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: 缓冲区 %ld 不存在"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: 缓冲区 %<PRId64> 不存在"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 无法切换，已是最后一个缓冲区"
@@ -77,8 +77,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 无法切换，已是第一个缓冲区"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: 缓冲区 %ld 已修改但尚未保存 (请加 ! 强制执行)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: 缓冲区 %<PRId64> 已修改但尚未保存 (请加 ! 强制执行)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: 无法释放最后一个缓冲区"
@@ -87,8 +87,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: 文件名过多"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: 找不到缓冲区 %ld"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: 找不到缓冲区 %<PRId64>"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -99,8 +99,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: 没有匹配的缓冲区 %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "第 %ld 行"
+msgid "line %<PRId64>"
+msgstr "第 %<PRId64> 行"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 已有缓冲区使用该名称"
@@ -125,12 +125,12 @@ msgid "1 line --%d%%--"
 msgstr "1 行 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "%ld 行 --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "%<PRId64> 行 --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "行 %ld / %ld --%d%%-- 列 "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "行 %<PRId64> / %<PRId64> --%d%%-- 列 "
 
 msgid "[No Name]"
 msgstr "[未命名]"
@@ -180,12 +180,12 @@ msgid "Signs for %s:"
 msgstr "%s 的 Signs:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    行=%ld  id=%d  名称=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    行=%<PRId64>  id=%d  名称=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: 不能比较(diff) %ld 个以上的缓冲区"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: 不能比较(diff) %<PRId64> 个以上的缓冲区"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: 无法创建 diff"
@@ -327,8 +327,8 @@ msgid "E18: Unexpected characters in :let"
 msgstr "E18: :let 中出现异常字符"
 
 #, c-format
-msgid "E684: list index out of range: %ld"
-msgstr "E684: List 索引超出范围: %ld"
+msgid "E684: list index out of range: %<PRId64>"
+msgstr "E684: List 索引超出范围: %<PRId64>"
 
 #, c-format
 msgid "E121: Undefined variable: %s"
@@ -657,8 +657,8 @@ msgid "%s aborted"
 msgstr "%s 已中止"
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s 返回 #%ld "
+msgid "%s returning #%<PRId64>"
+msgstr "%s 返回 #%<PRId64> "
 
 #, c-format
 msgid "%s returning %s"
@@ -705,12 +705,12 @@ msgid "1 line moved"
 msgstr "移动了 1 行"
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "移动了 %ld 行"
+msgid "%<PRId64> lines moved"
+msgstr "移动了 %<PRId64> 行"
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "过滤了 %ld 行"
+msgid "%<PRId64> lines filtered"
+msgstr "过滤了 %<PRId64> 行"
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* 自动命令不可以改变当前缓冲区"
@@ -796,8 +796,8 @@ msgid "E768: Swap file exists: %s (:silent! overrides)"
 msgstr "E768: 交换文件已存在: %s (:silent! 强制执行)"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: 缓冲区 %ld 没有文件名"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: 缓冲区 %<PRId64> 没有文件名"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 文件未写入: 写入被 'write' 选项禁用"
@@ -840,19 +840,19 @@ msgid "1 substitution"
 msgstr "1 次替换，"
 
 #, c-format
-msgid "%ld matches"
-msgstr "%ld 个匹配，"
+msgid "%<PRId64> matches"
+msgstr "%<PRId64> 个匹配，"
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "%ld 次替换，"
+msgid "%<PRId64> substitutions"
+msgstr "%<PRId64> 次替换，"
 
 msgid " on 1 line"
 msgstr "共 1 行"
 
 #, c-format
-msgid " on %ld lines"
-msgstr "共 %ld 行"
+msgid " on %<PRId64> lines"
+msgstr "共 %<PRId64> 行"
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global 不能递归执行"
@@ -936,8 +936,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 无效的缓冲区名: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: 无效的 sign ID: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: 无效的 sign ID: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (找不到)"
@@ -952,16 +952,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "进入调试模式。输入 \"cont\" 继续运行。"
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "第 %ld 行: %s"
+msgid "line %<PRId64>: %s"
+msgstr "第 %<PRId64> 行: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "命令: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "断点 \"%s%s\" 第 %ld 行"
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "断点 \"%s%s\" 第 %<PRId64> 行"
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -971,8 +971,8 @@ msgid "No breakpoints defined"
 msgstr "没有定义断点"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  第 %ld 行"
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  第 %<PRId64> 行"
 
 msgid "E750: First use :profile start <fname>"
 msgstr "E750: 请先使用 :profile start <fname>"
@@ -1028,16 +1028,16 @@ msgid "could not source \"%s\""
 msgstr "不能执行 \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "第 %ld 行: 不能执行 \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "第 %<PRId64> 行: 不能执行 \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "执行 \"%s\""
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "第 %ld 行: 执行 \"%s\""
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "第 %<PRId64> 行: 执行 \"%s\""
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1126,8 +1126,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 还有 1 个文件未编辑"
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 还有 %ld 个文件未编辑"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 还有 %<PRId64> 个文件未编辑"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 命令已存在: 请加 ! 强制替换"
@@ -1305,8 +1305,8 @@ msgid "Exception discarded: %s"
 msgstr "丢弃异常: %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s，第 %ld 行"
+msgid "%s, line %<PRId64>"
+msgstr "%s，第 %<PRId64> 行"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1510,12 +1510,12 @@ msgid "[crypted]"
 msgstr "[已加密]"
 
 #, c-format
-msgid "[CONVERSION ERROR in line %ld]"
-msgstr "[第 %ld 行转换错误]"
+msgid "[CONVERSION ERROR in line %<PRId64>]"
+msgstr "[第 %<PRId64> 行转换错误]"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[第 %ld 行无效字符]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[第 %<PRId64> 行无效字符]"
 
 msgid "[READ ERRORS]"
 msgstr "[读错误]"
@@ -1654,15 +1654,15 @@ msgid "1 line, "
 msgstr "1 行，"
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 行，"
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 行，"
 
 msgid "1 character"
 msgstr "1 个字符"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld 个字符"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64> 个字符"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -2074,19 +2074,19 @@ msgid "Font1: %s\n"
 msgstr "字体1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "字体%ld的宽度不是字体0的两倍\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "字体%<PRId64>的宽度不是字体0的两倍\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "字体0的宽度：%ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "字体0的宽度：%<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"字体1的宽度: %ld\n"
+"字体1的宽度: %<PRId64>\n"
 "\n"
 
 msgid "Invalid font specification"
@@ -2263,8 +2263,8 @@ msgid "Added cscope database %s"
 msgstr "添加了 cscope 数据库 %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: 读取 cscope 连接 %ld 出错"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: 读取 cscope 连接 %<PRId64> 出错"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知的 cscope 查找类型"
@@ -3419,12 +3419,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 保留失败"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 无效的 lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 无效的 lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: 找不到第 %ld 行"
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: 找不到第 %<PRId64> 行"
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 指针块 id 错误 3"
@@ -3442,8 +3442,8 @@ msgid "deleted block 1?"
 msgstr "删除了块 1？"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: 找不到第 %ld 行"
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: 找不到第 %<PRId64> 行"
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: 指针块 id 错误"
@@ -3452,12 +3452,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count 为零"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 行号超出范围: %ld 超出结尾"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 行号超出范围: %<PRId64> 超出结尾"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: 块 %ld 行数错误"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: 块 %<PRId64> 行数错误"
 
 msgid "Stack size increases"
 msgstr "堆栈大小增加"
@@ -3641,8 +3641,8 @@ msgid "Press ENTER or type command to continue"
 msgstr "请按 ENTER 或其它命令继续"
 
 #, c-format
-msgid "%s line %ld"
-msgstr "%s 第 %ld 行"
+msgid "%s line %<PRId64>"
+msgstr "%s 第 %<PRId64> 行"
 
 msgid "-- More --"
 msgstr "-- 更多 --"
@@ -3708,12 +3708,12 @@ msgid "1 line less"
 msgstr "少了 1 行"
 
 #, c-format
-msgid "%ld more lines"
-msgstr "多了 %ld 行"
+msgid "%<PRId64> more lines"
+msgstr "多了 %<PRId64> 行"
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "少了 %ld 行"
+msgid "%<PRId64> fewer lines"
+msgstr "少了 %<PRId64> 行"
 
 msgid " (Interrupted)"
 msgstr " (已中断)"
@@ -3752,8 +3752,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 此行过长"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 内部错误: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3824,8 +3824,8 @@ msgid "read from Netbeans socket"
 msgstr "从 Netbeans 套接字读取"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: 缓冲区 %ld 丢失 NetBeans 连接"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: 缓冲区 %<PRId64> 丢失 NetBeans 连接"
 
 msgid "E505: "
 msgstr "E505: "
@@ -3869,23 +3869,23 @@ msgid "1 line %sed %d times"
 msgstr "1 行 %s 了 %d 次"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld 行 %s 了 1 次"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> 行 %s 了 1 次"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld 行 %s 了 %d 次"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> 行 %s 了 %d 次"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "缩进 %ld 行…… "
+msgid "%<PRId64> lines to indent... "
+msgstr "缩进 %<PRId64> 行…… "
 
 msgid "1 line indented "
 msgstr "缩进了 1 行 "
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "缩进了 %ld 行 "
+msgid "%<PRId64> lines indented "
+msgstr "缩进了 %<PRId64> 行 "
 
 msgid "E748: No previously used register"
 msgstr "E748: 没有前一个使用的寄存器"
@@ -3898,12 +3898,12 @@ msgid "1 line changed"
 msgstr "改变了 1 行"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "改变了 %ld 行"
+msgid "%<PRId64> lines changed"
+msgstr "改变了 %<PRId64> 行"
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "释放了 %ld 行"
+msgid "freeing %<PRId64> lines"
+msgstr "释放了 %<PRId64> 行"
 
 msgid "block of 1 line yanked"
 msgstr "复制了 1 行的块"
@@ -3912,12 +3912,12 @@ msgid "1 line yanked"
 msgstr "复制了 1 行"
 
 #, c-format
-msgid "block of %ld lines yanked"
-msgstr "复制了 %ld 行的块"
+msgid "block of %<PRId64> lines yanked"
+msgstr "复制了 %<PRId64> 行的块"
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "复制了 %ld 行"
+msgid "%<PRId64> lines yanked"
+msgstr "复制了 %<PRId64> 行"
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3947,33 +3947,33 @@ msgid "E574: Unknown register type %d"
 msgstr "E574: 未知的寄存器类型 %d"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 列; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 列; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "选择了 %s%ld/%ld 行; %ld/%ld 个词; %ld/%ld 个字节"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字节"
 
 #, c-format
 msgid ""
-"Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Chars; %ld of %ld "
+"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> "
 "Bytes"
-msgstr "选择了 %s%ld/%ld 行; %ld/%ld 个词; %ld/%ld 个字符; %ld/%ld 个字节"
+msgstr "选择了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 个词; %<PRId64>/%<PRId64> 个字符; %<PRId64>/%<PRId64> 个字节"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "第 %s/%s 列; 第 %ld/%ld 行; 第 %ld/%ld 个词; 第 %ld/%ld 个字节"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字节"
 
 #, c-format
 msgid ""
-"Col %s of %s; Line %ld of %ld; Word %ld of %ld; Char %ld of %ld; Byte %ld of "
-"%ld"
+"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char %<PRId64> of %<PRId64>; Byte %<PRId64> of "
+"%<PRId64>"
 msgstr ""
-"第 %s/%s 列; 第 %ld/%ld 行; 第 %ld/%ld 个词; 第 %ld/%ld 个字符; 第 %ld/%ld 个"
+"第 %s/%s 列; 第 %<PRId64>/%<PRId64> 行; 第 %<PRId64>/%<PRId64> 个词; 第 %<PRId64>/%<PRId64> 个字符; 第 %<PRId64>/%<PRId64> 个"
 "字节"
 
 #, c-format
-#~ msgid "(+%ld for BOM)"
+#~ msgid "(+%<PRId64> for BOM)"
 #~ msgstr ""
 
 #~ msgid "%<%f%h%m%=Page %N"
@@ -4140,8 +4140,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "需要 Amigados 版本 2.04 以上\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "需要 %s 版本 %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "需要 %s 版本 %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "不能打开 NIL:\n"
@@ -4223,8 +4223,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: 拦截到致命信号(deadly signal)\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "打开 X display 用时 %ld 秒"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "打开 X display 用时 %<PRId64> 秒"
 
 msgid ""
 "\n"
@@ -4873,8 +4873,8 @@ msgid "Performing soundfolding..."
 msgstr "正在 soundfolding……"
 
 #, c-format
-msgid "Number of words after soundfolding: %ld"
-msgstr "soundfolding 后的单词数: %ld"
+msgid "Number of words after soundfolding: %<PRId64>"
+msgstr "soundfolding 后的单词数: %<PRId64>"
 
 #, c-format
 msgid "Total number of words: %d"
@@ -4909,8 +4909,8 @@ msgid "Done!"
 msgstr "完成！"
 
 #, c-format
-msgid "E765: 'spellfile' does not have %ld entries"
-msgstr "E765: 'spellfile' 没有 %ld 项"
+msgid "E765: 'spellfile' does not have %<PRId64> entries"
+msgstr "E765: 'spellfile' 没有 %<PRId64> 项"
 
 #, c-format
 msgid "Word removed from %s"
@@ -4927,8 +4927,8 @@ msgid "Sorry, no suggestions"
 msgstr "抱歉，没有建议"
 
 #, c-format
-msgid "Sorry, only %ld suggestions"
-msgstr "抱歉，只有 %ld 条建议"
+msgid "Sorry, only %<PRId64> suggestions"
+msgstr "抱歉，只有 %<PRId64> 条建议"
 
 #. avoid more prompt
 #, c-format
@@ -5229,8 +5229,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag 文件 \"%s\" 格式错误"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "在第 %ld 字节之前"
+msgid "Before byte %<PRId64>"
+msgstr "在第 %<PRId64> 字节之前"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -5293,8 +5293,8 @@ msgid "Already at newest change"
 msgstr "已位于最新的改变"
 
 #, c-format
-msgid "Undo number %ld not found"
-msgstr "找不到撤销号 %ld"
+msgid "Undo number %<PRId64> not found"
+msgstr "找不到撤销号 %<PRId64>"
 
 msgid "E438: u_undo: line numbers wrong"
 msgstr "E438: u_undo: 行号错误"
@@ -5318,8 +5318,8 @@ msgid "changes"
 msgstr "行发生改变"
 
 #, c-format
-msgid "%ld %s; %s #%ld  %s"
-msgstr "%ld %s；%s #%ld  %s"
+msgid "%<PRId64> %s; %s #%<PRId64>  %s"
+msgstr "%<PRId64> %s；%s #%<PRId64>  %s"
 
 msgid "before"
 msgstr "before"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -3735,17 +3735,17 @@ msgstr "错误: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[字节] 总共 alloc-free %lu-%lu，使用中 %lu，高峰使用 %lu\n"
+"[字节] 总共 alloc-free %<PRIu64>-%<PRIu64>，使用中 %<PRIu64>，高峰使用 %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[调用] 总共 re/malloc(): %lu，总共 free()': %lu\n"
+"[调用] 总共 re/malloc(): %<PRIu64>，总共 free()': %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3756,8 +3756,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 内部错误: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: 内存不足！(分配 %lu 字节)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 内存不足！(分配 %<PRIu64> 字节)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -3303,17 +3303,17 @@ msgstr "錯誤: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bytes] 全部 alloc-freed %lu-%lu, 使用中 %lu, peak 使用 %lu\n"
+"[bytes] 全部 alloc-freed %<PRIu64>-%<PRIu64>, 使用中 %<PRIu64>, peak 使用 %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[呼叫] 全部 re/malloc(): %lu, 全部 free()': %lu\n"
+"[呼叫] 全部 re/malloc(): %<PRIu64>, 全部 free()': %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3324,8 +3324,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 內部錯誤: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: 記憶體不足! (嘗試配置 %lu 位元組)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 記憶體不足! (嘗試配置 %<PRIu64> 位元組)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/po/zh_TW.UTF-8.po
+++ b/src/po/zh_TW.UTF-8.po
@@ -26,8 +26,8 @@
 #
 # Note (2005.01.27):
 #  A bug was found for UTF8 mode.
-#   > msgid "%ld fewer lines" "on %ld lines"
-#   If you don't put more (at least 2) spaces after %ld
+#   > msgid "%<PRId64> fewer lines" "on %<PRId64> lines"
+#   If you don't put more (at least 2) spaces after %<PRId64>
 #   gvim/win32 will crash (no reason).
 #   So please change [行"] to [行 "]
 #
@@ -99,8 +99,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: 沒有列出的緩衝區"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: 緩衝區 %ld 不存在"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: 緩衝區 %<PRId64> 不存在"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 無法切換到更後面的緩衝區"
@@ -109,8 +109,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 無法切換到更前面的緩衝區"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: 已更改過緩衝區 %ld 但尚未存檔 (可用 ! 強制執行)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: 已更改過緩衝區 %<PRId64> 但尚未存檔 (可用 ! 強制執行)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: 無法釋放最後一個緩衝區"
@@ -119,8 +119,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: 檔名過多"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: 找不到第 %ld 個緩衝區"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: 找不到第 %<PRId64> 個緩衝區"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -131,8 +131,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: 找不到 %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "行 %ld"
+msgid "line %<PRId64>"
+msgstr "行 %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 已有緩衝區使用這個名字"
@@ -157,12 +157,12 @@ msgid "1 line --%d%%--"
 msgstr "行數 1 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "行數 %ld --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "行數 %<PRId64> --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "行 %ld/%ld --%d%%-- 欄 "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "行 %<PRId64>/%<PRId64> --%d%%-- 欄 "
 
 msgid "[No file]"
 msgstr "[未命名]"
@@ -212,12 +212,12 @@ msgid "Signs for %s:"
 msgstr "%s 的符號:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    行=%ld  id=%d  名稱=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    行=%<PRId64>  id=%d  名稱=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: 無法比較(diff) %ld個以上的緩衝區"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: 無法比較(diff) %<PRId64>個以上的緩衝區"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: 不能建立 "
@@ -503,8 +503,8 @@ msgid "%s aborted"
 msgstr "%s 被強制中斷執行 "
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s 傳回值 #%ld "
+msgid "%s returning #%<PRId64>"
+msgstr "%s 傳回值 #%<PRId64> "
 
 #, c-format
 msgid "%s returning \"%s\""
@@ -545,12 +545,12 @@ msgid "1 line moved"
 msgstr "已搬移 1 行 "
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "已搬移 %ld 行 "
+msgid "%<PRId64> lines moved"
+msgstr "已搬移 %<PRId64> 行 "
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "已處理 %ld 行 "
+msgid "%<PRId64> lines filtered"
+msgstr "已處理 %<PRId64> 行 "
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autocommand 不可以更改緩衝區的內容"
@@ -629,8 +629,8 @@ msgid "Overwrite existing file \"%.*s\"?"
 msgstr "要覆寫已存在的檔案 \"%.*s\"？"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: 緩衝區 %ld 沒有檔案名稱"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: 緩衝區 %<PRId64> 沒有檔案名稱"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 檔案未寫入，因為 'write' 選項被關閉"
@@ -670,15 +670,15 @@ msgid "1 substitution"
 msgstr "取代一組 "
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "取代 %ld 組 "
+msgid "%<PRId64> substitutions"
+msgstr "取代 %<PRId64> 組 "
 
 msgid " on 1 line"
 msgstr "，範圍：一行 "
 
 #, c-format
-msgid " on %ld lines"
-msgstr "，範圍： %ld 行 "
+msgid " on %<PRId64> lines"
+msgstr "，範圍： %<PRId64> 行 "
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global 無法遞迴執行 "
@@ -761,8 +761,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 緩衝區名稱錯誤: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Sign ID 錯誤: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Sign ID 錯誤: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (找不到) "
@@ -777,16 +777,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "進入除錯模式. 輸入 \"cont\" 以回到正常模式."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "行 %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "行 %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "\"%s%s\" 中斷點: 第 %ld 行 "
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "\"%s%s\" 中斷點: 第 %<PRId64> 行 "
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -796,8 +796,8 @@ msgid "No breakpoints defined"
 msgstr "沒有定義中斷點"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  第 %ld 行 "
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  第 %<PRId64> 行 "
 
 #, c-format
 msgid "Save changes to \"%.*s\"?"
@@ -850,16 +850,16 @@ msgid "could not source \"%s\""
 msgstr "無法執行 \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "第 %ld 行: 無法執行 \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "第 %<PRId64> 行: 無法執行 \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "執行 \"%s\" 中"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "第 %ld 行: 結束執行 %s"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "第 %<PRId64> 行: 結束執行 %s"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1007,8 +1007,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 還有一個檔案未編輯 "
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 還有 %ld 個檔案未編輯"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 還有 %<PRId64> 個檔案未編輯"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 命令已經存在, 請使用 ! 強制重新定義"
@@ -1169,8 +1169,8 @@ msgid "Exception discarded: %s"
 msgstr "已丟棄例外： %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, 行 %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, 行 %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1353,8 +1353,8 @@ msgid "[CONVERSION ERROR]"
 msgstr "轉換錯誤"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[行 %ld 有不正確的位元]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[行 %<PRId64> 有不正確的位元]"
 
 msgid "[READ ERRORS]"
 msgstr "[讀取錯誤]"
@@ -1490,15 +1490,15 @@ msgid "1 line, "
 msgstr "1 行, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 行, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 行, "
 
 msgid "1 character"
 msgstr "一個字元"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld個字元"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64>個字元"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -1850,19 +1850,19 @@ msgid "Font1: %s\n"
 msgstr "Font1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "字型%ld 寬度不是 字型0 的兩倍\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "字型%<PRId64> 寬度不是 字型0 的兩倍\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "字型0的寬度：%ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "字型0的寬度：%<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"字型1寬度: %ld\n"
+"字型1寬度: %<PRId64>\n"
 "\n"
 
 msgid "E256: Hangul automata ERROR"
@@ -1915,8 +1915,8 @@ msgid "Added cscope database %s"
 msgstr "新增 cscope 資料庫 %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: 讀取 cscope 連線 %ld 錯誤"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: 讀取 cscope 連線 %<PRId64> 錯誤"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知的 cscope 搜尋形態"
@@ -3008,12 +3008,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 保留失敗"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 錯誤的 lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 錯誤的 lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: 找不到第 %ld 行 "
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: 找不到第 %<PRId64> 行 "
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 指標區塊 id 錯誤 3"
@@ -3031,8 +3031,8 @@ msgid "deleted block 1?"
 msgstr "刪除區塊 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: 找不到第 %ld 行 "
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: 找不到第 %<PRId64> 行 "
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: 指標區塊 id 錯誤"
@@ -3041,12 +3041,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count 為零"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 行號超出範圍: %ld 超過結尾"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 行號超出範圍: %<PRId64> 超過結尾"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: 區塊 %ld 行數錯誤"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: 區塊 %<PRId64> 行數錯誤"
 
 msgid "Stack size increases"
 msgstr "堆疊大小增加"
@@ -3279,12 +3279,12 @@ msgid "1 line less"
 msgstr "少於一行 "
 
 #, c-format
-msgid "%ld more lines"
-msgstr "多了 %ld 行 "
+msgid "%<PRId64> more lines"
+msgstr "多了 %<PRId64> 行 "
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "少了 %ld 行 "
+msgid "%<PRId64> fewer lines"
+msgstr "少了 %<PRId64> 行 "
 
 msgid " (Interrupted)"
 msgstr " (已中斷)"
@@ -3320,8 +3320,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 此行過長"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 內部錯誤: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 內部錯誤: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3401,8 +3401,8 @@ msgid "read from Netbeans socket"
 msgstr "由 Netbeans socket 讀取"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: 緩衝區 %ld 與 NetBeans 的連線已中斷"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: 緩衝區 %<PRId64> 與 NetBeans 的連線已中斷"
 
 msgid "Warning: terminal cannot highlight"
 msgstr "注意: 你的終端機無法顯示高亮度"
@@ -3437,23 +3437,23 @@ msgid "1 line %sed %d times"
 msgstr "一行 %s 過 %d 次"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld 行 %s 過 一次"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> 行 %s 過 一次"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld 行 %s 過 %d 次"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> 行 %s 過 %d 次"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "縮排 %ld 行... "
+msgid "%<PRId64> lines to indent... "
+msgstr "縮排 %<PRId64> 行... "
 
 msgid "1 line indented "
 msgstr "一行已縮排"
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "已縮排 %ld 行 "
+msgid "%<PRId64> lines indented "
+msgstr "已縮排 %<PRId64> 行 "
 
 #. must display the prompt
 msgid "cannot yank; delete anyway"
@@ -3463,19 +3463,19 @@ msgid "1 line changed"
 msgstr " 1 行 ~ed"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "已改變 %ld 行 "
+msgid "%<PRId64> lines changed"
+msgstr "已改變 %<PRId64> 行 "
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "釋放 %ld 行中 "
+msgid "freeing %<PRId64> lines"
+msgstr "釋放 %<PRId64> 行中 "
 
 msgid "1 line yanked"
 msgstr "已複製 1 行 "
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "已複製 %ld 行 "
+msgid "%<PRId64> lines yanked"
+msgstr "已複製 %<PRId64> 行 "
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3509,20 +3509,20 @@ msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 暫存器名稱錯誤: '%s'"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 欄; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 欄; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "選擇了 %s%ld/%ld 行; %ld/%ld 字(Word); %ld/%ld 字元(Bytes)"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "選擇了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 字(Word); %<PRId64>/%<PRId64> 字元(Bytes)"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "欄 %s/%s; 行 %ld/%ld; 字(Word) %ld/%ld; 字元(Byte) %ld/%ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "欄 %s/%s; 行 %<PRId64>/%<PRId64>; 字(Word) %<PRId64>/%<PRId64>; 字元(Byte) %<PRId64>/%<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld for BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=第 %N 頁"
@@ -3696,8 +3696,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "需要 Amigados 版本 2.04 以上\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "需要 %s 版本 %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "需要 %s 版本 %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "無法開啟 NIL:\n"
@@ -3782,8 +3782,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: 攔截到致命的信號(deadly signale)\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "開啟 X Window 耗時 %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "開啟 X Window 耗時 %<PRId64> msec"
 
 msgid ""
 "\n"
@@ -4434,8 +4434,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag 檔 \"%s\" 格式錯誤"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "在 %ld 位元之前"
+msgid "Before byte %<PRId64>"
+msgstr "在 %<PRId64> 位元之前"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -4498,8 +4498,8 @@ msgid "1 change"
 msgstr "一項改變"
 
 #, c-format
-msgid "%ld changes"
-msgstr "%ld 項改變"
+msgid "%<PRId64> changes"
+msgstr "%<PRId64> 項改變"
 
 msgid "E439: undo list corrupt"
 msgstr "E439: 復原列表損壞"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -19,8 +19,8 @@
 #
 # Note (2005.01.27):
 #  A bug was found for UTF8 mode.
-#   > msgid "%ld fewer lines" "on %ld lines"
-#   If you don't put more (at least 2) spaces after %ld
+#   > msgid "%<PRId64> fewer lines" "on %<PRId64> lines"
+#   If you don't put more (at least 2) spaces after %<PRId64>
 #   gvim/win32 will crash (no reason).
 #   So please change [行"] to [行 "]
 #
@@ -92,8 +92,8 @@ msgid "E85: There is no listed buffer"
 msgstr "E85: 沒有列出的緩衝區"
 
 #, c-format
-msgid "E86: Buffer %ld does not exist"
-msgstr "E86: 緩衝區 %ld 不存在"
+msgid "E86: Buffer %<PRId64> does not exist"
+msgstr "E86: 緩衝區 %<PRId64> 不存在"
 
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: 無法切換到更後面的緩衝區"
@@ -102,8 +102,8 @@ msgid "E88: Cannot go before first buffer"
 msgstr "E88: 無法切換到更前面的緩衝區"
 
 #, c-format
-msgid "E89: No write since last change for buffer %ld (add ! to override)"
-msgstr "E89: 已更改過緩衝區 %ld 但尚未存檔 (可用 ! 強制執行)"
+msgid "E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgstr "E89: 已更改過緩衝區 %<PRId64> 但尚未存檔 (可用 ! 強制執行)"
 
 msgid "E90: Cannot unload last buffer"
 msgstr "E90: 無法釋放最後一個緩衝區"
@@ -112,8 +112,8 @@ msgid "W14: Warning: List of file names overflow"
 msgstr "W14: 警告: 檔名過多"
 
 #, c-format
-msgid "E92: Buffer %ld not found"
-msgstr "E92: 找不到第 %ld 個緩衝區"
+msgid "E92: Buffer %<PRId64> not found"
+msgstr "E92: 找不到第 %<PRId64> 個緩衝區"
 
 #, c-format
 msgid "E93: More than one match for %s"
@@ -124,8 +124,8 @@ msgid "E94: No matching buffer for %s"
 msgstr "E94: 找不到 %s"
 
 #, c-format
-msgid "line %ld"
-msgstr "行 %ld"
+msgid "line %<PRId64>"
+msgstr "行 %<PRId64>"
 
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: 已有緩衝區使用這個名字"
@@ -150,12 +150,12 @@ msgid "1 line --%d%%--"
 msgstr "行數 1 --%d%%--"
 
 #, c-format
-msgid "%ld lines --%d%%--"
-msgstr "行數 %ld --%d%%--"
+msgid "%<PRId64> lines --%d%%--"
+msgstr "行數 %<PRId64> --%d%%--"
 
 #, c-format
-msgid "line %ld of %ld --%d%%-- col "
-msgstr "行 %ld/%ld --%d%%-- 欄 "
+msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
+msgstr "行 %<PRId64>/%<PRId64> --%d%%-- 欄 "
 
 msgid "[No file]"
 msgstr "[未命名]"
@@ -205,12 +205,12 @@ msgid "Signs for %s:"
 msgstr "%s 的符號:"
 
 #, c-format
-msgid "    line=%ld  id=%d  name=%s"
-msgstr "    行=%ld  id=%d  名稱=%s"
+msgid "    line=%<PRId64>  id=%d  name=%s"
+msgstr "    行=%<PRId64>  id=%d  名稱=%s"
 
 #, c-format
-msgid "E96: Can not diff more than %ld buffers"
-msgstr "E96: 無法比較(diff) %ld個以上的緩衝區"
+msgid "E96: Can not diff more than %<PRId64> buffers"
+msgstr "E96: 無法比較(diff) %<PRId64>個以上的緩衝區"
 
 msgid "E97: Cannot create diffs"
 msgstr "E97: 不能建立 "
@@ -496,8 +496,8 @@ msgid "%s aborted"
 msgstr "%s 被強制中斷執行 "
 
 #, c-format
-msgid "%s returning #%ld"
-msgstr "%s 傳回值 #%ld "
+msgid "%s returning #%<PRId64>"
+msgstr "%s 傳回值 #%<PRId64> "
 
 #, c-format
 msgid "%s returning \"%s\""
@@ -538,12 +538,12 @@ msgid "1 line moved"
 msgstr "已搬移 1 行 "
 
 #, c-format
-msgid "%ld lines moved"
-msgstr "已搬移 %ld 行 "
+msgid "%<PRId64> lines moved"
+msgstr "已搬移 %<PRId64> 行 "
 
 #, c-format
-msgid "%ld lines filtered"
-msgstr "已處理 %ld 行 "
+msgid "%<PRId64> lines filtered"
+msgstr "已處理 %<PRId64> 行 "
 
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: *Filter* Autocommand 不可以更改緩衝區的內容"
@@ -622,8 +622,8 @@ msgid "Overwrite existing file \"%.*s\"?"
 msgstr "要覆寫已存在的檔案 \"%.*s\"？"
 
 #, c-format
-msgid "E141: No file name for buffer %ld"
-msgstr "E141: 緩衝區 %ld 沒有檔案名稱"
+msgid "E141: No file name for buffer %<PRId64>"
+msgstr "E141: 緩衝區 %<PRId64> 沒有檔案名稱"
 
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: 檔案未寫入，因為 'write' 選項被關閉"
@@ -663,15 +663,15 @@ msgid "1 substitution"
 msgstr "取代一組 "
 
 #, c-format
-msgid "%ld substitutions"
-msgstr "取代 %ld 組 "
+msgid "%<PRId64> substitutions"
+msgstr "取代 %<PRId64> 組 "
 
 msgid " on 1 line"
 msgstr "，範圍：一行 "
 
 #, c-format
-msgid " on %ld lines"
-msgstr "，範圍： %ld 行 "
+msgid " on %<PRId64> lines"
+msgstr "，範圍： %<PRId64> 行 "
 
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: :global 無法遞迴執行 "
@@ -754,8 +754,8 @@ msgid "E158: Invalid buffer name: %s"
 msgstr "E158: 緩衝區名稱錯誤: %s"
 
 #, c-format
-msgid "E157: Invalid sign ID: %ld"
-msgstr "E157: Sign ID 錯誤: %ld"
+msgid "E157: Invalid sign ID: %<PRId64>"
+msgstr "E157: Sign ID 錯誤: %<PRId64>"
 
 msgid " (NOT FOUND)"
 msgstr " (找不到) "
@@ -770,16 +770,16 @@ msgid "Entering Debug mode.  Type \"cont\" to continue."
 msgstr "進入除錯模式. 輸入 \"cont\" 以回到正常模式."
 
 #, c-format
-msgid "line %ld: %s"
-msgstr "行 %ld: %s"
+msgid "line %<PRId64>: %s"
+msgstr "行 %<PRId64>: %s"
 
 #, c-format
 msgid "cmd: %s"
 msgstr "cmd: %s"
 
 #, c-format
-msgid "Breakpoint in \"%s%s\" line %ld"
-msgstr "\"%s%s\" 中斷點: 第 %ld 行 "
+msgid "Breakpoint in \"%s%s\" line %<PRId64>"
+msgstr "\"%s%s\" 中斷點: 第 %<PRId64> 行 "
 
 #, c-format
 msgid "E161: Breakpoint not found: %s"
@@ -789,8 +789,8 @@ msgid "No breakpoints defined"
 msgstr "沒有定義中斷點"
 
 #, c-format
-msgid "%3d  %s %s  line %ld"
-msgstr "%3d  %s %s  第 %ld 行 "
+msgid "%3d  %s %s  line %<PRId64>"
+msgstr "%3d  %s %s  第 %<PRId64> 行 "
 
 #, c-format
 msgid "Save changes to \"%.*s\"?"
@@ -843,16 +843,16 @@ msgid "could not source \"%s\""
 msgstr "無法執行 \"%s\""
 
 #, c-format
-msgid "line %ld: could not source \"%s\""
-msgstr "第 %ld 行: 無法執行 \"%s\""
+msgid "line %<PRId64>: could not source \"%s\""
+msgstr "第 %<PRId64> 行: 無法執行 \"%s\""
 
 #, c-format
 msgid "sourcing \"%s\""
 msgstr "執行 \"%s\" 中"
 
 #, c-format
-msgid "line %ld: sourcing \"%s\""
-msgstr "第 %ld 行: 結束執行 %s"
+msgid "line %<PRId64>: sourcing \"%s\""
+msgstr "第 %<PRId64> 行: 結束執行 %s"
 
 #, c-format
 msgid "finished sourcing %s"
@@ -1000,8 +1000,8 @@ msgid "E173: 1 more file to edit"
 msgstr "E173: 還有一個檔案未編輯 "
 
 #, c-format
-msgid "E173: %ld more files to edit"
-msgstr "E173: 還有 %ld 個檔案未編輯"
+msgid "E173: %<PRId64> more files to edit"
+msgstr "E173: 還有 %<PRId64> 個檔案未編輯"
 
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: 命令已經存在, 請使用 ! 強制重新定義"
@@ -1162,8 +1162,8 @@ msgid "Exception discarded: %s"
 msgstr "已丟棄例外： %s"
 
 #, c-format
-msgid "%s, line %ld"
-msgstr "%s, 行 %ld"
+msgid "%s, line %<PRId64>"
+msgstr "%s, 行 %<PRId64>"
 
 #. always scroll up, don't overwrite
 #, c-format
@@ -1346,8 +1346,8 @@ msgid "[CONVERSION ERROR]"
 msgstr "轉換錯誤"
 
 #, c-format
-msgid "[ILLEGAL BYTE in line %ld]"
-msgstr "[行 %ld 有不正確的位元]"
+msgid "[ILLEGAL BYTE in line %<PRId64>]"
+msgstr "[行 %<PRId64> 有不正確的位元]"
 
 msgid "[READ ERRORS]"
 msgstr "[讀取錯誤]"
@@ -1483,15 +1483,15 @@ msgid "1 line, "
 msgstr "1 行, "
 
 #, c-format
-msgid "%ld lines, "
-msgstr "%ld 行, "
+msgid "%<PRId64> lines, "
+msgstr "%<PRId64> 行, "
 
 msgid "1 character"
 msgstr "一個字元"
 
 #, c-format
-msgid "%ld characters"
-msgstr "%ld個字元"
+msgid "%<PRId64> characters"
+msgstr "%<PRId64>個字元"
 
 msgid "[noeol]"
 msgstr "[noeol]"
@@ -1843,19 +1843,19 @@ msgid "Font1: %s\n"
 msgstr "Font1: %s\n"
 
 #, c-format
-msgid "Font%ld width is not twice that of font0\n"
-msgstr "字型%ld 寬度不是 字型0 的兩倍\n"
+msgid "Font%<PRId64> width is not twice that of font0\n"
+msgstr "字型%<PRId64> 寬度不是 字型0 的兩倍\n"
 
 #, c-format
-msgid "Font0 width: %ld\n"
-msgstr "字型0的寬度：%ld\n"
+msgid "Font0 width: %<PRId64>\n"
+msgstr "字型0的寬度：%<PRId64>\n"
 
 #, c-format
 msgid ""
-"Font1 width: %ld\n"
+"Font1 width: %<PRId64>\n"
 "\n"
 msgstr ""
-"字型1寬度: %ld\n"
+"字型1寬度: %<PRId64>\n"
 "\n"
 
 msgid "E256: Hangul automata ERROR"
@@ -1908,8 +1908,8 @@ msgid "Added cscope database %s"
 msgstr "新增 cscope 資料庫 %s"
 
 #, c-format
-msgid "E262: error reading cscope connection %ld"
-msgstr "E262: 讀取 cscope 連線 %ld 錯誤"
+msgid "E262: error reading cscope connection %<PRId64>"
+msgstr "E262: 讀取 cscope 連線 %<PRId64> 錯誤"
 
 msgid "E561: unknown cscope search type"
 msgstr "E561: 未知的 cscope 搜尋形態"
@@ -3001,12 +3001,12 @@ msgid "E314: Preserve failed"
 msgstr "E314: 保留失敗"
 
 #, c-format
-msgid "E315: ml_get: invalid lnum: %ld"
-msgstr "E315: ml_get: 錯誤的 lnum: %ld"
+msgid "E315: ml_get: invalid lnum: %<PRId64>"
+msgstr "E315: ml_get: 錯誤的 lnum: %<PRId64>"
 
 #, c-format
-msgid "E316: ml_get: cannot find line %ld"
-msgstr "E316: ml_get: 找不到第 %ld 行 "
+msgid "E316: ml_get: cannot find line %<PRId64>"
+msgstr "E316: ml_get: 找不到第 %<PRId64> 行 "
 
 msgid "E317: pointer block id wrong 3"
 msgstr "E317: 指標區塊 id 錯誤 3"
@@ -3024,8 +3024,8 @@ msgid "deleted block 1?"
 msgstr "刪除區塊 1?"
 
 #, c-format
-msgid "E320: Cannot find line %ld"
-msgstr "E320: 找不到第 %ld 行 "
+msgid "E320: Cannot find line %<PRId64>"
+msgstr "E320: 找不到第 %<PRId64> 行 "
 
 msgid "E317: pointer block id wrong"
 msgstr "E317: 指標區塊 id 錯誤"
@@ -3034,12 +3034,12 @@ msgid "pe_line_count is zero"
 msgstr "pe_line_count 為零"
 
 #, c-format
-msgid "E322: line number out of range: %ld past the end"
-msgstr "E322: 行號超出範圍: %ld 超過結尾"
+msgid "E322: line number out of range: %<PRId64> past the end"
+msgstr "E322: 行號超出範圍: %<PRId64> 超過結尾"
 
 #, c-format
-msgid "E323: line count wrong in block %ld"
-msgstr "E323: 區塊 %ld 行數錯誤"
+msgid "E323: line count wrong in block %<PRId64>"
+msgstr "E323: 區塊 %<PRId64> 行數錯誤"
 
 msgid "Stack size increases"
 msgstr "堆疊大小增加"
@@ -3272,12 +3272,12 @@ msgid "1 line less"
 msgstr "少於一行 "
 
 #, c-format
-msgid "%ld more lines"
-msgstr "還有 %ld 行 "
+msgid "%<PRId64> more lines"
+msgstr "還有 %<PRId64> 行 "
 
 #, c-format
-msgid "%ld fewer lines"
-msgstr "只剩 %ld 行 "
+msgid "%<PRId64> fewer lines"
+msgstr "只剩 %<PRId64> 行 "
 
 msgid " (Interrupted)"
 msgstr " (已中斷)"
@@ -3313,8 +3313,8 @@ msgid "E340: Line is becoming too long"
 msgstr "E340: 此行過長"
 
 #, c-format
-msgid "E341: Internal error: lalloc(%ld, )"
-msgstr "E341: 內部錯誤: lalloc(%ld, )"
+msgid "E341: Internal error: lalloc(%<PRId64>, )"
+msgstr "E341: 內部錯誤: lalloc(%<PRId64>, )"
 
 #, c-format
 msgid "E342: Out of memory!  (allocating %lu bytes)"
@@ -3394,8 +3394,8 @@ msgid "read from Netbeans socket"
 msgstr "由 Netbeans socket 讀取"
 
 #, c-format
-msgid "E658: NetBeans connection lost for buffer %ld"
-msgstr "E658: 緩衝區 %ld 與 NetBeans 的連線已中斷"
+msgid "E658: NetBeans connection lost for buffer %<PRId64>"
+msgstr "E658: 緩衝區 %<PRId64> 與 NetBeans 的連線已中斷"
 
 msgid "Warning: terminal cannot highlight"
 msgstr "注意: 你的終端機無法顯示高亮度"
@@ -3430,23 +3430,23 @@ msgid "1 line %sed %d times"
 msgstr "一行 %s 過 %d 次"
 
 #, c-format
-msgid "%ld lines %sed 1 time"
-msgstr "%ld 行 %s 過 一次"
+msgid "%<PRId64> lines %sed 1 time"
+msgstr "%<PRId64> 行 %s 過 一次"
 
 #, c-format
-msgid "%ld lines %sed %d times"
-msgstr "%ld 行 %s 過 %d 次"
+msgid "%<PRId64> lines %sed %d times"
+msgstr "%<PRId64> 行 %s 過 %d 次"
 
 #, c-format
-msgid "%ld lines to indent... "
-msgstr "縮排 %ld 行... "
+msgid "%<PRId64> lines to indent... "
+msgstr "縮排 %<PRId64> 行... "
 
 msgid "1 line indented "
 msgstr "一行已縮排"
 
 #, c-format
-msgid "%ld lines indented "
-msgstr "已縮排 %ld 行 "
+msgid "%<PRId64> lines indented "
+msgstr "已縮排 %<PRId64> 行 "
 
 #. must display the prompt
 msgid "cannot yank; delete anyway"
@@ -3456,19 +3456,19 @@ msgid "1 line changed"
 msgstr " 1 行 ~ed"
 
 #, c-format
-msgid "%ld lines changed"
-msgstr "已改變 %ld 行 "
+msgid "%<PRId64> lines changed"
+msgstr "已改變 %<PRId64> 行 "
 
 #, c-format
-msgid "freeing %ld lines"
-msgstr "釋放 %ld 行中 "
+msgid "freeing %<PRId64> lines"
+msgstr "釋放 %<PRId64> 行中 "
 
 msgid "1 line yanked"
 msgstr "已複製 1 行 "
 
 #, c-format
-msgid "%ld lines yanked"
-msgstr "已複製 %ld 行 "
+msgid "%<PRId64> lines yanked"
+msgstr "已複製 %<PRId64> 行 "
 
 #, c-format
 msgid "E353: Nothing in register %s"
@@ -3502,20 +3502,20 @@ msgid "E354: Invalid register name: '%s'"
 msgstr "E354: 暫存器名稱錯誤: '%s'"
 
 #, c-format
-msgid "%ld Cols; "
-msgstr "%ld 欄; "
+msgid "%<PRId64> Cols; "
+msgstr "%<PRId64> 欄; "
 
 #, c-format
-msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
-msgstr "選擇了 %s%ld/%ld 行; %ld/%ld 字(Word); %ld/%ld 字元(Bytes)"
+msgid "Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; %<PRId64> of %<PRId64> Bytes"
+msgstr "選擇了 %s%<PRId64>/%<PRId64> 行; %<PRId64>/%<PRId64> 字(Word); %<PRId64>/%<PRId64> 字元(Bytes)"
 
 #, c-format
-msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
-msgstr "欄 %s/%s; 行 %ld/%ld; 字(Word) %ld/%ld; 字元(Byte) %ld/%ld"
+msgid "Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
+msgstr "欄 %s/%s; 行 %<PRId64>/%<PRId64>; 字(Word) %<PRId64>/%<PRId64>; 字元(Byte) %<PRId64>/%<PRId64>"
 
 #, c-format
-msgid "(+%ld for BOM)"
-msgstr "(+%ld for BOM)"
+msgid "(+%<PRId64> for BOM)"
+msgstr "(+%<PRId64> for BOM)"
 
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=第 %N 頁"
@@ -3689,8 +3689,8 @@ msgid "Need Amigados version 2.04 or later\n"
 msgstr "需要 Amigados 版本 2.04 以上\n"
 
 #, c-format
-msgid "Need %s version %ld\n"
-msgstr "需要 %s 版本 %ld\n"
+msgid "Need %s version %<PRId64>\n"
+msgstr "需要 %s 版本 %<PRId64>\n"
 
 msgid "Cannot open NIL:\n"
 msgstr "無法開啟 NIL:\n"
@@ -3775,8 +3775,8 @@ msgid "Vim: Caught deadly signal\n"
 msgstr "Vim: 攔截到致命的信號(deadly signale)\n"
 
 #, c-format
-msgid "Opening the X display took %ld msec"
-msgstr "開啟 X Window 耗時 %ld msec"
+msgid "Opening the X display took %<PRId64> msec"
+msgstr "開啟 X Window 耗時 %<PRId64> msec"
 
 msgid ""
 "\n"
@@ -4427,8 +4427,8 @@ msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Tag 檔 \"%s\" 格式錯誤"
 
 #, c-format
-msgid "Before byte %ld"
-msgstr "在 %ld 位元之前"
+msgid "Before byte %<PRId64>"
+msgstr "在 %<PRId64> 位元之前"
 
 #, c-format
 msgid "E432: Tags file not sorted: %s"
@@ -4491,8 +4491,8 @@ msgid "1 change"
 msgstr "一項改變"
 
 #, c-format
-msgid "%ld changes"
-msgstr "%ld 項改變"
+msgid "%<PRId64> changes"
+msgstr "%<PRId64> 項改變"
 
 msgid "E439: undo list corrupt"
 msgstr "E439: 復原列表損壞"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -3296,17 +3296,17 @@ msgstr "錯誤: "
 #, c-format
 msgid ""
 "\n"
-"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+"[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use %<PRIu64>\n"
 msgstr ""
 "\n"
-"[bytes] 全部 alloc-freed %lu-%lu, 使用中 %lu, peak 使用 %lu\n"
+"[bytes] 全部 alloc-freed %<PRIu64>-%<PRIu64>, 使用中 %<PRIu64>, peak 使用 %<PRIu64>\n"
 
 #, c-format
 msgid ""
-"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
 "\n"
 msgstr ""
-"[呼叫] 全部 re/malloc(): %lu, 全部 free()': %lu\n"
+"[呼叫] 全部 re/malloc(): %<PRIu64>, 全部 free()': %<PRIu64>\n"
 "\n"
 
 msgid "E340: Line is becoming too long"
@@ -3317,8 +3317,8 @@ msgid "E341: Internal error: lalloc(%<PRId64>, )"
 msgstr "E341: 內部錯誤: lalloc(%<PRId64>, )"
 
 #, c-format
-msgid "E342: Out of memory!  (allocating %lu bytes)"
-msgstr "E342: 記憶體不足! (嘗試配置 %lu 位元組)"
+msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
+msgstr "E342: 記憶體不足! (嘗試配置 %<PRIu64> 位元組)"
 
 #, c-format
 msgid "Calling shell to execute: \"%s\""

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -1802,10 +1802,10 @@ void qf_list(exarg_T *eap)
       if (qfp->qf_lnum == 0)
         IObuff[0] = NUL;
       else if (qfp->qf_col == 0)
-        sprintf((char *)IObuff, ":%ld", qfp->qf_lnum);
+        sprintf((char *)IObuff, ":%" PRId64, (int64_t)qfp->qf_lnum);
       else
-        sprintf((char *)IObuff, ":%ld col %d",
-            qfp->qf_lnum, qfp->qf_col);
+        sprintf((char *)IObuff, ":%" PRId64 " col %d",
+                (int64_t)qfp->qf_lnum, qfp->qf_col);
       sprintf((char *)IObuff + STRLEN(IObuff), "%s:",
           (char *)qf_types(qfp->qf_type, qfp->qf_nr));
       msg_puts_attr(IObuff, hl_attr(HLF_N));
@@ -2357,7 +2357,7 @@ static void qf_fill_buffer(qf_info_T *qi)
       IObuff[len++] = '|';
 
       if (qfp->qf_lnum > 0) {
-        sprintf((char *)IObuff + len, "%ld", qfp->qf_lnum);
+        sprintf((char *)IObuff + len, "%" PRId64, (int64_t)qfp->qf_lnum);
         len += (int)STRLEN(IObuff + len);
 
         if (qfp->qf_col > 0) {

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3386,7 +3386,7 @@ int set_errorlist(win_T *wp, list_T *list, int action, char_u *title)
     if (bufnum != 0 && (buflist_findnr(bufnum) == NULL)) {
       if (!did_bufnr_emsg) {
         did_bufnr_emsg = TRUE;
-        EMSGN(_("E92: Buffer %ld not found"), bufnum);
+        EMSGN(_("E92: Buffer %" PRId64 " not found"), bufnum);
       }
       valid = FALSE;
       bufnum = 0;

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -5770,15 +5770,16 @@ static void regdump(char_u *pattern, bt_regprog_T *r)
       end = next;
     if (op == BRACE_LIMITS) {
       /* Two ints */
-      fprintf(f, " minval %ld, maxval %ld", OPERAND_MIN(s), OPERAND_MAX(s));
+      fprintf(f, " minval %" PRId64 ", maxval %" PRId64,
+              (int64_t)OPERAND_MIN(s), (int64_t)OPERAND_MAX(s));
       s += 8;
     } else if (op == BEHIND || op == NOBEHIND) {
       /* one int */
-      fprintf(f, " count %ld", OPERAND_MIN(s));
+      fprintf(f, " count %" PRId64, (int64_t)OPERAND_MIN(s));
       s += 4;
     } else if (op == RE_LNUM || op == RE_COL || op == RE_VCOL) {
       /* one int plus comperator */
-      fprintf(f, " count %ld", OPERAND_MIN(s));
+      fprintf(f, " count %" PRId64, (int64_t)OPERAND_MIN(s));
       s += 5;
     }
     s += 3;

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1156,7 +1156,7 @@ static int nfa_regatom(void)
         rc_did_emsg = TRUE;
         return FAIL;
       }
-      EMSGN("INTERNAL: Unknown character class char: %ld", c);
+      EMSGN("INTERNAL: Unknown character class char: %" PRId64, c);
       return FAIL;
     }
     /* When '.' is followed by a composing char ignore the dot, so that
@@ -5823,7 +5823,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
 
 #ifdef REGEXP_DEBUG
         if (c < 0)
-          EMSGN("INTERNAL: Negative state char: %ld", c);
+          EMSGN("INTERNAL: Negative state char: %" PRId64, c);
 #endif
         result = (c == curc);
 
@@ -6272,8 +6272,9 @@ static regprog_T *nfa_regcomp(char_u *expr, int re_flags)
   if (postfix == NULL) {
     /* TODO: only give this error for debugging? */
     if (post_ptr >= post_end)
-      EMSGN("Internal error: estimated max number of states insufficient: %ld",
-          post_end - post_start);
+      EMSGN("Internal error: estimated max number "
+            "of states insufficient: %" PRId64,
+            post_end - post_start);
     goto fail;              /* Cascaded (syntax?) error */
   }
 

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -240,7 +240,7 @@ static char_u e_nul_found[] = N_(
     "E865: (NFA) Regexp end encountered prematurely");
 static char_u e_misplaced[] = N_("E866: (NFA regexp) Misplaced %c");
 static char_u e_ill_char_class[] = N_(
-    "E877: (NFA regexp) Invalid character class: %ld");
+    "E877: (NFA regexp) Invalid character class: %" PRId64);
 
 /* NFA regexp \ze operator encountered. */
 static int nfa_has_zend;

--- a/src/screen.c
+++ b/src/screen.c
@@ -2232,7 +2232,7 @@ win_line (
   int row;                              /* row in the window, excl w_winrow */
   int screen_row;                       /* row on the screen, incl w_winrow */
 
-  char_u extra[18];                     /* "%ld" and 'fdc' must fit in here */
+  char_u extra[18];                     /* line number and 'fdc' must fit in here */
   int n_extra = 0;                      /* number of extra chars */
   char_u      *p_extra = NULL;          /* string of extra chars, plus NUL */
   int c_extra = NUL;                    /* extra chars, all the same */

--- a/src/screen.c
+++ b/src/screen.c
@@ -7900,10 +7900,10 @@ static void win_redr_ruler(win_T *wp, int always)
      * Some sprintfs return the length, some return a pointer.
      * To avoid portability problems we use strlen() here.
      */
-    vim_snprintf((char *)buffer, RULER_BUF_LEN, "%ld,",
+    vim_snprintf((char *)buffer, RULER_BUF_LEN, "%" PRId64 ",",
         (wp->w_buffer->b_ml.ml_flags & ML_EMPTY)
-        ? 0L
-        : (long)(wp->w_cursor.lnum));
+        ? (int64_t)0L
+        : (int64_t)(wp->w_cursor.lnum));
     len = STRLEN(buffer);
     col_print(buffer + len, RULER_BUF_LEN - len,
         empty_line ? 0 : (int)wp->w_cursor.col + 1,

--- a/src/search.c
+++ b/src/search.c
@@ -4702,12 +4702,12 @@ wvsp_one (
   if (spats[idx].pat != NULL) {
     fprintf(fp, _("\n# Last %sSearch Pattern:\n~"), s);
     /* off.dir is not stored, it's reset to forward */
-    fprintf(fp, "%c%c%c%c%ld%s%c",
+    fprintf(fp, "%c%c%c%c%" PRId64 "%s%c",
         spats[idx].magic    ? 'M' : 'm',                /* magic */
         spats[idx].no_scs   ? 's' : 'S',                /* smartcase */
         spats[idx].off.line ? 'L' : 'l',                /* line offset */
         spats[idx].off.end  ? 'E' : 'e',                /* offset from end */
-        spats[idx].off.off,                             /* offset */
+        (int64_t)spats[idx].off.off,                    /* offset */
         last_idx == idx     ? "~" : "",                 /* last used pat */
         sc);
     viminfo_writestring(fp, spats[idx].pat);

--- a/src/search.c
+++ b/src/search.c
@@ -1074,7 +1074,7 @@ proftime_T      *tm;            /* timeout limit or NULL */
           if (spats[0].off.off > 0 || spats[0].off.line)
             *p++ = '+';
           if (spats[0].off.off != 0 || spats[0].off.line)
-            sprintf((char *)p, "%ld", spats[0].off.off);
+            sprintf((char *)p, "%" PRId64, (int64_t)spats[0].off.off);
           else
             *p = NUL;
         }

--- a/src/spell.c
+++ b/src/spell.c
@@ -8401,7 +8401,7 @@ spell_add_word (
       if (i == idx)
         break;
       if (*spf == NUL) {
-        EMSGN(_("E765: 'spellfile' does not have %ld entries"), idx);
+        EMSGN(_("E765: 'spellfile' does not have %" PRId64 " entries"), idx);
         vim_free(fnamebuf);
         return;
       }

--- a/src/spell.c
+++ b/src/spell.c
@@ -7680,8 +7680,8 @@ static void spell_make_sugfile(spellinfo_T *spin, char_u *wfname)
   if (sug_maketable(spin) == FAIL)
     goto theend;
 
-  smsg((char_u *)_("Number of words after soundfolding: %ld"),
-      (long)spin->si_spellbuf->b_ml.ml_line_count);
+  smsg((char_u *)_("Number of words after soundfolding: %" PRId64),
+      (int64_t)spin->si_spellbuf->b_ml.ml_line_count);
 
   /*
    * Compress the soundfold trie.
@@ -9084,8 +9084,8 @@ void spell_suggest(int count)
     MSG(_("Sorry, no suggestions"));
   else if (count > 0) {
     if (count > sug.su_ga.ga_len)
-      smsg((char_u *)_("Sorry, only %ld suggestions"),
-          (long)sug.su_ga.ga_len);
+      smsg((char_u *)_("Sorry, only %" PRId64 " suggestions"),
+          (int64_t)sug.su_ga.ga_len);
   } else {
     vim_free(repl_from);
     repl_from = NULL;

--- a/src/tag.c
+++ b/src/tag.c
@@ -1933,7 +1933,7 @@ parse_line:
       if (line_error) {
         EMSG2(_("E431: Format error in tags file \"%s\""), tag_fname);
         if (!use_cscope)
-          EMSGN(_("Before byte %ld"), (long)ftell(fp));
+          EMSGN(_("Before byte %" PRId64), ftell(fp));
         stop_searching = TRUE;
         line_error = FALSE;
       }

--- a/src/term.c
+++ b/src/term.c
@@ -4249,7 +4249,7 @@ replace_termcodes (
           result[dlen++] = K_SPECIAL;
           result[dlen++] = (int)KS_EXTRA;
           result[dlen++] = (int)KE_SNR;
-          sprintf((char *)result + dlen, "%ld", (long)current_SID);
+          sprintf((char *)result + dlen, "%" PRId64, (int64_t)current_SID);
           dlen += (int)STRLEN(result + dlen);
           result[dlen++] = '_';
           continue;

--- a/src/undo.c
+++ b/src/undo.c
@@ -1291,8 +1291,8 @@ void u_write_undo(char_u *name, int forceit, buf_T *buf, char_u *hash)
     write_ok = TRUE;
 #ifdef U_DEBUG
   if (headers_written != buf->b_u_numhead) {
-    EMSGN("Written %ld headers, ...", headers_written);
-    EMSGN("... but numhead is %ld", buf->b_u_numhead);
+    EMSGN("Written %" PRId64 " headers, ...", headers_written);
+    EMSGN("... but numhead is %" PRId64, buf->b_u_numhead);
   }
 #endif
 
@@ -1593,7 +1593,7 @@ void u_read_undo(char_u *name, char_u *hash, char_u *orig_name)
 #ifdef U_DEBUG
   for (i = 0; i < num_head; ++i)
     if (uhp_table_used[i] == 0)
-      EMSGN("uhp_table entry %ld not used, leaking memory", i);
+      EMSGN("uhp_table entry %" PRId64 " not used, leaking memory", i);
   vim_free(uhp_table_used);
   u_check(TRUE);
 #endif

--- a/src/undo.c
+++ b/src/undo.c
@@ -2465,8 +2465,8 @@ static void u_add_time(char_u *buf, size_t buflen, time_t tt)
       /* longer ago */
       (void)strftime((char *)buf, buflen, "%Y/%m/%d %H:%M:%S", curtime);
   } else
-  vim_snprintf((char *)buf, buflen, _("%ld seconds ago"),
-      (long)(time(NULL) - tt));
+  vim_snprintf((char *)buf, buflen, _("%" PRId64 " seconds ago"),
+      (int64_t)(time(NULL) - tt));
 }
 
 /*

--- a/src/undo.c
+++ b/src/undo.c
@@ -1910,7 +1910,7 @@ void undo_time(long step, int sec, int file, int absolute)
       break;
 
     if (absolute) {
-      EMSGN(_("E830: Undo number %ld not found"), step);
+      EMSGN(_("E830: Undo number %" PRId64 " not found"), step);
       return;
     }
 

--- a/src/undo.c
+++ b/src/undo.c
@@ -219,8 +219,8 @@ static void u_check(int newhead_may_be_NULL)                 {
     EMSGN("b_u_curhead invalid: 0x%x", curbuf->b_u_curhead);
   if (header_count != curbuf->b_u_numhead) {
     EMSG("b_u_numhead invalid");
-    smsg((char_u *)"expected: %ld, actual: %ld",
-        (long)header_count, (long)curbuf->b_u_numhead);
+    smsg((char_u *)"expected: %" PRId64 ", actual: %" PRId64,
+        (int64_t)header_count, (int64_t)curbuf->b_u_numhead);
   }
 }
 

--- a/src/undo.c
+++ b/src/undo.c
@@ -2330,11 +2330,11 @@ u_undo_end (
     }
   }
 
-  smsg((char_u *)_("%ld %s; %s #%ld  %s"),
-      u_oldcount < 0 ? -u_oldcount : u_oldcount,
+  smsg((char_u *)_("%" PRId64 " %s; %s #%" PRId64 "  %s"),
+      u_oldcount < 0 ? (int64_t)-u_oldcount : (int64_t)u_oldcount,
       _(msgstr),
       did_undo ? _("before") : _("after"),
-      uhp == NULL ? 0L : uhp->uh_seq,
+      uhp == NULL ? (int64_t)0L : (int64_t)uhp->uh_seq,
       msgbuf);
 }
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -1046,7 +1046,7 @@ typedef enum {
 #define EMSG2(s, p)                 emsg2((char_u *)(s), (char_u *)(p))
 #define EMSG3(s, p, q)              emsg3((char_u *)(s), (char_u *)(p), \
     (char_u *)(q))
-#define EMSGN(s, n)                 emsgn((char_u *)(s), (long)(n))
+#define EMSGN(s, n)                 emsgn((char_u *)(s), (int64_t)(n))
 #define EMSGU(s, n)                 emsgu((char_u *)(s), (long_u)(n))
 #define OUT_STR(s)                  out_str((char_u *)(s))
 #define OUT_STR_NF(s)               out_str_nf((char_u *)(s))

--- a/src/vim.h
+++ b/src/vim.h
@@ -88,10 +88,6 @@ Error: configure did not run properly.Check auto/config.log.
 #  define __w64
 typedef unsigned long __w64 long_u;
 typedef          long __w64 long_i;
-# define SCANF_HEX_LONG_U       "%lx"
-# define SCANF_DECIMAL_LONG_U   "%lu"
-# define PRINTF_HEX_LONG_U      "0x%lx"
-#define PRINTF_DECIMAL_LONG_U SCANF_DECIMAL_LONG_U
 
 /*
  * The characters and attributes cached for the screen.

--- a/src/vim.h
+++ b/src/vim.h
@@ -94,16 +94,6 @@ typedef          long __w64 long_i;
 #define PRINTF_DECIMAL_LONG_U SCANF_DECIMAL_LONG_U
 
 /*
- * Only systems which use configure will have SIZEOF_OFF_T and SIZEOF_LONG
- * defined, which is ok since those are the same systems which can have
- * varying sizes for off_t.  The other systems will continue to use "%ld" to
- * print off_t since off_t is simply a typedef to long for them.
- */
-#if defined(SIZEOF_OFF_T) && (SIZEOF_OFF_T > SIZEOF_LONG)
-# define LONG_LONG_OFF_T
-#endif
-
-/*
  * The characters and attributes cached for the screen.
  */
 typedef char_u schar_T;

--- a/src/window.c
+++ b/src/window.c
@@ -172,7 +172,7 @@ do_window (
     STRCPY(cbuf, "split #");
     if (Prenum)
       vim_snprintf((char *)cbuf + 7, sizeof(cbuf) - 7,
-          "%ld", Prenum);
+          "%" PRId64, (int64_t)Prenum);
     do_cmdline_cmd(cbuf);
     break;
 
@@ -183,7 +183,7 @@ do_window (
 newwindow:
     if (Prenum)
       /* window height */
-      vim_snprintf((char *)cbuf, sizeof(cbuf) - 5, "%ld", Prenum);
+      vim_snprintf((char *)cbuf, sizeof(cbuf) - 5, "%" PRId64, (int64_t)Prenum);
     else
       cbuf[0] = NUL;
     if (nchar == 'v' || nchar == Ctrl_V)

--- a/src/window.c
+++ b/src/window.c
@@ -5263,14 +5263,16 @@ int match_add(win_T *wp, char_u *grp, char_u *pat, int prio, int id)
   if (*grp == NUL || *pat == NUL)
     return -1;
   if (id < -1 || id == 0) {
-    EMSGN("E799: Invalid ID: %ld (must be greater than or equal to 1)", id);
+    EMSGN("E799: Invalid ID: %" PRId64
+          " (must be greater than or equal to 1)",
+          id);
     return -1;
   }
   if (id != -1) {
     cur = wp->w_match_head;
     while (cur != NULL) {
       if (cur->id == id) {
-        EMSGN("E801: ID already taken: %ld", id);
+        EMSGN("E801: ID already taken: %" PRId64, id);
         return -1;
       }
       cur = cur->next;
@@ -5334,8 +5336,9 @@ int match_delete(win_T *wp, int id, int perr)
 
   if (id < 1) {
     if (perr == TRUE)
-      EMSGN("E802: Invalid ID: %ld (must be greater than or equal to 1)",
-          id);
+      EMSGN("E802: Invalid ID: %" PRId64
+            " (must be greater than or equal to 1)",
+            id);
     return -1;
   }
   while (cur != NULL && cur->id != id) {
@@ -5344,7 +5347,7 @@ int match_delete(win_T *wp, int id, int perr)
   }
   if (cur == NULL) {
     if (perr == TRUE)
-      EMSGN("E803: ID not found: %ld", id);
+      EMSGN("E803: ID not found: %" PRId64, id);
     return -1;
   }
   if (cur == prev)

--- a/src/window.c
+++ b/src/window.c
@@ -470,9 +470,9 @@ wingotofile:
      * cursor in a new window.
      */
     if (bt_quickfix(curbuf)) {
-      sprintf((char *)cbuf, "split +%ld%s",
-          (long)curwin->w_cursor.lnum,
-          (curwin->w_llist_ref == NULL) ? "cc" : "ll");
+      sprintf((char *)cbuf, "split +%" PRId64 "%s",
+              (int64_t)curwin->w_cursor.lnum,
+              (curwin->w_llist_ref == NULL) ? "cc" : "ll");
       do_cmdline_cmd(cbuf);
     }
     break;


### PR DESCRIPTION
This replaces #574, which seemed to have gotten corrupt somehow.
