### PR TITLE
[RDY] Remove shortname option and support for filesystems that limit the length of filenames to 8 characters

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -466,9 +466,7 @@ void buf_clear_file(buf_T *buf)
 {
   buf->b_ml.ml_line_count = 1;
   unchanged(buf, TRUE);
-#ifndef SHORT_FNAME
   buf->b_shortname = FALSE;
-#endif
   buf->b_p_eol = TRUE;
   buf->b_start_eol = TRUE;
   buf->b_p_bomb = FALSE;
@@ -2273,9 +2271,6 @@ setfname (
       return FAIL;
     }
 #ifdef USE_FNAME_CASE
-# ifdef USE_LONG_FNAME
-    if (USE_LONG_FNAME)
-# endif
     fname_case(sfname, 0);            /* set correct case for short file name */
 #endif
     vim_free(buf->b_ffname);
@@ -2294,9 +2289,7 @@ setfname (
   }
 #endif
 
-#ifndef SHORT_FNAME
   buf->b_shortname = FALSE;
-#endif
 
   buf_name_changed(buf);
   return OK;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -466,7 +466,6 @@ void buf_clear_file(buf_T *buf)
 {
   buf->b_ml.ml_line_count = 1;
   unchanged(buf, TRUE);
-  buf->b_shortname = FALSE;
   buf->b_p_eol = TRUE;
   buf->b_start_eol = TRUE;
   buf->b_p_bomb = FALSE;
@@ -2288,8 +2287,6 @@ setfname (
     buf->b_ino = st.st_ino;
   }
 #endif
-
-  buf->b_shortname = FALSE;
 
   buf_name_changed(buf);
   return OK;

--- a/src/buffer_defs.h
+++ b/src/buffer_defs.h
@@ -596,7 +596,6 @@ struct file_buffer {
   char_u      *b_p_qe;          /* 'quoteescape' */
   int b_p_ro;                   /* 'readonly' */
   long b_p_sw;                  /* 'shiftwidth' */
-  int b_p_sn;                   /* 'shortname' */
   int b_p_si;                   /* 'smartindent' */
   long b_p_sts;                 /* 'softtabstop' */
   long b_p_sts_nopaste;          /* b_p_sts saved for paste mode */
@@ -697,8 +696,6 @@ struct file_buffer {
   int b_spell;                  /* TRUE for a spell file buffer, most fields
                                    are not used!  Use the B_SPELL macro to
                                    access b_spell without #ifdef. */
-
-  int b_shortname;              /* this file has an 8.3 file name */
 
   synblock_T b_s;               /* Info related to syntax highlighting.  w_s
                                  * normally points to this, but some windows

--- a/src/buffer_defs.h
+++ b/src/buffer_defs.h
@@ -596,9 +596,7 @@ struct file_buffer {
   char_u      *b_p_qe;          /* 'quoteescape' */
   int b_p_ro;                   /* 'readonly' */
   long b_p_sw;                  /* 'shiftwidth' */
-#ifndef SHORT_FNAME
   int b_p_sn;                   /* 'shortname' */
-#endif
   int b_p_si;                   /* 'smartindent' */
   long b_p_sts;                 /* 'softtabstop' */
   long b_p_sts_nopaste;          /* b_p_sts saved for paste mode */
@@ -700,9 +698,7 @@ struct file_buffer {
                                    are not used!  Use the B_SPELL macro to
                                    access b_spell without #ifdef. */
 
-#ifndef SHORT_FNAME
   int b_shortname;              /* this file has an 8.3 file name */
-#endif
 
   synblock_T b_s;               /* Info related to syntax highlighting.  w_s
                                  * normally points to this, but some windows

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1569,44 +1569,14 @@ void write_viminfo(char_u *file, int forceit)
     }
 #endif
 
-    /*
-     * Make tempname.
-     * May try twice: Once normal and once with shortname set, just in
-     * case somebody puts his viminfo file in an 8.3 filesystem.
-     */
-    for (;; ) {
-      tempname = buf_modname(
-#ifdef UNIX
-          shortname,
-#else
-          FALSE,
-#endif
-          fname,
-          (char_u *)".tmp",
-          FALSE);
-      if (tempname == NULL)                     /* out of memory */
-        break;
-
+    // Make tempname
+    tempname = buf_modname(FALSE, fname, (char_u *)".tmp", FALSE);
+    if (tempname != NULL) {
       /*
        * Check if tempfile already exists.  Never overwrite an
        * existing file!
        */
       if (mch_stat((char *)tempname, &st_new) == 0) {
-#ifdef UNIX
-        /*
-         * Check if tempfile is same as original file.  May happen
-         * when modname() gave the same file back.  E.g.  silly
-         * link, or file name-length reached.  Try again with
-         * shortname set.
-         */
-        if (!shortname && st_new.st_dev == st_old.st_dev
-            && st_new.st_ino == st_old.st_ino) {
-          vim_free(tempname);
-          tempname = NULL;
-          shortname = TRUE;
-          continue;
-        }
-#endif
         /*
          * Try another name.  Change one character, just before
          * the extension.  This should also work for an 8.3
@@ -1629,7 +1599,6 @@ void write_viminfo(char_u *file, int forceit)
           }
         }
       }
-      break;
     }
 
     if (tempname != NULL) {

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1569,7 +1569,7 @@ void write_viminfo(char_u *file, int forceit)
 #endif
 
     // Make tempname
-    tempname = buf_modname(fname, (char_u *)".tmp", FALSE);
+    tempname = modname(fname, (char_u *)".tmp", FALSE);
     if (tempname != NULL) {
       /*
        * Check if tempfile already exists.  Never overwrite an

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1569,7 +1569,7 @@ void write_viminfo(char_u *file, int forceit)
 #endif
 
     // Make tempname
-    tempname = buf_modname(FALSE, fname, (char_u *)".tmp", FALSE);
+    tempname = buf_modname(fname, (char_u *)".tmp", FALSE);
     if (tempname != NULL) {
       /*
        * Check if tempfile already exists.  Never overwrite an

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1510,7 +1510,6 @@ void write_viminfo(char_u *file, int forceit)
   mode_t umask_save;
 #endif
 #ifdef UNIX
-  int shortname = FALSE;                /* use 8.3 file name */
   struct stat st_old;           /* mch_stat() of existing viminfo file */
 #endif
 
@@ -1579,9 +1578,7 @@ void write_viminfo(char_u *file, int forceit)
       if (mch_stat((char *)tempname, &st_new) == 0) {
         /*
          * Try another name.  Change one character, just before
-         * the extension.  This should also work for an 8.3
-         * file name, when after adding the extension it still is
-         * the same file as the original.
+         * the extension.
          */
         wp = tempname + STRLEN(tempname) - 5;
         if (wp < path_tail(tempname))                 /* empty file name? */

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1579,11 +1579,7 @@ void write_viminfo(char_u *file, int forceit)
 #ifdef UNIX
           shortname,
 #else
-# ifdef SHORT_FNAME
-          TRUE,
-# else
           FALSE,
-# endif
 #endif
           fname,
           (char_u *)".tmp",
@@ -2659,9 +2655,6 @@ do_ecmd (
     if (sfname == NULL)
       sfname = ffname;
 #ifdef USE_FNAME_CASE
-# ifdef USE_LONG_FNAME
-    if (USE_LONG_FNAME)
-# endif
     if (sfname != NULL)
       fname_case(sfname, 0);             /* set correct case for sfname */
 #endif

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3039,7 +3039,7 @@ buf_write (
           /*
            * Make backup file name.
            */
-          backup = buf_modname(FALSE, rootname, backup_ext, FALSE);
+          backup = buf_modname(rootname, backup_ext, FALSE);
           if (backup == NULL) {
             vim_free(rootname);
             some_error = TRUE;                          /* out of memory */
@@ -3215,7 +3215,7 @@ nobackup:
         if (rootname == NULL)
           backup = NULL;
         else {
-          backup = buf_modname(FALSE, rootname, backup_ext, FALSE);
+          backup = buf_modname(rootname, backup_ext, FALSE);
           vim_free(rootname);
         }
 
@@ -3852,7 +3852,7 @@ restore_backup:
    * the backup file our 'original' file.
    */
   if (*p_pm && dobackup) {
-    char *org = (char *)buf_modname(FALSE, fname, p_pm, FALSE);
+    char *org = (char *)buf_modname(fname, p_pm, FALSE);
 
     if (backup != NULL) {
       struct stat st;
@@ -4644,12 +4644,11 @@ modname (
     int prepend_dot                /* may prepend a '.' to file name */
 )
 {
-  return buf_modname(FALSE, fname, ext, prepend_dot);
+  return buf_modname(fname, ext, prepend_dot);
 }
 
 char_u *
 buf_modname (
-    int shortname,           // use 8.3 file name, should always be FALSE now
     char_u *fname,
     char_u *ext,
     int prepend_dot                /* may prepend a '.' to file name */
@@ -4662,8 +4661,6 @@ buf_modname (
   int fnamelen, extlen;
 
   extlen = (int)STRLEN(ext);
-
-  assert(!shortname);
 
   /*
    * If there is no file name we must get the name of the current directory

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3039,7 +3039,7 @@ buf_write (
           /*
            * Make backup file name.
            */
-          backup = buf_modname(rootname, backup_ext, FALSE);
+          backup = modname(rootname, backup_ext, FALSE);
           if (backup == NULL) {
             vim_free(rootname);
             some_error = TRUE;                          /* out of memory */
@@ -3215,7 +3215,7 @@ nobackup:
         if (rootname == NULL)
           backup = NULL;
         else {
-          backup = buf_modname(rootname, backup_ext, FALSE);
+          backup = modname(rootname, backup_ext, FALSE);
           vim_free(rootname);
         }
 
@@ -3852,7 +3852,7 @@ restore_backup:
    * the backup file our 'original' file.
    */
   if (*p_pm && dobackup) {
-    char *org = (char *)buf_modname(fname, p_pm, FALSE);
+    char *org = (char *)modname(fname, p_pm, FALSE);
 
     if (backup != NULL) {
       struct stat st;
@@ -4639,16 +4639,6 @@ void shorten_fnames(int force)
  */
 char_u *
 modname (
-    char_u *fname,
-    char_u *ext,
-    int prepend_dot                /* may prepend a '.' to file name */
-)
-{
-  return buf_modname(fname, ext, prepend_dot);
-}
-
-char_u *
-buf_modname (
     char_u *fname,
     char_u *ext,
     int prepend_dot                /* may prepend a '.' to file name */

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -2997,7 +2997,7 @@ buf_write (
       struct stat st_new;
       char_u      *dirp;
       char_u      *rootname;
-#if defined(UNIX) && !defined(SHORT_FNAME)
+#if defined(UNIX)
       int did_set_shortname;
 #endif
 
@@ -3038,7 +3038,7 @@ buf_write (
           goto nobackup;
         }
 
-#if defined(UNIX) && !defined(SHORT_FNAME)
+#if defined(UNIX)
         did_set_shortname = FALSE;
 #endif
 
@@ -3050,11 +3050,7 @@ buf_write (
            * Make backup file name.
            */
           backup = buf_modname(
-#ifdef SHORT_FNAME
-              TRUE,
-#else
               (buf->b_p_sn || buf->b_shortname),
-#endif
               rootname, backup_ext, FALSE);
           if (backup == NULL) {
             vim_free(rootname);
@@ -3078,7 +3074,6 @@ buf_write (
                 && st_new.st_ino == st_old.st_ino) {
               vim_free(backup);
               backup = NULL;                    /* no backup file to delete */
-# ifndef SHORT_FNAME
               /*
                * may try again with 'shortname' set
                */
@@ -3090,7 +3085,6 @@ buf_write (
               /* setting shortname didn't help */
               if (did_set_shortname)
                 buf->b_shortname = FALSE;
-# endif
               break;
             }
 #endif
@@ -3248,11 +3242,7 @@ nobackup:
           backup = NULL;
         else {
           backup = buf_modname(
-#ifdef SHORT_FNAME
-              TRUE,
-#else
               (buf->b_p_sn || buf->b_shortname),
-#endif
               rootname, backup_ext, FALSE);
           vim_free(rootname);
         }
@@ -3891,11 +3881,7 @@ restore_backup:
    */
   if (*p_pm && dobackup) {
     char *org = (char *)buf_modname(
-#ifdef SHORT_FNAME
-        TRUE,
-#else
         (buf->b_p_sn || buf->b_shortname),
-#endif
         fname, p_pm, FALSE);
 
     if (backup != NULL) {
@@ -4690,11 +4676,7 @@ modname (
 )
 {
   return buf_modname(
-#ifdef SHORT_FNAME
-      TRUE,
-#else
       (curbuf->b_p_sn || curbuf->b_shortname),
-#endif
       fname, ext, prepend_dot);
 }
 
@@ -4729,9 +4711,7 @@ buf_modname (
       retval[fnamelen++] = PATHSEP;
       retval[fnamelen] = NUL;
     }
-#ifndef SHORT_FNAME
     prepend_dot = FALSE;            /* nothing to prepend a dot to */
-#endif
   } else {
     fnamelen = (int)STRLEN(fname);
     retval = alloc((unsigned)(fnamelen + extlen + 3));
@@ -4745,13 +4725,7 @@ buf_modname (
    */
   for (ptr = retval + fnamelen; ptr > retval; mb_ptr_back(retval, ptr)) {
     if (*ext == '.'
-#ifdef USE_LONG_FNAME
-        && (!USE_LONG_FNAME || shortname)
-#else
-# ifndef SHORT_FNAME
         && shortname
-# endif
-#endif
         )
       if (*ptr == '.')          /* replace '.' by '_' */
         *ptr = '_';
@@ -4762,23 +4736,15 @@ buf_modname (
   }
 
   /* the file name has at most BASENAMELEN characters. */
-#ifndef SHORT_FNAME
   if (STRLEN(ptr) > (unsigned)BASENAMELEN)
     ptr[BASENAMELEN] = '\0';
-#endif
 
   s = ptr + STRLEN(ptr);
 
   /*
    * For 8.3 file names we may have to reduce the length.
    */
-#ifdef USE_LONG_FNAME
-  if (!USE_LONG_FNAME || shortname)
-#else
-# ifndef SHORT_FNAME
   if (shortname)
-# endif
-#endif
   {
     /*
      * If there is no file name, or the file name ends in '/', and the
@@ -4813,7 +4779,7 @@ buf_modname (
     else if ((int)STRLEN(e) + extlen > 4)
       s = e + 4 - extlen;
   }
-#if defined(USE_LONG_FNAME) || defined(WIN3264)
+#if defined(WIN3264)
   /*
    * If there is no file name, and the extension starts with '.', put a
    * '_' before the dot, because just ".ext" may be invalid if it's on a
@@ -4829,19 +4795,14 @@ buf_modname (
    */
   STRCPY(s, ext);
 
-#ifndef SHORT_FNAME
   /*
    * Prepend the dot.
    */
   if (prepend_dot && !shortname && *(e = path_tail(retval)) != '.'
-#ifdef USE_LONG_FNAME
-      && USE_LONG_FNAME
-#endif
       ) {
     STRMOVE(e + 1, e);
     *e = '.';
   }
-#endif
 
   /*
    * Check that, after appending the extension, the file name is really

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -35,8 +35,7 @@ void msg_add_fname(buf_T *buf, char_u *fname);
 void msg_add_lines(int insert_space, long lnum, off_t nchars);
 void shorten_fnames(int force);
 char_u *modname(char_u *fname, char_u *ext, int prepend_dot);
-char_u *buf_modname(int shortname, char_u *fname, char_u *ext,
-                    int prepend_dot);
+char_u *buf_modname(char_u *fname, char_u *ext, int prepend_dot);
 int vim_fgets(char_u *buf, int size, FILE *fp);
 int tag_fgets(char_u *buf, int size, FILE *fp);
 int vim_rename(char_u *from, char_u *to);

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -35,7 +35,6 @@ void msg_add_fname(buf_T *buf, char_u *fname);
 void msg_add_lines(int insert_space, long lnum, off_t nchars);
 void shorten_fnames(int force);
 char_u *modname(char_u *fname, char_u *ext, int prepend_dot);
-char_u *buf_modname(char_u *fname, char_u *ext, int prepend_dot);
 int vim_fgets(char_u *buf, int size, FILE *fp);
 int tag_fgets(char_u *buf, int size, FILE *fp);
 int vim_rename(char_u *from, char_u *to);

--- a/src/memline.c
+++ b/src/memline.c
@@ -1610,9 +1610,7 @@ recover_names (
       struct stat st;
       char_u          *swapname;
 
-      swapname = modname(fname_res,
-          (char_u *)".swp", TRUE
-          );
+      swapname = modname(fname_res, (char_u *)".swp", TRUE);
       if (swapname != NULL) {
         if (mch_stat((char *)swapname, &st) != -1) {                /* It exists! */
           files = (char_u **)alloc((unsigned)sizeof(char_u *));
@@ -3372,8 +3370,8 @@ char_u *makeswapname(char_u *fname, char_u *ffname, buf_T *buf, char_u *dir_name
 #endif
 
   // Prepend a '.' to the swap file name for the current directory.
-  r = buf_modname(fname_res, (char_u *)".swp",
-                  dir_name[0] == '.' && dir_name[1] == NUL);
+  r = modname(fname_res, (char_u *)".swp",
+              dir_name[0] == '.' && dir_name[1] == NUL);
   if (r == NULL)            /* out of memory */
     return NULL;
 

--- a/src/memline.c
+++ b/src/memline.c
@@ -3371,14 +3371,9 @@ char_u *makeswapname(char_u *fname, char_u *ffname, buf_T *buf, char_u *dir_name
     fname_res = fname_buf;
 #endif
 
-  r = buf_modname(
-      FALSE,
-      fname_res,
-      (char_u *)
-      ".swp",
-      /* Prepend a '.' to the swap file name for the current directory. */
-      dir_name[0] == '.' && dir_name[1] == NUL
-      );
+  // Prepend a '.' to the swap file name for the current directory.
+  r = buf_modname(fname_res, (char_u *)".swp",
+                  dir_name[0] == '.' && dir_name[1] == NUL);
   if (r == NULL)            /* out of memory */
     return NULL;
 

--- a/src/option.c
+++ b/src/option.c
@@ -150,7 +150,6 @@
 # define PV_QE          OPT_BUF(BV_QE)
 #define PV_RO           OPT_BUF(BV_RO)
 # define PV_SI          OPT_BUF(BV_SI)
-# define PV_SN          OPT_BUF(BV_SN)
 # define PV_SMC         OPT_BUF(BV_SMC)
 # define PV_SYN         OPT_BUF(BV_SYN)
 # define PV_SPC         OPT_BUF(BV_SPC)
@@ -263,7 +262,6 @@ static int p_pi;
 static char_u   *p_qe;
 static int p_ro;
 static int p_si;
-static int p_sn;
 static long p_sts;
 static char_u   *p_sua;
 static long p_sw;
@@ -1414,9 +1412,6 @@ static struct vimoption
    (char_u *)&p_shm, PV_NONE,
    {(char_u *)"", (char_u *)"filnxtToO"}
    SCRIPTID_INIT},
-  {"shortname",   "sn",   P_BOOL|P_VI_DEF,
-   (char_u *)&p_sn, PV_SN,
-   {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"showbreak",   "sbr",  P_STRING|P_VI_DEF|P_RALL,
    (char_u *)&p_sbr, PV_NONE,
    {(char_u *)"", (char_u *)0L} SCRIPTID_INIT},
@@ -6777,7 +6772,6 @@ static char_u *get_varp(struct vimoption *p)
   case PV_QE:     return (char_u *)&(curbuf->b_p_qe);
   case PV_RO:     return (char_u *)&(curbuf->b_p_ro);
   case PV_SI:     return (char_u *)&(curbuf->b_p_si);
-  case PV_SN:     return (char_u *)&(curbuf->b_p_sn);
   case PV_STS:    return (char_u *)&(curbuf->b_p_sts);
   case PV_SUA:    return (char_u *)&(curbuf->b_p_sua);
   case PV_SWF:    return (char_u *)&(curbuf->b_p_swf);
@@ -7003,7 +6997,6 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_ofu = vim_strsave(p_ofu);
       buf->b_p_sts = p_sts;
       buf->b_p_sts_nopaste = p_sts_nopaste;
-      buf->b_p_sn = p_sn;
       buf->b_p_com = vim_strsave(p_com);
       buf->b_p_cms = vim_strsave(p_cms);
       buf->b_p_fo = vim_strsave(p_fo);

--- a/src/option.c
+++ b/src/option.c
@@ -150,9 +150,7 @@
 # define PV_QE          OPT_BUF(BV_QE)
 #define PV_RO           OPT_BUF(BV_RO)
 # define PV_SI          OPT_BUF(BV_SI)
-#ifndef SHORT_FNAME
 # define PV_SN          OPT_BUF(BV_SN)
-#endif
 # define PV_SMC         OPT_BUF(BV_SMC)
 # define PV_SYN         OPT_BUF(BV_SYN)
 # define PV_SPC         OPT_BUF(BV_SPC)
@@ -265,9 +263,7 @@ static int p_pi;
 static char_u   *p_qe;
 static int p_ro;
 static int p_si;
-#ifndef SHORT_FNAME
 static int p_sn;
-#endif
 static long p_sts;
 static char_u   *p_sua;
 static long p_sw;
@@ -1419,11 +1415,7 @@ static struct vimoption
    {(char_u *)"", (char_u *)"filnxtToO"}
    SCRIPTID_INIT},
   {"shortname",   "sn",   P_BOOL|P_VI_DEF,
-#ifdef SHORT_FNAME
-   (char_u *)NULL, PV_NONE,
-#else
    (char_u *)&p_sn, PV_SN,
-#endif
    {(char_u *)FALSE, (char_u *)0L} SCRIPTID_INIT},
   {"showbreak",   "sbr",  P_STRING|P_VI_DEF|P_RALL,
    (char_u *)&p_sbr, PV_NONE,
@@ -6785,9 +6777,7 @@ static char_u *get_varp(struct vimoption *p)
   case PV_QE:     return (char_u *)&(curbuf->b_p_qe);
   case PV_RO:     return (char_u *)&(curbuf->b_p_ro);
   case PV_SI:     return (char_u *)&(curbuf->b_p_si);
-#ifndef SHORT_FNAME
   case PV_SN:     return (char_u *)&(curbuf->b_p_sn);
-#endif
   case PV_STS:    return (char_u *)&(curbuf->b_p_sts);
   case PV_SUA:    return (char_u *)&(curbuf->b_p_sua);
   case PV_SWF:    return (char_u *)&(curbuf->b_p_swf);
@@ -7013,9 +7003,7 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_ofu = vim_strsave(p_ofu);
       buf->b_p_sts = p_sts;
       buf->b_p_sts_nopaste = p_sts_nopaste;
-#ifndef SHORT_FNAME
       buf->b_p_sn = p_sn;
-#endif
       buf->b_p_com = vim_strsave(p_com);
       buf->b_p_cms = vim_strsave(p_cms);
       buf->b_p_fo = vim_strsave(p_fo);

--- a/src/option_defs.h
+++ b/src/option_defs.h
@@ -691,9 +691,7 @@ enum {
   , BV_QE
   , BV_RO
   , BV_SI
-#ifndef SHORT_FNAME
   , BV_SN
-#endif
   , BV_SMC
   , BV_SYN
   , BV_SPC

--- a/src/option_defs.h
+++ b/src/option_defs.h
@@ -691,7 +691,6 @@ enum {
   , BV_QE
   , BV_RO
   , BV_SI
-  , BV_SN
   , BV_SMC
   , BV_SYN
   , BV_SPC

--- a/src/path.c
+++ b/src/path.c
@@ -1580,12 +1580,8 @@ char_u *fix_fname(char_u *fname)
   fname = vim_strsave(fname);
 
 # ifdef USE_FNAME_CASE
-#  ifdef USE_LONG_FNAME
-  if (USE_LONG_FNAME)
-#  endif
-  {
-    if (fname != NULL)
-      fname_case(fname, 0);             /* set correct case for file name */
+  if (fname != NULL) {
+    fname_case(fname, 0);             /* set correct case for file name */
   }
 # endif
 


### PR DESCRIPTION
Justification: it's 2014.

This PR also includes a commit from #605. I suggested that @watk removed `shortname` support in that same PR as I think it makes more sense to remove the `SHORT_FNAME` and `USE_LONG_FNAME` macros along with the `shortname` support.
