### PR TITLE
[RFC] Spliting two-iteration loops in ExpandBufnames()

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -67,6 +67,7 @@
 #include "window.h"
 
 static char_u   *buflist_match(regprog_T *prog, buf_T *buf);
+static int store_buf_match(char_u ***file, regprog_T *prog, int options);
 # define HAVE_BUFLIST_MATCH
 static char_u   *fname_match(regprog_T *prog, char_u *name);
 static void buflist_setfpos(buf_T *buf, win_T *win, linenr_T lnum,
@@ -1819,6 +1820,45 @@ buflist_findpat (
   return match;
 }
 
+/*
+ * Find the matches & store the matches in (*file) array.
+ * Return the count of matches found.
+ */
+static int store_buf_match(char_u ***file, regprog_T *prog, int options)
+{
+  buf_T       *buf;
+  char_u      *p;
+  int count = 0;
+
+  /* Count the matches */
+  for (buf = firstbuf; buf != NULL; buf = buf->b_next) {
+    if (!buf->b_p_bl)               /* skip unlisted buffers */
+      continue;
+    if (buflist_match(prog, buf) != NULL)
+      ++count;
+  }
+
+  /* Allocate space for storing the matches */
+  *file = xmalloc(count * sizeof(**file));
+
+  /* If matches found, build the array to keep the matches */
+  if (count) {
+    for (buf = firstbuf; buf != NULL; buf = buf->b_next) {
+      if (!buf->b_p_bl)               /* skip unlisted buffers */
+        continue;
+      p = buflist_match(prog, buf);
+      if (p != NULL) {
+        if (options & WILD_HOME_REPLACE)
+          p = home_replace_save(buf, p);
+        else
+          p = vim_strsave(p);
+        (*file)[count++] = p;
+      }
+    }
+  }
+
+  return count;
+}
 
 /*
  * Find all buffer names that match.
@@ -1828,9 +1868,6 @@ buflist_findpat (
 int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
 {
   int count = 0;
-  buf_T       *buf;
-  int round;
-  char_u      *p;
   int attempt;
   regprog_T   *prog;
   char_u      *patc;
@@ -1860,34 +1897,9 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
       return FAIL;
     }
 
-    /*
-     * round == 1: Count the matches.
-     * round == 2: Build the array to keep the matches.
-     */
-    for (round = 1; round <= 2; ++round) {
-      count = 0;
-      for (buf = firstbuf; buf != NULL; buf = buf->b_next) {
-        if (!buf->b_p_bl)               /* skip unlisted buffers */
-          continue;
-        p = buflist_match(prog, buf);
-        if (p != NULL) {
-          if (round == 1)
-            ++count;
-          else {
-            if (options & WILD_HOME_REPLACE)
-              p = home_replace_save(buf, p);
-            else
-              p = vim_strsave(p);
-            (*file)[count++] = p;
-          }
-        }
-      }
-      if (count == 0)           /* no match found, break here */
-        break;
-      if (round == 1) {
-        *file = xmalloc(count * sizeof(**file));
-      }
-    }
+    /* Count the matches & allocate space for storing them */
+    count = store_buf_match(file, prog, options);
+
     vim_regfree(prog);
     if (count)                  /* match(es) found, break here */
       break;


### PR DESCRIPTION
Two 2-iteration loops (one inside the other) were present in ExpandBufnames() which have been split.
As in #572
