### PR TITLE
[RFC] fix strict-overflow cases

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -4204,7 +4204,6 @@ check_map (
   int hash;
   int len, minlen;
   mapblock_T  *mp;
-  char_u      *s;
   int local;
 
   validate_maphash();
@@ -4228,17 +4227,14 @@ check_map (
         /* skip entries with wrong mode, wrong length and not matching
          * ones */
         if ((mp->m_mode & mode) && (!exact || mp->m_keylen == len)) {
-          if (len > mp->m_keylen)
-            minlen = mp->m_keylen;
-          else
-            minlen = len;
-          s = mp->m_keys;
-          if (ign_mod && s[0] == K_SPECIAL && s[1] == KS_MODIFIER
-              && s[2] != NUL) {
+          char_u *s = mp->m_keys;
+          int keylen = mp->m_keylen;
+          if (ign_mod && keylen >= 3
+              && s[0] == K_SPECIAL && s[1] == KS_MODIFIER) {
             s += 3;
-            if (len > mp->m_keylen - 3)
-              minlen = mp->m_keylen - 3;
+            keylen -= 3;
           }
+          minlen = keylen < len ? keylen : len;
           if (STRNCMP(s, keys, minlen) == 0) {
             if (mp_ptr != NULL)
               *mp_ptr = mp;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -206,8 +206,11 @@ static void u_check(int newhead_may_be_NULL)                 {
  */
 int u_save_cursor(void)
 {
-  return u_save((linenr_T)(curwin->w_cursor.lnum - 1),
-      (linenr_T)(curwin->w_cursor.lnum + 1));
+  linenr_T cur = curwin->w_cursor.lnum;
+  linenr_T top = cur > 0 ? cur - 1 : 0;
+  linenr_T bot = cur + 1;
+
+  return u_save(top, bot);
 }
 
 /*
@@ -221,9 +224,7 @@ int u_save(linenr_T top, linenr_T bot)
   if (undo_off)
     return OK;
 
-  if (top > curbuf->b_ml.ml_line_count
-      || top >= bot
-      || bot > curbuf->b_ml.ml_line_count + 1)
+  if (top >= bot || bot > (curbuf->b_ml.ml_line_count + 1))
     return FALSE;       /* rely on caller to do error messages */
 
   if (top + 2 == bot)


### PR DESCRIPTION
This fixes overflows caused by (X - 1) and (X - 3) that can result into negative numbers for values that are not intended to be like this.

Effectively fixes issues #464 and #513 .
