### PR TITLE
[RDY] Remove references to FEAT_{X11,CLIPBOARD} and USE_XSMP.

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1118,10 +1118,6 @@ EXTERN char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 
 EXTERN char need_key_msg[] INIT(= N_("Need encryption key for \"%s\""));
 
-/*
- * Comms. with the session manager (XSMP)
- */
-
 /* For undo we need to know the lowest time possible. */
 EXTERN time_t starttime;
 

--- a/src/message.c
+++ b/src/message.c
@@ -126,8 +126,7 @@ int msg(char_u *s)
   return msg_attr_keep(s, 0, FALSE);
 }
 
-#if defined(FEAT_EVAL) || defined(FEAT_X11) || defined(USE_XSMP) \
-  || defined(FEAT_GUI_GTK) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_GUI_GTK) || defined(PROTO)
 /*
  * Like msg() but keep it silent when 'verbosefile' is set.
  */

--- a/src/ops.c
+++ b/src/ops.c
@@ -44,20 +44,14 @@
 #include "window.h"
 
 /*
- * Number of registers.
- *	0 = unnamed register, for normal yanks and puts
+ * Registers:
+ *      0 = unnamed register, for normal yanks and puts
  *   1..9 = registers '1' to '9', for deletes
  * 10..35 = registers 'a' to 'z'
  *     36 = delete register '-'
- *     37 = Selection register '*'. Only if FEAT_CLIPBOARD defined
- *     38 = Clipboard register '+'. Only if FEAT_CLIPBOARD and FEAT_X11 defined
  */
-/*
- * Symbolic names for some registers.
- */
-#define DELETION_REGISTER       36
-
-# define NUM_REGISTERS          37
+#define NUM_REGISTERS 37
+#define DELETION_REGISTER 36
 
 /*
  * Each yank register is an array of pointers to lines.

--- a/src/option.c
+++ b/src/option.c
@@ -363,7 +363,7 @@ struct vimoption {
 /* The 16 bit MS-DOS version is low on space, make the string as short as
  * possible when compiling with few features. */
 #if defined(FEAT_DIFF) || defined(FEAT_FOLDING) || defined(FEAT_SPELL) \
-  || defined(FEAT_VERTSPLIT) || defined(FEAT_CLIPBOARD) \
+  || defined(FEAT_VERTSPLIT) \
   || defined(FEAT_INS_EXPAND) || defined(FEAT_SYN_HL) || defined(FEAT_CONCEAL)
 # define HIGHLIGHT_INIT \
   "8:SpecialKey,@:NonText,d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn"

--- a/src/ui.c
+++ b/src/ui.c
@@ -539,7 +539,7 @@ void ui_cursor_shape(void)
   conceal_check_cursur_line();
 }
 
-#if defined(FEAT_CLIPBOARD) || defined(FEAT_GUI) || defined(FEAT_RIGHTLEFT) \
+#if defined(FEAT_GUI) || defined(FEAT_RIGHTLEFT) \
   || defined(FEAT_MBYTE) || defined(PROTO)
 /*
  * Check bounds for column number


### PR DESCRIPTION
These were removed in the initial unifdeffing.

I also couldn't resist a tiny bit of formatting in ops.c 

`git grep '\(FEAT_X11\|FEAT_CLIPBOARD\|USE_XSMP\)'` outputs nothing.
