### PR TITLE
[WIP] [ci skip] Fixed garray_T member types

### DIFF
--- a/src/garray.c
+++ b/src/garray.c
@@ -42,7 +42,7 @@ void ga_clear_strings(garray_T *gap)
 /// @param gap
 /// @param itemsize
 /// @param growsize
-void ga_init(garray_T *gap, int itemsize, int growsize)
+void ga_init(garray_T *gap, size_t itemsize, unsigned int growsize)
 {
   gap->ga_data = NULL;
   gap->ga_maxlen = 0;
@@ -55,7 +55,7 @@ void ga_init(garray_T *gap, int itemsize, int growsize)
 ///
 /// @param gap
 /// @param n
-void ga_grow(garray_T *gap, int n)
+void ga_grow(garray_T *gap, unsigned int n)
 {
   size_t old_len;
   size_t new_len;

--- a/src/garray.h
+++ b/src/garray.h
@@ -7,19 +7,19 @@
 /// This is used to store information that only grows, is deleted all at
 /// once, and needs to be accessed by index.  See ga_clear() and ga_grow().
 typedef struct growarray {
-  int ga_len;                       // current number of items used
-  int ga_maxlen;                    // maximum number of items possible
-  int ga_itemsize;                  // sizeof(item)
-  int ga_growsize;                  // number of items to grow each time
-  void *ga_data;                    // pointer to the first item
+  unsigned int  ga_len;         // current number of items used
+  unsigned int  ga_maxlen;      // maximum number of items possible
+  size_t        ga_itemsize;    // sizeof(item)
+  unsigned int  ga_growsize;    // number of items to grow each time
+  void          *ga_data;       // pointer to the first item
 } garray_T;
 
 #define GA_EMPTY { 0, 0, 0, 0, NULL }
 
 void ga_clear(garray_T *gap);
 void ga_clear_strings(garray_T *gap);
-void ga_init(garray_T *gap, int itemsize, int growsize);
-void ga_grow(garray_T *gap, int n);
+void ga_init(garray_T *gap, size_t itemsize, unsigned int growsize);
+void ga_grow(garray_T *gap, unsigned int n);
 char_u *ga_concat_strings(garray_T *gap) FUNC_ATTR_NONNULL_RET;
 void ga_remove_duplicate_strings(garray_T *gap);
 void ga_concat(garray_T *gap, char_u *s);


### PR DESCRIPTION
This PR contains a patch for fixing up the member types inside `garray_T`. The point is, that an array can't be of negative size. So we should use the `unsigned` types in here, as well as we should use the `size_t` type for the size of an array element.

This first patch(set) does not compile yet, as the compiler warns about comparison of signed and unsigned integer variables. I am willing to clean these errors up, **if this patch is desired**!

Please tell me what you think about it.
