### PR TITLE
Remove incorrect trailing backslash

### DIFF
--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -50,7 +50,7 @@ ifdef USE_VALGRIND
 	                 --error-exitcode=123                \
 	                 --log-file=valgrind.\%p.$*          \
 	                 $(VGDB)                             \
-	                 --trace-children=yes                \
+	                 --trace-children=yes
 else
 	ifdef USE_GDB
 		TOOL = gdb --args


### PR DESCRIPTION
If this backslash is here and USE_VALGRIND is defined, valgrind complains that "else" is not a command.
