### PR TITLE
[RDY] Remove modelines (pt.2)

### DIFF
--- a/src/blowfish.h
+++ b/src/blowfish.h
@@ -10,5 +10,4 @@ void bf_crypt_save(void);
 void bf_crypt_restore(void);
 int blowfish_self_test(void);
 
-// vim: set ft=c:
 #endif  // NEOVIM_BLOWFISH_H

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -79,5 +79,5 @@ void sign_mark_adjust(linenr_T line1, linenr_T line2, long amount,
 void set_buflisted(int on);
 int buf_contents_changed(buf_T *buf);
 void wipe_buffer(buf_T *buf, int aucmd);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_BUFFER_H */

--- a/src/charset.h
+++ b/src/charset.h
@@ -64,5 +64,4 @@ void backslash_halve(char_u *p);
 char_u *backslash_halve_save(char_u *p);
 void ebcdic2ascii(char_u *buffer, int len);
 
-// vim: set ft=c:
 #endif  // NEOVIM_CHARSET_H

--- a/src/diff.h
+++ b/src/diff.h
@@ -30,5 +30,4 @@ linenr_T diff_get_corresponding_line(buf_T *buf1, linenr_T lnum1,
                                      linenr_T lnum3);
 linenr_T diff_lnum_win(linenr_T lnum, win_T *wp);
 
-// vim: set ft=c:
 #endif  // NEOVIM_DIFF_H

--- a/src/digraph.h
+++ b/src/digraph.h
@@ -9,5 +9,4 @@ void listdigraphs(void);
 char_u *keymap_init(void);
 void ex_loadkeymap(exarg_T *eap);
 
-// vim: set ft=c:
 #endif  // NEOVIM_DIGRAPH_H

--- a/src/edit.h
+++ b/src/edit.h
@@ -56,5 +56,5 @@ int hkmap(int c);
 void ins_scroll(void);
 void ins_horscroll(void);
 int ins_copychar(linenr_T lnum);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_EDIT_H */

--- a/src/eval.h
+++ b/src/eval.h
@@ -148,5 +148,5 @@ int modify_fname(char_u *src, int *usedlen, char_u **fnamep,
                  int *fnamelen);
 char_u *do_string_sub(char_u *str, char_u *pat, char_u *sub,
                       char_u *flags);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_EVAL_H */

--- a/src/ex_cmds.h
+++ b/src/ex_cmds.h
@@ -72,5 +72,5 @@ void free_signs(void);
 char_u *get_sign_name(expand_T *xp, int idx);
 void set_context_in_sign_cmd(expand_T *xp, char_u *arg);
 void ex_drop(exarg_T *eap);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_EX_CMDS_H */

--- a/src/ex_cmds2.h
+++ b/src/ex_cmds2.h
@@ -93,5 +93,5 @@ void ex_language(exarg_T *eap);
 void free_locales(void);
 char_u *get_lang_arg(expand_T *xp, int idx);
 char_u *get_locales(expand_T *xp, int idx);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_EX_CMDS2_H */

--- a/src/ex_docmd.h
+++ b/src/ex_docmd.h
@@ -66,5 +66,5 @@ int put_eol(FILE *fd);
 int put_line(FILE *fd, char *s);
 void dialog_msg(char_u *buff, char *format, char_u *fname);
 char_u *get_behave_arg(expand_T *xp, int idx);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_EX_DOCMD_H */

--- a/src/ex_eval.h
+++ b/src/ex_eval.h
@@ -155,5 +155,5 @@ void rewind_conditionals(struct condstack *cstack, int idx,
                          int *cond_level);
 void ex_endfunction(exarg_T *eap);
 int has_loop_cmd(char_u *p);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_EX_EVAL_H */

--- a/src/ex_getln.h
+++ b/src/ex_getln.h
@@ -65,5 +65,5 @@ void write_viminfo_history(FILE *fp, int merge);
 void cmd_pchar(int c, int offset);
 int cmd_gchar(int offset);
 char_u *script_get(exarg_T *eap, char_u *cmd);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_EX_GETLN_H */

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -93,5 +93,5 @@ char_u *file_pat_to_reg_pat(char_u *pat, char_u *pat_end,
                             int no_bslash);
 long read_eintr(int fd, void *buf, size_t bufsize);
 long write_eintr(int fd, void *buf, size_t bufsize);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_FILEIO_H */

--- a/src/fold.h
+++ b/src/fold.h
@@ -61,5 +61,5 @@ char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume,
                      char_u *buf);
 void foldtext_cleanup(char_u *str);
 int put_folds(FILE *fd, win_T *wp);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_FOLD_H */

--- a/src/getchar.h
+++ b/src/getchar.h
@@ -74,5 +74,5 @@ char_u *check_map(char_u *keys, int mode, int exact, int ign_mod,
                   int *local_ptr);
 void init_mappings(void);
 void add_map(char_u *map, int mode);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_GETCHAR_H */

--- a/src/hardcopy.h
+++ b/src/hardcopy.h
@@ -89,5 +89,5 @@ int mch_print_text_out(char_u *p, int len);
 void mch_print_set_font(int iBold, int iItalic, int iUnderline);
 void mch_print_set_bg(long_u bgcol);
 void mch_print_set_fg(long_u fgcol);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_HARDCOPY_H */

--- a/src/hashtab.h
+++ b/src/hashtab.h
@@ -52,5 +52,5 @@ void hash_remove(hashtab_T *ht, hashitem_T *hi);
 void hash_lock(hashtab_T *ht);
 void hash_unlock(hashtab_T *ht);
 hash_T hash_hash(char_u *key);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_HASHTAB_H */

--- a/src/if_cscope.h
+++ b/src/if_cscope.h
@@ -12,5 +12,5 @@ void cs_free_tags(void);
 void cs_print_tags(void);
 int cs_connection(int num, char_u *dbpath, char_u *ppath);
 void cs_end(void);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_IF_CSCOPE_H */

--- a/src/main.h
+++ b/src/main.h
@@ -14,5 +14,5 @@ void time_msg(char *mesg, void *tv_start);
 void server_to_input_buf(char_u *str);
 char_u *eval_client_expr_to_string(char_u *expr);
 char_u *serverConvert(char_u *client_enc, char_u *data, char_u **tofree);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MAIN_H */

--- a/src/mark.h
+++ b/src/mark.h
@@ -38,5 +38,5 @@ int removable(char_u *name);
 int write_viminfo_marks(FILE *fp_out);
 void copy_viminfo_marks(vir_T *virp, FILE *fp_out, int count, int eof,
                         int flags);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MARK_H */

--- a/src/mbyte.h
+++ b/src/mbyte.h
@@ -99,5 +99,5 @@ int convert_input_safe(char_u *ptr, int len, int maxlen, char_u **restp,
 char_u *string_convert(vimconv_T *vcp, char_u *ptr, int *lenp);
 char_u *string_convert_ext(vimconv_T *vcp, char_u *ptr, int *lenp,
                            int *unconvlenp);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MBYTE_H */

--- a/src/memfile.h
+++ b/src/memfile.h
@@ -21,5 +21,5 @@ blocknr_T mf_trans_del(memfile_T *mfp, blocknr_T old_nr);
 void mf_set_ffname(memfile_T *mfp);
 void mf_fullname(memfile_T *mfp);
 int mf_need_trans(memfile_T *mfp);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MEMFILE_H */

--- a/src/memline.h
+++ b/src/memline.h
@@ -43,5 +43,5 @@ void ml_decrypt_data(memfile_T *mfp, char_u *data, off_t offset,
                      unsigned size);
 long ml_find_line_or_offset(buf_T *buf, linenr_T lnum, long *offp);
 void goto_byte(long cnt);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MEMLINE_H */

--- a/src/menu.h
+++ b/src/menu.h
@@ -69,5 +69,5 @@ void gui_mch_toggle_tearoffs(int enable);
 void ex_emenu(exarg_T *eap);
 vimmenu_T *gui_find_menu(char_u *path_name);
 void ex_menutranslate(exarg_T *eap);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MENU_H */

--- a/src/message.h
+++ b/src/message.h
@@ -81,5 +81,5 @@ int vim_dialog_yesnoallcancel(int type, char_u *title, char_u *message,
 char_u *do_browse(int flags, char_u *title, char_u *dflt, char_u *ext,
                   char_u *initdir, char_u *filter,
                   buf_T *buf);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MESSAGE_H */

--- a/src/misc1.h
+++ b/src/misc1.h
@@ -70,5 +70,5 @@ void fast_breakcheck(void);
 char_u *get_cmd_output(char_u *cmd, char_u *infile, int flags);
 void FreeWild(int count, char_u **files);
 int goto_im(void);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MISC1_H */

--- a/src/misc2.h
+++ b/src/misc2.h
@@ -70,5 +70,5 @@ char_u *read_string(FILE *fd, int cnt);
 int put_bytes(FILE *fd, long_u nr, int len);
 void put_time(FILE *fd, time_t the_time);
 int has_non_ascii(char_u *s);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MISC2_H */

--- a/src/move.h
+++ b/src/move.h
@@ -40,5 +40,5 @@ void cursor_correct(void);
 int onepage(int dir, long count);
 void halfpage(int flag, linenr_T Prenum);
 void do_check_cursorbind(void);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_MOVE_H */

--- a/src/normal.h
+++ b/src/normal.h
@@ -83,5 +83,5 @@ void do_nv_ident(int c1, int c2);
 int get_visual_text(cmdarg_T *cap, char_u **pp, int *lenp);
 void start_selection(void);
 void may_start_select(int c);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_NORMAL_H */

--- a/src/ops.h
+++ b/src/ops.h
@@ -69,5 +69,5 @@ void write_reg_contents_ex(int name, char_u *str, int maxlen,
                            long block_len);
 void clear_oparg(oparg_T *oap);
 void cursor_pos_info(void);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_OPS_H */

--- a/src/option.h
+++ b/src/option.h
@@ -73,5 +73,5 @@ long get_sw_value(buf_T *buf);
 long get_sts_value(void);
 void find_mps_values(int *initc, int *findc, int *backwards,
                              int switchit);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_OPTION_H */

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -42,5 +42,5 @@ int mch_has_wildcard(char_u *p);
 int mch_libcall(char_u *libname, char_u *funcname, char_u *argstring,
                 int argint, char_u **string_result,
                 int *number_result);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_OS_UNIX_H */

--- a/src/popupmnu.h
+++ b/src/popupmnu.h
@@ -16,5 +16,4 @@ void pum_clear(void);
 int pum_visible(void);
 int pum_get_height(void);
 
-// vim: set ft=c:
 #endif  // NEOVIM_POPUPMNU_H

--- a/src/quickfix.h
+++ b/src/quickfix.h
@@ -32,5 +32,5 @@ int set_errorlist(win_T *wp, list_T *list, int action, char_u *title);
 void ex_cbuffer(exarg_T *eap);
 void ex_cexpr(exarg_T *eap);
 void ex_helpgrep(exarg_T *eap);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_QUICKFIX_H */

--- a/src/regexp.h
+++ b/src/regexp.h
@@ -23,5 +23,5 @@ int vim_regexec_nl(regmatch_T *rmp, char_u *line, colnr_T col);
 long vim_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf,
                                linenr_T lnum, colnr_T col,
                                proftime_T *tm);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_REGEXP_H */

--- a/src/screen.h
+++ b/src/screen.h
@@ -65,5 +65,5 @@ void showruler(int always);
 int number_width(win_T *wp);
 int screen_screencol(void);
 int screen_screenrow(void);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_SCREEN_H */

--- a/src/search.h
+++ b/src/search.h
@@ -48,5 +48,5 @@ void find_pattern_in_path(char_u *ptr, int dir, int len, int whole,
                           linenr_T end_lnum);
 int read_viminfo_search_pattern(vir_T *virp, int force);
 void write_viminfo_search_pattern(FILE *fp);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_SEARCH_H */

--- a/src/sha256.h
+++ b/src/sha256.h
@@ -15,5 +15,4 @@ char_u *sha256_key(char_u *buf, char_u *salt, int salt_len);
 int sha256_self_test(void);
 void sha2_seed(char_u *header, int header_len, char_u *salt, int salt_len);
 
-// vim: set ft=c:
 #endif  // NEOVIM_SHA256_H

--- a/src/spell.h
+++ b/src/spell.h
@@ -29,5 +29,5 @@ char_u *spell_to_word_end(char_u *start, win_T *win);
 int spell_word_start(int startcol);
 void spell_expand_check_cap(colnr_T col);
 int expand_spelling(linenr_T lnum, char_u *pat, char_u ***matchp);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_SPELL_H */

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -62,5 +62,5 @@ int highlight_changed(void);
 void set_context_in_highlight_cmd(expand_T *xp, char_u *arg);
 char_u *get_highlight_name(expand_T *xp, int idx);
 void free_highlight_fonts(void);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_SYNTAX_H */

--- a/src/tag.h
+++ b/src/tag.h
@@ -24,5 +24,5 @@ void tagname_free(tagname_T *tnp);
 int expand_tags(int tagnames, char_u *pat, int *num_file,
                 char_u ***file);
 int get_tags(list_T *list, char_u *pat);
-/* vim: set ft=c : */
+
 #endif /* NEOVIM_TAG_H */

--- a/src/term.h
+++ b/src/term.h
@@ -64,5 +64,4 @@ void show_termcodes(void);
 int show_one_termcode(char_u *name, char_u *code, int printit);
 char_u *translate_mapping(char_u *str, int expmap);
 void update_tcap(int attr);
-/* vim: set ft=c : */
 #endif /* NEOVIM_TERM_H */

--- a/src/ui.h
+++ b/src/ui.h
@@ -65,5 +65,4 @@ int get_fpos_of_mouse(pos_T *mpos);
 int vcol2col(win_T *wp, linenr_T lnum, int vcol);
 void ui_focus_change(int in_focus);
 void im_save_status(long *psave);
-/* vim: set ft=c : */
 #endif /* NEOVIM_UI_H */

--- a/src/undo.h
+++ b/src/undo.h
@@ -33,5 +33,4 @@ void u_blockfree(buf_T *buf);
 int bufIsChanged(buf_T *buf);
 int curbufIsChanged(void);
 void u_eval_tree(u_header_T *first_uhp, list_T *list);
-/* vim: set ft=c : */
 #endif /* NEOVIM_UNDO_H */

--- a/src/version.h
+++ b/src/version.h
@@ -10,5 +10,4 @@ void maybe_intro_message(void);
 void intro_message(int colon);
 void ex_intro(exarg_T *eap);
 
-// vim: set ft=c:
 #endif  // NEOVIM_VERSION_H

--- a/src/window.h
+++ b/src/window.h
@@ -86,5 +86,4 @@ void clear_matches(win_T *wp);
 matchitem_T *get_match(win_T *wp, int id);
 int get_win_number(win_T *wp, win_T *first_win);
 int get_tab_number(tabpage_T *tp);
-/* vim: set ft=c : */
 #endif /* NEOVIM_WINDOW_H */


### PR DESCRIPTION
This patch mostly removes useless modelines from header files. 

This was left out in: https://github.com/neovim/neovim/pull/547
