### PR TITLE
[RDY] Remove O_EXTRA which was only for EMX and cygwin.

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1656,12 +1656,12 @@ void write_viminfo(char_u *file, int forceit)
 # ifdef UNIX
       umask_save = umask(0);
       fd = mch_open((char *)tempname,
-          O_CREAT|O_EXTRA|O_EXCL|O_WRONLY|O_NOFOLLOW,
+          O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW,
           (int)((st_old.st_mode & 0777) | 0600));
       (void)umask(umask_save);
 # else
       fd = mch_open((char *)tempname,
-          O_CREAT|O_EXTRA|O_EXCL|O_WRONLY|O_NOFOLLOW, 0600);
+          O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW, 0600);
 # endif
       if (fd < 0)
         fp_out = NULL;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -478,13 +478,13 @@ readfile (
   if (!read_buffer && !read_stdin) {
     if (!newfile || readonlymode) {
       file_readonly = TRUE;
-    } else if ((fd = mch_open((char *)fname, O_RDWR | O_EXTRA, 0)) < 0) {
+    } else if ((fd = mch_open((char *)fname, O_RDWR, 0)) < 0) {
       // opening in readwrite mode failed => file is readonly
       file_readonly = TRUE;
     }
     if (file_readonly == TRUE) {
       // try to open readonly
-      fd = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0);
+      fd = mch_open((char *)fname, O_RDONLY, 0);
     }
   }
 
@@ -668,7 +668,7 @@ readfile (
                         || (using_b_ffname && (old_b_ffname != curbuf->b_ffname))
                         || (using_b_fname && (old_b_fname != curbuf->b_fname))
                         || (fd =
-                              mch_open((char *)fname, O_RDONLY | O_EXTRA,
+                              mch_open((char *)fname, O_RDONLY,
                                   0)) < 0)) {
       --no_wait_return;
       msg_scroll = msg_save;
@@ -2179,7 +2179,7 @@ readfile_charconvert (
             fname, tmpname) == FAIL)
       errmsg = (char_u *)_("Conversion with 'charconvert' failed");
     if (errmsg == NULL && (*fdp = mch_open((char *)tmpname,
-                               O_RDONLY | O_EXTRA, 0)) < 0)
+                               O_RDONLY, 0)) < 0)
       errmsg = (char_u *)_("can't read output of 'charconvert'");
   }
 
@@ -2196,7 +2196,7 @@ readfile_charconvert (
 
   /* If the input file is closed, open it (caller should check for error). */
   if (*fdp < 0)
-    *fdp = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0);
+    *fdp = mch_open((char *)fname, O_RDONLY, 0);
 
   return tmpname;
 }
@@ -2995,7 +2995,7 @@ buf_write (
       backup_ext = p_bex;
 
     if (backup_copy
-        && (fd = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0)) >= 0) {
+        && (fd = mch_open((char *)fname, O_RDONLY, 0)) >= 0) {
       int bfd;
       char_u      *copybuf, *wp;
       int some_error = FALSE;
@@ -3129,7 +3129,7 @@ buf_write (
           /* Open with O_EXCL to avoid the file being created while
            * we were sleeping (symlink hacker attack?) */
           bfd = mch_open((char *)backup,
-              O_WRONLY|O_CREAT|O_EXTRA|O_EXCL|O_NOFOLLOW,
+              O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW,
               perm & 0777);
           if (bfd < 0) {
             vim_free(backup);
@@ -3431,7 +3431,7 @@ nobackup:
    * (this may happen when the user reached his quotum for number of files).
    * Appending will fail if the file does not exist and forceit is FALSE.
    */
-  while ((fd = mch_open((char *)wfname, O_WRONLY | O_EXTRA | (append
+  while ((fd = mch_open((char *)wfname, O_WRONLY | (append
                                                               ? (forceit ? (
                                                                    O_APPEND |
                                                                    O_CREAT) :
@@ -3776,9 +3776,9 @@ restore_backup:
           MSG(_(e_interr));
           out_flush();
         }
-        if ((fd = mch_open((char *)backup, O_RDONLY | O_EXTRA, 0)) >= 0) {
+        if ((fd = mch_open((char *)backup, O_RDONLY, 0)) >= 0) {
           if ((write_info.bw_fd = mch_open((char *)fname,
-                   O_WRONLY | O_CREAT | O_TRUNC | O_EXTRA,
+                   O_WRONLY | O_CREAT | O_TRUNC,
                    perm & 0777)) >= 0) {
             /* copy the file. */
             write_info.bw_buf = smallbuf;
@@ -3921,7 +3921,7 @@ restore_backup:
 
       if (org == NULL
           || (empty_fd = mch_open(org,
-                  O_CREAT | O_EXTRA | O_EXCL | O_NOFOLLOW,
+                  O_CREAT | O_EXCL | O_NOFOLLOW,
                   perm < 0 ? 0666 : (perm & 0777))) < 0)
         EMSG(_("E206: patchmode: can't touch empty original file"));
       else
@@ -5029,7 +5029,7 @@ int vim_rename(char_u *from, char_u *to)
   /* For systems that support ACL: get the ACL from the original file. */
   acl = mch_get_acl(from);
 #endif
-  fd_in = mch_open((char *)from, O_RDONLY|O_EXTRA, 0);
+  fd_in = mch_open((char *)from, O_RDONLY, 0);
   if (fd_in == -1) {
 #ifdef HAVE_ACL
     mch_free_acl(acl);
@@ -5039,7 +5039,7 @@ int vim_rename(char_u *from, char_u *to)
 
   /* Create the new file with same permissions as the original. */
   fd_out = mch_open((char *)to,
-      O_CREAT|O_EXCL|O_WRONLY|O_EXTRA|O_NOFOLLOW, (int)perm);
+      O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW, (int)perm);
   if (fd_out == -1) {
     close(fd_in);
 #ifdef HAVE_ACL

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -1113,7 +1113,7 @@ mf_do_open (
     /*
      * try to open the file
      */
-    flags |= O_EXTRA | O_NOFOLLOW;
+    flags |= O_NOFOLLOW;
     mfp->mf_fd = mch_open_rw((char *)mfp->mf_fname, flags);
   }
 

--- a/src/memline.c
+++ b/src/memline.c
@@ -612,7 +612,7 @@ void ml_setname(buf_T *buf)
   }
 
   if (mfp->mf_fd == -1) {           /* need to (re)open the swap file */
-    mfp->mf_fd = mch_open((char *)mfp->mf_fname, O_RDWR | O_EXTRA, 0);
+    mfp->mf_fd = mch_open((char *)mfp->mf_fname, O_RDWR, 0);
     if (mfp->mf_fd < 0) {
       /* could not (re)open the swap file, what can we do???? */
       EMSG(_("E301: Oops, lost the swap file!!!"));
@@ -1764,7 +1764,7 @@ static time_t swapfile_info(char_u *fname)
   /*
    * print the original file name
    */
-  fd = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0);
+  fd = mch_open((char *)fname, O_RDONLY, 0);
   if (fd >= 0) {
     if (read_eintr(fd, &b0, sizeof(b0)) == sizeof(b0)) {
       if (STRNCMP(b0.b0_version, "VIM 3.0", 7) == 0) {
@@ -3707,17 +3707,17 @@ findswapname (
         /*
          * may need to create the files to be able to use mch_stat()
          */
-        f1 = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0);
+        f1 = mch_open((char *)fname, O_RDONLY, 0);
         if (f1 < 0) {
           f1 = mch_open_rw((char *)fname,
-              O_RDWR|O_CREAT|O_EXCL|O_EXTRA);
+              O_RDWR|O_CREAT|O_EXCL);
           created1 = TRUE;
         }
         if (f1 >= 0) {
-          f2 = mch_open((char *)fname2, O_RDONLY | O_EXTRA, 0);
+          f2 = mch_open((char *)fname2, O_RDONLY, 0);
           if (f2 < 0) {
             f2 = mch_open_rw((char *)fname2,
-                O_RDWR|O_CREAT|O_EXCL|O_EXTRA);
+                O_RDWR|O_CREAT|O_EXCL);
             created2 = TRUE;
           }
           if (f2 >= 0) {
@@ -3815,7 +3815,7 @@ findswapname (
          * Try to read block 0 from the swap file to get the original
          * file name (and inode number).
          */
-        fd = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0);
+        fd = mch_open((char *)fname, O_RDONLY, 0);
         if (fd >= 0) {
           if (read_eintr(fd, &b0, sizeof(b0)) == sizeof(b0)) {
             /*

--- a/src/undo.c
+++ b/src/undo.c
@@ -1155,7 +1155,7 @@ void u_write_undo(char_u *name, int forceit, buf_T *buf, char_u *hash)
   if (os_file_exists(file_name)) {
     if (name == NULL || !forceit) {
       /* Check we can read it and it's an undo file. */
-      fd = mch_open((char *)file_name, O_RDONLY|O_EXTRA, 0);
+      fd = mch_open((char *)file_name, O_RDONLY, 0);
       if (fd < 0) {
         if (name != NULL || p_verbose > 0) {
           if (name == NULL)
@@ -1200,7 +1200,7 @@ void u_write_undo(char_u *name, int forceit, buf_T *buf, char_u *hash)
   }
 
   fd = mch_open((char *)file_name,
-      O_CREAT|O_EXTRA|O_WRONLY|O_EXCL|O_NOFOLLOW, perm);
+      O_CREAT|O_WRONLY|O_EXCL|O_NOFOLLOW, perm);
   if (fd < 0) {
     EMSG2(_(e_not_open), file_name);
     goto theend;

--- a/src/vim.h
+++ b/src/vim.h
@@ -34,12 +34,6 @@
 # if (SIZEOF_INT == 0)
 Error: configure did not run properly.Check auto/config.log.
 # endif
-
-/*
- * Cygwin may have fchdir() in a newer release, but in most versions it
- * doesn't work well and avoiding it keeps the binary backward compatible.
- */
-
 #endif
 
 /* user ID of root is usually zero, but not for everybody */
@@ -977,12 +971,6 @@ typedef enum {
 # define READBIN    "r"
 # define APPENDBIN  "a"
 #endif
-
-/*
- * EMX doesn't have a global way of making open() use binary I/O.
- * Use O_BINARY for all open() calls.
- */
-# define O_EXTRA    0
 
 #ifndef O_NOFOLLOW
 # define O_NOFOLLOW 0


### PR DESCRIPTION
This got a bit messed up by the initial cleanup of vim.h. O_EXTRA was set to O_BINARY when either `__EMX__` or `__CYWGIN32__` were defined. Now it's meaningless and it seemed to be an error prone approach anyway.
