### PR TITLE
[RDY] vim-patch:7.4.264

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -17356,7 +17356,6 @@ void ex_function(exarg_T *eap)
   // Get the function name.  There are these situations:
   // func        function name
   //             "name" == func, "fudi.fd_dict" == NULL
-  // s:func      script-local function name
   // dict.func   new dictionary entry
   //             "name" == NULL, "fudi.fd_dict" set,
   //             "fudi.fd_di" == NULL, "fudi.fd_newkey" == func
@@ -17366,6 +17365,8 @@ void ex_function(exarg_T *eap)
   // dict.func   existing dict entry that's not a Funcref
   //             "name" == NULL, "fudi.fd_dict" set,
   //             "fudi.fd_di" set, "fudi.fd_newkey" == NULL
+  // s:func      script-local function name
+  // g:func      global function name, same as "func"
   p = eap->arg;
   name = trans_function_name(&p, eap->skip, 0, &fudi);
   paren = (vim_strchr(p, '(') != NULL);
@@ -17971,8 +17972,10 @@ trans_function_name (
       lead = 2;
     }
   } else {
-    if (lead == 2)      /* skip over "s:" */
+    // Skip over "s:" and "g:".
+    if (lead == 2 || (lv.ll_name[0] == 'g' && lv.ll_name[1] == ':')) {
       lv.ll_name += 2;
+    }
     len = (int)(end - lv.ll_name);
   }
 
@@ -17996,17 +17999,16 @@ trans_function_name (
       lead += (int)STRLEN(sid_buf);
     }
   } else if (!(flags & TFN_INT) && builtin_function(lv.ll_name, len)) {
-    EMSG2(_(
-            "E128: Function name must start with a capital or \"s:\": %s"),
-          lv.ll_name);
+    EMSG2(_("E128: Function name must start with a capital or \"s:\": %s"),
+          start);
     goto theend;
   }
 
-  if (!skip) {
+  if (!skip && !(flags & TFN_QUIET)) {
     char_u *cp = vim_strchr(lv.ll_name, ':');
 
     if (cp != NULL && cp < end) {
-      EMSG2(_("E884: Function name cannot contain a colon: %s"), lv.ll_name);
+      EMSG2(_("E884: Function name cannot contain a colon: %s"), start);
       goto theend;
     }
   }

--- a/src/testdir/test_eval.in
+++ b/src/testdir/test_eval.in
@@ -1,5 +1,5 @@
 STARTTEST
-:" function name includes a colon
+:" function name not starting with a capital
 :try
 :  func! g:test()
 :    echo "test"
@@ -15,9 +15,28 @@ STARTTEST
 :catch
 :  let @b = v:exception
 :endtry
+:" function name includes a colon
+:try
+:  func! b:test()
+:    echo "test"
+:  endfunc
+:catch
+:  let @c = v:exception
+:endtry
+:" function name starting with/without "g:", buffer-local funcref.
+:function! g:Foo()
+:  let @d = 'called Foo()'
+:endfunction
+:let b:my_func = function('Foo')
+:let @d = 'xxx'
+:call b:my_func()
+:endfunction
+:" clean up
 :%d
 :pu a
 :pu b
+:pu c
+:pu d
 :1d
 :wq! test.out
 ENDTEST

--- a/src/testdir/test_eval.ok
+++ b/src/testdir/test_eval.ok
@@ -1,2 +1,4 @@
 Vim(function):E128: Function name must start with a capital or "s:": g:test()
 Vim(function):E128: Function name must start with a capital or "s:": test2() "#
+Vim(function):E128: Function name must start with a capital or "s:": b:test()
+called Foo()

--- a/src/version.c
+++ b/src/version.c
@@ -203,7 +203,7 @@ static char *(features[]) = {
 static int included_patches[] = {
   // Add new patch number below this line
   //265,
-  //264,
+  264,
   //263,
   //262,
   261,


### PR DESCRIPTION
```
Problem:  Can't define a function starting with "g:". Can't assign a
          funcref to a buffer-local variable.
Solution: Skip "g:" at the start of a function name.
          Don't check for colons when assigning to a variable.
```

https://code.google.com/p/vim/source/detail?r=00acac0af680c2d8c82db5258474b121a5908926
