### PR TITLE
[RDY] Clean up some list append functions

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -5567,23 +5567,21 @@ void list_append_dict(list_T *list, dict_T *dict)
 /*
  * Make a copy of "str" and append it as an item to list "l".
  * When "len" >= 0 use "str[len]".
- * Returns FAIL when out of memory.
  */
-int list_append_string(list_T *l, char_u *str, int len)
+void list_append_string(list_T *l, char_u *str, int len)
 {
   listitem_T *li = listitem_alloc();
 
-  if (li == NULL)
-    return FAIL;
   list_append(l, li);
   li->li_tv.v_type = VAR_STRING;
   li->li_tv.v_lock = 0;
-  if (str == NULL)
+
+  if (str == NULL) {
     li->li_tv.vval.v_string = NULL;
-  else if ((li->li_tv.vval.v_string = (len >= 0 ? vim_strnsave(str, len)
-                                       : vim_strsave(str))) == NULL)
-    return FAIL;
-  return OK;
+  } else {
+    li->li_tv.vval.v_string = (len >= 0) ? vim_strnsave(str, len)
+                                         : vim_strsave(str);
+  }
 }
 
 /*
@@ -9449,10 +9447,10 @@ static void get_buffer_lines(buf_T *buf, linenr_T start, linenr_T end, int retli
       start = 1;
     if (end > buf->b_ml.ml_line_count)
       end = buf->b_ml.ml_line_count;
-    while (start <= end)
-      if (list_append_string(rettv->vval.v_list,
-              ml_get_buf(buf, start++, FALSE), -1) == FAIL)
-        break;
+    while (start <= end) {
+      list_append_string(
+        rettv->vval.v_list, ml_get_buf(buf, start++, FALSE), -1);
+    }
   }
 }
 
@@ -11583,14 +11581,12 @@ static void find_some_match(typval_T *argvars, typval_T *rettv, int type)
         /* return list with matched string and submatches */
         for (i = 0; i < NSUBEXP; ++i) {
           if (regmatch.endp[i] == NULL) {
-            if (list_append_string(rettv->vval.v_list,
-                    (char_u *)"", 0) == FAIL)
-              break;
-          } else if (list_append_string(rettv->vval.v_list,
-                         regmatch.startp[i],
-                         (int)(regmatch.endp[i] - regmatch.startp[i]))
-                     == FAIL)
-            break;
+            list_append_string(rettv->vval.v_list, (char_u *)"", 0);
+          } else {
+            list_append_string(rettv->vval.v_list,
+                               regmatch.startp[i],
+                               (int)(regmatch.endp[i] - regmatch.startp[i]));
+          }
         }
       } else if (type == 2) {
         /* return matched string */
@@ -14137,9 +14133,7 @@ static void f_split(typval_T *argvars, typval_T *rettv)
       if (keepempty || end > str || (rettv->vval.v_list->lv_len > 0
                                      && *str != NUL && match && end <
                                      regmatch.endp[0])) {
-        if (list_append_string(rettv->vval.v_list, str,
-                (int)(end - str)) == FAIL)
-          break;
+        list_append_string(rettv->vval.v_list, str, (int)(end - str));
       }
       if (!match)
         break;
@@ -14876,7 +14870,6 @@ static void f_tagfiles(typval_T *argvars, typval_T *rettv)
 {
   char_u      *fname;
   tagname_T tn;
-  int first;
 
   if (rettv_list_alloc(rettv) == FAIL)
     return;
@@ -14884,10 +14877,12 @@ static void f_tagfiles(typval_T *argvars, typval_T *rettv)
   if (fname == NULL)
     return;
 
-  for (first = TRUE;; first = FALSE)
-    if (get_tagfname(&tn, first, fname) == FAIL
-        || list_append_string(rettv->vval.v_list, fname, -1) == FAIL)
-      break;
+  int first = TRUE;
+  while (get_tagfname(&tn, first, fname) == OK) {
+    list_append_string(rettv->vval.v_list, fname, -1);
+    first = FALSE;
+  }
+
   tagname_free(&tn);
   vim_free(fname);
 }

--- a/src/eval.c
+++ b/src/eval.c
@@ -5552,20 +5552,16 @@ int list_append_tv(list_T *l, typval_T *tv)
 
 /*
  * Add a dictionary to a list.  Used by getqflist().
- * Return FAIL when out of memory.
  */
-int list_append_dict(list_T *list, dict_T *dict)
+void list_append_dict(list_T *list, dict_T *dict)
 {
   listitem_T  *li = listitem_alloc();
 
-  if (li == NULL)
-    return FAIL;
   li->li_tv.v_type = VAR_DICT;
   li->li_tv.v_lock = 0;
   li->li_tv.vval.v_dict = dict;
   list_append(list, li);
   ++dict->dv_refcount;
-  return OK;
 }
 
 /*

--- a/src/eval.h
+++ b/src/eval.h
@@ -64,7 +64,7 @@ listitem_T *list_find(list_T *l, long n);
 char_u *list_find_str(list_T *l, long idx);
 void list_append(list_T *l, listitem_T *item);
 int list_append_tv(list_T *l, typval_T *tv);
-int list_append_dict(list_T *list, dict_T *dict);
+void list_append_dict(list_T *list, dict_T *dict);
 int list_append_string(list_T *l, char_u *str, int len);
 int list_insert_tv(list_T *l, typval_T *tv, listitem_T *item);
 void list_remove(list_T *l, listitem_T *item, listitem_T *item2);

--- a/src/eval.h
+++ b/src/eval.h
@@ -65,7 +65,7 @@ char_u *list_find_str(list_T *l, long idx);
 void list_append(list_T *l, listitem_T *item);
 int list_append_tv(list_T *l, typval_T *tv);
 void list_append_dict(list_T *list, dict_T *dict);
-int list_append_string(list_T *l, char_u *str, int len);
+void list_append_string(list_T *l, char_u *str, int len);
 int list_insert_tv(list_T *l, typval_T *tv, listitem_T *item);
 void list_remove(list_T *l, listitem_T *item, listitem_T *item2);
 void list_insert(list_T *l, listitem_T *ni, listitem_T *item);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3287,8 +3287,7 @@ int get_errorlist(win_T *wp, list_T *list)
 
     if ((dict = dict_alloc()) == NULL)
       return FAIL;
-    if (list_append_dict(list, dict) == FAIL)
-      return FAIL;
+    list_append_dict(list, dict);
 
     buf[0] = qfp->qf_type;
     buf[1] = NUL;

--- a/src/tag.c
+++ b/src/tag.c
@@ -789,10 +789,7 @@ do_tag (
 
           if ((dict = dict_alloc()) == NULL)
             continue;
-          if (list_append_dict(list, dict) == FAIL) {
-            vim_free(dict);
-            continue;
-          }
+          list_append_dict(list, dict);
 
           dict_add_nr_str(dict, "text", 0L, tag_name);
           dict_add_nr_str(dict, "filename", 0L, fname);
@@ -2878,8 +2875,7 @@ int get_tags(list_T *list, char_u *pat)
 
       if ((dict = dict_alloc()) == NULL)
         ret = FAIL;
-      if (list_append_dict(list, dict) == FAIL)
-        ret = FAIL;
+      list_append_dict(list, dict);
 
       full_fname = tag_full_fname(&tp);
       if (add_tag_field(dict, "name", tp.tagname, tp.tagname_end) == FAIL


### PR DESCRIPTION
`list_append_{dict,string}` cannot fail, because the memory allocation is based on `xmalloc`. So the use of this functions can be simplified and error checks can be removed.
