### PR TITLE
[WIP] Remove project int types: Case long_u: do_outofmem_msg.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -12104,17 +12104,11 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
           /* Change "prev" buffer to be the right size.  This way
            * the bytes are only copied once, and very long lines are
            * allocated only once.  */
-          if ((s = xrealloc(prev, prevlen + len + 1)) != NULL) {
-            memmove(s + prevlen, start, len);
-            s[prevlen + len] = NUL;
-            prev = NULL;             /* the list will own the string */
-            prevlen = prevsize = 0;
-          }
-        }
-        if (s == NULL) {
-          do_outofmem_msg((long_u) prevlen + len + 1);
-          failed = TRUE;
-          break;
+          s = xrealloc(prev, prevlen + len + 1);
+          memmove(s + prevlen, start, len);
+          s[prevlen + len] = NUL;
+          prev = NULL;               /* the list will own the string */
+          prevlen = prevsize = 0;
         }
 
         if ((li = listitem_alloc()) == NULL) {
@@ -12174,10 +12168,8 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
     if (start < p) {
       /* There's part of a line in buf, store it in "prev". */
       if (p - start + prevlen >= prevsize) {
-        /* need bigger "prev" buffer */
-        char_u *newprev;
-
-        /* A common use case is ordinary text files and "prev" gets a
+        /* Need bigger "prev" buffer.
+         * A common use case is ordinary text files and "prev" gets a
          * fragment of a line, so the first allocation is made
          * small, to avoid repeatedly 'allocing' large and
          * 'reallocing' small. */
@@ -12188,14 +12180,7 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
           long growmin  = (long)((p - start) * 2 + prevlen);
           prevsize = grow50pc > growmin ? grow50pc : growmin;
         }
-        newprev = prev == NULL ? alloc(prevsize)
-                  : xrealloc(prev, prevsize);
-        if (newprev == NULL) {
-          do_outofmem_msg((long_u)prevsize);
-          failed = TRUE;
-          break;
-        }
-        prev = newprev;
+        prev = prev == NULL ? xmalloc(prevsize) : xrealloc(prev, prevsize);
       }
       /* Add the line part to end of "prev". */
       memmove(prev + prevlen, start, p - start);

--- a/src/memory.c
+++ b/src/memory.c
@@ -93,7 +93,7 @@ void *verbose_try_malloc(size_t size)
 {
   void *ret = try_malloc(size);
   if (!ret) {
-    do_outofmem_msg((long_u)size);
+    do_outofmem_msg(size);
   }
   return ret;
 }
@@ -219,7 +219,7 @@ char *xstrndup(const char *str, size_t len)
  * Avoid repeating the error message many times (they take 1 second each).
  * Did_outofmem_msg is reset when a character is read.
  */
-void do_outofmem_msg(long_u size)
+void do_outofmem_msg(size_t size)
 {
   if (!did_outofmem_msg) {
     /* Don't hide this message */

--- a/src/memory.h
+++ b/src/memory.h
@@ -127,7 +127,7 @@ char *xstpcpy(char *restrict dst, const char *restrict src);
 /// @param maxlen
 char *xstpncpy(char *restrict dst, const char *restrict src, size_t maxlen);
 
-void do_outofmem_msg(long_u size);
+void do_outofmem_msg(size_t size);
 void free_all_mem(void);
 
 #endif

--- a/src/screen.c
+++ b/src/screen.c
@@ -6290,7 +6290,7 @@ retry:
       || outofmem) {
     if (ScreenLines != NULL || !done_outofmem_msg) {
       /* guess the size */
-      do_outofmem_msg((long_u)((Rows + 1) * Columns));
+      do_outofmem_msg((Rows + 1) * Columns);
 
       /* Remember we did this to avoid getting outofmem messages over
        * and over again. */

--- a/src/strings.c
+++ b/src/strings.c
@@ -41,32 +41,22 @@
 #include "os/os.h"
 #include "os/shell.h"
 
-/*
- * Copy "string" into newly allocated memory.
- */
+// TODO(elmart): Refactor this function to return void *,
+//               and its callers to remove checks for NULL.
 char_u *vim_strsave(char_u *string)
 {
-  char_u      *p;
-  unsigned len;
-
-  len = (unsigned)STRLEN(string) + 1;
-  p = alloc(len);
-  if (p != NULL)
-    memmove(p, string, (size_t)len);
+  size_t len = STRLEN(string) + 1;
+  char_u *p = xmalloc(len);
+  memmove(p, string, len);
   return p;
 }
 
-/*
- * Copy up to "len" bytes of "string" into newly allocated memory and
- * terminate with a NUL.
- * The allocated memory always has size "len + 1", also when "string" is
- * shorter.
- */
+// TODO(elmart): Refactor this function to have size_t 'len' parameter and
+//               to return void *.
+//               Refactor its callers to remove checks for NULL.
 char_u *vim_strnsave(char_u *string, int len)
 {
-  char_u      *p;
-
-  p = alloc((unsigned)(len + 1));
+  char_u *p = xmalloc(len + 1);
   STRNCPY(p, string, len);
   p[len] = NUL;
   return p;

--- a/src/strings.h
+++ b/src/strings.h
@@ -1,7 +1,29 @@
 #ifndef NEOVIM_STRINGS_H
 #define NEOVIM_STRINGS_H
-char_u *vim_strsave(char_u *string);
-char_u *vim_strnsave(char_u *string, int len);
+
+#include "func_attr.h"
+
+/// Copy "string" into newly allocated memory.
+/// 
+/// Never return null. Succeed or gracefully abort when out of memory.
+///
+/// @param string The string to be copied.
+/// @return pointer to newly allocated space. Never NULL.
+char_u *vim_strsave(char_u *string) FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET;
+
+/// Copy up to "len" bytes of "string" into newly allocated memory and
+/// terminate with a NUL.
+///
+/// Allocated memory always has size "len + 1", also when "string" is
+/// shorter.
+/// Never return null. Succeed or gracefully abort when out of memory.
+/// 
+/// @param string The string to be copied.
+/// @param len The maximum number of bytes to be copied.
+/// @return pointer to newly allocated space. Never NULL.
+char_u *vim_strnsave(char_u *string, int len)
+  FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(2) FUNC_ATTR_NONNULL_RET;
+
 char_u *vim_strsave_escaped(char_u *string, char_u *esc_chars);
 char_u *vim_strsave_escaped_ext(char_u *string, char_u *esc_chars,
                                 int cc,

--- a/src/undo.c
+++ b/src/undo.c
@@ -621,7 +621,7 @@ nomem:
     undo_off = TRUE;                /* will be reset when character typed */
     return OK;
   }
-  do_outofmem_msg((long_u)0);
+  do_outofmem_msg(0U);
   return FAIL;
 }
 
@@ -2124,8 +2124,7 @@ static void u_undoredo(int undo)
       /* delete backwards, it goes faster in most cases */
       for (lnum = bot - 1, i = oldsize; --i >= 0; --lnum) {
         /* what can we do when we run out of memory? */
-        if ((newarray[i] = u_save_line(lnum)) == NULL)
-          do_outofmem_msg((long_u)0);
+        newarray[i] = u_save_line(lnum);
         /* remember we deleted the last line in the buffer, and a
          * dummy empty line will be inserted */
         if (curbuf->b_ml.ml_line_count == 1)
@@ -2756,8 +2755,7 @@ void u_saveline(linenr_T lnum)
     curbuf->b_u_line_colnr = curwin->w_cursor.col;
   else
     curbuf->b_u_line_colnr = 0;
-  if ((curbuf->b_u_line_ptr = u_save_line(lnum)) == NULL)
-    do_outofmem_msg((long_u)0);
+  curbuf->b_u_line_ptr = u_save_line(lnum);
 }
 
 /*
@@ -2798,10 +2796,6 @@ void u_undoline(void)
           curbuf->b_u_line_lnum + 1, (linenr_T)0, FALSE) == FAIL)
     return;
   oldp = u_save_line(curbuf->b_u_line_lnum);
-  if (oldp == NULL) {
-    do_outofmem_msg((long_u)0);
-    return;
-  }
   ml_replace(curbuf->b_u_line_lnum, curbuf->b_u_line_ptr, TRUE);
   changed_bytes(curbuf->b_u_line_lnum, 0);
   free(curbuf->b_u_line_ptr);


### PR DESCRIPTION
Remove long_u occurrences due to do_outofmem_msg's size parameter.
To achieve that:
- If possible, remove do_outofmem_msg's occurrence altogether.
  That requires making functions vim_strsave and vim_strnsave use the
  new safe memory functions (xmalloc). Once that is done, corresponding
  checks for null can be removed (thus deleting do_outofmem_msg call).
  Some more possible refactoring work on vim_strsave and vim_strnsave
  and their callers is left to be done, as not essential to this task, and to
  avoid collisions with other currently working on that.
- For the remaining occurrences of do_outofmem_msg, refactor it to take
  a size_t 'size' parameter instead of a long_u.

@philix @watk
As a need of my ongoing work to remove `long_u`, I stumped into the need of slightly modifying `vim_strsave` and `vim_strnsave` to use `xmalloc`. As I explain above, I've left TODO's on those functions because work of the type you were doing (removing checks for null allocations, and some other things related) can be done there. 
I leave that as TODO's in order not to collide with you again. 
If you are not planning to tackle those cases soon, please say it to me so that I can fix that myself.
