### PR TITLE
[RFC] Repaced use of xmalloc and STRCPY with xstrdup

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -272,13 +272,12 @@ int vim_fnamencmp(char_u *x, char_u *y, size_t len)
  */
 char_u *concat_fnames(char_u *fname1, char_u *fname2, int sep)
 {
-  char_u *dest = xmalloc(STRLEN(fname1) + STRLEN(fname2) + 3);
+  char_u *dest = xstrdup(fname1);
 
-  STRCPY(dest, fname1);
-  if (sep) {
-    add_pathsep(dest);
+  if (sep && *dest != NUL && !after_pathsep(dest, dest + STRLEN(dest))) {
+    dest = concat_str(dest, PATHSEPSTR);
   }
-  STRCAT(dest, fname2);
+  dest = concat_str(dest, fname2);
 
   return dest;
 }


### PR DESCRIPTION
This patch removes the use of xmalloc and teh STRCPY macro by replacing
it with xstrdup.

It therefor changes the seperator-appending to the fnames by (kind of)
reimplementing add_pathsep() but with concat_str() instead of STRCPY, as
we need to do a reallocation of the string.

---

What my question is: the `concat_str()` function does _always_ a `xmalloc()` call? Wouldn't it be better to try a `realloc()` first and then appending the content? Should we fix this? Should I before submitting this actual change (which makes more use of the `concat_str()` function in the `concat_fnames()` function)?
