### PR TITLE
Allow most tests to pass with nocp

### DIFF
--- a/src/testdir/dotest.in
+++ b/src/testdir/dotest.in
@@ -1,3 +1,3 @@
-:set cp
+:set nocp
 :map dotest /^STARTTESTj:set ff=unix cpo-=A:.,/ENDTEST/-1w! Xdotest:set ff& cpo+=Anj0:so! Xdotestdotest
 dotest

--- a/src/testdir/test26.in
+++ b/src/testdir/test26.in
@@ -2,7 +2,7 @@ Test for :execute, :while and :if
 
 STARTTEST
 :so small.vim
-mt:let i = 0
+jmt:let i = 0
 :while i < 12
 :  let i = i + 1
 :  if has("ebcdic")

--- a/src/testdir/test33.ok
+++ b/src/testdir/test33.ok
@@ -3,21 +3,21 @@
 
 (defmacro page (name title &rest body)
   (let ((ti (gensym)))
-       `(with-open-file (*standard-output*
-			 (html-file ,name)
-			 :direction :output
-			 :if-exists :supersede)
-			(let ((,ti ,title))
-			     (as title ,ti)
-			     (with center 
-				   (as h2 (string-upcase ,ti)))
-			     (brs 3)
-			     ,@body))))
+    `(with-open-file (*standard-output*
+		       (html-file ,name)
+		       :direction :output
+		       :if-exists :supersede)
+       (let ((,ti ,title))
+	 (as title ,ti)
+	 (with center 
+	       (as h2 (string-upcase ,ti)))
+	 (brs 3)
+	 ,@body))))
 
 ;;; Utilities for generating links
 
 (defmacro with-link (dest &rest body)
   `(progn
-    (format t "<a href=\"~A\">" (html-file ,dest))
-    ,@body
-    (princ "</a>")))
+     (format t "<a href=\"~A\">" (html-file ,dest))
+     ,@body
+     (princ "</a>")))

--- a/src/testdir/test48.in
+++ b/src/testdir/test48.in
@@ -4,7 +4,7 @@ STARTTEST
 :so small.vim
 :set noswf
 :set ve=all
--dgg
+j-dgg
 :"
 :"   Insert "keyword keyw", ESC, C CTRL-N, shows "keyword ykeyword".
 :"    Repeating CTRL-N fixes it. (Mary Ellen Foster)

--- a/src/testdir/test68.in
+++ b/src/testdir/test68.in
@@ -30,7 +30,7 @@ STARTTEST
 /^{/+1
 :set tw=3 fo=t
 gqgqo
-a 
+a 
 ENDTEST
 
 {
@@ -99,7 +99,7 @@ ENDTEST
 STARTTEST
 /^{/+2
 :set tw& fo=a
-I^^
+I^^
 ENDTEST
 
 {

--- a/src/testdir/test69.in
+++ b/src/testdir/test69.in
@@ -15,7 +15,7 @@ STARTTEST
 :set tw=2 fo=t
 gqgqjgqgqo
 ＸＹＺ
-abc ＸＹＺ
+abc ＸＹＺ
 ENDTEST
 
 {
@@ -31,7 +31,7 @@ gqgqjgqgqjgqgqjgqgqjgqgqo
 Ｘa
 Ｘ a
 ＸＹ
-Ｘ Ｙ
+Ｘ Ｙ
 ENDTEST
 
 {
@@ -55,7 +55,7 @@ aＸ
 abＸ
 abcＸ
 abＸ c
-abＸＹ
+abＸＹ
 ENDTEST
 
 {
@@ -110,7 +110,7 @@ gqgqjgqgqjgqgqjgqgqjgqgqjgqgqjgqgqjgqgqjgqgqjgqgqo
 Ｘ ＹＺ
 ＸＸ
 ＸＸa
-ＸＸＹ
+ＸＸＹ
 ENDTEST
 
 {


### PR DESCRIPTION
Currently the only tests to fail with this change are tests 40 and 60. I have not been able to figure out why they are different with nocp on.

test40 just off by one line now
test60 is completely broken with nocp
