### PR TITLE
Do not detect macros like VIM_TRUE as boolean values

### DIFF
--- a/clint.py
+++ b/clint.py
@@ -2802,7 +2802,7 @@ def CheckLanguage(filename, clean_lines, linenum, file_extension,
             "('k' followed by CamelCase) compile-time constant for the size.")
 
   # Detect TRUE and FALSE.
-  match = Search(r'(TRUE|FALSE)', line)
+  match = Search(r'\b(TRUE|FALSE)\b', line)
   if match:
     token = match.group(1)
     error(filename, linenum, 'readability/bool', 4,


### PR DESCRIPTION
I use VIM_TRUE macros set (in different times) to `vim.number.new(state, 1)`, `vim.true` and `vim.true_`, but clint detects them as boolean values and suggests to use `true`/`false`.
