### PR TITLE
[RDY] Refactor alloc() calls.

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1843,7 +1843,7 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
 
   /* Make a copy of "pat" and change "^" to "\(^\|[\/]\)". */
   if (*pat == '^') {
-    patc = alloc((unsigned)STRLEN(pat) + 11);
+    patc = xmalloc(STRLEN(pat) + 11);
     STRCPY(patc, "\\(^\\|[\\/]\\)");
     STRCPY(patc + 11, pat + 1);
   } else
@@ -1888,7 +1888,7 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
       if (count == 0)           /* no match found, break here */
         break;
       if (round == 1) {
-        *file = (char_u **)alloc((unsigned)(count * sizeof(char_u *)));
+        *file = xmalloc(count * sizeof(**file));
       }
     }
     vim_regfree(prog);
@@ -2520,7 +2520,7 @@ fileinfo (
   char_u      *buffer;
   size_t len;
 
-  buffer = alloc(IOSIZE);
+  buffer = xmalloc(IOSIZE);
 
   if (fullname > 1) {       /* 2 CTRL-G: include buffer number */
     vim_snprintf((char *)buffer, IOSIZE, "buf %d: ", curbuf->b_fnum);
@@ -4285,7 +4285,7 @@ void write_viminfo_bufferlist(FILE *fp)
 
   /* Allocate room for the file name, lnum and col. */
 #define LINE_BUF_LEN (MAXPATHL + 40)
-  line = alloc(LINE_BUF_LEN);
+  line = xmalloc(LINE_BUF_LEN);
 
   FOR_ALL_TAB_WINDOWS(tp, win)
   set_last_cursor(win);

--- a/src/charset.c
+++ b/src/charset.c
@@ -335,13 +335,13 @@ char_u *transstr(char_u *s)
 {
   char_u *res;
   char_u *p;
-  int l, len, c;
+  int l, c;
   char_u hexbuf[11];
 
   if (has_mbyte) {
     // Compute the length of the result, taking account of unprintable
     // multi-byte characters.
-    len = 0;
+    size_t len = 0;
     p = s;
 
     while (*p != '\0') {
@@ -353,7 +353,7 @@ char_u *transstr(char_u *s)
           len += l;
         } else {
           transchar_hex(hexbuf, c);
-          len += (int)STRLEN(hexbuf);
+          len += STRLEN(hexbuf);
         }
       } else {
         l = byte2cells(*p++);
@@ -366,9 +366,9 @@ char_u *transstr(char_u *s)
         }
       }
     }
-    res = alloc((unsigned)(len + 1));
+    res = xmallocz(len);
   } else {
-    res = alloc((unsigned)(vim_strsize(s) + 1));
+    res = xmallocz(vim_strsize(s));
   }
 
   *res = '\0';

--- a/src/diff.c
+++ b/src/diff.c
@@ -462,7 +462,7 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1,
 /// @return The new diff block.
 static diff_T* diff_alloc_new(tabpage_T *tp, diff_T *dprev, diff_T *dp)
 {
-  diff_T *dnew = (diff_T *)alloc((unsigned)sizeof(diff_T));
+  diff_T *dnew = xmalloc(sizeof(*dnew));
 
   dnew->df_next = dp;
   if (dprev == NULL) {
@@ -819,7 +819,7 @@ static void diff_file(char_u *tmp_orig, char_u *tmp_new, char_u *tmp_diff)
   } else {
     size_t len = STRLEN(tmp_orig) + STRLEN(tmp_new) + STRLEN(tmp_diff)
         + STRLEN(p_srr) + 27;
-    char_u *cmd = alloc((unsigned)len);
+    char_u *cmd = xmalloc(len);
 
     /* We don't want $DIFF_OPTIONS to get in the way. */
     if (os_getenv("DIFF_OPTIONS")) {
@@ -895,7 +895,7 @@ void ex_diffpatch(exarg_T *eap)
   size_t buflen = STRLEN(tmp_orig) + (STRLEN(eap->arg)) + STRLEN(tmp_new) + 16;
 #endif  // ifdef UNIX
 
-  buf = alloc((unsigned)buflen);
+  buf = xmalloc(buflen);
 
 #ifdef UNIX
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -1652,11 +1652,9 @@ change_indent (
     if (vcol != (int)curwin->w_virtcol) {
       curwin->w_cursor.col = (colnr_T)new_cursor_col;
       i = (int)curwin->w_virtcol - vcol;
-      ptr = alloc((unsigned)(i + 1));
+      ptr = xmallocz(i);
+      memset(ptr, ' ', i);
       new_cursor_col += i;
-      ptr[i] = '\0';
-      while (--i >= 0)
-        ptr[i] = ' ';
       ins_str(ptr);
       vim_free(ptr);
     }
@@ -1994,7 +1992,7 @@ int ins_compl_add_infercase(char_u *str, int len, int icase, char_u *fname, int 
               ? actual_len : actual_compl_length;
 
     /* Allocate wide character array for the completion and fill it. */
-    wca = (int *)alloc((unsigned)(actual_len * sizeof(int)));
+    wca = xmalloc(actual_len * sizeof(*wca));
     p = str;
     for (i = 0; i < actual_len; ++i)
       if (has_mbyte)
@@ -2080,8 +2078,8 @@ int ins_compl_add_infercase(char_u *str, int len, int icase, char_u *fname, int 
 /*
  * Add a match to the list of matches.
  * If the given string is already in the list of completions, then return
- * NOTDONE, otherwise add it to the list and return OK.  If there is an error,
- * maybe because alloc() returns NULL, then FAIL is returned.
+ * NOTDONE, otherwise add it to the list and return OK.  If there is an error
+ * then FAIL is returned.
  */
 static int 
 ins_compl_add (
@@ -2576,7 +2574,7 @@ ins_compl_dictionaries (
       return;
   }
 
-  buf = alloc(LSIZE);
+  buf = xmalloc(LSIZE);
   regmatch.regprog = NULL;      /* so that we can goto theend */
 
   /* If 'infercase' is set, don't use 'smartcase' here */
@@ -2589,12 +2587,11 @@ ins_compl_dictionaries (
    * pattern. Also need to double backslashes. */
   if (ctrl_x_mode == CTRL_X_WHOLE_LINE) {
     char_u *pat_esc = vim_strsave_escaped(pat, (char_u *)"\\");
-    size_t len;
 
     if (pat_esc == NULL)
       goto theend;
-    len = STRLEN(pat_esc) + 10;
-    ptr = alloc((unsigned)len);
+    size_t len = STRLEN(pat_esc) + 10;
+    ptr = xmalloc(len);
     vim_snprintf((char *)ptr, len, "^\\s*\\zs\\V%s", pat_esc);
     regmatch.regprog = vim_regcomp(ptr, RE_MAGIC);
     vim_free(pat_esc);
@@ -3475,8 +3472,8 @@ static void ins_compl_add_dict(dict_T *dict)
 /*
  * Add a match to the list of matches from a typeval_T.
  * If the given string is already in the list of completions, then return
- * NOTDONE, otherwise add it to the list and return OK.  If there is an error,
- * maybe because alloc() returns NULL, then FAIL is returned.
+ * NOTDONE, otherwise add it to the list and return OK.  If there is an error
+ * then FAIL is returned.
  */
 int ins_compl_add_tv(typval_T *tv, int dir)
 {
@@ -4342,7 +4339,7 @@ static int ins_complete(int c)
         char_u      *prefix = (char_u *)"\\<";
 
         /* we need up to 2 extra chars for the prefix */
-        compl_pattern = alloc(quote_meta(NULL, line + compl_col,
+        compl_pattern = xmalloc(quote_meta(NULL, line + compl_col,
                 compl_length) + 2);
         if (!vim_iswordp(line + compl_col)
             || (compl_col > 0
@@ -4386,14 +4383,14 @@ static int ins_complete(int c)
         if (compl_length == 1) {
           /* Only match word with at least two chars -- webb
            * there's no need to call quote_meta,
-           * alloc(7) is enough  -- Acevedo
+           * xmalloc(7) is enough  -- Acevedo
            */
-          compl_pattern = alloc(7);
+          compl_pattern = xmalloc(7);
           STRCPY((char *)compl_pattern, "\\<");
           (void)quote_meta(compl_pattern + 2, line + compl_col, 1);
           STRCAT((char *)compl_pattern, "\\k");
         } else {
-          compl_pattern = alloc(quote_meta(NULL, line + compl_col,
+          compl_pattern = xmalloc(quote_meta(NULL, line + compl_col,
                   compl_length) + 2);
           STRCPY((char *)compl_pattern, "\\<");
           (void)quote_meta(compl_pattern + 2, line + compl_col,
@@ -5875,7 +5872,7 @@ void set_last_insert(int c)
   char_u      *s;
 
   vim_free(last_insert);
-  last_insert = alloc(MB_MAXBYTES * 3 + 5);
+  last_insert = xmalloc(MB_MAXBYTES * 3 + 5);
   s = last_insert;
   /* Use the CTRL-V only when entering a special char */
   if (c < ' ' || c == DEL)

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -489,12 +489,8 @@ void ex_sort(exarg_T *eap)
   }
 
   /* Allocate a buffer that can hold the longest line. */
-  sortbuf1 = alloc((unsigned)maxlen + 1);
-  if (sortbuf1 == NULL)
-    goto sortend;
-  sortbuf2 = alloc((unsigned)maxlen + 1);
-  if (sortbuf2 == NULL)
-    goto sortend;
+  sortbuf1 = xmalloc(maxlen + 1);
+  sortbuf2 = xmalloc(maxlen + 1);
 
   /* Sort the array of line numbers.  Note: can't be interrupted! */
   qsort((void *)nrs, count, sizeof(sorti_T), sort_compare);
@@ -892,10 +888,7 @@ void do_bang(int addr_count, exarg_T *eap, int forceit, int do_in, int do_out)
       }
       len += (int)STRLEN(prevcmd);
     }
-    if ((t = alloc((unsigned)len)) == NULL) {
-      vim_free(newcmd);
-      return;
-    }
+    t = xmalloc(len);
     *t = '\0';
     if (newcmd != NULL)
       STRCAT(t, newcmd);
@@ -944,9 +937,7 @@ void do_bang(int addr_count, exarg_T *eap, int forceit, int do_in, int do_out)
    * Add quotes around the command, for shells that need them.
    */
   if (*p_shq != '\0') {
-    newcmd = alloc((unsigned)(STRLEN(prevcmd) + 2 * STRLEN(p_shq) + 1));
-    if (newcmd == NULL)
-      return;
+    newcmd = xmalloc(STRLEN(prevcmd) + 2 * STRLEN(p_shq) + 1);
     STRCPY(newcmd, p_shq);
     STRCAT(newcmd, prevcmd);
     STRCAT(newcmd, p_shq);
@@ -1770,8 +1761,7 @@ static void do_viminfo(FILE *fp_in, FILE *fp_out, int flags)
   vir_T vir;
   int merge = FALSE;
 
-  if ((vir.vir_line = alloc(LSIZE)) == NULL)
-    return;
+  vir.vir_line = xmalloc(LSIZE);
   vir.vir_fd = fp_in;
   vir.vir_conv.vc_type = CONV_NONE;
 
@@ -2378,14 +2368,10 @@ check_overwrite (
        * Use 'shortname' of the current buffer, since there is no buffer
        * for the written file. */
       if (*p_dir == '\0') {
-        dir = alloc(5);
-        if (dir == NULL)
-          return FAIL;
+        dir = xmalloc(5);
         STRCPY(dir, ".");
       } else {
-        dir = alloc(MAXPATHL);
-        if (dir == NULL)
-          return FAIL;
+        dir = xmalloc(MAXPATHL);
         p = p_dir;
         copy_option_part(&p, dir, MAXPATHL, ",");
       }
@@ -2725,24 +2711,19 @@ do_ecmd (
 
   if ((command != NULL || newlnum > (linenr_T)0)
       && *get_vim_var_str(VV_SWAPCOMMAND) == '\0') {
-    int len;
     char_u  *p;
 
     /* Set v:swapcommand for the SwapExists autocommands. */
-    if (command != NULL)
-      len = (int)STRLEN(command) + 3;
-    else
-      len = 30;
-    p = alloc((unsigned)len);
-    if (p != NULL) {
-      if (command != NULL)
-        vim_snprintf((char *)p, len, ":%s\r", command);
-      else
-        vim_snprintf((char *)p, len, "%" PRId64 "G", (int64_t)newlnum);
-      set_vim_var_string(VV_SWAPCOMMAND, p, -1);
-      did_set_swapcommand = TRUE;
-      vim_free(p);
+    size_t len = (command != NULL) ? STRLEN(command) + 3 : 30;
+    p = xmalloc(len);
+    if (command != NULL) {
+      vim_snprintf((char *)p, len, ":%s\r", command);
+    } else {
+      vim_snprintf((char *)p, len, "%" PRId64 "G", (int64_t)newlnum);
     }
+    set_vim_var_string(VV_SWAPCOMMAND, p, -1);
+    did_set_swapcommand = TRUE;
+    vim_free(p);
   }
 
   /*
@@ -3861,7 +3842,7 @@ void do_sub(exarg_T *eap)
        *   accordingly.
        *
        * The new text is built up in new_start[].  It has some extra
-       * room to avoid using alloc()/free() too often.  new_start_len is
+       * room to avoid using xmalloc()/free() too often.  new_start_len is
        * the length of the allocated memory at new_start.
        *
        * Make a copy of the old line, so it won't be taken away when
@@ -4178,26 +4159,23 @@ void do_sub(exarg_T *eap)
           /*
            * Get some space for a temporary buffer to do the
            * substitution into (and some extra space to avoid
-           * too many calls to alloc()/free()).
+           * too many calls to xmalloc()/free()).
            */
           new_start_len = needed_len + 50;
-          new_start = (char_u *)xmalloc((size_t)new_start_len);
+          new_start = xmalloc(new_start_len);
           *new_start = '\0';
           new_end = new_start;
         } else {
           /*
            * Check if the temporary buffer is long enough to do the
            * substitution into.  If not, make it larger (with a bit
-           * extra to avoid too many calls to alloc()/free()).
+           * extra to avoid too many calls to xmalloc()/free()).
            */
           len = (unsigned)STRLEN(new_start);
           needed_len += len;
           if (needed_len > (int)new_start_len) {
             new_start_len = needed_len + 50;
-            p1 = (char_u *) xmalloc((size_t)new_start_len);
-            memmove(p1, new_start, (size_t)(len + 1));
-            vim_free(new_start);
-            new_start = p1;
+            new_start = xrealloc(new_start, new_start_len);
           }
           new_end = new_start + len;
         }
@@ -5552,7 +5530,7 @@ helptags_one (
   if (add_help_tags || path_full_compare((char_u *)"$VIMRUNTIME/doc",
           dir, FALSE) == kEqualFiles) {
     ga_grow(&ga, 1);
-    s = alloc(18 + (unsigned)STRLEN(tagfname));
+    s = xmalloc(18 + STRLEN(tagfname));
     sprintf((char *)s, "help-tags\t%s\t1\n", tagfname);
     ((char_u **)ga.ga_data)[ga.ga_len] = s;
     ++ga.ga_len;
@@ -5623,11 +5601,7 @@ helptags_one (
             *p2 = '\0';
             ++p1;
             ga_grow(&ga, 1);
-            s = alloc((unsigned)(p2 - p1 + STRLEN(fname) + 2));
-            if (s == NULL) {
-              got_int = TRUE;
-              break;
-            }
+            s = xmalloc((p2 - p1) + STRLEN(fname) + 2);
             ((char_u **)ga.ga_data)[ga.ga_len] = s;
             ++ga.ga_len;
             sprintf((char *)s, "%s\t%s", p1, fname);
@@ -6100,9 +6074,7 @@ void ex_sign(exarg_T *eap)
 		{			/* ... not currently in a window */
 		    char_u	*cmd;
 
-		    cmd = alloc((unsigned)STRLEN(buf->b_fname) + 25);
-		    if (cmd == NULL)
-			return;
+		    cmd = xmalloc(STRLEN(buf->b_fname) + 25);
 		    sprintf((char *)cmd, "e +%" PRId64 " %s",
                     (int64_t)lnum, buf->b_fname);
 		    do_cmdline_cmd(cmd);

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3569,9 +3569,7 @@ static char_u *replace_makeprg(exarg_T *eap, char_u *p, char_u **cmdlinep)
       while ((pos = (char_u *)strstr((char *)pos + 2, "$*")) != NULL)
         ++i;
       len = (int)STRLEN(p);
-      new_cmdline = alloc((int)(STRLEN(program) + i * (len - 2) + 1));
-      if (new_cmdline == NULL)
-        return NULL;                            /* out of memory */
+      new_cmdline = xmalloc(STRLEN(program) + i * (len - 2) + 1);
       ptr = new_cmdline;
       while ((pos = (char_u *)strstr((char *)program, "$*")) != NULL) {
         i = (int)(pos - program);
@@ -3582,9 +3580,7 @@ static char_u *replace_makeprg(exarg_T *eap, char_u *p, char_u **cmdlinep)
       }
       STRCPY(ptr, program);
     } else {
-      new_cmdline = alloc((int)(STRLEN(program) + STRLEN(p) + 2));
-      if (new_cmdline == NULL)
-        return NULL;                            /* out of memory */
+      new_cmdline = xmalloc(STRLEN(program) + STRLEN(p) + 2);
       STRCPY(new_cmdline, program);
       STRCAT(new_cmdline, " ");
       STRCAT(new_cmdline, p);
@@ -3715,8 +3711,6 @@ int expand_filename(exarg_T *eap, char_u **cmdlinep, char_u **errormsgp)
 
     p = repl_cmdline(eap, p, srclen, repl, cmdlinep);
     vim_free(repl);
-    if (p == NULL)
-      return FAIL;
   }
 
   /*
@@ -3811,7 +3805,6 @@ int expand_filename(exarg_T *eap, char_u **cmdlinep, char_u **errormsgp)
  * "src" points to the part that is to be replaced, of length "srclen".
  * "repl" is the replacement string.
  * Returns a pointer to the character after the replaced string.
- * Returns NULL for failure.
  */
 static char_u *repl_cmdline(exarg_T *eap, char_u *src, int srclen, char_u *repl, char_u **cmdlinep)
 {
@@ -3828,8 +3821,7 @@ static char_u *repl_cmdline(exarg_T *eap, char_u *src, int srclen, char_u *repl,
   i = (int)(src - *cmdlinep) + (int)STRLEN(src + srclen) + len + 3;
   if (eap->nextcmd != NULL)
     i += (int)STRLEN(eap->nextcmd);    /* add space for next command */
-  if ((new_cmdline = alloc((unsigned)i)) == NULL)
-    return NULL;                        /* out of memory! */
+  new_cmdline = xmalloc(i);
 
   /*
    * Copy the stuff before the expanded part.
@@ -4823,11 +4815,7 @@ static char_u *uc_split_args(char_u *arg, size_t *lenp)
     }
   }
 
-  buf = alloc(len + 1);
-  if (buf == NULL) {
-    *lenp = 0;
-    return buf;
-  }
+  buf = xmalloc(len + 1);
 
   p = arg;
   q = buf;
@@ -5142,11 +5130,7 @@ static void do_ucmd(exarg_T *eap)
     }
 
     totlen += STRLEN(p);            /* Add on the trailing characters */
-    buf = alloc((unsigned)(totlen + 1));
-    if (buf == NULL) {
-      vim_free(split_buf);
-      return;
-    }
+    buf = xmalloc(totlen + 1);
   }
 
   current_SID = cmd->uc_scriptID;
@@ -5698,7 +5682,7 @@ static void ex_goto(exarg_T *eap)
  * code is very similar to :args and hence needs access to a lot of the static
  * functions in this file.
  *
- * The list should be allocated using alloc(), as should each item in the
+ * The list should be allocated using xmalloc(), as should each item in the
  * list. This function takes over responsibility for freeing the list.
  *
  * XXX The list is made into the argument list. This is freed using
@@ -5806,14 +5790,9 @@ void alist_unlink(alist_T *al)
  */
 void alist_new(void)
 {
-  curwin->w_alist = (alist_T *)alloc((unsigned)sizeof(alist_T));
-  if (curwin->w_alist == NULL) {
-    curwin->w_alist = &global_alist;
-    ++global_alist.al_refcount;
-  } else {
-    curwin->w_alist->al_refcount = 1;
-    alist_init(curwin->w_alist);
-  }
+  curwin->w_alist = xmalloc(sizeof(*curwin->w_alist));
+  curwin->w_alist->al_refcount = 1;
+  alist_init(curwin->w_alist);
 }
 
 #if !defined(UNIX) || defined(PROTO)
@@ -5835,19 +5814,17 @@ void alist_expand(int *fnum_list, int fnum_len)
    * expansion.  Also, the vimrc file isn't read yet, thus the user
    * can't set the options. */
   p_su = empty_option;
-  old_arg_files = (char_u **)alloc((unsigned)(sizeof(char_u *) * GARGCOUNT));
-  if (old_arg_files != NULL) {
-    for (i = 0; i < GARGCOUNT; ++i)
-      old_arg_files[i] = vim_strsave(GARGLIST[i].ae_fname);
-    old_arg_count = GARGCOUNT;
-    if (expand_wildcards(old_arg_count, old_arg_files,
-            &new_arg_file_count, &new_arg_files,
-            EW_FILE|EW_NOTFOUND|EW_ADDSLASH|EW_NOERROR) == OK
-        && new_arg_file_count > 0) {
-      alist_set(&global_alist, new_arg_file_count, new_arg_files,
-          TRUE, fnum_list, fnum_len);
-      FreeWild(old_arg_count, old_arg_files);
-    }
+  old_arg_files = xmalloc(sizeof(*old_arg_files) * GARGCOUNT);
+  for (i = 0; i < GARGCOUNT; ++i)
+    old_arg_files[i] = vim_strsave(GARGLIST[i].ae_fname);
+  old_arg_count = GARGCOUNT;
+  if (expand_wildcards(old_arg_count, old_arg_files,
+          &new_arg_file_count, &new_arg_files,
+          EW_FILE|EW_NOTFOUND|EW_ADDSLASH|EW_NOERROR) == OK
+      && new_arg_file_count > 0) {
+    alist_set(&global_alist, new_arg_file_count, new_arg_files,
+        TRUE, fnum_list, fnum_len);
+    FreeWild(old_arg_count, old_arg_files);
   }
   p_su = save_p_su;
 }
@@ -7287,37 +7264,33 @@ static void ex_mkrc(exarg_T *eap)
       if (eap->cmdidx == CMD_mksession) {
         char_u *dirnow;          /* current directory */
 
-        dirnow = alloc(MAXPATHL);
-        if (dirnow == NULL)
-          failed = TRUE;
-        else {
-          /*
-           * Change to session file's dir.
-           */
-          if (os_dirname(dirnow, MAXPATHL) == FAIL
-              || os_chdir((char *)dirnow) != 0)
-            *dirnow = '\0';
-          if (*dirnow != '\0' && (ssop_flags & SSOP_SESDIR)) {
-            if (vim_chdirfile(fname) == OK)
-              shorten_fnames(TRUE);
-          } else if (*dirnow != '\0'
-                     && (ssop_flags & SSOP_CURDIR) && globaldir != NULL) {
-            if (os_chdir((char *)globaldir) == 0)
-              shorten_fnames(TRUE);
-          }
-
-          failed |= (makeopens(fd, dirnow) == FAIL);
-
-          /* restore original dir */
-          if (*dirnow != '\0' && ((ssop_flags & SSOP_SESDIR)
-                                 || ((ssop_flags & SSOP_CURDIR) && globaldir !=
-                                     NULL))) {
-            if (os_chdir((char *)dirnow) != 0)
-              EMSG(_(e_prev_dir));
+        dirnow = xmalloc(MAXPATHL);
+        /*
+         * Change to session file's dir.
+         */
+        if (os_dirname(dirnow, MAXPATHL) == FAIL
+            || os_chdir((char *)dirnow) != 0)
+          *dirnow = '\0';
+        if (*dirnow != '\0' && (ssop_flags & SSOP_SESDIR)) {
+          if (vim_chdirfile(fname) == OK)
             shorten_fnames(TRUE);
-          }
-          vim_free(dirnow);
+        } else if (*dirnow != '\0'
+                   && (ssop_flags & SSOP_CURDIR) && globaldir != NULL) {
+          if (os_chdir((char *)globaldir) == 0)
+            shorten_fnames(TRUE);
         }
+
+        failed |= (makeopens(fd, dirnow) == FAIL);
+
+        /* restore original dir */
+        if (*dirnow != '\0' && ((ssop_flags & SSOP_SESDIR)
+                               || ((ssop_flags & SSOP_CURDIR) && globaldir !=
+                                   NULL))) {
+          if (os_chdir((char *)dirnow) != 0)
+            EMSG(_(e_prev_dir));
+          shorten_fnames(TRUE);
+        }
+        vim_free(dirnow);
       } else {
         failed |= (put_view(fd, curwin, !using_vdir, flagp,
                        -1) == FAIL);
@@ -7343,12 +7316,10 @@ static void ex_mkrc(exarg_T *eap)
       /* successful session write - set this_session var */
       char_u      *tbuf;
 
-      tbuf = alloc(MAXPATHL);
-      if (tbuf != NULL) {
-        if (vim_FullName(fname, tbuf, MAXPATHL, FALSE) == OK)
-          set_vim_var_string(VV_THIS_SESSION, tbuf, -1);
-        vim_free(tbuf);
-      }
+      tbuf = xmalloc(MAXPATHL);
+      if (vim_FullName(fname, tbuf, MAXPATHL, FALSE) == OK)
+        set_vim_var_string(VV_THIS_SESSION, tbuf, -1);
+      vim_free(tbuf);
     }
 #ifdef MKSESSION_NL
     mksession_nl = FALSE;
@@ -7478,20 +7449,18 @@ static void ex_normal(exarg_T *eap)
           len += 2;
     }
     if (len > 0) {
-      arg = alloc((unsigned)(STRLEN(eap->arg) + len + 1));
-      if (arg != NULL) {
-        len = 0;
-        for (p = eap->arg; *p != '\0'; ++p) {
-          arg[len++] = *p;
-          for (l = (*mb_ptr2len)(p) - 1; l > 0; --l) {
-            arg[len++] = *++p;
-            if (*p == K_SPECIAL) {
-              arg[len++] = KS_SPECIAL;
-              arg[len++] = KE_FILLER;
-            }
+      arg = xmalloc(STRLEN(eap->arg) + len + 1);
+      len = 0;
+      for (p = eap->arg; *p != '\0'; ++p) {
+        arg[len++] = *p;
+        for (l = (*mb_ptr2len)(p) - 1; l > 0; --l) {
+          arg[len++] = *++p;
+          if (*p == K_SPECIAL) {
+            arg[len++] = KS_SPECIAL;
+            arg[len++] = KE_FILLER;
           }
-          arg[len] = '\0';
         }
+        arg[len] = '\0';
       }
     }
   }
@@ -8038,7 +8007,6 @@ eval_vars (
  * Concatenate all files in the argument list, separated by spaces, and return
  * it in one allocated string.
  * Spaces and backslashes in the file names are escaped with a backslash.
- * Returns NULL when out of memory.
  */
 static char_u *arg_all(void)
 {
@@ -8084,9 +8052,7 @@ static char_u *arg_all(void)
     }
 
     /* allocate memory */
-    retval = alloc((unsigned)len + 1);
-    if (retval == NULL)
-      break;
+    retval = xmalloc(len + 1);
   }
 
   return retval;
@@ -8128,12 +8094,7 @@ char_u *expand_sfile(char_u *arg)
         continue;
       }
       len = (int)STRLEN(result) - srclen + (int)STRLEN(repl) + 1;
-      newres = alloc(len);
-      if (newres == NULL) {
-        vim_free(repl);
-        vim_free(result);
-        return NULL;
-      }
+      newres = xmalloc(len);
       memmove(newres, result, (size_t)(p - result));
       STRCPY(newres + (p - result), repl);
       len = (int)STRLEN(newres);
@@ -8777,11 +8738,9 @@ ses_arglist (
     s = alist_name(&((aentry_T *)gap->ga_data)[i]);
     if (s != NULL) {
       if (fullname) {
-        buf = alloc(MAXPATHL);
-        if (buf != NULL) {
-          (void)vim_FullName(s, buf, MAXPATHL, FALSE);
-          s = buf;
-        }
+        buf = xmalloc(MAXPATHL);
+        (void)vim_FullName(s, buf, MAXPATHL, FALSE);
+        s = buf;
       }
       if (fputs("argadd ", fd) < 0 || ses_put_fname(fd, s, flagp) == FAIL
           || put_eol(fd) == FAIL) {
@@ -8900,30 +8859,28 @@ static char_u *get_view_file(int c)
   for (p = sname; *p; ++p)
     if (*p == '=' || vim_ispathsep(*p))
       ++len;
-  retval = alloc((unsigned)(STRLEN(sname) + len + STRLEN(p_vdir) + 9));
-  if (retval != NULL) {
-    STRCPY(retval, p_vdir);
-    add_pathsep(retval);
-    s = retval + STRLEN(retval);
-    for (p = sname; *p; ++p) {
-      if (*p == '=') {
-        *s++ = '=';
-        *s++ = '=';
-      } else if (vim_ispathsep(*p)) {
-        *s++ = '=';
+  retval = xmalloc(STRLEN(sname) + len + STRLEN(p_vdir) + 9);
+  STRCPY(retval, p_vdir);
+  add_pathsep(retval);
+  s = retval + STRLEN(retval);
+  for (p = sname; *p; ++p) {
+    if (*p == '=') {
+      *s++ = '=';
+      *s++ = '=';
+    } else if (vim_ispathsep(*p)) {
+      *s++ = '=';
 #if defined(BACKSLASH_IN_FILENAME)
-        if (*p == ':')
-          *s++ = '-';
-        else
+      if (*p == ':')
+        *s++ = '-';
+      else
 #endif
-        *s++ = '+';
-      } else
-        *s++ = *p;
-    }
-    *s++ = '=';
-    *s++ = c;
-    STRCPY(s, ".vim");
+      *s++ = '+';
+    } else
+      *s++ = *p;
   }
+  *s++ = '=';
+  *s++ = c;
+  STRCPY(s, ".vim");
 
   vim_free(sname);
   return retval;


### PR DESCRIPTION
Converting calls to `alloc` to `xmalloc` or `xmallocz`. I will leave any `alloc` call that has non-trivial error handling. Those will have to refactored in a separate PR.

Other refactorings:
- don't cast the return value of xmalloc
- let the compiler implicitly cast the arguments to xmalloc
- replace `sizeof(actual_type)` with `sizeof(*lhs)`
