### PR TITLE
[RDY] Remove project-specific integer types: short_u, int_u, long_i.

### DIFF
--- a/src/buffer_defs.h
+++ b/src/buffer_defs.h
@@ -378,7 +378,7 @@ typedef struct {
   synstate_T  *b_sst_firstfree;
   int b_sst_freecount;
   linenr_T b_sst_check_lnum;
-  short_u b_sst_lasttick;       /* last display tick */
+  uint16_t b_sst_lasttick;      /* last display tick */
 
   /* for spell checking */
   garray_T b_langp;             /* list of pointers to slang_T, see spell.c */
@@ -774,7 +774,7 @@ struct tabpage_S {
  */
 typedef struct w_line {
   linenr_T wl_lnum;             /* buffer line number for logical line */
-  short_u wl_size;              /* height in screen lines */
+  uint16_t wl_size;             /* height in screen lines */
   char wl_valid;                /* TRUE values are valid for text in buffer */
   char wl_folded;               /* TRUE when this is a range of folded lines */
   linenr_T wl_lastlnum;         /* last buffer line number for logical line */

--- a/src/memline.c
+++ b/src/memline.c
@@ -100,9 +100,9 @@ struct pointer_entry {
  * A pointer block contains a list of branches in the tree.
  */
 struct pointer_block {
-  short_u pb_id;                /* ID for pointer block: PTR_ID */
-  short_u pb_count;             /* number of pointers in this block */
-  short_u pb_count_max;         /* maximum value for pb_count */
+  uint16_t pb_id;               /* ID for pointer block: PTR_ID */
+  uint16_t pb_count;            /* number of pointers in this block */
+  uint16_t pb_count_max;        /* maximum value for pb_count */
   PTR_EN pb_pointer[1];         /* list of pointers to blocks (actually longer)
                                  * followed by empty space until end of page */
 };
@@ -115,7 +115,7 @@ struct pointer_block {
  * etc. Thus the order of the lines is the opposite of the line number.
  */
 struct data_block {
-  short_u db_id;                /* ID for data block: DATA_ID */
+  uint16_t db_id;               /* ID for data block: DATA_ID */
   unsigned db_free;             /* free space available */
   unsigned db_txt_start;        /* byte where text starts */
   unsigned db_txt_end;          /* byte just after data block */
@@ -3011,8 +3011,7 @@ static bhdr_T *ml_new_ptr(memfile_T *mfp)
   pp = (PTR_BL *)(hp->bh_data);
   pp->pb_id = PTR_ID;
   pp->pb_count = 0;
-  pp->pb_count_max = (short_u)((mfp->mf_page_size - sizeof(PTR_BL))
-                               / sizeof(PTR_EN) + 1);
+  pp->pb_count_max = (mfp->mf_page_size - sizeof(PTR_BL)) / sizeof(PTR_EN) + 1;
 
   return hp;
 }

--- a/src/normal.c
+++ b/src/normal.c
@@ -218,7 +218,7 @@ typedef void (*nv_func_T)(cmdarg_T *cap);
 static const struct nv_cmd {
   int cmd_char;                 /* (first) command character */
   nv_func_T cmd_func;           /* function for this command */
-  short_u cmd_flags;            /* NV_ flags */
+  uint16_t cmd_flags;           /* NV_ flags */
   short cmd_arg;                /* value for ca.arg */
 } nv_cmds[] =
 {

--- a/src/option.c
+++ b/src/option.c
@@ -2231,16 +2231,14 @@ set_option_default (
       if (options[opt_idx].indir == PV_SCROLL)
         win_comp_scroll(curwin);
       else {
-        *(long *)varp = (long)(long_i)options[opt_idx].def_val[dvi];
+        *(long *)varp = (long)options[opt_idx].def_val[dvi];
         /* May also set global value for local option. */
         if (both)
           *(long *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL) =
             *(long *)varp;
       }
     } else {  /* P_BOOL */
-      /* the cast to long is required for Manx C, long_i is needed for
-       * MSVC */
-      *(int *)varp = (int)(long)(long_i)options[opt_idx].def_val[dvi];
+      *(int *)varp = (int)(intptr_t)options[opt_idx].def_val[dvi];
 #ifdef UNIX
       /* 'modeline' defaults to off for root */
       if (options[opt_idx].indir == PV_ML && getuid() == ROOT_UID)
@@ -2312,7 +2310,7 @@ void set_number_default(char *name, long val)
 
   opt_idx = findoption((char_u *)name);
   if (opt_idx >= 0)
-    options[opt_idx].def_val[VI_DEFAULT] = (char_u *)(long_i)val;
+    options[opt_idx].def_val[VI_DEFAULT] = (char_u *)val;
 }
 
 #if defined(EXITFREE) || defined(PROTO)
@@ -2554,13 +2552,13 @@ void set_title_defaults(void)
   idx1 = findoption((char_u *)"title");
   if (idx1 >= 0 && !(options[idx1].flags & P_WAS_SET)) {
     val = mch_can_restore_title();
-    options[idx1].def_val[VI_DEFAULT] = (char_u *)(long_i)val;
+    options[idx1].def_val[VI_DEFAULT] = (char_u *)val;
     p_title = val;
   }
   idx1 = findoption((char_u *)"icon");
   if (idx1 >= 0 && !(options[idx1].flags & P_WAS_SET)) {
     val = mch_can_restore_icon();
-    options[idx1].def_val[VI_DEFAULT] = (char_u *)(long_i)val;
+    options[idx1].def_val[VI_DEFAULT] = (char_u *)val;
     p_icon = val;
   }
 }
@@ -2853,7 +2851,7 @@ do_set (
           if (nextchar == '!')
             value = *(int *)(varp) ^ 1;
           else if (nextchar == '&')
-            value = (int)(long)(long_i)options[opt_idx].def_val[
+            value = (int)(intptr_t)options[opt_idx].def_val[
               ((flags & P_VI_DEF) || cp_val)
               ?  VI_DEFAULT : VIM_DEFAULT];
           else if (nextchar == '<') {
@@ -2900,7 +2898,7 @@ do_set (
              */
             ++arg;
             if (nextchar == '&')
-              value = (long)(long_i)options[opt_idx].def_val[
+              value = (long)options[opt_idx].def_val[
                 ((flags & P_VI_DEF) || cp_val)
                 ?  VI_DEFAULT : VIM_DEFAULT];
             else if (nextchar == '<') {
@@ -6189,11 +6187,9 @@ static int optval_default(struct vimoption *p, char_u *varp)
     return TRUE;            /* hidden option is always at default */
   dvi = ((p->flags & P_VI_DEF) || p_cp) ? VI_DEFAULT : VIM_DEFAULT;
   if (p->flags & P_NUM)
-    return *(long *)varp == (long)(long_i)p->def_val[dvi];
+    return *(long *)varp == (long)p->def_val[dvi];
   if (p->flags & P_BOOL)
-    /* the cast to long is required for Manx C, long_i is
-     * needed for MSVC */
-    return *(int *)varp == (int)(long)(long_i)p->def_val[dvi];
+    return *(int *)varp == (int)(intptr_t)p->def_val[dvi];
   /* P_STRING */
   return STRCMP(*(char_u **)varp, p->def_val[dvi]) == 0;
 }

--- a/src/spell.c
+++ b/src/spell.c
@@ -568,7 +568,7 @@ typedef struct langp_S {
 static char_u   *int_wordlist = NULL;
 
 typedef struct wordcount_S {
-  short_u wc_count;                 // nr of times word was seen
+  uint16_t wc_count;                // nr of times word was seen
   char_u wc_word[1];                // word, actually longer
 } wordcount_T;
 
@@ -4252,7 +4252,7 @@ struct wordnode_S {
   // In the soundfolded word tree "wn_flags" has the MSW of the wordnr and
   // "wn_region" the LSW of the wordnr.
   char_u wn_affixID;            // supported/required prefix ID or 0
-  short_u wn_flags;             // WF_ flags
+  uint16_t wn_flags;            // WF_ flags
   short wn_region;              // region mask
 
 #ifdef SPELL_PRINTTREE
@@ -7236,7 +7236,7 @@ put_node (
           // associated condition nr (stored in wn_region).  The
           // byte value is misused to store the "rare" and "not
           // combining" flags
-          if (np->wn_flags == (short_u)PFX_FLAGS)
+          if (np->wn_flags == (uint16_t)PFX_FLAGS)
             putc(BY_NOFLAGS, fd);                       // <byte>
           else {
             putc(BY_FLAGS, fd);                         // <byte>

--- a/src/syntax_defs.h
+++ b/src/syntax_defs.h
@@ -69,8 +69,8 @@ typedef struct attr_entry {
     } term;
     struct {
       /* These colors need to be > 8 bits to hold 256. */
-      short_u fg_color;                 /* foreground color number */
-      short_u bg_color;                 /* background color number */
+      uint16_t fg_color;                /* foreground color number */
+      uint16_t bg_color;                /* background color number */
     } cterm;
   } ae_u;
 } attrentry_T;

--- a/src/types.h
+++ b/src/types.h
@@ -15,7 +15,6 @@
  * already defined, so we use char_u to avoid trouble.
  */
 typedef unsigned char char_u;
-typedef unsigned short short_u;
 typedef unsigned int int_u;
 
 #endif /* NEOVIM_TYPES_H */

--- a/src/types.h
+++ b/src/types.h
@@ -15,6 +15,5 @@
  * already defined, so we use char_u to avoid trouble.
  */
 typedef unsigned char char_u;
-typedef unsigned int int_u;
 
 #endif /* NEOVIM_TYPES_H */

--- a/src/ui.h
+++ b/src/ui.h
@@ -21,7 +21,7 @@ int clip_isautosel_plus(void);
 void clip_modeless(int button, int is_click, int is_drag);
 void clip_start_selection(int col, int row, int repeated_click);
 void clip_process_selection(int button, int col, int row,
-                            int_u repeated_click);
+                            uint32_t repeated_click);
 void clip_may_redraw_selection(int row, int col, int len);
 void clip_clear_selection(VimClipboard *cbd);
 void clip_may_clear_selection(int row1, int row2);

--- a/src/vim.h
+++ b/src/vim.h
@@ -71,17 +71,10 @@ Error: configure did not run properly.Check auto/config.log.
 
 #define NUMBUFLEN 30        /* length of a buffer to store a number in ASCII */
 
-/* Make sure long_u is big enough to hold a pointer.
- * On Win64, longs are 32 bits and pointers are 64 bits.
- * For printf() and scanf(), we need to take care of long_u specifically. */
-/* Microsoft-specific. The __w64 keyword should be specified on any typedefs
- * that change size between 32-bit and 64-bit platforms.  For any such type,
- * __w64 should appear only on the 32-bit definition of the typedef.
- * Define __w64 as an empty token for everything but MSVC 7.x or later.
- */
-#  define __w64
-typedef unsigned long __w64 long_u;
-typedef          long __w64 long_i;
+// Make sure long_u is big enough to hold a pointer.
+// On Win64, longs are 32 bits and pointers are 64 bits.
+// For printf() and scanf(), we need to take care of long_u specifically.
+typedef unsigned long long_u;
 
 /*
  * The characters and attributes cached for the screen.


### PR DESCRIPTION
This is the first of a series of PR's aiming to remove project-specific typedefs for integer types, as requested in #459.

This PR deals with `short_u`, `int_u`, and `long_i`. See commit messages for details.

I'm now working on `long_u`, but that will take a while, and I'll open another PR for that.
