### PR TITLE
[RFC] add GA_DEEP_CLEAR(ga), and refactor two files using this function

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5632,9 +5632,7 @@ helptags_one (
   if (mix)
     got_int = FALSE;        /* continue with other languages */
 
-  for (i = 0; i < ga.ga_len; ++i)
-    free(((char_u **)ga.ga_data)[i]);
-  ga_clear(&ga);
+  GA_DEEP_CLEAR_PTR(&ga);
   fclose(fd_tags);          /* there is no check for an error... */
 }
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1193,7 +1193,7 @@ static void store_loop_line(garray_T *gap, char_u *line)
  * Free the lines stored for a ":while" or ":for" loop.
  */
 static void wcmd_clear(wcmd_T *wdp){
-  free(wpd->line);
+  free(wdp->line);
 }
 
 /*

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -307,7 +307,7 @@ static void store_loop_line(garray_T *gap, char_u *line);
 ///
 /// clear the content in wcmd_T
 ///
-/// @param wdp ptr to wmcd_T to be cleared
+/// @param wdp ptr to wcmd_T to be cleared
 ///
 /// @warming wcmd_T will no longer have valid empty data
 ///
@@ -882,7 +882,7 @@ int flags;
       if (lines_ga.ga_len > 0) {
         sourcing_lnum =
           ((wcmd_T *)lines_ga.ga_data)[lines_ga.ga_len - 1].lnum;
-        GA_DEEP_CLEAR(&lines_ga, wcmd_T, wmcd_clear);
+        GA_DEEP_CLEAR(&lines_ga, wcmd_T, wcmd_clear);
       }
       current_line = 0;
     }

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -303,7 +303,6 @@ struct loop_cookie {
 
 static char_u   *get_loop_line(int c, void *cookie, int indent);
 static void store_loop_line(garray_T *gap, char_u *line);
-
 ///
 /// clear the content in wcmd_T
 ///
@@ -1189,10 +1188,8 @@ static void store_loop_line(garray_T *gap, char_u *line)
   ++gap->ga_len;
 }
 
-/*
- * Free the lines stored for a ":while" or ":for" loop.
- */
-static void wcmd_clear(wcmd_T *wdp){
+static void wcmd_clear(wcmd_T *wdp)
+{
   free(wdp->line);
 }
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -303,7 +303,15 @@ struct loop_cookie {
 
 static char_u   *get_loop_line(int c, void *cookie, int indent);
 static void store_loop_line(garray_T *gap, char_u *line);
-static void free_cmdlines(garray_T *gap);
+
+///
+/// clear the content in wcmd_T
+///
+/// @param wdp ptr to wmcd_T to be cleared
+///
+/// @warming wcmd_T will no longer have valid empty data
+///
+static void wcmd_clear(wcmd_T * wdp);
 
 /* Struct to save a few things while debugging.  Used in do_cmdline() only. */
 struct dbg_stuff {
@@ -361,7 +369,7 @@ static void restore_dbg_stuff(struct dbg_stuff *dsp)
  * do_exmode(): Repeatedly get commands for the "Ex" mode, until the ":vi"
  * command is given.
  */
-void 
+void
 do_exmode (
     int improved                       /* TRUE for "improved Ex" mode */
 )
@@ -874,7 +882,7 @@ int flags;
       if (lines_ga.ga_len > 0) {
         sourcing_lnum =
           ((wcmd_T *)lines_ga.ga_data)[lines_ga.ga_len - 1].lnum;
-        free_cmdlines(&lines_ga);
+        GA_DEEP_CLEAR(&lines_ga, wcmd_T, wmcd_clear);
       }
       current_line = 0;
     }
@@ -941,8 +949,7 @@ int flags;
 
   free(cmdline_copy);
   did_emsg_syntax = FALSE;
-  free_cmdlines(&lines_ga);
-  ga_clear(&lines_ga);
+  GA_DEEP_CLEAR(&lines_ga, wcmd_T, wcmd_clear);
 
   if (cstack.cs_idx >= 0) {
     /*
@@ -1185,12 +1192,8 @@ static void store_loop_line(garray_T *gap, char_u *line)
 /*
  * Free the lines stored for a ":while" or ":for" loop.
  */
-static void free_cmdlines(garray_T *gap)
-{
-  while (gap->ga_len > 0) {
-    free(((wcmd_T *)(gap->ga_data))[gap->ga_len - 1].line);
-    --gap->ga_len;
-  }
+static void wcmd_clear(wcmd_T *wdp){
+  free(wpd->line);
 }
 
 /*
@@ -2160,7 +2163,7 @@ doend:
  * Check for an Ex command with optional tail.
  * If there is a match advance "pp" to the argument and return TRUE.
  */
-int 
+int
 checkforcmd (
     char_u **pp,               /* start of command */
     char *cmd,               /* name of command */
@@ -3266,7 +3269,7 @@ skip_range (
  *
  * Return MAXLNUM when no Ex address was found.
  */
-static linenr_T 
+static linenr_T
 get_address (
     char_u **ptr,
     int skip,                   /* only skip the address, don't use it */
@@ -4226,7 +4229,7 @@ char_u *check_nextcmd(char_u *p)
  *    return FAIL and give error message if 'message' TRUE
  * return OK otherwise
  */
-static int 
+static int
 check_more (
     int message,                /* when FALSE check only, no messages */
     int forceit
@@ -4853,7 +4856,7 @@ static char_u *uc_split_args(char_u *arg, size_t *lenp)
  * Returns the length of the replacement, which has been added to "buf".
  * Returns -1 if there was no match, and only the "<" has been copied.
  */
-static size_t 
+static size_t
 uc_check_code (
     char_u *code,
     size_t len,
@@ -5399,7 +5402,7 @@ static void ex_pclose(exarg_T *eap)
  * Close window "win" and take care of handling closing the last window for a
  * modified buffer.
  */
-static void 
+static void
 ex_win_close (
     int forceit,
     win_T *win,
@@ -5780,7 +5783,7 @@ void alist_set(alist_T *al, int count, char_u **files, int use_curbuf, int *fnum
  * Add file "fname" to argument list "al".
  * "fname" must have been allocated and "al" must have been checked for room.
  */
-void 
+void
 alist_add (
     alist_T *al,
     char_u *fname,
@@ -6159,7 +6162,7 @@ static void ex_edit(exarg_T *eap)
 /*
  * ":edit <file>" command and alikes.
  */
-void 
+void
 do_exedit (
     exarg_T *eap,
     win_T *old_curwin            /* curwin before doing a split or NULL */
@@ -8042,7 +8045,7 @@ static int ses_fname(FILE *fd, buf_T *buf, unsigned *flagp);
  * Write openfile commands for the current buffers to an .exrc file.
  * Return FAIL on error, OK otherwise.
  */
-static int 
+static int
 makeopens (
     FILE *fd,
     char_u *dirnow            /* Current directory name */
@@ -8452,7 +8455,7 @@ static int ses_do_win(win_T *wp)
  * Write commands to "fd" to restore the view of a window.
  * Caller must make sure 'scrolloff' is zero.
  */
-static int 
+static int
 put_view (
     FILE *fd,
     win_T *wp,
@@ -8633,7 +8636,7 @@ put_view (
  * Write an argument list to the session file.
  * Returns FAIL if writing fails.
  */
-static int 
+static int
 ses_arglist (
     FILE *fd,
     char *cmd,

--- a/src/garray.c
+++ b/src/garray.c
@@ -25,14 +25,12 @@ void ga_clear(garray_T *gap)
   gap->ga_len = 0;
 }
 
-#define FREE_PTR(ptr) free(*ptr)
-
 /// Clear a growing array that contains a list of strings.
 ///
 /// @param gap
 void ga_clear_strings(garray_T *gap)
 {
-  GA_DEEP_CLEAR(gap, void*, FREE_PTR);
+  GA_DEEP_CLEAR_PTR(gap);
 }
 
 /// Initialize a growing array.

--- a/src/garray.c
+++ b/src/garray.c
@@ -25,16 +25,14 @@ void ga_clear(garray_T *gap)
   gap->ga_len = 0;
 }
 
+#define FREE_PTR(ptr) free(*ptr)
+
 /// Clear a growing array that contains a list of strings.
 ///
 /// @param gap
 void ga_clear_strings(garray_T *gap)
 {
-  int i;
-  for (i = 0; i < gap->ga_len; ++i) {
-    free(((char_u **)(gap->ga_data))[i]);
-  }
-  ga_clear(gap);
+  GA_DEEP_CLEAR(gap, void*, FREE_PTR);
 }
 
 /// Initialize a growing array.

--- a/src/garray.h
+++ b/src/garray.h
@@ -29,7 +29,7 @@ typedef struct growarray {
 /// @return nothing
 ///
 #define GA_DEEP_CLEAR(gap, item_type, free_item_fn) \
-  { \
+  do{ \
     garray_T* _gap = (gap); \
     while (_gap->ga_len > 0) {  \
       _gap->ga_len--; \
@@ -37,7 +37,7 @@ typedef struct growarray {
       free_item_fn(_item);  \
     }  \
     ga_clear(_gap); \
-  }
+  }while(false)
 
 #define GA_DEEP_CLEAR_PTR(gap) GA_DEEP_CLEAR(gap, void*, FREE_PTR)
 

--- a/src/garray.h
+++ b/src/garray.h
@@ -16,6 +16,25 @@ typedef struct growarray {
 
 #define GA_EMPTY { 0, 0, 0, 0, NULL }
 
+/// free garry of specific type using customized free function.
+/// items in array as well as array itself will be freed.
+///
+/// @param gap the array to be freed
+///
+/// @param item_type type of the item in array
+///
+/// @param free_item_fn free function that takes (*item_type) as parameter
+///
+/// @return nothing
+///
+#define GA_DEEP_CLEAR(gap, item_type, free_item_fn) \
+  while ((gap)->ga_len > 0) {  \
+    (gap)->ga_len--;
+    item_type *item = &((item_type *)(gap)->ga_data)[(gap)->ga_len]; \
+    free_item_fn(item);  \
+  }  \
+  ga_clear(gap)
+
 void ga_clear(garray_T *gap);
 void ga_clear_strings(garray_T *gap);
 void ga_init(garray_T *gap, int itemsize, int growsize);

--- a/src/garray.h
+++ b/src/garray.h
@@ -29,7 +29,7 @@ typedef struct growarray {
 ///
 #define GA_DEEP_CLEAR(gap, item_type, free_item_fn) \
   while ((gap)->ga_len > 0) {  \
-    (gap)->ga_len--;
+    (gap)->ga_len--; \
     item_type *item = &((item_type *)(gap)->ga_data)[(gap)->ga_len]; \
     free_item_fn(item);  \
   }  \

--- a/src/garray.h
+++ b/src/garray.h
@@ -29,12 +29,15 @@ typedef struct growarray {
 /// @return nothing
 ///
 #define GA_DEEP_CLEAR(gap, item_type, free_item_fn) \
-  while ((gap)->ga_len > 0) {  \
-    (gap)->ga_len--; \
-    item_type *item = &((item_type *)(gap)->ga_data)[(gap)->ga_len]; \
-    free_item_fn(item);  \
-  }  \
-  ga_clear(gap)
+  { \
+    garray_T* _gap = (gap); \
+    while (_gap->ga_len > 0) {  \
+      _gap->ga_len--; \
+      item_type *_item = &((item_type *)_gap->ga_data)[_gap->ga_len]; \
+      free_item_fn(_item);  \
+    }  \
+    ga_clear(_gap); \
+  }
 
 #define GA_DEEP_CLEAR_PTR(gap) GA_DEEP_CLEAR(gap, void*, FREE_PTR)
 

--- a/src/garray.h
+++ b/src/garray.h
@@ -35,6 +35,9 @@ typedef struct growarray {
   }  \
   ga_clear(gap)
 
+#define GA_DEEP_CEAR_PTR(gap) ga_clear_strings(gap)
+
+
 void ga_clear(garray_T *gap);
 void ga_clear_strings(garray_T *gap);
 void ga_init(garray_T *gap, int itemsize, int growsize);

--- a/src/garray.h
+++ b/src/garray.h
@@ -15,6 +15,7 @@ typedef struct growarray {
 } garray_T;
 
 #define GA_EMPTY { 0, 0, 0, 0, NULL }
+#define FREE_PTR(ptr) free(*(ptr))
 
 /// free garry of specific type using customized free function.
 /// items in array as well as array itself will be freed.
@@ -35,7 +36,7 @@ typedef struct growarray {
   }  \
   ga_clear(gap)
 
-#define GA_DEEP_CLEAR_PTR(gap) ga_clear_strings(gap)
+#define GA_DEEP_CLEAR_PTR(gap) GA_DEEP_CLEAR(gap, void*, FREE_PTR)
 
 
 void ga_clear(garray_T *gap);

--- a/src/garray.h
+++ b/src/garray.h
@@ -35,7 +35,7 @@ typedef struct growarray {
   }  \
   ga_clear(gap)
 
-#define GA_DEEP_CEAR_PTR(gap) ga_clear_strings(gap)
+#define GA_DEEP_CLEAR_PTR(gap) ga_clear_strings(gap)
 
 
 void ga_clear(garray_T *gap);

--- a/src/spell.c
+++ b/src/spell.c
@@ -2356,7 +2356,7 @@ static void slang_clear(slang_T *lp)
     // "ga_len" is set to 1 without adding an item for latin1
     if(gap->ga_data != NULL) {
       // SOFOFROM and SOFOTO items: free lists of wide characters.
-      ga_clear_strings(gap);
+      GA_DEEP_CLEAR_PTR(gap);
     } else {
       ga_clear(gap);
     }

--- a/src/spell.c
+++ b/src/spell.c
@@ -2356,8 +2356,10 @@ static void slang_clear(slang_T *lp)
     // "ga_len" is set to 1 without adding an item for latin1
     if(gap->ga_data != NULL) {
       // SOFOFROM and SOFOTO items: free lists of wide characters.
-      GA_DEEP_CLEAR(gap, int*, free);
+      for (i = 0; i < gap->ga_len; ++i)
+        free(((int **)gap->ga_data)[i]);
     }
+    ga_clear(gap);
   } else {
   // SAL items: free salitem_T items
     GA_DEEP_CLEAR(gap,salitem_T, salitem_clear);

--- a/src/spell.c
+++ b/src/spell.c
@@ -802,7 +802,6 @@ typedef struct trystate_S {
 
 static slang_T *slang_alloc(char_u *lang);
 static void slang_free(slang_T *lp);
-
 ///
 /// clear the content in salitem
 ///
@@ -811,7 +810,6 @@ static void slang_free(slang_T *lp);
 /// @warming salitem_T will no longer have valid empty data
 ///
 static void salitem_clear(salitem_T *smp);
-
 ///
 /// clear the content in fromto_T
 ///
@@ -2314,7 +2312,8 @@ static void slang_free(slang_T *lp)
   free(lp);
 }
 
-static void salitem_clear(salitem_T *smp) {
+static void salitem_clear(salitem_T *smp)
+{
   free(smp->sm_lead);
   // Don't free sm_oneof and sm_rules, they point into sm_lead.
   free(smp->sm_to);
@@ -2323,7 +2322,8 @@ static void salitem_clear(salitem_T *smp) {
   free(smp->sm_to_w);
 }
 
-static void fromto_clear(fromto_T *ftp) {
+static void fromto_clear(fromto_T *ftp)
+{
   free(ftp->ft_from);
   free(ftp->ft_to);
 }
@@ -2348,16 +2348,16 @@ static void slang_clear(slang_T *lp)
   free(lp->sl_pidxs);
   lp->sl_pidxs = NULL;
 
-  gap = &lp->sl_rep;
-  GA_DEEP_CLEAR(gap, fromto_T, fromto_clear);
-  gap = &lp->sl_repsal;
-  GA_DEEP_CLEAR(gap, fromto_T, fromto_clear);
+  GA_DEEP_CLEAR(&lp->sl_rep, fromto_T, fromto_clear);
+  GA_DEEP_CLEAR(&lp->sl_repsal, fromto_T, fromto_clear);
 
   gap = &lp->sl_sal;
   if (lp->sl_sofo) {
     // "ga_len" is set to 1 without adding an item for latin1
-    // SOFOFROM and SOFOTO items: free lists of wide characters.
-    GA_DEEP_CLEAR(gap,int*,free);
+    if(gap->ga_data != NULL) {
+      // SOFOFROM and SOFOTO items: free lists of wide characters.
+      GA_DEEP_CLEAR(gap, int*, free);
+    }
   } else {
   // SAL items: free salitem_T items
     GA_DEEP_CLEAR(gap,salitem_T, salitem_clear);

--- a/src/spell.c
+++ b/src/spell.c
@@ -808,7 +808,10 @@ static void slang_free(slang_T *lp);
 ///
 /// @param ftp ptr to salitem_T to be cleared
 ///
+/// @warming salitem_T will no longer have valid empty data
+///
 static void salitem_clear(salitem_T *smp);
+
 ///
 /// clear the content in fromto_T
 ///

--- a/src/spell.c
+++ b/src/spell.c
@@ -2332,9 +2332,7 @@ static void fromto_clear(fromto_T *ftp) {
 static void slang_clear(slang_T *lp)
 {
   garray_T    *gap;
-  salitem_T   *smp;
   int i;
-  int round;
 
   free(lp->sl_fbyts);
   lp->sl_fbyts = NULL;

--- a/src/spell.c
+++ b/src/spell.c
@@ -2356,10 +2356,10 @@ static void slang_clear(slang_T *lp)
     // "ga_len" is set to 1 without adding an item for latin1
     if(gap->ga_data != NULL) {
       // SOFOFROM and SOFOTO items: free lists of wide characters.
-      for (i = 0; i < gap->ga_len; ++i)
-        free(((int **)gap->ga_data)[i]);
+      ga_clear_strings(gap);
+    } else {
+      ga_clear(gap);
     }
-    ga_clear(gap);
   } else {
   // SAL items: free salitem_T items
     GA_DEEP_CLEAR(gap,salitem_T, salitem_clear);


### PR DESCRIPTION
As suggested, I added GA_DEEP_CLEAR(ga) to deep clear garray. It seems that we can use this function in two only files: "spell.c" and "ex_cmd.c"
