### PR TITLE
[RDY] Replace `struct stat` with `FileInfo`

### DIFF
--- a/src/buffer_defs.h
+++ b/src/buffer_defs.h
@@ -423,11 +423,9 @@ struct file_buffer {
   char_u      *b_sfname;        /* short file name */
   char_u      *b_fname;         /* current file name */
 
-#ifdef UNIX
   int b_dev_valid;              /* TRUE when b_dev has a valid number */
-  dev_t b_dev;                  /* device number */
-  ino_t b_ino;                  /* inode number */
-#endif
+  uint64_t b_dev;                  /* device number */
+  uint64_t b_ino;                  /* inode number */
 
   int b_fnum;                   /* buffer number for this file. */
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -863,8 +863,6 @@ void ex_diffpatch(exarg_T *eap)
   char_u dirbuf[MAXPATHL];
   char_u *fullname = NULL;
 #endif  // ifdef UNIX
-  struct stat st;
-
   // We need two temp file names.
   // Name of original temp file.
   char_u *tmp_orig = vim_tempname('o');
@@ -965,7 +963,9 @@ void ex_diffpatch(exarg_T *eap)
   os_remove((char *)buf);
 
   // Only continue if the output file was created.
-  if ((mch_stat((char *)tmp_new, &st) < 0) || (st.st_size == 0)) {
+  off_t file_size;
+  bool file_size_success = os_get_file_size((char *)tmp_new, &file_size);
+  if (!file_size_success || file_size == 0) {
     EMSG(_("E816: Cannot read patch output"));
   } else {
     if (curbuf->b_fname != NULL) {

--- a/src/eval.c
+++ b/src/eval.c
@@ -9687,25 +9687,25 @@ static void f_getfperm(typval_T *argvars, typval_T *rettv)
  */
 static void f_getfsize(typval_T *argvars, typval_T *rettv)
 {
-  char_u      *fname;
-  struct stat st;
-
-  fname = get_tv_string(&argvars[0]);
+  char *fname = (char *)get_tv_string(&argvars[0]);
 
   rettv->v_type = VAR_NUMBER;
 
-  if (mch_stat((char *)fname, &st) >= 0) {
-    if (os_isdir(fname))
+  off_t file_size;
+  if (os_get_file_size(fname, &file_size)) {
+    if (os_isdir((char_u *)fname))
       rettv->vval.v_number = 0;
     else {
-      rettv->vval.v_number = (varnumber_T)st.st_size;
+      rettv->vval.v_number = (varnumber_T)file_size;
 
       /* non-perfect check for overflow */
-      if ((off_t)rettv->vval.v_number != (off_t)st.st_size)
+      if ((off_t)rettv->vval.v_number != file_size) {
         rettv->vval.v_number = -2;
+      }
     }
-  } else
+  } else {
     rettv->vval.v_number = -1;
+  }
 }
 
 /*

--- a/src/eval.c
+++ b/src/eval.c
@@ -9729,44 +9729,45 @@ static void f_getftime(typval_T *argvars, typval_T *rettv)
 static void f_getftype(typval_T *argvars, typval_T *rettv)
 {
   char_u      *fname;
-  struct stat st;
   char_u      *type = NULL;
   char        *t;
 
   fname = get_tv_string(&argvars[0]);
 
   rettv->v_type = VAR_STRING;
-  if (mch_lstat((char *)fname, &st) >= 0) {
+  FileInfo file_info;
+  if (os_get_file_info_link((char *)fname, &file_info)) {
+    uint64_t mode = file_info.stat.st_mode;
 #ifdef S_ISREG
-    if (S_ISREG(st.st_mode))
+    if (S_ISREG(mode))
       t = "file";
-    else if (S_ISDIR(st.st_mode))
+    else if (S_ISDIR(mode))
       t = "dir";
 # ifdef S_ISLNK
-    else if (S_ISLNK(st.st_mode))
+    else if (S_ISLNK(mode))
       t = "link";
 # endif
 # ifdef S_ISBLK
-    else if (S_ISBLK(st.st_mode))
+    else if (S_ISBLK(mode))
       t = "bdev";
 # endif
 # ifdef S_ISCHR
-    else if (S_ISCHR(st.st_mode))
+    else if (S_ISCHR(mode))
       t = "cdev";
 # endif
 # ifdef S_ISFIFO
-    else if (S_ISFIFO(st.st_mode))
+    else if (S_ISFIFO(mode))
       t = "fifo";
 # endif
 # ifdef S_ISSOCK
-    else if (S_ISSOCK(st.st_mode))
+    else if (S_ISSOCK(mode))
       t = "fifo";
 # endif
     else
       t = "other";
 #else
 # ifdef S_IFMT
-    switch (st.st_mode & S_IFMT) {
+    switch (mode & S_IFMT) {
     case S_IFREG: t = "file"; break;
     case S_IFDIR: t = "dir"; break;
 #  ifdef S_IFLNK

--- a/src/eval.c
+++ b/src/eval.c
@@ -9664,24 +9664,21 @@ static void f_getfontname(typval_T *argvars, typval_T *rettv)
  */
 static void f_getfperm(typval_T *argvars, typval_T *rettv)
 {
-  char_u      *fname;
-  struct stat st;
-  char_u      *perm = NULL;
+  char_u *perm = NULL;
   char_u flags[] = "rwx";
-  int i;
 
-  fname = get_tv_string(&argvars[0]);
-
-  rettv->v_type = VAR_STRING;
-  if (mch_stat((char *)fname, &st) >= 0) {
+  char_u *filename = get_tv_string(&argvars[0]);
+  int32_t file_perm = os_getperm(filename);
+  if (file_perm >= 0) {
     perm = vim_strsave((char_u *)"---------");
     if (perm != NULL) {
-      for (i = 0; i < 9; i++) {
-        if (st.st_mode & (1 << (8 - i)))
+      for (int i = 0; i < 9; i++) {
+        if (file_perm & (1 << (8 - i)))
           perm[i] = flags[i % 3];
       }
     }
   }
+  rettv->v_type = VAR_STRING;
   rettv->vval.v_string = perm;
 }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -9713,15 +9713,14 @@ static void f_getfsize(typval_T *argvars, typval_T *rettv)
  */
 static void f_getftime(typval_T *argvars, typval_T *rettv)
 {
-  char_u      *fname;
-  struct stat st;
+  char *fname = (char *)get_tv_string(&argvars[0]);
 
-  fname = get_tv_string(&argvars[0]);
-
-  if (mch_stat((char *)fname, &st) >= 0)
-    rettv->vval.v_number = (varnumber_T)st.st_mtime;
-  else
+  FileInfo file_info;
+  if (os_get_file_info(fname, &file_info)) {
+    rettv->vval.v_number = (varnumber_T)file_info.stat.st_mtim.tv_sec;
+  } else {
     rettv->vval.v_number = -1;
+  }
 }
 
 /*

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1492,7 +1492,6 @@ void write_viminfo(char_u *file, int forceit)
   FILE        *fp_in = NULL;    /* input viminfo file, if any */
   FILE        *fp_out = NULL;   /* output viminfo file */
   char_u      *tempname = NULL;         /* name of temp viminfo file */
-  struct stat st_new;           /* mch_stat() of potential new file */
   char_u      *wp;
 #if defined(UNIX)
   mode_t umask_save;
@@ -1511,7 +1510,7 @@ void write_viminfo(char_u *file, int forceit)
   fp_in = mch_fopen((char *)fname, READBIN);
   if (fp_in == NULL) {
     /* if it does exist, but we can't read it, don't try writing */
-    if (mch_stat((char *)fname, &st_new) == 0)
+    if (os_file_exists(fname))
       goto end;
 #if defined(UNIX)
     /*
@@ -1563,7 +1562,7 @@ void write_viminfo(char_u *file, int forceit)
        * Check if tempfile already exists.  Never overwrite an
        * existing file!
        */
-      if (mch_stat((char *)tempname, &st_new) == 0) {
+      if (os_file_exists(tempname)) {
         /*
          * Try another name.  Change one character, just before
          * the extension.
@@ -1571,8 +1570,7 @@ void write_viminfo(char_u *file, int forceit)
         wp = tempname + STRLEN(tempname) - 5;
         if (wp < path_tail(tempname))                 /* empty file name? */
           wp = path_tail(tempname);
-        for (*wp = 'z'; mch_stat((char *)tempname, &st_new) == 0;
-             --*wp) {
+        for (*wp = 'z'; os_file_exists(tempname); --*wp) {
           /*
            * They all exist?  Must be something wrong! Don't
            * write the viminfo file then.

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -86,7 +86,7 @@ static void set_file_time(char_u *fname, time_t atime, time_t mtime);
 static int set_rw_fname(char_u *fname, char_u *sfname);
 static int msg_add_fileformat(int eol_type);
 static void msg_add_eol(void);
-static int check_mtime(buf_T *buf, struct stat *s);
+static int check_mtime(buf_T *buf, FileInfo *file_info);
 static int time_differs(long t1, long t2);
 static int apply_autocmds_exarg(event_T event, char_u *fname, char_u *fname_io,
                                 int force, buf_T *buf,
@@ -262,7 +262,6 @@ readfile (
 #endif
   int fileformat = 0;                   /* end-of-line format */
   int keep_fileformat = FALSE;
-  struct stat st;
   int file_readonly;
   linenr_T skip_count = 0;
   linenr_T read_count = 0;
@@ -441,8 +440,9 @@ readfile (
 
   if (newfile && !read_stdin && !read_buffer) {
     /* Remember time of file. */
-    if (mch_stat((char *)fname, &st) >= 0) {
-      buf_store_time(curbuf, &st, fname);
+    FileInfo file_info;
+    if (os_get_file_info((char *)fname, &file_info)) {
+      buf_store_file_info(curbuf, &file_info, fname);
       curbuf->b_mtime_read = curbuf->b_mtime;
 #ifdef UNIX
       /*
@@ -456,7 +456,7 @@ readfile (
        * not be able to write to the file ourselves.
        * Setting the bits is done below, after creating the swap file.
        */
-      swap_mode = (st.st_mode & 0644) | 0600;
+      swap_mode = (file_info.stat.st_mode & 0644) | 0600;
 #endif
     } else {
       curbuf->b_mtime = 0;
@@ -2473,7 +2473,6 @@ buf_write (
   int overwriting;                          /* TRUE if writing over original */
   int no_eol = FALSE;                       /* no end-of-line written */
   int device = FALSE;                       /* writing to a device */
-  struct stat st_old;
   int prev_got_int = got_int;
   bool file_readonly = false;               /* overwritten file is read-only */
   static char     *err_readonly =
@@ -2774,15 +2773,14 @@ buf_write (
    * Get information about original file (if there is one).
    */
 #if defined(UNIX)
-  st_old.st_dev = 0;
-  st_old.st_ino = 0;
   perm = -1;
-  if (mch_stat((char *)fname, &st_old) < 0)
+  FileInfo file_info_old;
+  if (!os_get_file_info((char *)fname, &file_info_old)) {
     newfile = TRUE;
-  else {
-    perm = st_old.st_mode;
-    if (!S_ISREG(st_old.st_mode)) {             /* not a file */
-      if (S_ISDIR(st_old.st_mode)) {
+  } else {
+    perm = file_info_old.stat.st_mode;
+    if (!S_ISREG(file_info_old.stat.st_mode)) {             /* not a file */
+      if (S_ISDIR(file_info_old.stat.st_mode)) {
         errnum = (char_u *)"E502: ";
         errmsg = (char_u *)_("is a directory");
         goto fail;
@@ -2822,8 +2820,10 @@ buf_write (
       errmsg = (char_u *)_("is a directory");
       goto fail;
     }
-    if (overwriting)
-      (void)mch_stat((char *)fname, &st_old);
+    if (overwriting) {
+      os_get_file_info((char *)fname, &file_info_old);
+    }
+
   }
 #endif /* !UNIX */
 
@@ -2849,7 +2849,7 @@ buf_write (
      * Check if the timestamp hasn't changed since reading the file.
      */
     if (overwriting) {
-      retval = check_mtime(buf, &st_old);
+      retval = check_mtime(buf, &file_info_old);
       if (retval == FAIL)
         goto fail;
     }
@@ -2890,14 +2890,11 @@ buf_write (
    * off.  This helps when editing large files on almost-full disks.
    */
   if (!(append && *p_pm == NUL) && !filtering && perm >= 0 && dobackup) {
-#if defined(UNIX) || defined(WIN32)
-    struct stat st;
-#endif
+    FileInfo file_info;
 
-    if ((bkc_flags & BKC_YES) || append)        /* "yes" */
+    if ((bkc_flags & BKC_YES) || append) {       /* "yes" */
       backup_copy = TRUE;
-#if defined(UNIX) || defined(WIN32)
-    else if ((bkc_flags & BKC_AUTO)) {          /* "auto" */
+    } else if ((bkc_flags & BKC_AUTO)) {          /* "auto" */
       int i;
 
 # ifdef UNIX
@@ -2908,18 +2905,16 @@ buf_write (
        * - we don't have write permission in the directory
        * - we can't set the owner/group of the new file
        */
-      if (st_old.st_nlink > 1
-          || mch_lstat((char *)fname, &st) < 0
-          || st.st_dev != st_old.st_dev
-          || st.st_ino != st_old.st_ino
+      if (file_info_old.stat.st_nlink > 1
+          || !os_get_file_info_link((char *)fname, &file_info)
+          || !os_file_info_id_equal(&file_info, &file_info_old)
 #  ifndef HAVE_FCHOWN
-          || st.st_uid != st_old.st_uid
-          || st.st_gid != st_old.st_gid
+          || file_info.stat.st_uid != file_info_old.stat.st_uid
+          || file_info.stat.st_gid != file_info_old.stat.st_gid
 #  endif
-          )
+          ) {
         backup_copy = TRUE;
-      else
-# else
+      } else
 # endif
       {
         /*
@@ -2931,8 +2926,9 @@ buf_write (
         STRCPY(IObuff, fname);
         for (i = 4913;; i += 123) {
           sprintf((char *)path_tail(IObuff), "%d", i);
-          if (mch_lstat((char *)IObuff, &st) < 0)
+          if (!os_get_file_info_link((char *)IObuff, &file_info)) {
             break;
+          }
         }
         fd = mch_open((char *)IObuff,
             O_CREAT|O_WRONLY|O_EXCL|O_NOFOLLOW, perm);
@@ -2941,13 +2937,14 @@ buf_write (
         else {
 # ifdef UNIX
 #  ifdef HAVE_FCHOWN
-          ignored = fchown(fd, st_old.st_uid, st_old.st_gid);
+          fchown(fd, file_info_old.stat.st_uid, file_info_old.stat.st_gid);
 #  endif
-          if (mch_stat((char *)IObuff, &st) < 0
-              || st.st_uid != st_old.st_uid
-              || st.st_gid != st_old.st_gid
-              || (long)st.st_mode != perm)
+          if (!os_get_file_info((char *)IObuff, &file_info)
+              || file_info.stat.st_uid != file_info_old.stat.st_uid
+              || file_info.stat.st_gid != file_info_old.stat.st_gid
+              || (long)file_info.stat.st_mode != perm) {
             backup_copy = TRUE;
+          }
 # endif
           /* Close the file before removing it, on MS-Windows we
            * can't delete an open file. */
@@ -2962,26 +2959,24 @@ buf_write (
      */
     if ((bkc_flags & BKC_BREAKSYMLINK) || (bkc_flags & BKC_BREAKHARDLINK)) {
 # ifdef UNIX
-      int lstat_res;
-
-      lstat_res = mch_lstat((char *)fname, &st);
+      bool file_info_link_ok = os_get_file_info_link((char *)fname, &file_info);
 
       /* Symlinks. */
       if ((bkc_flags & BKC_BREAKSYMLINK)
-          && lstat_res == 0
-          && st.st_ino != st_old.st_ino)
+          && file_info_link_ok
+          && !os_file_info_id_equal(&file_info, &file_info_old)) {
         backup_copy = FALSE;
+      }
 
       /* Hardlinks. */
       if ((bkc_flags & BKC_BREAKHARDLINK)
-          && st_old.st_nlink > 1
-          && (lstat_res != 0 || st.st_ino == st_old.st_ino))
+          && file_info_old.stat.st_nlink > 1
+          && (!file_info_link_ok
+              || os_file_info_id_equal(&file_info, &file_info_old))) {
         backup_copy = FALSE;
-# else
+      }
 # endif
     }
-
-#endif
 
     /* make sure we have a valid backup extension to use */
     if (*p_bex == NUL)
@@ -2994,7 +2989,6 @@ buf_write (
       int bfd;
       char_u      *copybuf, *wp;
       int some_error = FALSE;
-      struct stat st_new;
       char_u      *dirp;
       char_u      *rootname;
 
@@ -3019,12 +3013,6 @@ buf_write (
        */
       dirp = p_bdir;
       while (*dirp) {
-#ifdef UNIX
-        st_new.st_ino = 0;
-        st_new.st_dev = 0;
-        st_new.st_gid = 0;
-#endif
-
         /*
          * Isolate one directory name, using an entry in 'bdir'.
          */
@@ -3035,6 +3023,7 @@ buf_write (
           goto nobackup;
         }
 
+        FileInfo file_info_new;
         {
           /*
            * Make backup file name.
@@ -3049,20 +3038,17 @@ buf_write (
           /*
            * Check if backup file already exists.
            */
-          if (mch_stat((char *)backup, &st_new) >= 0) {
-#ifdef UNIX
+          if (os_get_file_info((char *)backup, &file_info_new)) {
             /*
              * Check if backup file is same as original file.
              * May happen when modname() gave the same file back (e.g. silly
              * link). If we don't check here, we either ruin the file when
              * copying or erase it after writing.
              */
-            if (st_new.st_dev == st_old.st_dev
-                && st_new.st_ino == st_old.st_ino) {
+            if (os_file_info_id_equal(&file_info_new, &file_info_old)) {
               free(backup);
               backup = NULL;                    /* no backup file to delete */
             }
-#endif
 
             /*
              * If we are not going to keep the backup file, don't
@@ -3076,8 +3062,9 @@ buf_write (
                 wp = backup;
               *wp = 'z';
               while (*wp > 'a'
-                     && mch_stat((char *)backup, &st_new) >= 0)
+                     && os_get_file_info((char *)backup, &file_info_new)) {
                 --*wp;
+              }
               /* They all exist??? Must be something wrong. */
               if (*wp == 'a') {
                 free(backup);
@@ -3114,13 +3101,13 @@ buf_write (
              * bits for the group same as the protection bits for
              * others.
              */
-            if (st_new.st_gid != st_old.st_gid
+            if (file_info_new.stat.st_gid != file_info_old.stat.st_gid
 # ifdef HAVE_FCHOWN  /* sequent-ptx lacks fchown() */
-                && fchown(bfd, (uid_t)-1, st_old.st_gid) != 0
+                && fchown(bfd, (uid_t)-1, file_info_old.stat.st_gid) != 0
 # endif
-                )
-              os_setperm(backup,
-                  (perm & 0707) | ((perm & 07) << 3));
+                ) {
+              os_setperm(backup, (perm & 0707) | ((perm & 07) << 3));
+            }
 # ifdef HAVE_SELINUX
             mch_copy_sec(fname, backup);
 # endif
@@ -3155,7 +3142,9 @@ buf_write (
               errmsg = (char_u *)_(
                   "E508: Can't read file for backup (add ! to override)");
 #ifdef UNIX
-            set_file_time(backup, st_old.st_atime, st_old.st_mtime);
+            set_file_time(backup,
+                          file_info_old.stat.st_atim.tv_sec,
+                          file_info_old.stat.st_mtim.tv_sec);
 #endif
 #ifdef HAVE_ACL
             mch_set_acl(backup, acl);
@@ -3266,7 +3255,8 @@ nobackup:
 
 #if defined(UNIX)
   /* When using ":w!" and the file was read-only: make it writable */
-  if (forceit && perm >= 0 && !(perm & 0200) && st_old.st_uid == getuid()
+  if (forceit && perm >= 0 && !(perm & 0200)
+      && file_info_old.stat.st_uid == getuid()
       && vim_strchr(p_cpo, CPO_FWRITE) == NULL) {
     perm |= 0200;
     (void)os_setperm(fname, perm);
@@ -3412,15 +3402,14 @@ nobackup:
      */
     if (errmsg == NULL) {
 #ifdef UNIX
-      struct stat st;
+      FileInfo file_info;
 
       /* Don't delete the file when it's a hard or symbolic link. */
-      if ((!newfile && st_old.st_nlink > 1)
-          || (mch_lstat((char *)fname, &st) == 0
-              && (st.st_dev != st_old.st_dev
-                  || st.st_ino != st_old.st_ino)))
+      if ((!newfile && file_info_old.stat.st_nlink > 1)
+          || (os_get_file_info_link((char *)fname, &file_info)
+              && !os_file_info_id_equal(&file_info, &file_info_old))) {
         errmsg = (char_u *)_("E166: Can't open linked file for writing");
-      else
+      } else
 #endif
       {
         errmsg = (char_u *)_("E212: Can't open file for writing");
@@ -3432,8 +3421,10 @@ nobackup:
           if (!(perm & 0200))
             made_writable = TRUE;
           perm |= 0200;
-          if (st_old.st_uid != getuid() || st_old.st_gid != getgid())
+          if (file_info_old.stat.st_uid != getuid()
+              || file_info_old.stat.st_gid != getgid()) {
             perm &= 0777;
+          }
 #endif
           if (!append)                      /* don't remove when appending */
             os_remove((char *)wfname);
@@ -3650,14 +3641,14 @@ restore_backup:
    * file.  Get the new device and inode number. */
   if (backup != NULL && !backup_copy) {
 # ifdef HAVE_FCHOWN
-    struct stat st;
 
     /* don't change the owner when it's already OK, some systems remove
      * permission or ACL stuff */
-    if (mch_stat((char *)wfname, &st) < 0
-        || st.st_uid != st_old.st_uid
-        || st.st_gid != st_old.st_gid) {
-      ignored = fchown(fd, st_old.st_uid, st_old.st_gid);
+    FileInfo file_info;
+    if (!os_get_file_info((char *)wfname, &file_info)
+        || file_info.stat.st_uid != file_info_old.stat.st_uid
+        || file_info.stat.st_gid != file_info_old.stat.st_gid) {
+      fchown(fd, file_info_old.stat.st_uid, file_info_old.stat.st_gid);
       if (perm >= 0)            /* set permission again, may have changed */
         (void)os_setperm(wfname, perm);
     }
@@ -3867,7 +3858,9 @@ restore_backup:
         free(backup);                   /* don't delete the file */
         backup = NULL;
 #ifdef UNIX
-        set_file_time((char_u *)org, st_old.st_atime, st_old.st_mtime);
+        set_file_time((char_u *)org,
+                      file_info_old.stat.st_atim.tv_sec,
+                      file_info_old.stat.st_mtim.tv_sec);
 #endif
       }
     }
@@ -3960,8 +3953,8 @@ nofail:
 
       /* Update the timestamp to avoid an "overwrite changed file"
        * prompt when writing again. */
-      if (mch_stat((char *)fname, &st_old) >= 0) {
-        buf_store_time(buf, &st_old, fname);
+      if (os_get_file_info((char *)fname, &file_info_old)) {
+        buf_store_file_info(buf, &file_info_old, fname);
         buf->b_mtime_read = buf->b_mtime;
       }
     }
@@ -4137,10 +4130,11 @@ static void msg_add_eol(void)
  * The size isn't checked, because using a tool like "gzip" takes care of
  * using the same timestamp but can't set the size.
  */
-static int check_mtime(buf_T *buf, struct stat *st)
+static int check_mtime(buf_T *buf, FileInfo *file_info)
 {
   if (buf->b_mtime_read != 0
-      && time_differs((long)st->st_mtime, buf->b_mtime_read)) {
+      && time_differs((long)file_info->stat.st_mtim.tv_sec,
+                      buf->b_mtime_read)) {
     msg_scroll = TRUE;              /* don't overwrite messages here */
     msg_silent = 0;                 /* must give this prompt */
     /* don't use emsg() here, don't want to flush the buffers */
@@ -5079,8 +5073,6 @@ buf_check_timestamp (
     int focus               /* called for GUI focus event */
 )
 {
-  struct stat st;
-  int stat_res;
   int retval = 0;
   char_u      *path;
   char_u      *tbuf;
@@ -5107,27 +5099,25 @@ buf_check_timestamp (
       )
     return 0;
 
-  if (       !(buf->b_flags & BF_NOTEDITED)
-             && buf->b_mtime != 0
-             && ((stat_res = mch_stat((char *)buf->b_ffname, &st)) < 0
-                 || time_differs((long)st.st_mtime, buf->b_mtime)
-                 || st.st_size != buf->b_orig_size
-#ifdef HAVE_ST_MODE
-                 || (int)st.st_mode != buf->b_orig_mode
-#else
-                 || os_getperm(buf->b_ffname) != buf->b_orig_mode
-#endif
-                 )) {
+  FileInfo file_info;
+  bool file_info_ok;
+  if (!(buf->b_flags & BF_NOTEDITED)
+      && buf->b_mtime != 0
+      && (!(file_info_ok = os_get_file_info((char *)buf->b_ffname, &file_info))
+          || time_differs((long)file_info.stat.st_mtim.tv_sec, buf->b_mtime)
+          || (int)file_info.stat.st_mode != buf->b_orig_mode
+          )) {
     retval = 1;
 
     /* set b_mtime to stop further warnings (e.g., when executing
      * FileChangedShell autocmd) */
-    if (stat_res < 0) {
+    if (!file_info_ok) {
       buf->b_mtime = 0;
       buf->b_orig_size = 0;
       buf->b_orig_mode = 0;
-    } else
-      buf_store_time(buf, &st, buf->b_ffname);
+    } else {
+      buf_store_file_info(buf, &file_info, buf->b_ffname);
+    }
 
     /* Don't do anything for a directory.  Might contain the file
      * explorer. */
@@ -5140,10 +5130,10 @@ buf_check_timestamp (
      * was set, the global option value otherwise.
      */
     else if ((buf->b_p_ar >= 0 ? buf->b_p_ar : p_ar)
-             && !bufIsChanged(buf) && stat_res >= 0)
+             && !bufIsChanged(buf) && file_info_ok)
       reload = TRUE;
     else {
-      if (stat_res < 0)
+      if (!file_info_ok)
         reason = "deleted";
       else if (bufIsChanged(buf))
         reason = "conflict";
@@ -5428,15 +5418,12 @@ void buf_reload(buf_T *buf, int orig_mode)
   /* Careful: autocommands may have made "buf" invalid! */
 }
 
-void buf_store_time(buf_T *buf, struct stat *st, char_u *fname)
+// TODO(stefan991): remove unused parameter fname
+void buf_store_file_info(buf_T *buf, FileInfo *file_info, char_u *fname)
 {
-  buf->b_mtime = (long)st->st_mtime;
-  buf->b_orig_size = st->st_size;
-#ifdef HAVE_ST_MODE
-  buf->b_orig_mode = (int)st->st_mode;
-#else
-  buf->b_orig_mode = os_getperm(fname);
-#endif
+  buf->b_mtime = (long)file_info->stat.st_mtim.tv_sec;
+  buf->b_orig_size = file_info->stat.st_size;
+  buf->b_orig_mode = (int)file_info->stat.st_mode;
 }
 
 /*

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -2,6 +2,7 @@
 #define NEOVIM_FILEIO_H
 
 #include "buffer_defs.h"
+#include "os/os.h"
 
 /*
  * Struct to save values in before executing autocommands for a buffer that is
@@ -40,7 +41,7 @@ int vim_rename(char_u *from, char_u *to);
 int check_timestamps(int focus);
 int buf_check_timestamp(buf_T *buf, int focus);
 void buf_reload(buf_T *buf, int orig_mode);
-void buf_store_time(buf_T *buf, struct stat *st, char_u *fname);
+void buf_store_file_info(buf_T *buf, FileInfo *file_info, char_u *fname);
 void write_lnum_adjust(linenr_T offset);
 void vim_deltempdir(void);
 char_u *vim_tempname(int extra_char);

--- a/src/if_cscope_defs.h
+++ b/src/if_cscope_defs.h
@@ -51,10 +51,9 @@ typedef struct csi {
   char *          flags;        /* additional cscope flags/options (e.g, -p2) */
 #if defined(UNIX)
   pid_t pid;                    /* PID of the connected cscope process. */
-  dev_t st_dev;                 /* ID of dev containing cscope db */
-  ino_t st_ino;                 /* inode number of cscope db */
-#else
 #endif
+  uint64_t st_dev;                 /* ID of dev containing cscope db */
+  uint64_t st_ino;                 /* inode number of cscope db */
 
   FILE *          fr_fp;        /* from cscope: FILE. */
   FILE *          to_fp;        /* to cscope: FILE. */

--- a/src/macros.h
+++ b/src/macros.h
@@ -98,7 +98,6 @@
 #define vim_isbreak(c) (breakat_flags[(char_u)(c)])
 
 #  define mch_fopen(n, p)       fopen((n), (p))
-# define mch_fstat(n, p)        fstat((n), (p))
 #  ifdef STAT_IGNORES_SLASH
 /* On Solaris stat() accepts "file/" as if it was "file".  Return -1 if
  * the name ends in "/" and it's not a directory. */

--- a/src/macros.h
+++ b/src/macros.h
@@ -98,20 +98,6 @@
 #define vim_isbreak(c) (breakat_flags[(char_u)(c)])
 
 #  define mch_fopen(n, p)       fopen((n), (p))
-#  ifdef STAT_IGNORES_SLASH
-/* On Solaris stat() accepts "file/" as if it was "file".  Return -1 if
- * the name ends in "/" and it's not a directory. */
-#   define mch_stat(n, p)       (illegal_slash(n) ? -1 : stat((n), (p)))
-#  else
-#   define mch_stat(n, p)       stat((n), (p))
-#  endif
-
-#ifdef HAVE_LSTAT
-# define mch_lstat(n, p)        lstat((n), (p))
-#else
-# define mch_lstat(n, p)        mch_stat((n), (p))
-#endif
-
 #   define mch_open(n, m, p)    open((n), (m), (p))
 
 /* mch_open_rw(): invoke mch_open() with third argument for user R/W. */

--- a/src/main.c
+++ b/src/main.c
@@ -2130,14 +2130,13 @@ process_env (
  */
 static int file_owned(char *fname)
 {
-  struct stat s;
   uid_t uid = getuid();
-
-  return !(mch_stat(fname, &s) != 0 || s.st_uid != uid
-# ifdef HAVE_LSTAT
-      || mch_lstat(fname, &s) != 0 || s.st_uid != uid
-# endif
-      );
+  FileInfo file_info;
+  bool file_owned = os_get_file_info(fname, &file_info)
+                    && file_info.stat.st_uid == uid;
+  bool link_owned = os_get_file_info_link(fname, &file_info)
+                    && file_info.stat.st_uid == uid;
+  return file_owned && link_owned;
 }
 #endif
 

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -46,25 +46,6 @@
 #include "ui.h"
 #include "os/os.h"
 
-/*
- * Some systems have the page size in statfs.f_bsize, some in stat.st_blksize
- */
-#ifdef HAVE_ST_BLKSIZE
-# define STATFS stat
-# define F_BSIZE st_blksize
-# define fstatfs(fd, buf, len, nul) mch_fstat((fd), (buf))
-#else
-# ifdef HAVE_SYS_STATFS_H
-#  include <sys/statfs.h>
-#  define STATFS statfs
-#  define F_BSIZE f_bsize
-# endif
-#endif
-
-/*
- * for Amiga Dos 2.0x we use Flush
- */
-
 #define MEMFILE_PAGE_SIZE 4096          /* default page size */
 
 static long_u total_mem_used = 0;       /* total memory used for memfiles */
@@ -125,10 +106,6 @@ memfile_T *mf_open(char_u *fname, int flags)
 {
   memfile_T           *mfp;
   off_t size;
-#if defined(STATFS) && defined(UNIX) && !defined(__QNX__) && !defined(__minix)
-# define USE_FSTATFS
-  struct STATFS stf;
-#endif
 
   if ((mfp = (memfile_T *)alloc((unsigned)sizeof(memfile_T))) == NULL)
     return NULL;
@@ -157,7 +134,6 @@ memfile_T *mf_open(char_u *fname, int flags)
   mfp->mf_page_size = MEMFILE_PAGE_SIZE;
   mfp->mf_old_key = NULL;
 
-#ifdef USE_FSTATFS
   /*
    * Try to set the page size equal to the block size of the device.
    * Speeds up I/O a lot.
@@ -165,12 +141,13 @@ memfile_T *mf_open(char_u *fname, int flags)
    * in ml_recover().  The size used here may be wrong, therefore
    * mf_blocknr_max must be rounded up.
    */
+  FileInfo file_info;
   if (mfp->mf_fd >= 0
-      && fstatfs(mfp->mf_fd, &stf, sizeof(struct statfs), 0) == 0
-      && stf.F_BSIZE >= MIN_SWAP_PAGE_SIZE
-      && stf.F_BSIZE <= MAX_SWAP_PAGE_SIZE)
-    mfp->mf_page_size = stf.F_BSIZE;
-#endif
+      && os_get_file_info_fd(mfp->mf_fd, &file_info)
+      && file_info.stat.st_blksize >= MIN_SWAP_PAGE_SIZE
+      && file_info.stat.st_blksize <= MAX_SWAP_PAGE_SIZE) {
+    mfp->mf_page_size = file_info.stat.st_blksize;
+  }
 
   if (mfp->mf_fd < 0 || (flags & (O_TRUNC|O_EXCL))
       || (size = lseek(mfp->mf_fd, (off_t)0L, SEEK_END)) <= 0)

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -1041,10 +1041,6 @@ mf_do_open (
     int flags                      /* flags for open() */
 )
 {
-#ifdef HAVE_LSTAT
-  struct stat sb;
-#endif
-
   mfp->mf_fname = fname;
 
   /*
@@ -1054,17 +1050,16 @@ mf_do_open (
    */
   mf_set_ffname(mfp);
 
-#ifdef HAVE_LSTAT
   /*
    * Extra security check: When creating a swap file it really shouldn't
    * exist yet.  If there is a symbolic link, this is most likely an attack.
    */
-  if ((flags & O_CREAT) && mch_lstat((char *)mfp->mf_fname, &sb) >= 0) {
+  FileInfo file_info;
+  if ((flags & O_CREAT)
+      && os_get_file_info_link((char *)mfp->mf_fname, &file_info)) {
     mfp->mf_fd = -1;
     EMSG(_("E300: Swap file already exists (symlink attack?)"));
-  } else
-#endif
-  {
+  } else {
     /*
      * try to open the file
      */

--- a/src/memline.c
+++ b/src/memline.c
@@ -1607,12 +1607,9 @@ recover_names (
      * Try finding a swap file by simply adding ".swp" to the file name.
      */
     if (*dirp == NUL && file_count + num_files == 0 && fname != NULL) {
-      struct stat st;
-      char_u          *swapname;
-
-      swapname = modname(fname_res, (char_u *)".swp", TRUE);
+      char_u *swapname = modname(fname_res, (char_u *)".swp", TRUE);
       if (swapname != NULL) {
-        if (mch_stat((char *)swapname, &st) != -1) {                /* It exists! */
+        if (os_file_exists(swapname)) {
           files = (char_u **)alloc((unsigned)sizeof(char_u *));
           files[0] = swapname;
           swapname = NULL;

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -826,24 +826,6 @@ int vim_chdirfile(char_u *fname)
 }
 #endif
 
-#if defined(STAT_IGNORES_SLASH) || defined(PROTO)
-/*
- * Check if "name" ends in a slash and is not a directory.
- * Used for systems where stat() ignores a trailing slash on a file name.
- * The Vim code assumes a trailing slash is only ignored for a directory.
- */
-int illegal_slash(char *name)
-{
-  if (name[0] == NUL)
-    return FALSE;           /* no file name is not illegal */
-  if (name[strlen(name) - 1] != '/')
-    return FALSE;           /* no trailing slash */
-  if (os_isdir((char_u *)name))
-    return FALSE;           /* trailing slash for a directory */
-  return TRUE;
-}
-#endif
-
 /*
  * Change directory to "new_dir".  If FEAT_SEARCHPATH is defined, search
  * 'cdpath' for relative directory names, otherwise just os_chdir().

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -189,6 +189,16 @@ int os_file_is_writable(const char *name)
   return 0;
 }
 
+bool os_get_file_size(const char *name, off_t *size)
+{
+  uv_stat_t statbuf;
+  if (os_stat((char_u *)name, &statbuf) == OK) {
+    *size = statbuf.st_size;
+    return true;
+  }
+  return false;
+}
+
 int os_rename(const char_u *path, const char_u *new_path)
 {
   uv_fs_t request;

--- a/src/os/fs.c
+++ b/src/os/fs.c
@@ -237,3 +237,41 @@ int os_remove(const char *path)
   return result;
 }
 
+bool os_get_file_info(const char *path, FileInfo *file_info)
+{
+  if (os_stat((char_u *)path, &(file_info->stat)) == OK) {
+    return true;
+  }
+  return false;
+}
+
+bool os_get_file_info_link(const char *path, FileInfo *file_info)
+{
+  uv_fs_t request;
+  int result = uv_fs_lstat(uv_default_loop(), &request, path, NULL);
+  file_info->stat = request.statbuf;
+  uv_fs_req_cleanup(&request);
+  if (result == kLibuvSuccess) {
+    return true;
+  }
+  return false;
+}
+
+bool os_get_file_info_fd(int file_descriptor, FileInfo *file_info)
+{
+  uv_fs_t request;
+  int result = uv_fs_fstat(uv_default_loop(), &request, file_descriptor, NULL);
+  file_info->stat = request.statbuf;
+  uv_fs_req_cleanup(&request);
+  if (result == kLibuvSuccess) {
+    return true;
+  }
+  return false;
+}
+
+bool os_file_info_id_equal(FileInfo *file_info_1, FileInfo *file_info_2)
+{
+  return file_info_1->stat.st_ino == file_info_2->stat.st_ino
+         && file_info_1->stat.st_dev == file_info_2->stat.st_dev;
+}
+

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -111,4 +111,36 @@ char *os_get_user_directory(const char *name);
 /// @return OK on success, FAIL if an failure occured.
 int os_stat(const char_u *name, uv_stat_t *statbuf);
 
+/// Struct which encapsulates stat information.
+typedef struct {
+  // TODO(stefan991): make stat private
+  uv_stat_t stat;
+} FileInfo;
+
+/// Get the file information for a given path
+///
+/// @param file_descriptor File descriptor of the file.
+/// @param[out] file_info Pointer to a FileInfo to put the information in.
+/// @return `true` on sucess, `false` for failure.
+bool os_get_file_info(const char *path, FileInfo *file_info);
+
+/// Get the file information for a given path without following links
+///
+/// @param path Path to the file.
+/// @param[out] file_info Pointer to a FileInfo to put the information in.
+/// @return `true` on sucess, `false` for failure.
+bool os_get_file_info_link(const char *path, FileInfo *file_info);
+
+/// Get the file information for a given file descriptor
+///
+/// @param file_descriptor File descriptor of the file.
+/// @param[out] file_info Pointer to a FileInfo to put the information in.
+/// @return `true` on sucess, `false` for failure.
+bool os_get_file_info_fd(int file_descriptor, FileInfo *file_info);
+
+/// Compare the inodes of two FileInfos
+///
+/// @return `true` if the two FileInfos represent the same file.
+bool os_file_info_id_equal(FileInfo *file_info_1, FileInfo *file_info_2);
+
 #endif  // NEOVIM_OS_OS_H

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -58,6 +58,12 @@ bool os_file_is_readonly(const char *name);
 /// @return `2` for a directory which we have rights to write into.
 int os_file_is_writable(const char *name);
 
+/// Get the size of a file in bytes.
+///
+/// @param[out] size pointer to an off_t to put the size into.
+/// @return `true` for success, `false` for failure.
+bool os_get_file_size(const char *name, off_t *size);
+
 /// Rename a file or directory.
 ///
 /// @return `OK` for success, `FAIL` for failure.

--- a/src/os_unix_defs.h
+++ b/src/os_unix_defs.h
@@ -229,6 +229,7 @@
 # define MAXPATHL       1024
 #endif
 
+// TODO(stefan991): remove macro
 #define CHECK_INODE             /* used when checking if a swap file already
                                     exists for a file */
 # ifndef DFLT_MAXMEM
@@ -276,7 +277,6 @@
 #endif
 
 #define HAVE_DUP                /* have dup() */
-#define HAVE_ST_MODE            /* have stat.st_mode */
 
 /* We have three kinds of ACL support. */
 #define HAVE_ACL (HAVE_POSIX_ACL || HAVE_SOLARIS_ACL || HAVE_AIX_ACL)

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2573,9 +2573,6 @@ static char_u *get_mef_name(void)
   char_u      *name;
   static int start = -1;
   static int off = 0;
-#ifdef HAVE_LSTAT
-  struct stat sb;
-#endif
 
   if (*p_mef == NUL) {
     name = vim_tempname('e');
@@ -2602,13 +2599,12 @@ static char_u *get_mef_name(void)
     STRCPY(name, p_mef);
     sprintf((char *)name + (p - p_mef), "%d%d", start, off);
     STRCAT(name, p + 2);
-    if (!os_file_exists(name)
-#ifdef HAVE_LSTAT
-        /* Don't accept a symbolic link, its a security risk. */
-        && mch_lstat((char *)name, &sb) < 0
-#endif
-        )
+    // Don't accept a symbolic link, its a security risk.
+    FileInfo file_info;
+    bool file_or_link_found = os_get_file_info_link((char *)name, &file_info);
+    if (!file_or_link_found) {
       break;
+    }
     free(name);
   }
   return name;

--- a/src/spell.c
+++ b/src/spell.c
@@ -7768,7 +7768,6 @@ mkspell (
   afffile_T   *(afile[8]);
   int i;
   int len;
-  struct stat st;
   int error = FALSE;
   spellinfo_T spin;
 
@@ -7832,7 +7831,7 @@ mkspell (
   else {
     // Check for overwriting before doing things that may take a lot of
     // time.
-    if (!over_write && mch_stat((char *)wfname, &st) >= 0) {
+    if (!over_write && os_file_exists(wfname)) {
       EMSG(_(e_exists));
       goto theend;
     }
@@ -7888,7 +7887,7 @@ mkspell (
       spin.si_region = 1 << i;
 
       vim_snprintf((char *)fname, MAXPATHL, "%s.aff", innames[i]);
-      if (mch_stat((char *)fname, &st) >= 0) {
+      if (os_file_exists(fname)) {
         // Read the .aff file.  Will init "spin->si_conv" based on the
         // "SET" line.
         afile[i] = spell_read_aff(&spin, fname);

--- a/src/tag.c
+++ b/src/tag.c
@@ -1511,12 +1511,10 @@ line_read_in:
            * compute the first offset.
            */
           if (state == TS_BINARY) {
-            /* Get the tag file size (don't use mch_fstat(), it's not
-             * portable). */
-            if ((filesize = lseek(fileno(fp),
-                     (off_t)0L, SEEK_END)) <= 0)
+            // Get the tag file size.
+            if ((filesize = lseek(fileno(fp), (off_t)0L, SEEK_END)) <= 0) {
               state = TS_LINEAR;
-            else {
+            } else {
               lseek(fileno(fp), (off_t)0L, SEEK_SET);
 
               /* Calculate the first read offset in the file.  Start


### PR DESCRIPTION
`mch_stat` is used very often in the codebase. I think it is the best to refactor all uses of `mch_stat` and `struct stat` into functions in `os/fs.c`. This pull request won't probably refactor every use of `mch_stat`, but it is a good start.
