### PR TITLE
[RDY] vim-patch:7.4.268

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -17929,6 +17929,13 @@ trans_function_name (
   if (name != NULL) {
     name = vim_strsave(name);
     *pp = end;
+    if (strncmp((char *)name, "<SNR>", 5) == 0) {
+      // Change "<SNR>" to the byte sequence.
+      name[0] = K_SPECIAL;
+      name[1] = KS_EXTRA;
+      name[2] = (int)KE_SNR;
+      memmove(name + 3, name + 5, strlen((char *)name + 5) + 1);
+    }
     goto theend;
   }
 

--- a/src/testdir/test_eval.in
+++ b/src/testdir/test_eval.in
@@ -36,7 +36,10 @@ STARTTEST
 :echo g:Foo(2)
 :echo Foo(3)
 
-:$-5,$w! test.out
+:" script-local function used in Funcref must exist.
+:so test_eval_func.vim
+
+:$-9,$w! test.out
 :q!
 
 ENDTEST

--- a/src/testdir/test_eval.in
+++ b/src/testdir/test_eval.in
@@ -1,45 +1,43 @@
 STARTTEST
+
 :" function name not starting with a capital
 :try
 :  func! g:test()
 :    echo "test"
 :  endfunc
 :catch
-:  let @a = v:exception
+:  $put =v:exception
 :endtry
+
 :" function name folowed by #
 :try
 :  func! test2() "#
 :    echo "test2"
 :  endfunc
 :catch
-:  let @b = v:exception
+:  $put =v:exception
 :endtry
+
 :" function name includes a colon
 :try
 :  func! b:test()
 :    echo "test"
 :  endfunc
 :catch
-:  let @c = v:exception
+:  $put =v:exception
 :endtry
+
 :" function name starting with/without "g:", buffer-local funcref.
 :function! g:Foo(n)
-:  let @d = 'called Foo(' . a:n . ')'
+:  $put ='called Foo(' . a:n . ')'
 :endfunction
 :let b:my_func = function('Foo')
-:" clean up
-:%d
-:pu a
-:pu b
-:pu c
 :call b:my_func(1)
-:pu d
 :echo g:Foo(2)
-:pu d
 :echo Foo(3)
-:pu d
-:1d
-:wq! test.out
+
+:$-5,$w! test.out
+:q!
+
 ENDTEST
-start:
+

--- a/src/testdir/test_eval.ok
+++ b/src/testdir/test_eval.ok
@@ -4,3 +4,7 @@ Vim(function):E128: Function name must start with a capital or "s:": b:test()
 called Foo(1)
 called Foo(2)
 called Foo(3)
+s:Testje exists: 0
+func s:Testje exists: 1
+Bar exists: 1
+func Bar exists: 1

--- a/src/testdir/test_eval_func.vim
+++ b/src/testdir/test_eval_func.vim
@@ -1,0 +1,12 @@
+" Vim script used in test_eval.in.  Needed for script-local function.
+
+func! s:Testje()
+  return "foo"
+endfunc
+
+let Bar = function('s:Testje')
+
+$put ='s:Testje exists: ' . exists('s:Testje')
+$put ='func s:Testje exists: ' . exists('*s:Testje')
+$put ='Bar exists: ' . exists('Bar')
+$put ='func Bar exists: ' . exists('*Bar')

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,11 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  //270,
+  //269,
+  268,
+  //267,
+  //266,
   265,
   264,
   //263,


### PR DESCRIPTION
```
Problem:  Using exists() on a funcref for a script-local function
          does not work.
Solution: Translate <SNR> to the special byte sequence.
          Add a test.
```

https://code.google.com/p/vim/source/detail?r=1a5ed2626b26a982e307a206572121a557adf709

---

I also "refactored" `test_eval.in` to not use registers anymore. Let's see if this ends these scruffy clang asan errors.
