### PR TITLE
[RDY] Fix last non-portable format specifier

### DIFF
--- a/src/mark.c
+++ b/src/mark.c
@@ -1493,9 +1493,12 @@ void copy_viminfo_marks(vir_T *virp, FILE *fp_out, int count, int eof, int flags
     while (!(eof = viminfo_readline(virp)) && line[0] == TAB) {
       if (load_marks) {
         if (line[1] != NUL) {
+          int64_t lnum_64;
           unsigned u;
-
-          sscanf((char *)line + 2, "%ld %u", &pos.lnum, &u);
+          sscanf((char *)line + 2, "%" SCNd64 "%u", &lnum_64, &u);
+          // safely downcast to linenr_T (long); remove when linenr_T refactored
+          assert(lnum_64 <= LONG_MAX); 
+          pos.lnum = (linenr_T)lnum_64;
           pos.col = u;
           switch (line[1]) {
           case '"': curbuf->b_last_cursor = pos; break;


### PR DESCRIPTION
Before, I said there remained a single instance of unportable format string at https://github.com/neovim/neovim/blob/8f710a4103607c3568b31bc9b1002aafc6954489/src/mark.c#L1497
I had left that to be done when type refactoring was dealt with, because it was a sscanf.

Now, on [suggestion](https://github.com/neovim/neovim/issues/490#issuecomment-41316437) from @philix, I saw I could easily fix that one too.

So, with this, there are no more non-portable format specifiers in the code.
