### PR TITLE
[RDY] vim-patch:7.4.274

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5118,6 +5118,7 @@ buf_check_timestamp (
              && buf->b_mtime != 0
              && ((stat_res = mch_stat((char *)buf->b_ffname, &st)) < 0
                  || time_differs((long)st.st_mtime, buf->b_mtime)
+                 || st.st_size != buf->b_orig_size
 #ifdef HAVE_ST_MODE
                  || (int)st.st_mode != buf->b_orig_mode
 #else

--- a/src/version.c
+++ b/src/version.c
@@ -202,6 +202,7 @@ static char *(features[]) = {
 
 static int included_patches[] = {
   // Add new patch number below this line
+  274,
   //273,
   272,
   //271,


### PR DESCRIPTION
```
Problem:  When doing ":update" just before running an external command that
          changes the file, the timestamp may be unchanged and the file
          is not reloaded.
Solution: Also check the file size.
```

https://code.google.com/p/vim/source/detail?r=1ee3fc5b40ae94c2a7fc5a62bca38d4f730f9bb2
