### PR TITLE
[RDY] vim-patch:7.4.272

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -6718,45 +6718,50 @@ string2float (
   return (int)((char_u *)s - text);
 }
 
-/*
- * Get the value of an environment variable.
- * "arg" is pointing to the '$'.  It is advanced to after the name.
- * If the environment variable was not set, silently assume it is empty.
- * Always return OK.
- */
+/// Get the value of an environment variable.
+///
+/// If the environment variable was not set, silently assume it is empty.
+///
+/// @param arg Points to the '$'.  It is advanced to after the name.
+/// @return FAIL if the name is invalid.
+///
 static int get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
 {
-  char_u      *string = NULL;
-  int len;
-  int cc;
-  char_u      *name;
-  int mustfree = FALSE;
+  char_u *name;
+  char_u *string = NULL;
+  int     mustfree = FALSE;
+  int     len;
+  int     cc;
 
   ++*arg;
   name = *arg;
   len = get_env_len(arg);
-  if (evaluate) {
-    if (len != 0) {
-      cc = name[len];
-      name[len] = NUL;
-      /* first try vim_getenv(), fast for normal environment vars */
-      string = vim_getenv(name, &mustfree);
-      if (string != NULL && *string != NUL) {
-        if (!mustfree)
-          string = vim_strsave(string);
-      } else {
-        if (mustfree)
-          vim_free(string);
 
-        /* next try expanding things like $VIM and ${HOME} */
-        string = expand_env_save(name - 1);
-        if (string != NULL && *string == '$') {
-          vim_free(string);
-          string = NULL;
-        }
-      }
-      name[len] = cc;
+  if (evaluate) {
+    if (len == 0) {
+      return FAIL;  // Can't be an environment variable.
     }
+    cc = name[len];
+    name[len] = '\0';
+    // First try vim_getenv(), fast for normal environment vars.
+    string = vim_getenv(name, &mustfree);
+    if (string != NULL && *string != '\0') {
+      if (!mustfree) {
+        string = vim_strsave(string);
+      }
+    } else {
+      if (mustfree) {
+        vim_free(string);
+      }
+
+      // Next try expanding things like $VIM and ${HOME}.
+      string = expand_env_save(name - 1);
+      if (string != NULL && *string == '$') {
+        vim_free(string);
+        string = NULL;
+      }
+    }
+    name[len] = cc;
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = string;
   }

--- a/src/testdir/test_eval.in
+++ b/src/testdir/test_eval.in
@@ -39,7 +39,14 @@ STARTTEST
 :" script-local function used in Funcref must exist.
 :so test_eval_func.vim
 
-:$-9,$w! test.out
+:" using $ instead of '$' must give an error
+:try
+:  call append($, 'foobar')
+:catch
+:  $put =v:exception
+:endtry
+
+:$-10,$w! test.out
 :q!
 
 ENDTEST

--- a/src/testdir/test_eval.ok
+++ b/src/testdir/test_eval.ok
@@ -8,3 +8,4 @@ s:Testje exists: 0
 func s:Testje exists: 1
 Bar exists: 1
 func Bar exists: 1
+Vim(call):E116: Invalid arguments for function append

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,9 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  //273,
+  272,
+  //271,
   //270,
   269,
   268,


### PR DESCRIPTION
```
Problem:  Using just "$" does not cause an error message.
Solution: Check for empty environment variable name.
          (Christian Brabandt)
```

https://code.google.com/p/vim/source/detail?r=00228400629e28384f7f52556c3c119ba0d0a44d
