### PR TITLE
[RDY] Fix unit test cleanup of path_shorten_fname_if_possible.

### DIFF
--- a/test/unit/path.moon
+++ b/test/unit/path.moon
@@ -113,10 +113,11 @@ describe 'path function', ->
       eq 'directory/file.txt', (ffi.string path.path_shorten_fname full, dir)
 
 describe 'path_shorten_fname_if_possible', ->
+  cwd = lfs.currentdir!
   before_each ->
       lfs.mkdir 'ut_directory'
   after_each ->
-      lfs.chdir '..'
+      lfs.chdir cwd
       lfs.rmdir 'ut_directory'
 
   describe 'path_shorten_fname_if_possible', ->


### PR DESCRIPTION
Currently the cleanup of `path_shorten_fname_if_possible` fails and leaves the empty directory `ut_directory` in the root of the project, because `after_each` assumes that each test enters the named directory, which is not true for the last test.
