### PR TITLE
[RDY] Clarify some castings in portable format specifiers

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2184,8 +2184,9 @@ void buflist_list(exarg_T *eap)
       IObuff[len++] = ' ';
     } while (--i > 0 && len < IOSIZE - 18);
     vim_snprintf((char *)IObuff + len, (size_t)(IOSIZE - len),
-        _("line %" PRId64), buf == curbuf ? (int64_t)curwin->w_cursor.lnum
-        : (int64_t)buflist_findlnum(buf));
+        _("line %" PRId64),
+        buf == curbuf ? (int64_t)curwin->w_cursor.lnum
+                      : (int64_t)buflist_findlnum(buf));
     msg_outtrans(IObuff);
     out_flush();            /* output one line at a time */
     ui_breakcheck();

--- a/src/eval.c
+++ b/src/eval.c
@@ -9988,7 +9988,7 @@ static void f_getregtype(typval_T *argvars, typval_T *rettv)
   case MCHAR: buf[0] = 'v'; break;
   case MBLOCK:
     buf[0] = Ctrl_V;
-    sprintf((char *)buf + 1, "%" PRId64, (int64_t)reglen + 1);
+    sprintf((char *)buf + 1, "%" PRId64, (int64_t)(reglen + 1));
     break;
   }
   rettv->v_type = VAR_STRING;

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4480,9 +4480,8 @@ do_sub_msg (
           "%s", count_only ? _("1 match") : _("1 substitution"));
     else
       vim_snprintf_add((char *)msg_buf, sizeof(msg_buf),
-          count_only ?
-          _("%" PRId64 " matches") :
-          _("%" PRId64 " substitutions"),
+          count_only ? _("%" PRId64 " matches")
+                     : _("%" PRId64 " substitutions"),
           (int64_t)sub_nsubs);
     if (sub_nlines == 1)
       vim_snprintf_add((char *)msg_buf, sizeof(msg_buf),

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -8460,7 +8460,7 @@ static int ses_winsizes(FILE *fd, int restore_size, win_T *tab_firstwin)
                   "exe '%dresize ' . ((&lines * %" PRId64
                   " + %" PRId64 ") / %" PRId64 ")",
                   n, (int64_t)wp->w_height,
-                  (int64_t)Rows / 2, (int64_t)Rows) < 0
+                  (int64_t)(Rows / 2), (int64_t)Rows) < 0
               || put_eol(fd) == FAIL))
         return FAIL;
 
@@ -8468,7 +8468,7 @@ static int ses_winsizes(FILE *fd, int restore_size, win_T *tab_firstwin)
       if (wp->w_width < Columns
           && (fprintf(fd, "exe 'vert %dresize ' . ((&columns * %" PRId64
                           " + %" PRId64 ") / %" PRId64 ")",
-                      n, (int64_t)wp->w_width, (int64_t)Columns / 2,
+                      n, (int64_t)wp->w_width, (int64_t)(Columns / 2),
                       (int64_t)Columns) < 0
               || put_eol(fd) == FAIL))
         return FAIL;
@@ -8613,7 +8613,7 @@ put_view (
    * arguments may have been deleted, check if the index is valid. */
   if (wp->w_arg_idx != current_arg_idx && wp->w_arg_idx < WARGCOUNT(wp)
       && flagp == &ssop_flags) {
-    if (fprintf(fd, "%" PRId64 "argu", (int64_t)wp->w_arg_idx + 1) < 0
+    if (fprintf(fd, "%" PRId64 "argu", (int64_t)(wp->w_arg_idx + 1)) < 0
         || put_eol(fd) == FAIL)
       return FAIL;
     did_next = TRUE;
@@ -8700,7 +8700,7 @@ put_view (
                 " * winheight(0) + %" PRId64 ") / %" PRId64 ")",
                 (int64_t)wp->w_cursor.lnum,
                 (int64_t)(wp->w_cursor.lnum - wp->w_topline),
-                (int64_t)wp->w_height / 2,
+                (int64_t)(wp->w_height / 2),
                 (int64_t)wp->w_height) < 0
         || put_eol(fd) == FAIL
         || put_line(fd, "if s:l < 1 | let s:l = 1 | endif") == FAIL
@@ -8717,14 +8717,14 @@ put_view (
       if (!wp->w_p_wrap && wp->w_leftcol > 0 && wp->w_width > 0) {
         if (fprintf(fd, "let s:c = %" PRId64 " - ((%" PRId64
                         " * winwidth(0) + %" PRId64 ") / %" PRId64 ")",
-                    (int64_t)wp->w_virtcol + 1,
+                    (int64_t)(wp->w_virtcol + 1),
                     (int64_t)(wp->w_virtcol - wp->w_leftcol),
-                    (int64_t)wp->w_width / 2,
+                    (int64_t)(wp->w_width / 2),
                     (int64_t)wp->w_width) < 0
             || put_eol(fd) == FAIL
             || put_line(fd, "if s:c > 0") == FAIL
             || fprintf(fd, "  exe 'normal! ' . s:c . '|zs' . %" PRId64 " . '|'",
-                (int64_t)wp->w_virtcol + 1) < 0
+                (int64_t)(wp->w_virtcol + 1)) < 0
             || put_eol(fd) == FAIL
             || put_line(fd, "else") == FAIL
             || fprintf(fd, "  normal! 0%d|", wp->w_virtcol + 1) < 0

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5704,7 +5704,7 @@ vim_tempname (
           mode_t umask_save;
 #  endif
 
-          sprintf((char *)itmp + itmplen, "v%" PRId64, (int64_t)nr + off);
+          sprintf((char *)itmp + itmplen, "v%" PRId64, (int64_t)(nr + off));
 #  ifndef EEXIST
           /* If mkdir() does not set errno to EEXIST, check for
            * existing file here.  There is a race condition then,

--- a/src/fold.c
+++ b/src/fold.c
@@ -2958,8 +2958,8 @@ static int put_folds_recurse(FILE *fd, garray_T *gap, linenr_T off)
     if (put_folds_recurse(fd, &fp->fd_nested, off + fp->fd_top) == FAIL)
       return FAIL;
     if (fprintf(fd, "%" PRId64 ",%" PRId64 "fold",
-                (int64_t)fp->fd_top + off,
-                (int64_t)fp->fd_top + off + fp->fd_len - 1) < 0
+                (int64_t)(fp->fd_top + off),
+                (int64_t)(fp->fd_top + off + fp->fd_len - 1)) < 0
         || put_eol(fd) == FAIL)
       return FAIL;
     ++fp;
@@ -2983,7 +2983,7 @@ static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off
     if (fp->fd_flags != FD_LEVEL) {
       if (fp->fd_nested.ga_len > 0) {
         /* open nested folds while this fold is open */
-        if (fprintf(fd, "%" PRId64, (int64_t)fp->fd_top + off) < 0
+        if (fprintf(fd, "%" PRId64, (int64_t)(fp->fd_top + off)) < 0
             || put_eol(fd) == FAIL
             || put_line(fd, "normal! zo") == FAIL)
           return FAIL;
@@ -3020,7 +3020,7 @@ static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off
  */
 static int put_fold_open_close(FILE *fd, fold_T *fp, linenr_T off)
 {
-  if (fprintf(fd, "%" PRId64, (int64_t)fp->fd_top + off) < 0
+  if (fprintf(fd, "%" PRId64, (int64_t)(fp->fd_top + off)) < 0
       || put_eol(fd) == FAIL
       || fprintf(fd, "normal! z%c",
           fp->fd_flags == FD_CLOSED ? 'c' : 'o') < 0

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -172,7 +172,7 @@ void hash_debug_results(void)
   fprintf(stderr, "Number of perturb loops: %" PRId64 "\r\n",
           (int64_t)hash_count_perturb);
   fprintf(stderr, "Percentage of perturb loops: %" PRId64 "%%\r\n",
-          (int64_t)hash_count_perturb * 100 / hash_count_lookup);
+          (int64_t)(hash_count_perturb * 100 / hash_count_lookup));
 #endif  // ifdef HT_DEBUG
 }
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -4451,7 +4451,7 @@ static void nv_ident(cmdarg_T *cap)
       isman = (STRCMP(kp, "man") == 0);
       isman_s = (STRCMP(kp, "man -s") == 0);
       if (cap->count0 != 0 && !(isman || isman_s))
-        sprintf((char *)buf, ".,.+%" PRId64, (int64_t)cap->count0 - 1);
+        sprintf((char *)buf, ".,.+%" PRId64, (int64_t)(cap->count0 - 1));
 
       STRCAT(buf, "! ");
       if (cap->count0 == 0 && isman_s)

--- a/src/screen.c
+++ b/src/screen.c
@@ -7899,7 +7899,7 @@ static void win_redr_ruler(win_T *wp, int always)
     vim_snprintf((char *)buffer, RULER_BUF_LEN, "%" PRId64 ",",
         (wp->w_buffer->b_ml.ml_flags & ML_EMPTY)
         ? (int64_t)0L
-        : (int64_t)(wp->w_cursor.lnum));
+        : (int64_t)wp->w_cursor.lnum);
     len = STRLEN(buffer);
     col_print(buffer + len, RULER_BUF_LEN - len,
         empty_line ? 0 : (int)wp->w_cursor.col + 1,

--- a/src/screen.c
+++ b/src/screen.c
@@ -7897,9 +7897,8 @@ static void win_redr_ruler(win_T *wp, int always)
      * To avoid portability problems we use strlen() here.
      */
     vim_snprintf((char *)buffer, RULER_BUF_LEN, "%" PRId64 ",",
-        (wp->w_buffer->b_ml.ml_flags & ML_EMPTY)
-        ? (int64_t)0L
-        : (int64_t)wp->w_cursor.lnum);
+        (wp->w_buffer->b_ml.ml_flags & ML_EMPTY) ? (int64_t)0L
+                                                 : (int64_t)wp->w_cursor.lnum);
     len = STRLEN(buffer);
     col_print(buffer + len, RULER_BUF_LEN - len,
         empty_line ? 0 : (int)wp->w_cursor.col + 1,


### PR DESCRIPTION
@justinmk pointed out some cases where the introduced castings could be incorrect (see https://github.com/neovim/neovim/pull/574#discussion-diff-11974822).

Though, to my understanding, they are correct in their context, I do agree they can be confusing, and, as explained in the discussion, me myself don't like them that way and only did it so because the semi-automated process I used was easier that way.

In any case, I have reviewed them to eliminate any possible doubt about this.
