### PR TITLE
Prevent preserve_exit() from executing more than once.

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -3373,11 +3373,14 @@ void preserve_exit(void)
 {
   buf_T       *buf;
 
-  prepare_to_exit();
+  // Prevent repeated calls into this method.
+  if (really_exiting) {
+    exit(2);
+  }
 
-  /* Setting this will prevent free() calls.  That avoids calling free()
-   * recursively when free() was invoked with a bad pointer. */
   really_exiting = TRUE;
+
+  prepare_to_exit();
 
   out_str(IObuff);
   screen_start();                   /* don't know where cursor is now */

--- a/src/os/signal.c
+++ b/src/os/signal.c
@@ -139,8 +139,7 @@ static void deadly_signal(int signum)
   snprintf((char *)IObuff, sizeof(IObuff), "Vim: Caught deadly signal '%s'\n",
       signal_name(signum));
 
-  // Preserve files and exit.  This sets the really_exiting flag to prevent
-  // calling free().
+  // Preserve files and exit.
   preserve_exit();
 }
 


### PR DESCRIPTION
https://github.com/neovim/neovim/issues/563
