### PR TITLE
[RDY] Improve test_eval.in

### DIFF
--- a/src/testdir/test_eval.in
+++ b/src/testdir/test_eval.in
@@ -1,5 +1,8 @@
 STARTTEST
 
+:e test.out
+:%d
+
 :" function name not starting with a capital
 :try
 :  func! g:test()
@@ -46,8 +49,9 @@ STARTTEST
 :  $put =v:exception
 :endtry
 
-:$-10,$w! test.out
-:q!
+:1d
+:w
+:qa!
 
 ENDTEST
 


### PR DESCRIPTION
The old version required to change the range given to `:w` for each new
test. Now a new buffer is used instead.

Looking at Vim's `test_eval.in`, which got quite big, it's better to be safe now than sorry later.
