### PR TITLE
[RDY] Added missing #define guards in headers

### DIFF
--- a/src/if_cscope_defs.h
+++ b/src/if_cscope_defs.h
@@ -1,3 +1,6 @@
+#ifndef NEOVIM_IF_CSCOPE_DEFS_H
+#define NEOVIM_IF_CSCOPE_DEFS_H
+
 /*
  * CSCOPE support for Vim added by Andy Kahn <kahn@zk3.dec.com>
  * Ported to Win32 by Sergey Khorev <sergey.khorev@gmail.com>
@@ -66,6 +69,4 @@ typedef enum {
   Print
 } mcmd_e;
 
-
-
-/* the end */
+#endif  // NEOVIM_IF_CSCOPE_DEFS_H

--- a/src/macros.h
+++ b/src/macros.h
@@ -1,3 +1,6 @@
+#ifndef NEOVIM_MACROS_H
+#define NEOVIM_MACROS_H
+
 /*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
@@ -159,3 +162,5 @@
 # define PTR2CHAR(p)        (has_mbyte ? mb_ptr2char(p) : (int)*(p))
 
 # define RESET_BINDING(wp)  (wp)->w_p_scb = FALSE; (wp)->w_p_crb = FALSE
+
+#endif  // NEOVIM_MACROS_H

--- a/src/os_unix_defs.h
+++ b/src/os_unix_defs.h
@@ -1,3 +1,6 @@
+#ifndef NEOVIM_OS_UNIX_DEFS_H
+#define NEOVIM_OS_UNIX_DEFS_H
+
 /*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
@@ -277,3 +280,5 @@
 
 /* We have three kinds of ACL support. */
 #define HAVE_ACL (HAVE_POSIX_ACL || HAVE_SOLARIS_ACL || HAVE_AIX_ACL)
+
+#endif  // NEOVIM_OS_UNIX_DEFS_H

--- a/src/proto.h
+++ b/src/proto.h
@@ -1,3 +1,6 @@
+#ifndef NEOVIM_PROTO_H
+#define NEOVIM_PROTO_H
+
 /*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
@@ -42,3 +45,5 @@ vim_snprintf(char *, size_t, char *, ...);
 int vim_vsnprintf(char *str, size_t str_m, char *fmt, va_list ap, typval_T *tvs);
 
 #endif /* !PROTO && !NOPROTO */
+
+#endif  // NEOVIM_PROTO_H

--- a/src/regexp_defs.h
+++ b/src/regexp_defs.h
@@ -9,8 +9,8 @@
  * NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE
  */
 
-#ifndef _REGEXP_H
-#define _REGEXP_H
+#ifndef NEOVIM_REGEXP_DEFS_H
+#define NEOVIM_REGEXP_DEFS_H
 
 #include "pos.h"
 
@@ -146,4 +146,4 @@ struct regengine {
 #endif
 };
 
-#endif  /* _REGEXP_H */
+#endif  // NEOVIM_REGEXP_DEFS_H

--- a/src/term_defs.h
+++ b/src/term_defs.h
@@ -1,3 +1,6 @@
+#ifndef NEOVIM_TERM_DEFS_H
+#define NEOVIM_TERM_DEFS_H
+
 /*
  * VIM - Vi IMproved	by Bram Moolenaar
  *
@@ -153,3 +156,5 @@ extern char_u *(term_strings[]);    /* current terminal strings */
 #define TMODE_COOK  0   /* terminal mode for external cmds and Ex mode */
 #define TMODE_SLEEP 1   /* terminal mode for sleeping (cooked but no echo) */
 #define TMODE_RAW   2   /* terminal mode for Normal and Insert mode */
+
+#endif  // NEOVIM_TERM_DEFS_H

--- a/src/version_defs.h
+++ b/src/version_defs.h
@@ -1,3 +1,6 @@
+#ifndef NEOVIM_VERSION_DEFS_H
+#define NEOVIM_VERSION_DEFS_H
+
 /*
  * VIM - Vi IMproved		by Bram Moolenaar
  *
@@ -40,3 +43,5 @@
 
 /* Displayed on splash screen. */
 #define MODIFIED_BY "the Neovim contributors."
+
+#endif  // NEOVIM_VERSION_DEFS_H


### PR DESCRIPTION
While playing with [include-what-you-use](https://code.google.com/p/include-what-you-use/) proposed by @aktau in #549, I noticed that not all headers contain the `#define guards`.
I added guards to all except `ex_cmds_defs.h` because

``` cpp
/*
 * This file defines the Ex commands.
 * When DO_DECLARE_EXCMD is defined, the table with ex command names and
 * options results.
 * When DO_DECLARE_EXCMD is NOT defined, the enum with all the Ex commands
 * results.
 * This clever trick was invented by Ron Aaron.
 */
```

And if I add guard to that file then compilation fails. This "clever trick" looks to me like "ugly hack", but I don't know how to avoid it in the simple way.
