### PR TITLE
[RDY] vim-patch:7.4.266

### DIFF
--- a/src/testdir/test62.in
+++ b/src/testdir/test62.in
@@ -2,6 +2,7 @@ Tests for tab pages
 
 STARTTEST
 :so small.vim
+:lang C
 :" Simple test for opening and closing a tab page
 :tabnew
 :let nr = tabpagenr()

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,11 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  //270,
+  //269,
+  //268,
+  //267,
+  266,
   265,
   264,
   //263,


### PR DESCRIPTION
```
Problem:  Test 62 fails.
Solution: Set the language to C. (Christian Brabandt)
```

https://code.google.com/p/vim/source/detail?r=8f84e906d454a95d3167678a745dde9de442b604
