### PR TITLE
test33: Disable cp and instead set cpo=p

### DIFF
--- a/src/testdir/test33.in
+++ b/src/testdir/test33.in
@@ -3,6 +3,8 @@ If the lisp feature is not enabled, this will fail!
 
 STARTTEST
 :so small.vim
+:set nocp
+:set cpo=p
 :set lisp
 /^(defun
 =G:/^(defun/,$w! test.out


### PR DESCRIPTION
The test has whitespace differences with nocp, so explicitly set cpo=p in order to get the expected whitespace.

It might be a better idea though to simply update the expected output instead of setting cpo=p. Any opinions on that?
