### PR TITLE
[RDY] Remove checks for SHORT_FNAME and USE_LONG_FNAME.

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -466,9 +466,7 @@ void buf_clear_file(buf_T *buf)
 {
   buf->b_ml.ml_line_count = 1;
   unchanged(buf, TRUE);
-#ifndef SHORT_FNAME
   buf->b_shortname = FALSE;
-#endif
   buf->b_p_eol = TRUE;
   buf->b_start_eol = TRUE;
   buf->b_p_bomb = FALSE;
@@ -2277,9 +2275,6 @@ setfname (
       return FAIL;
     }
 #ifdef USE_FNAME_CASE
-# ifdef USE_LONG_FNAME
-    if (USE_LONG_FNAME)
-# endif
     fname_case(sfname, 0);            /* set correct case for short file name */
 #endif
     vim_free(buf->b_ffname);
@@ -2298,9 +2293,7 @@ setfname (
   }
 #endif
 
-#ifndef SHORT_FNAME
   buf->b_shortname = FALSE;
-#endif
 
   buf_name_changed(buf);
   return OK;

--- a/src/buffer_defs.h
+++ b/src/buffer_defs.h
@@ -596,9 +596,7 @@ struct file_buffer {
   char_u      *b_p_qe;          /* 'quoteescape' */
   int b_p_ro;                   /* 'readonly' */
   long b_p_sw;                  /* 'shiftwidth' */
-#ifndef SHORT_FNAME
   int b_p_sn;                   /* 'shortname' */
-#endif
   int b_p_si;                   /* 'smartindent' */
   long b_p_sts;                 /* 'softtabstop' */
   long b_p_sts_nopaste;          /* b_p_sts saved for paste mode */
@@ -700,9 +698,7 @@ struct file_buffer {
                                    are not used!  Use the B_SPELL macro to
                                    access b_spell without #ifdef. */
 
-#ifndef SHORT_FNAME
   int b_shortname;              /* this file has an 8.3 file name */
-#endif
 
   synblock_T b_s;               /* Info related to syntax highlighting.  w_s
                                  * normally points to this, but some windows

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1588,11 +1588,7 @@ void write_viminfo(char_u *file, int forceit)
 #ifdef UNIX
           shortname,
 #else
-# ifdef SHORT_FNAME
-          TRUE,
-# else
           FALSE,
-# endif
 #endif
           fname,
           (char_u *)".tmp",
@@ -2673,9 +2669,6 @@ do_ecmd (
     if (sfname == NULL)
       sfname = ffname;
 #ifdef USE_FNAME_CASE
-# ifdef USE_LONG_FNAME
-    if (USE_LONG_FNAME)
-# endif
     if (sfname != NULL)
       fname_case(sfname, 0);             /* set correct case for sfname */
 #endif

--- a/src/memline.c
+++ b/src/memline.c
@@ -1810,19 +1810,11 @@ static time_t swapfile_info(char_u *fname)
 static int recov_file_names(char_u **names, char_u *path, int prepend_dot)
 {
   int num_names;
-
-#ifdef SHORT_FNAME
   /*
-   * (MS-DOS) always short names
+   * (Win32 and Win64) never short names, but do prepend a dot.
+   * (Not MS-DOS or Win32 or Win64) maybe short name, maybe not: Try both.
+   * Only use the short name if it is different.
    */
-  names[0] = modname(path, (char_u *)".sw?", FALSE);
-  num_names = 1;
-#else /* !SHORT_FNAME */
-      /*
-       * (Win32 and Win64) never short names, but do prepend a dot.
-       * (Not MS-DOS or Win32 or Win64) maybe short name, maybe not: Try both.
-       * Only use the short name if it is different.
-       */
   char_u      *p;
   int i;
   int shortname = curbuf->b_shortname;
@@ -1880,7 +1872,6 @@ static int recov_file_names(char_u **names, char_u *path, int prepend_dot)
 end:
   curbuf->b_shortname = shortname;
 
-#endif /* !SHORT_FNAME */
 
   return num_names;
 }
@@ -3415,20 +3406,12 @@ char_u *makeswapname(char_u *fname, char_u *ffname, buf_T *buf, char_u *dir_name
 #endif
 
   r = buf_modname(
-#ifdef SHORT_FNAME
-      TRUE,
-#else
       (buf->b_p_sn || buf->b_shortname),
-#endif
       fname_res,
       (char_u *)
       ".swp",
-#ifdef SHORT_FNAME              /* always 8.3 file name */
-      FALSE
-#else
       /* Prepend a '.' to the swap file name for the current directory. */
       dir_name[0] == '.' && dir_name[1] == NUL
-#endif
       );
   if (r == NULL)            /* out of memory */
     return NULL;
@@ -3593,13 +3576,10 @@ findswapname (
   char_u      *fname;
   int n;
   char_u      *dir_name;
-#ifndef SHORT_FNAME
   int r;
-#endif
   char_u      *buf_fname = buf->b_fname;
 
-#if !defined(SHORT_FNAME) \
-  && ((!defined(UNIX) && !defined(OS2)) || defined(ARCHIE))
+#if (!defined(UNIX) && !defined(OS2)) || defined(ARCHIE)
 # define CREATE_DUMMY_FILE
   FILE        *dummyfd = NULL;
 
@@ -3639,7 +3619,7 @@ findswapname (
       fname = NULL;
       break;
     }
-#if (defined(UNIX) || defined(OS2)) && !defined(ARCHIE) && !defined(SHORT_FNAME)
+#if (defined(UNIX) || defined(OS2)) && !defined(ARCHIE)
     /*
      * Some systems have a MS-DOS compatible filesystem that use 8.3 character
      * file names. If this is the first try and the swap file name does not fit in
@@ -3749,7 +3729,6 @@ findswapname (
      * get here when file already exists
      */
     if (fname[n - 2] == 'w' && fname[n - 1] == 'p') {   /* first try */
-#ifndef SHORT_FNAME
       /*
        * on MS-DOS compatible filesystems (e.g. messydos) file.doc.swp
        * and file.doc are the same file. To guess if this problem is
@@ -3770,7 +3749,6 @@ findswapname (
           continue;                 /* try again with '.' replaced with '_' */
         }
       }
-#endif
       /*
        * If we get here the ".swp" file really exists.
        * Give an error message, unless recovering, no file name, we are

--- a/src/option.c
+++ b/src/option.c
@@ -150,9 +150,7 @@
 # define PV_QE          OPT_BUF(BV_QE)
 #define PV_RO           OPT_BUF(BV_RO)
 # define PV_SI          OPT_BUF(BV_SI)
-#ifndef SHORT_FNAME
 # define PV_SN          OPT_BUF(BV_SN)
-#endif
 # define PV_SMC         OPT_BUF(BV_SMC)
 # define PV_SYN         OPT_BUF(BV_SYN)
 # define PV_SPC         OPT_BUF(BV_SPC)
@@ -265,9 +263,7 @@ static int p_pi;
 static char_u   *p_qe;
 static int p_ro;
 static int p_si;
-#ifndef SHORT_FNAME
 static int p_sn;
-#endif
 static long p_sts;
 static char_u   *p_sua;
 static long p_sw;
@@ -1429,11 +1425,7 @@ static struct vimoption
    {(char_u *)"", (char_u *)"filnxtToO"}
    SCRIPTID_INIT},
   {"shortname",   "sn",   P_BOOL|P_VI_DEF,
-#ifdef SHORT_FNAME
-   (char_u *)NULL, PV_NONE,
-#else
    (char_u *)&p_sn, PV_SN,
-#endif
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"showbreak",   "sbr",  P_STRING|P_VI_DEF|P_RALL,
    (char_u *)&p_sbr, PV_NONE,
@@ -6796,9 +6788,7 @@ static char_u *get_varp(struct vimoption *p)
   case PV_QE:     return (char_u *)&(curbuf->b_p_qe);
   case PV_RO:     return (char_u *)&(curbuf->b_p_ro);
   case PV_SI:     return (char_u *)&(curbuf->b_p_si);
-#ifndef SHORT_FNAME
   case PV_SN:     return (char_u *)&(curbuf->b_p_sn);
-#endif
   case PV_STS:    return (char_u *)&(curbuf->b_p_sts);
   case PV_SUA:    return (char_u *)&(curbuf->b_p_sua);
   case PV_SWF:    return (char_u *)&(curbuf->b_p_swf);
@@ -7024,9 +7014,7 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_ofu = vim_strsave(p_ofu);
       buf->b_p_sts = p_sts;
       buf->b_p_sts_nopaste = p_sts_nopaste;
-#ifndef SHORT_FNAME
       buf->b_p_sn = p_sn;
-#endif
       buf->b_p_com = vim_strsave(p_com);
       buf->b_p_cms = vim_strsave(p_cms);
       buf->b_p_fo = vim_strsave(p_fo);

--- a/src/option_defs.h
+++ b/src/option_defs.h
@@ -691,9 +691,7 @@ enum {
   , BV_QE
   , BV_RO
   , BV_SI
-#ifndef SHORT_FNAME
   , BV_SN
-#endif
   , BV_SMC
   , BV_SYN
   , BV_SPC

--- a/src/path.c
+++ b/src/path.c
@@ -1581,12 +1581,8 @@ char_u *fix_fname(char_u *fname)
   fname = vim_strsave(fname);
 
 # ifdef USE_FNAME_CASE
-#  ifdef USE_LONG_FNAME
-  if (USE_LONG_FNAME)
-#  endif
-  {
-    if (fname != NULL)
-      fname_case(fname, 0);             /* set correct case for file name */
+  if (fname != NULL) {
+    fname_case(fname, 0);             /* set correct case for file name */
   }
 # endif
 


### PR DESCRIPTION
They were only defined for MSDOS which is now unsupported.
