### PR TITLE
[RDY] GA_EMPTY(ga) macro to encapsulate ga->ga_len tests

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17137,7 +17137,7 @@ void ex_execute(exarg_T *eap)
       p = get_tv_string(&rettv);
       len = (int)STRLEN(p);
       ga_grow(&ga, len + 2);
-      if (ga.ga_len)
+      if (!GA_EMPTY(&ga))
         ((char_u *)(ga.ga_data))[ga.ga_len++] = ' ';
       STRCPY((char_u *)(ga.ga_data) + ga.ga_len, p);
       ga.ga_len += len;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18397,7 +18397,7 @@ char_u *get_user_func_name(expand_T *xp, int idx)
     cat_func_name(IObuff, fp);
     if (xp->xp_context != EXPAND_USER_FUNC) {
       STRCAT(IObuff, "(");
-      if (!fp->uf_varargs && fp->uf_args.ga_len == 0)
+      if (!fp->uf_varargs && GA_EMPTY(&fp->uf_args))
         STRCAT(IObuff, ")");
     }
     return IObuff;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10766,7 +10766,7 @@ static garray_T ga_userinput = {0, 0, sizeof(tasave_T), 4, NULL};
  */
 static void f_inputrestore(typval_T *argvars, typval_T *rettv)
 {
-  if (ga_userinput.ga_len > 0) {
+  if (!GA_EMPTY(&ga_userinput)) {
     --ga_userinput.ga_len;
     restore_typeahead((tasave_T *)(ga_userinput.ga_data)
         + ga_userinput.ga_len);

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -594,7 +594,7 @@ void ex_breakdel(exarg_T *eap)
     }
 
     /* If all breakpoints were removed clear the array. */
-    if (gap->ga_len == 0)
+    if (GA_EMPTY(gap))
       ga_clear(gap);
   }
 }
@@ -607,7 +607,7 @@ void ex_breaklist(exarg_T *eap)
   struct debuggy *bp;
   int i;
 
-  if (dbg_breakp.ga_len == 0)
+  if (GA_EMPTY(&dbg_breakp))
     MSG(_("No breakpoints defined"));
   else
     for (i = 0; i < dbg_breakp.ga_len; ++i) {
@@ -670,7 +670,7 @@ debuggy_find (
   int prev_got_int;
 
   /* Return quickly when there are no breakpoints. */
-  if (gap->ga_len == 0)
+  if (GA_EMPTY(gap))
     return (linenr_T)0;
 
   /* Replace K_SNR in function name with "<SNR>". */

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -580,7 +580,7 @@ void ex_breakdel(exarg_T *eap)
   if (todel < 0)
     EMSG2(_("E161: Breakpoint not found: %s"), eap->arg);
   else {
-    while (gap->ga_len > 0) {
+    while (!GA_EMPTY(gap)) {
       free(DEBUGGY(gap, todel).dbg_name);
       vim_regfree(DEBUGGY(gap, todel).dbg_prog);
       --gap->ga_len;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -872,7 +872,7 @@ int flags;
      * When not inside any ":while" loop, clear remembered lines.
      */
     if (cstack.cs_looplevel == 0) {
-      if (lines_ga.ga_len > 0) {
+      if (!GA_EMPTY(&lines_ga)) {
         sourcing_lnum =
           ((wcmd_T *)lines_ga.ga_data)[lines_ga.ga_len - 1].lnum;
         free_cmdlines(&lines_ga);
@@ -1188,7 +1188,7 @@ static void store_loop_line(garray_T *gap, char_u *line)
  */
 static void free_cmdlines(garray_T *gap)
 {
-  while (gap->ga_len > 0) {
+  while (!GA_EMPTY(gap)) {
     free(((wcmd_T *)(gap->ga_data))[gap->ga_len - 1].line);
     --gap->ga_len;
   }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4187,7 +4187,7 @@ static int ExpandRTDir(char_u *pat, int *num_file, char_u ***file, char *dirname
     }
     free(matches);
   }
-  if (ga.ga_len == 0)
+  if (GA_EMPTY(&ga))
     return FAIL;
 
   /* Sort and remove duplicates which can happen when specifying multiple

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1831,7 +1831,7 @@ getexmodeline (
 
       if (c1 == BS || c1 == K_BS
           || c1 == DEL || c1 == K_DEL || c1 == K_KDEL) {
-        if (line_ga.ga_len > 0) {
+        if (!GA_EMPTY(&line_ga)) {
           --line_ga.ga_len;
           goto redraw;
         }
@@ -1940,7 +1940,7 @@ redraw:
 
     /* We are done when a NL is entered, but not when it comes after an
      * odd number of backslashes, that results in a NUL. */
-    if (line_ga.ga_len > 0 && pend[-1] == '\n') {
+    if (!GA_EMPTY(&line_ga) && pend[-1] == '\n') {
       int bcount = 0;
 
       while (line_ga.ga_len - 2 >= bcount && pend[-2 - bcount] == '\\')

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1013,7 +1013,7 @@ void cloneFoldGrowArray(garray_T *from, garray_T *to)
 
   ga_init(to, from->ga_itemsize, from->ga_growsize);
 
-  if (from->ga_len == 0)
+  if (GA_EMPTY(from))
     return;
 
   ga_grow(to, from->ga_len);
@@ -1302,7 +1302,7 @@ static void deleteFoldEntry(garray_T *gap, int idx, int recursive)
   fold_T      *nfp;
 
   fp = (fold_T *)gap->ga_data + idx;
-  if (recursive || fp->fd_nested.ga_len == 0) {
+  if (recursive || GA_EMPTY(&fp->fd_nested)) {
     /* recursively delete the contained folds */
     deleteFoldRecurse(&fp->fd_nested);
     --gap->ga_len;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -138,7 +138,7 @@ int hasAnyFolding(win_T *win)
 {
   /* very simple now, but can become more complex later */
   return win->w_p_fen
-         && (!foldmethodIsManual(win) || win->w_folds.ga_len > 0);
+         && (!foldmethodIsManual(win) || !GA_EMPTY(&win->w_folds));
 }
 
 /* hasFolding() {{{2 */
@@ -2655,7 +2655,7 @@ static void foldMerge(fold_T *fp1, garray_T *gap, fold_T *fp2)
     foldMerge(fp3, gap2, fp4);
 
   /* Move nested folds in fp2 to the end of fp1. */
-  if (gap2->ga_len > 0) {
+  if (!GA_EMPTY(gap2)) {
     ga_grow(gap1, gap2->ga_len);
     for (idx = 0; idx < gap2->ga_len; ++idx) {
       ((fold_T *)gap1->ga_data)[gap1->ga_len]
@@ -2982,7 +2982,7 @@ static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off
   fp = (fold_T *)gap->ga_data;
   for (i = 0; i < gap->ga_len; i++) {
     if (fp->fd_flags != FD_LEVEL) {
-      if (fp->fd_nested.ga_len > 0) {
+      if (!GA_EMPTY(&fp->fd_nested)) {
         /* open nested folds while this fold is open */
         if (fprintf(fd, "%" PRId64, (int64_t)(fp->fd_top + off)) < 0
             || put_eol(fd) == FAIL

--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -185,7 +185,7 @@ void ga_append(garray_T *gap, char c)
 void append_ga_line(garray_T *gap)
 {
   // Remove trailing CR.
-  if ((gap->ga_len > 0)
+  if (!GA_EMPTY(gap)
       && !curbuf->b_p_bin
       && (((char_u *)gap->ga_data)[gap->ga_len - 1] == CAR)) {
     gap->ga_len--;

--- a/src/nvim/garray.h
+++ b/src/nvim/garray.h
@@ -16,6 +16,8 @@ typedef struct growarray {
 
 #define GA_EMPTY_INIT_VALUE { 0, 0, 0, 0, NULL }
 
+#define GA_EMPTY(ga_ptr) ((ga_ptr)->ga_len <= 0)
+
 void ga_clear(garray_T *gap);
 void ga_clear_strings(garray_T *gap);
 void ga_init(garray_T *gap, int itemsize, int growsize);

--- a/src/nvim/garray.h
+++ b/src/nvim/garray.h
@@ -14,7 +14,7 @@ typedef struct growarray {
   void *ga_data;                    // pointer to the first item
 } garray_T;
 
-#define GA_EMPTY { 0, 0, 0, 0, NULL }
+#define GA_EMPTY_INIT_VALUE { 0, 0, 0, 0, NULL }
 
 void ga_clear(garray_T *gap);
 void ga_clear_strings(garray_T *gap);

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -1513,7 +1513,7 @@ static void prt_def_var(char *name, double value, int prec)
 
 static void prt_flush_buffer(void)
 {
-  if (prt_ps_buffer.ga_len > 0) {
+  if (!GA_EMPTY(&prt_ps_buffer)) {
     /* Any background color must be drawn first */
     if (prt_do_bgcol && (prt_new_bgcol != PRCOLOR_WHITE)) {
       int r, g, b;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1964,7 +1964,7 @@ void set_init_1(void)
         /* First time count the NUL, otherwise count the ','. */
         len = (int)STRLEN(p) + 3;
         ga_grow(&ga, len);
-        if (ga.ga_len > 0)
+        if (!GA_EMPTY(&ga))
           STRCAT(ga.ga_data, ",");
         STRCAT(ga.ga_data, p);
         add_pathsep(ga.ga_data);

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -229,7 +229,7 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_shell_arg)
   }
 
   if (opts & kShellOptRead) {
-    if (pdata.ga.ga_len > 0) {
+    if (!GA_EMPTY(&pdata.ga)) {
       // If there's an unfinished line in the growable array, append it now.
       append_ga_line(&pdata.ga);
       // remember that the NL was missing

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1094,7 +1094,7 @@ gen_expand_wildcards (
       free(t);
     }
 
-    if (did_expand_in_path && ga.ga_len > 0 && (flags & EW_PATH))
+    if (did_expand_in_path && !GA_EMPTY(&ga) && (flags & EW_PATH))
       uniquefy_paths(&ga, p);
     if (p != pat[i])
       free(p);

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -893,7 +893,7 @@ expand_in_path (
   ga_init(&path_ga, (int)sizeof(char_u *), 1);
   expand_path_option(curdir, &path_ga);
   free(curdir);
-  if (path_ga.ga_len == 0)
+  if (GA_EMPTY(&path_ga))
     return 0;
 
   paths = ga_concat_strings(&path_ga);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -4697,7 +4697,7 @@ regmatch (
      * If there is something on the regstack execute the code for the state.
      * If the state is popped then loop and use the older state.
      */
-    while (regstack.ga_len > 0 && status != RA_FAIL) {
+    while (!GA_EMPTY(&regstack) && status != RA_FAIL) {
       rp = (regitem_T *)((char *)regstack.ga_data + regstack.ga_len) - 1;
       switch (rp->rs_state) {
       case RS_NOPEN:

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -5021,7 +5021,7 @@ regmatch (
     /*
      * If the regstack is empty or something failed we are done.
      */
-    if (regstack.ga_len == 0 || status == RA_FAIL) {
+    if (GA_EMPTY(&regstack) || status == RA_FAIL) {
       if (scan == NULL) {
         /*
          * We get here only if there's trouble -- normally "case END" is

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2380,7 +2380,7 @@ win_line (
 
   if (wp->w_p_spell
       && *wp->w_s->b_p_spl != NUL
-      && wp->w_s->b_langp.ga_len > 0
+      && !GA_EMPTY(&wp->w_s->b_langp)
       && *(char **)(wp->w_s->b_langp.ga_data) != NULL) {
     /* Prepare for spell checking. */
     has_spell = TRUE;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -997,7 +997,7 @@ spell_check (
     return 1;
 
   // Return here when loading language files failed.
-  if (wp->w_s->b_langp.ga_len == 0)
+  if (GA_EMPTY(&wp->w_s->b_langp))
     return 1;
 
   memset(&mi, 0, sizeof(matchinf_T));
@@ -1947,7 +1947,7 @@ spell_valid_case (
 static int no_spell_checking(win_T *wp)
 {
   if (!wp->w_p_spell || *wp->w_s->b_p_spl == NUL
-      || wp->w_s->b_langp.ga_len == 0) {
+      || GA_EMPTY(&wp->w_s->b_langp)) {
     EMSG(_("E756: Spell checking is not enabled"));
     return TRUE;
   }
@@ -4557,16 +4557,16 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
   spell_message(spin, IObuff);
 
   // Only do REP lines when not done in another .aff file already.
-  do_rep = spin->si_rep.ga_len == 0;
+  do_rep = GA_EMPTY(&spin->si_rep);
 
   // Only do REPSAL lines when not done in another .aff file already.
-  do_repsal = spin->si_repsal.ga_len == 0;
+  do_repsal = GA_EMPTY(&spin->si_repsal);
 
   // Only do SAL lines when not done in another .aff file already.
-  do_sal = spin->si_sal.ga_len == 0;
+  do_sal = GA_EMPTY(&spin->si_sal);
 
   // Only do MAP lines when not done in another .aff file already.
-  do_mapline = spin->si_map.ga_len == 0;
+  do_mapline = GA_EMPTY(&spin->si_map);
 
   // Allocate and init the afffile_T structure.
   aff = (afffile_T *)getroom(spin, sizeof(afffile_T), TRUE);
@@ -6938,7 +6938,7 @@ static int write_vim_spell(spellinfo_T *spin, char_u *fname)
       gap = &spin->si_repsal;
 
     // Don't write the section if there are no items.
-    if (gap->ga_len == 0)
+    if (GA_EMPTY(gap))
       continue;
 
     // Sort the REP/REPSAL items.
@@ -8691,7 +8691,7 @@ void spell_suggest(int count)
   spell_find_suggest(line + curwin->w_cursor.col, badlen, &sug, limit,
       TRUE, need_cap, TRUE);
 
-  if (sug.su_ga.ga_len == 0)
+  if (GA_EMPTY(&sug.su_ga))
     MSG(_("Sorry, no suggestions"));
   else if (count > 0) {
     if (count > sug.su_ga.ga_len)
@@ -11680,7 +11680,7 @@ add_suggestion (
     // the first "the" to itself.
     return;
 
-  if (gap->ga_len == 0)
+  if (GA_EMPTY(gap))
     i = -1;
   else {
     // Check if the word is already there.  Also check the length that is

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -2376,12 +2376,12 @@ static void check_state_ends(void)
 
         pop_current_state();
 
-        if (current_state.ga_len == 0)
+        if (GA_EMPTY(&current_state))
           break;
 
         if (had_extend && keepend_level >= 0) {
           syn_update_ends(FALSE);
-          if (current_state.ga_len == 0)
+          if (GA_EMPTY(&current_state))
             break;
         }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -892,7 +892,7 @@ static void syn_sync(win_T *wp, linenr_T start_lnum, synstate_T *last_valid)
          * For "groupthere" the parsing starts at start_lnum.
          */
         if (found_flags & HL_SYNC_HERE) {
-          if (current_state.ga_len) {
+          if (!GA_EMPTY(&current_state)) {
             cur_si = &CUR_STATE(current_state.ga_len - 1);
             cur_si->si_h_startpos.lnum = found_current_lnum;
             cur_si->si_h_startpos.col = found_current_col;
@@ -2595,7 +2595,7 @@ static void push_current_state(int idx)
  */
 static void pop_current_state(void)
 {
-  if (current_state.ga_len) {
+  if (!GA_EMPTY(&current_state)) {
     unref_extmatch(CUR_STATE(current_state.ga_len - 1).si_extmatch);
     --current_state.ga_len;
   }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -951,7 +951,7 @@ static void syn_start_line(void)
    * Need to update the end of a start/skip/end that continues from the
    * previous line and regions that have "keepend".
    */
-  if (current_state.ga_len > 0) {
+  if (!GA_EMPTY(&current_state)) {
     syn_update_ends(TRUE);
     check_state_ends();
   }
@@ -2187,7 +2187,7 @@ syn_current_attr (
      */
     if (!syncing && !keep_state) {
       check_state_ends();
-      if (current_state.ga_len > 0
+      if (!GA_EMPTY(&current_state)
           && syn_getcurline()[current_col] != NUL) {
         ++current_col;
         check_state_ends();
@@ -2207,7 +2207,7 @@ syn_current_attr (
       && !(current_next_flags & (HL_SKIPNL | HL_SKIPEMPTY)))
     current_next_list = NULL;
 
-  if (zero_width_next_ga.ga_len > 0)
+  if (!GA_EMPTY(&zero_width_next_ga))
     ga_clear(&zero_width_next_ga);
 
   /* No longer need external matches.  But keep next_match_extmatch. */

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2019,7 +2019,7 @@ findtag_end:
   return retval;
 }
 
-static garray_T tag_fnames = GA_EMPTY;
+static garray_T tag_fnames = GA_EMPTY_INIT_VALUE;
 static void found_tagfile_cb(char_u *fname, void *cookie);
 
 /*

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2419,7 +2419,7 @@ void ex_undolist(exarg_T *eap)
     }
   }
 
-  if (ga.ga_len == 0)
+  if (GA_EMPTY(&ga))
     MSG(_("Nothing to undo"));
   else {
     sort_strings((char_u **)ga.ga_data, ga.ga_len);


### PR DESCRIPTION
This is the first of many steps to allow us to move away from `garray.c` API someday.

I used Coccinelle to automate these changes. I'm still a n00b on it, but these two semantic patches did the job.
- Replace ga->ga_len > 0 checks with !GA_EMPTY(ga)

``` diff
@@
expression E;
@@

<...
(
- E.ga_len > 0
+ !GA_EMPTY(&E)
|
- E->ga_len > 0
+ !GA_EMPTY(E)
)
...>
```
- Replace ga->ga_len == 0 checks with GA_EMPTY(ga)

``` diff
@@
expression E;
@@

<...
(
// E.ga_len == 0 is isomorphic to !E.ga_len
- E.ga_len == 0
+ GA_EMPTY(&E)
|
- E->ga_len == 0
+ GA_EMPTY(E)
)
...>
```
- Replace if (ga->ga_len) with if (!GA_EMPTY(ga)) …

``` diff
@@
expression E;
statement S;
@@

(
- if (E.ga_len) S
+ if (!GA_EMPTY(&E)) S
|
- if (E->ga_len) S
+ if (!GA_EMPTY(E)) S
)
```
