### PR TITLE
[RFC] Spliting two-iteration loops in ExpandBufnames()

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -67,6 +67,19 @@
 #include "window.h"
 
 static char_u   *buflist_match(regprog_T *prog, buf_T *buf);
+
+/// Finds the number of matches & stores the matches
+///
+/// Allocates memory for array for storing matches in file. This must be freed
+/// using FreeWild() when no longer needed
+///
+/// @param file In the array pointed by it, matches will be stored.
+/// @param prog Regular expression program got from vim_regcomp()
+/// @param options Wildcard expansion options & flags
+///
+/// @return The count of matches found
+static int store_buf_match(char_u ***file, regprog_T *prog, int options);
+
 # define HAVE_BUFLIST_MATCH
 static char_u   *fname_match(regprog_T *prog, char_u *name);
 static void buflist_setfpos(buf_T *buf, win_T *win, linenr_T lnum,
@@ -1820,6 +1833,46 @@ buflist_findpat (
 }
 
 
+static int store_buf_match(char_u ***file, regprog_T *prog, int options)
+{
+  // Count the matches
+  int count = 0;
+  for (buf_T *buf = firstbuf; buf != NULL; buf = buf->b_next) {
+    // skip unlisted buffers
+    if (!buf->b_p_bl) {
+      continue;
+    }
+
+    if (buflist_match(prog, buf) != NULL) {
+      count++;
+    }
+  }
+
+  if (count == 0) {
+    return 0;
+  }
+
+  *file = xmalloc(count * sizeof(**file));  // Space for storing the matches
+
+  // Build the array to keep the matches
+  for (buf_T *buf = firstbuf; buf != NULL; buf = buf->b_next) {
+    // skip unlisted buffers
+    if (!buf->b_p_bl) {
+      continue;
+    }
+
+    char_u *p = buflist_match(prog, buf);
+    if (p == NULL) {
+      continue;
+    }
+
+    p = (options & WILD_HOME_REPLACE) ? home_replace_save(buf, p) : vim_strsave(p);
+    (*file)[count++] = p;
+  }
+
+  return count;
+}
+
 /*
  * Find all buffer names that match.
  * For command line expansion of ":buf" and ":sbuf".
@@ -1828,9 +1881,6 @@ buflist_findpat (
 int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
 {
   int count = 0;
-  buf_T       *buf;
-  int round;
-  char_u      *p;
   int attempt;
   regprog_T   *prog;
   char_u      *patc;
@@ -1860,34 +1910,7 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
       return FAIL;
     }
 
-    /*
-     * round == 1: Count the matches.
-     * round == 2: Build the array to keep the matches.
-     */
-    for (round = 1; round <= 2; ++round) {
-      count = 0;
-      for (buf = firstbuf; buf != NULL; buf = buf->b_next) {
-        if (!buf->b_p_bl)               /* skip unlisted buffers */
-          continue;
-        p = buflist_match(prog, buf);
-        if (p != NULL) {
-          if (round == 1)
-            ++count;
-          else {
-            if (options & WILD_HOME_REPLACE)
-              p = home_replace_save(buf, p);
-            else
-              p = vim_strsave(p);
-            (*file)[count++] = p;
-          }
-        }
-      }
-      if (count == 0)           /* no match found, break here */
-        break;
-      if (round == 1) {
-        *file = xmalloc(count * sizeof(**file));
-      }
-    }
+    count = store_buf_match(file, prog, options);  // Count & store matches
     vim_regfree(prog);
     if (count)                  /* match(es) found, break here */
       break;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1881,7 +1881,6 @@ static int store_buf_match(char_u ***file, regprog_T *prog, int options)
 int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
 {
   int count = 0;
-  int attempt;
   regprog_T   *prog;
   char_u      *patc;
 
@@ -1896,24 +1895,29 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
   } else
     patc = pat;
 
-  /*
-   * attempt == 0: try match with    '\<', match at start of word
-   * attempt == 1: try match without '\<', match anywhere
-   */
-  for (attempt = 0; attempt <= 1; ++attempt) {
-    if (attempt > 0 && patc == pat)
-      break;            /* there was no anchor, no need to try again */
-    prog = vim_regcomp(patc + attempt * 11, RE_MAGIC);
+  // Try match with '\<', match at start of word
+  prog = vim_regcomp(patc, RE_MAGIC);
+  if (prog == NULL) {
+    if (patc != pat) {
+      free(patc);
+    }
+    return FAIL;
+  }
+
+  count = store_buf_match(file, prog, options);  // Count & store matches
+  vim_regfree(prog);
+
+  // If above matching resulted in count=0, then
+  //   Try match without '\<', match anywhere
+  if (count == 0 && patc != pat) {
+    prog = vim_regcomp(patc + 11, RE_MAGIC);
     if (prog == NULL) {
-      if (patc != pat)
-        free(patc);
+      free(patc);
       return FAIL;
     }
 
     count = store_buf_match(file, prog, options);  // Count & store matches
     vim_regfree(prog);
-    if (count)                  /* match(es) found, break here */
-      break;
   }
 
   if (patc != pat)


### PR DESCRIPTION
( I made the changes that were mentioned in comments of #678. This new pull-request created so that git history does not clutter. )

Two 2-iteration loops (one inside the other) were present in ExpandBufnames() which have been split.
As in #572
