### PR TITLE
[RFC] spatch to drop check after alloc/lalloc/xmalloc

### DIFF
--- a/src/digraph.c
+++ b/src/digraph.c
@@ -1745,10 +1745,6 @@ char_u* keymap_init(void)
     buflen = STRLEN(curbuf->b_p_keymap) + STRLEN(p_enc) + 14;
     buf = alloc((unsigned)buflen);
 
-    if (buf == NULL) {
-      return e_outofmem;
-    }
-
     // try finding "keymap/'keymap'_'encoding'.vim"  in 'runtimepath'
     vim_snprintf((char *)buf, buflen, "keymap/%s_%s.vim",
                  curbuf->b_p_keymap, p_enc);

--- a/src/eval.c
+++ b/src/eval.c
@@ -3442,10 +3442,6 @@ static char_u *cat_prefix_varname(int prefix, char_u *name)
     vim_free(varnamebuf);
     len += 10;                          /* some additional space */
     varnamebuf = alloc(len);
-    if (varnamebuf == NULL) {
-      varnamebuflen = 0;
-      return NULL;
-    }
     varnamebuflen = len;
   }
   *varnamebuf = prefix;
@@ -4924,8 +4920,6 @@ static int get_string_tv(char_u **arg, typval_T *rettv, int evaluate)
    * characters.
    */
   name = alloc((unsigned)(p - *arg + extra));
-  if (name == NULL)
-    return FAIL;
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = name;
 
@@ -5041,8 +5035,6 @@ static int get_lit_string_tv(char_u **arg, typval_T *rettv, int evaluate)
    * Copy the string into allocated memory, handling '' to ' reduction.
    */
   str = alloc((unsigned)((p - *arg) - reduce));
-  if (str == NULL)
-    return FAIL;
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = str;
 
@@ -12521,8 +12513,6 @@ static void f_resolve(typval_T *argvars, typval_T *rettv)
     }
 
     buf = alloc(MAXPATHL + 1);
-    if (buf == NULL)
-      goto fail;
 
     for (;; ) {
       for (;; ) {
@@ -16008,8 +15998,6 @@ char_u *set_cmdarg(exarg_T *eap, char_u *oldarg)
     len += 7 + 4;      /* " ++bad=" + "keep" or "drop" */
 
   newval = alloc(len + 1);
-  if (newval == NULL)
-    return NULL;
 
   if (eap->force_bin == FORCE_BIN)
     sprintf((char *)newval, " ++bin");
@@ -18350,8 +18338,6 @@ static char_u *autoload_name(char_u *name)
 
   /* Get the script file name: replace '#' with '/', append ".vim". */
   scriptname = alloc((unsigned)(STRLEN(name) + 14));
-  if (scriptname == NULL)
-    return FALSE;
   STRCPY(scriptname, "autoload/");
   STRCAT(scriptname, name);
   *vim_strrchr(scriptname, AUTOLOAD_CHAR) = NUL;

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -623,8 +623,6 @@ void ex_retab(exarg_T *eap)
             old_len = (long)STRLEN(ptr);
             new_line = lalloc(old_len - col + start_col + len + 1,
                 TRUE);
-            if (new_line == NULL)
-              break;
             if (start_col > 0)
               memmove(new_line, ptr, (size_t)start_col);
             memmove(new_line + start_col + len,
@@ -1337,8 +1335,6 @@ make_filter_cmd (
   if (otmp != NULL)
     len += (long_u)STRLEN(otmp) + (long_u)STRLEN(p_srr) + 2;     /* "  " */
   buf = lalloc(len, TRUE);
-  if (buf == NULL)
-    return NULL;
 
 #if defined(UNIX)
   /*
@@ -1898,11 +1894,6 @@ viminfo_readstring (
   if (virp->vir_line[off] == Ctrl_V && vim_isdigit(virp->vir_line[off + 1])) {
     len = atol((char *)virp->vir_line + off + 1);
     retval = lalloc(len, TRUE);
-    if (retval == NULL) {
-      /* Line too long?  File messed up?  Skip next line. */
-      (void)vim_fgets(virp->vir_line, 10, virp->vir_fd);
-      return NULL;
-    }
     (void)vim_fgets(retval, (int)len, virp->vir_fd);
     s = retval + 1;         /* Skip the leading '<' */
   } else {

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2082,8 +2082,6 @@ static void draw_cmdline(int start, int len)
       vim_free(arshape_buf);
       buflen = len * 2 + 2;
       arshape_buf = alloc(buflen);
-      if (arshape_buf == NULL)
-        return;         /* out of memory */
     }
 
     if (utf_iscomposing(utf_ptr2char(ccline.cmdbuff + start))) {
@@ -4160,10 +4158,6 @@ static int ExpandRTDir(char_u *pat, int *num_file, char_u ***file, char *dirname
 
   for (i = 0; dirnames[i] != NULL; ++i) {
     s = alloc((unsigned)(STRLEN(dirnames[i]) + pat_len + 7));
-    if (s == NULL) {
-      ga_clear_strings(&ga);
-      return FAIL;
-    }
     sprintf((char *)s, "%s/%s*.vim", dirnames[i], pat);
     matches = globpath(p_rtp, s, 0);
     vim_free(s);
@@ -4219,8 +4213,6 @@ char_u *globpath(char_u *path, char_u *file, int expand_options)
   char_u      *cur = NULL;
 
   buf = alloc(MAXPATHL);
-  if (buf == NULL)
-    return NULL;
 
   ExpandInit(&xpc);
   xpc.xp_context = EXPAND_FILES;

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -894,13 +894,7 @@ int ins_typebuf(char_u *str, int noremap, int offset, int nottyped, int silent)
       return FAIL;
     }
     s1 = alloc(newlen);
-    if (s1 == NULL)                 /* out of memory */
-      return FAIL;
     s2 = alloc(newlen);
-    if (s2 == NULL) {               /* out of memory */
-      vim_free(s1);
-      return FAIL;
-    }
     typebuf.tb_buflen = newlen;
 
     /* copy the old chars, before the insertion point */

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -1708,8 +1708,6 @@ del_bytes (
     newp = oldp;                            /* use same allocated memory */
   else {                                    /* need to allocate a new line */
     newp = alloc((unsigned)(oldlen + 1 - count));
-    if (newp == NULL)
-      return FAIL;
     memmove(newp, oldp, (size_t)col);
   }
   memmove(newp + col, oldp + col + count, (size_t)movelen);

--- a/src/search.c
+++ b/src/search.c
@@ -4024,8 +4024,6 @@ find_pattern_in_path (
   def_regmatch.regprog = NULL;
 
   file_line = alloc(LSIZE);
-  if (file_line == NULL)
-    return;
 
   if (type != CHECK_PATH && type != FIND_DEFINE
       /* when CONT_SOL is set compare "ptr" with the beginning of the line
@@ -4033,8 +4031,6 @@ find_pattern_in_path (
       && !(compl_cont_status & CONT_SOL)
       ) {
     pat = alloc(len + 5);
-    if (pat == NULL)
-      goto fpip_end;
     sprintf((char *)pat, whole ? "\\<%.*s\\>" : "%.*s", len, ptr);
     /* ignore case according to p_ic, p_scs and pat */
     regmatch.rm_ic = ignorecase(pat);


### PR DESCRIPTION
Sample of what can be done with [coccinelle](http://coccinelle.lip6.fr/) for helping resolving tickets like #488 . This patch built by:

```
spatch --in-place --sp-file allocs.cocci src/*.c
```

When contents of `allocs.cocci` (that's the whole contents):

``` patch
@@ identifier p; statement S; @@
  p =
(
  alloc(...)
|
  lalloc(...)
|
  xmalloc(...)
)
  ;
- if (p == NULL) S
```

In case of situations like:

``` c
    s1 = alloc(newlen);
    if (s1 == NULL)                 /* out of memory */
      return FAIL;
    s2 = alloc(newlen);
```

It generates extra space in place of removed statement.

And for

``` c
      vim_free(arshape_buf);
      buflen = len * 2 + 2;
      arshape_buf = alloc(buflen);
      if (arshape_buf == NULL)
        return;         /* out of memory */
```

It leaves comment in place of removed content since comment isn't catched by statement metavariable.
