### PR TITLE
[RFC] Generate a lua module to help pass build-related settings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,16 +136,22 @@ if(NOT BUSTED_OUTPUT_TYPE)
 endif()
 
 if(BUSTED_PRG)
-  get_target_property(NVIM_TEST_LIB nvim-test LOCATION)
+  get_property(TEST_INCLUDE_DIRS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    PROPERTY INCLUDE_DIRECTORIES)
+  get_target_property(TEST_LIBNVIM_PATH nvim-test LOCATION)
+
+  configure_file(
+    test/config/paths.lua.in
+    ${CMAKE_BINARY_DIR}/test/config/paths.lua)
+
   add_custom_target(unittest
     COMMAND ${CMAKE_COMMAND}
       -DBUSTED_PRG=${BUSTED_PRG}
       -DLUA_PRG=${LUA_PRG}
       -DWORKING_DIR=${CMAKE_CURRENT_SOURCE_DIR}
-      -DNVIM_TEST_LIB=${NVIM_TEST_LIB}
       -DBUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
       -DTEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test
-      -DTEST_INCLUDES=${CMAKE_BINARY_DIR}/test/includes/post
+      -DBUILD_DIR=${CMAKE_BINARY_DIR}
       -P ${CMAKE_MODULE_PATH}/RunUnittests.cmake
     DEPENDS nvim-test unittest-headers)
 endif()

--- a/cmake/RunUnittests.cmake
+++ b/cmake/RunUnittests.cmake
@@ -1,13 +1,11 @@
 get_filename_component(BUSTED_DIR ${BUSTED_PRG} PATH)
 set(ENV{PATH} "${BUSTED_DIR}:$ENV{PATH}")
-set(ENV{NVIM_TEST_LIB} ${NVIM_TEST_LIB})
-set(ENV{TEST_INCLUDES} ${TEST_INCLUDES})
 if(DEFINED ENV{TEST_FILE})
   set(TEST_DIR $ENV{TEST_FILE})
 endif()
 
 execute_process(
-  COMMAND ${BUSTED_PRG} -o ${BUSTED_OUTPUT_TYPE} --pattern=.moon ${TEST_DIR}
+  COMMAND ${BUSTED_PRG} -o ${BUSTED_OUTPUT_TYPE} --lpath=${BUILD_DIR}/?.lua --pattern=.moon ${TEST_DIR}
   WORKING_DIRECTORY ${WORKING_DIR}
   RESULT_VARIABLE res)
 

--- a/test/config/paths.lua.in
+++ b/test/config/paths.lua.in
@@ -1,0 +1,11 @@
+local module = {}
+
+module.include_paths = {}
+for p in ("${TEST_INCLUDE_DIRS}" .. ";"):gmatch("[^;]+") do
+  table.insert(module.include_paths, p)
+end
+
+module.test_include_path = "${CMAKE_BINARY_DIR}/test/includes/post"
+module.test_libnvim_path = "${TEST_LIBNVIM_PATH}"
+
+return module

--- a/test/unit/helpers.moon
+++ b/test/unit/helpers.moon
@@ -3,24 +3,14 @@ lpeg = require 'lpeg'
 formatc = require 'test.unit.formatc'
 Set = require 'test.unit.set'
 Preprocess = require 'test.unit.preprocess'
+Paths = require 'test.config.paths'
 
 -- add some standard header locations
--- TODO(aktau, jszakmeister): optionally pass more header locations via env
-Preprocess.add_to_include_path('./src')
-Preprocess.add_to_include_path('./.deps/usr/include')
-Preprocess.add_to_include_path('./build/config')
-
-if ffi.abi('32bit')
-  Preprocess.add_to_include_path('/opt/neovim-deps/32/include')
-else
-  Preprocess.add_to_include_path('/opt/neovim-deps/include')
+for i,p in ipairs(Paths.include_paths)
+  Preprocess.add_to_include_path(p)
 
 -- load neovim shared library
-testlib = os.getenv 'NVIM_TEST_LIB'
-unless testlib
-    testlib = './build/src/libnvim-test.so'
-
-libnvim = ffi.load testlib
+libnvim = ffi.load Paths.test_libnvim_path
 
 trim = (s) ->
   s\match'^%s*(.*%S)' or ''
@@ -91,12 +81,8 @@ cimport = (...) ->
 
   return libnvim
 
-testinc = os.getenv 'TEST_INCLUDES'
-unless testinc
-    testinc = './build/test/includes/post'
-
 cppimport = (path) ->
-  return cimport testinc .. '/' .. path
+  return cimport Paths.test_include_path .. '/' .. path
 
 cimport './src/types.h'
 


### PR DESCRIPTION
This allows us to avoid hard-coding paths and using environment
variables to communicate key information to unit tests, which fits
with the overall goal of making sure that folks driving CMake directly
can continue to do out-of-tree builds.

This in response to discussions in #639.
