### PR TITLE
[RDY] vim-patch:7.4.265

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -7317,28 +7317,34 @@ call_func (
 
   /* execute the function if no errors detected and executing */
   if (evaluate && error == ERROR_NONE) {
+    char_u *rfname = fname;
+
+    /* Ignore "g:" before a function name. */
+    if (fname[0] == 'g' && fname[1] == ':') {
+      rfname = fname + 2;
+    }
+
     rettv->v_type = VAR_NUMBER;         /* default rettv is number zero */
     rettv->vval.v_number = 0;
     error = ERROR_UNKNOWN;
 
-    if (!builtin_function(fname, -1)) {
+    if (!builtin_function(rfname, -1)) {
       /*
        * User defined function.
        */
-      fp = find_func(fname);
+      fp = find_func(rfname);
 
       /* Trigger FuncUndefined event, may load the function. */
       if (fp == NULL
-          && apply_autocmds(EVENT_FUNCUNDEFINED,
-              fname, fname, TRUE, NULL)
+          && apply_autocmds(EVENT_FUNCUNDEFINED, rfname, rfname, TRUE, NULL)
           && !aborting()) {
         /* executed an autocommand, search for the function again */
-        fp = find_func(fname);
+        fp = find_func(rfname);
       }
       /* Try loading a package. */
-      if (fp == NULL && script_autoload(fname, TRUE) && !aborting()) {
+      if (fp == NULL && script_autoload(rfname, TRUE) && !aborting()) {
         /* loaded a package, search for the function again */
-        fp = find_func(fname);
+        fp = find_func(rfname);
       }
 
       if (fp != NULL) {

--- a/src/testdir/test_eval.in
+++ b/src/testdir/test_eval.in
@@ -24,18 +24,20 @@ STARTTEST
 :  let @c = v:exception
 :endtry
 :" function name starting with/without "g:", buffer-local funcref.
-:function! g:Foo()
-:  let @d = 'called Foo()'
+:function! g:Foo(n)
+:  let @d = 'called Foo(' . a:n . ')'
 :endfunction
 :let b:my_func = function('Foo')
-:let @d = 'xxx'
-:call b:my_func()
-:endfunction
 :" clean up
 :%d
 :pu a
 :pu b
 :pu c
+:call b:my_func(1)
+:pu d
+:echo g:Foo(2)
+:pu d
+:echo Foo(3)
 :pu d
 :1d
 :wq! test.out

--- a/src/testdir/test_eval.ok
+++ b/src/testdir/test_eval.ok
@@ -1,4 +1,6 @@
 Vim(function):E128: Function name must start with a capital or "s:": g:test()
 Vim(function):E128: Function name must start with a capital or "s:": test2() "#
 Vim(function):E128: Function name must start with a capital or "s:": b:test()
-called Foo()
+called Foo(1)
+called Foo(2)
+called Foo(3)

--- a/src/version.c
+++ b/src/version.c
@@ -202,7 +202,7 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
-  //265,
+  265,
   264,
   //263,
   //262,


### PR DESCRIPTION
```
Problem:    Can't call a global function with "g:" in an expression.
Solution:   Skip the "g:" when looking up the function.
```

https://code.google.com/p/vim/source/detail?r=8ec9d2196bee0c5108f2d2c196a660a7f4e5f29f
