### PR TITLE
[RDY] Portable format specifiers fix (%lu using EMSGN instead of EMSGU).

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -235,7 +235,7 @@ void do_outofmem_msg(long_u size)
      * message fails, e.g. when setting v:errmsg. */
     did_outofmem_msg = TRUE;
 
-    EMSGN(_("E342: Out of memory!  (allocating %" PRIu64 " bytes)"), size);
+    EMSGU(_("E342: Out of memory!  (allocating %" PRIu64 " bytes)"), size);
   }
 }
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -900,6 +900,17 @@ int emsgn(char_u *s, int64_t n)
 }
 
 /*
+ * Print an error message with one "%" PRIu64 and one (uint64_t) argument.
+ */
+int emsgu(char_u *s, uint64_t n)
+{
+  if (emsg_not_now())
+    return TRUE;                /* no error messages at the moment */
+  vim_snprintf((char *)IObuff, IOSIZE, (char *)s, n);
+  return emsg(IObuff);
+}
+
+/*
  * Read 2 bytes from "fd" and turn them into an int, MSB first.
  */
 int get2c(FILE *fd)

--- a/src/misc2.h
+++ b/src/misc2.h
@@ -39,6 +39,7 @@ int illegal_slash(char *name);
 int vim_chdir(char_u *new_dir);
 int emsg3(char_u *s, char_u *a1, char_u *a2);
 int emsgn(char_u *s, int64_t n);
+int emsgu(char_u *s, uint64_t n);
 int get2c(FILE *fd);
 int get3c(FILE *fd);
 int get4c(FILE *fd);

--- a/src/vim.h
+++ b/src/vim.h
@@ -1031,7 +1031,7 @@ typedef enum {
 #define EMSG3(s, p, q)              emsg3((char_u *)(s), (char_u *)(p), \
     (char_u *)(q))
 #define EMSGN(s, n)                 emsgn((char_u *)(s), (int64_t)(n))
-#define EMSGU(s, n)                 emsgu((char_u *)(s), (long_u)(n))
+#define EMSGU(s, n)                 emsgu((char_u *)(s), (uint64_t)(n))
 #define OUT_STR(s)                  out_str((char_u *)(s))
 #define OUT_STR_NF(s)               out_str_nf((char_u *)(s))
 #define MSG_PUTS(s)                 msg_puts((char_u *)(s))


### PR DESCRIPTION
In code before portable-format-specifiers task, there was a bug:
The only case of a `"%lu"` format string was using `EMSGN` instead of `EMSGU`, which is incorrect since `EMSGN` will cast its argument to `int64_t` (previously `long`).

In fact, `EMSGU` macro was defined as the unsigned counterpart of `EMSGN` (thus taking a `long_u` instead of a `long`), and invoking `emsgu` instead of `emsgn`.

But, `emsgu` was not defined anywhere, which didn't result in an error, because EMSGU was in fact not used, the only case of a `"%lu"` erroneously using `EMSGN`, as explained above.

I missed this all when doing the main task.
This PR corrects that all.
