### PR TITLE
[RDY] Broken build on 32 bit: Pending TODO: Reenable assertion.

### DIFF
--- a/src/os/rstream.c
+++ b/src/os/rstream.c
@@ -234,9 +234,9 @@ static void fread_idle_cb(uv_idle_t *handle)
 
   // the offset argument to uv_fs_read is int64_t, could someone really try
   // to read more than 9 quintillion (9e18) bytes?
-  // DISABLED TO FIX BROKEN BUILD ON 32bit
-  // TODO(elmart): Review types to allow assertion
-  // assert(rstream->fpos <= INT64_MAX);
+  // upcast is meant to avoid tautological condition warning on 32 bits
+  uintmax_t fpos_intmax = rstream->fpos;
+  assert(fpos_intmax <= INT64_MAX);
 
   // Synchronous read
   uv_fs_read(


### PR DESCRIPTION
On a1a0c00589a8efc664db82be6743136bb462e08f, an assertion was disabled
because of breaking 32bit build.
This fixes that so that it now always work.
