### PR TITLE
[RDY] vim-patch:7.4.269

### DIFF
--- a/src/testdir/test29.in
+++ b/src/testdir/test29.in
@@ -102,6 +102,34 @@ if (condition) // Remove the next comment leader!
 }
 
 STARTTEST
+:" Test with backspace set to the non-compatible setting
+/^\d\+ this
+:set cp bs=2
+Avim1
+Avim2u
+:set cpo-=<
+:inoremap <c-u> <left><c-u>
+Avim3
+:iunmap <c-u>
+Avim4
+:" Test with backspace set to the compatible setting
+:set bs=
+A vim5A
+A vim6Azweiu
+:inoremap <c-u> <left><c-u>
+A vim7
+:set cp
+ENDTEST
+1 this shouldn't be deleted
+2 this shouldn't be deleted
+3 this shouldn't be deleted
+4 this should be deleted
+5 this shouldn't be deleted
+6 this shouldn't be deleted
+7 this shouldn't be deleted
+8 this shouldn't be deleted (not touched yet)
+
+STARTTEST
 /^{/+1
 :set comments=sO:*\ -,mO:*\ \ ,exO:*/
 :set comments+=s1:/*,mb:*,ex:*/,://

--- a/src/testdir/test29.ok
+++ b/src/testdir/test29.ok
@@ -62,6 +62,15 @@ if (condition) // Remove the next comment leader! OK, I will.
     action();
 }
 
+1 this shouldn't be deleted
+2 this shouldn't be deleted
+3 this shouldn't be deleted
+4 this should be deleted3
+
+6 this shouldn't be deleted vim5
+7 this shouldn't be deleted vim6
+8 this shouldn't be deleted (not touched yet) vim7
+
 
 {
 /* Make sure the previous comment leader is not removed.  */

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,11 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  //270,
+  269,
+  //268,
+  //267,
+  //266,
   265,
   264,
   //263,


### PR DESCRIPTION
```
Problem:  CTRL-U in Insert mode does not work after using a cursor key.
          (Pine Wu)
Solution: Use the original insert start position. (Christian Brabandt)
```

https://code.google.com/p/vim/source/detail?r=81c26975e8f9dc7435353581346542409403f296
