### PR TITLE
[RDY] Remove NULL/non-NULL tests after calls to vim_str(n)save and replace alloc with xmalloc

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2237,9 +2237,8 @@ setfname (
       close_buffer(NULL, obuf, DOBUF_WIPE, FALSE);
     }
     sfname = vim_strsave(sfname);
-    if (ffname == NULL || sfname == NULL) {
+    if (ffname == NULL) {
       free(sfname);
-      free(ffname);
       return FAIL;
     }
 #ifdef USE_FNAME_CASE
@@ -4116,8 +4115,6 @@ chk_modeline (
     while (s[-1] != ':');
 
     s = linecopy = vim_strsave(s);      /* copy the line, it will change */
-    if (linecopy == NULL)
-      return FAIL;
 
     save_sourcing_lnum = sourcing_lnum;
     save_sourcing_name = sourcing_name;

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1911,9 +1911,6 @@ void backslash_halve(char_u *p)
 char_u* backslash_halve_save(char_u *p)
 {
   char_u *res = vim_strsave(p);
-  if (res == NULL) {
-    return p;
-  }
   backslash_halve(res);
   return res;
 }

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1910,6 +1910,7 @@ void backslash_halve(char_u *p)
 /// @return String with the number of backslashes halved.
 char_u* backslash_halve_save(char_u *p)
 {
+  // TODO(philix): simplify and improve backslash_halve_save algorithm
   char_u *res = vim_strsave(p);
   backslash_halve(res);
   return res;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -519,10 +519,6 @@ static void diff_check_unchanged(tabpage_T *tp, diff_T *dp)
                                                 dp->df_lnum[i_org] + off_org,
                                                 FALSE));
 
-      if (line_org == NULL) {
-        return;
-      }
-
       int i_new;
       for (i_new = i_org + 1; i_new < DB_COUNT; ++i_new) {
         if (tp->tp_diffbuf[i_new] == NULL) {
@@ -972,10 +968,7 @@ void ex_diffpatch(exarg_T *eap)
     if (curbuf->b_fname != NULL) {
       newname = vim_strnsave(curbuf->b_fname,
                              (int)(STRLEN(curbuf->b_fname) + 4));
-
-      if (newname != NULL) {
-        STRCAT(newname, ".new");
-      }
+      STRCAT(newname, ".new");
     }
 
     // don't use a new tab page, each tab page has its own diffs
@@ -1580,9 +1573,6 @@ static int diff_equal_entry(diff_T *dp, int idx1, int idx2)
     char_u *line = vim_strsave(ml_get_buf(curtab->tp_diffbuf[idx1],
                                           dp->df_lnum[idx1] + i, FALSE));
 
-    if (line == NULL) {
-      return FALSE;
-    }
     int cmp = diff_cmp(line, ml_get_buf(curtab->tp_diffbuf[idx2],
                                         dp->df_lnum[idx2] + i, FALSE));
     free(line);
@@ -1886,9 +1876,6 @@ int diff_find_change(win_T *wp, linenr_T lnum, int *startp, int *endp)
 
   // Make a copy of the line, the next ml_get() will invalidate it.
   char_u *line_org = vim_strsave(ml_get_buf(wp->w_buffer, lnum, FALSE));
-  if (line_org == NULL) {
-    return FALSE;
-  }
 
   int idx = diff_buf_idx(wp->w_buffer);
   if (idx == DB_COUNT) {
@@ -2283,16 +2270,14 @@ void ex_diffgetput(exarg_T *eap)
           break;
         }
         p = vim_strsave(ml_get_buf(curtab->tp_diffbuf[idx_from], nr, FALSE));
-        if (p != NULL) {
-          ml_append(lnum + i - 1, p, 0, FALSE);
-          free(p);
-          added++;
-          if (buf_empty && (curbuf->b_ml.ml_line_count == 2)) {
-            // Added the first line into an empty buffer, need to
-            // delete the dummy empty line.
-            buf_empty = FALSE;
-            ml_delete((linenr_T)2, FALSE);
-          }
+        ml_append(lnum + i - 1, p, 0, FALSE);
+        free(p);
+        added++;
+        if (buf_empty && (curbuf->b_ml.ml_line_count == 2)) {
+          // Added the first line into an empty buffer, need to
+          // delete the dummy empty line.
+          buf_empty = FALSE;
+          ml_delete((linenr_T)2, FALSE);
         }
       }
       new_count = dp->df_count[idx_to] + added;

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1738,28 +1738,24 @@ char_u* keymap_init(void)
     keymap_unload();
     do_cmdline_cmd((char_u *)"unlet! b:keymap_name");
   } else {
-    char_u  *buf;
+    char *buf;
     size_t buflen;
 
     // Source the keymap file.  It will contain a ":loadkeymap" command
     // which will call ex_loadkeymap() below.
     buflen = STRLEN(curbuf->b_p_keymap) + STRLEN(p_enc) + 14;
-    buf = alloc((unsigned)buflen);
-
-    if (buf == NULL) {
-      return e_outofmem;
-    }
+    buf = xmalloc(buflen);
 
     // try finding "keymap/'keymap'_'encoding'.vim"  in 'runtimepath'
-    vim_snprintf((char *)buf, buflen, "keymap/%s_%s.vim",
+    vim_snprintf(buf, buflen, "keymap/%s_%s.vim",
                  curbuf->b_p_keymap, p_enc);
 
-    if (source_runtime(buf, FALSE) == FAIL) {
+    if (source_runtime((char_u *)buf, FALSE) == FAIL) {
       // try finding "keymap/'keymap'.vim" in 'runtimepath'
-      vim_snprintf((char *)buf, buflen, "keymap/%s.vim",
+      vim_snprintf(buf, buflen, "keymap/%s.vim",
                    curbuf->b_p_keymap);
 
-      if (source_runtime(buf, FALSE) == FAIL) {
+      if (source_runtime((char_u *)buf, FALSE) == FAIL) {
         free(buf);
         return (char_u *)N_("E544: Keymap file not found");
       }

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1818,12 +1818,10 @@ void ex_loadkeymap(exarg_T *eap)
       s = skiptowhite(p);
       kp->to = vim_strnsave(p, (int)(s - p));
 
-      if ((kp->from == NULL)
-          || (kp->to == NULL)
-          || (STRLEN(kp->from) + STRLEN(kp->to) >= KMAP_LLEN)
+      if ((STRLEN(kp->from) + STRLEN(kp->to) >= KMAP_LLEN)
           || (*kp->from == NUL)
           || (*kp->to == NUL)) {
-        if ((kp->to != NULL) && (*kp->to == NUL)) {
+        if (*kp->to == NUL) {
           EMSG(_("E791: Empty keymap entry"));
         }
         free(kp->from);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9592,9 +9592,8 @@ static void f_getcmdpos(typval_T *argvars, typval_T *rettv)
 static void f_getcmdtype(typval_T *argvars, typval_T *rettv)
 {
   rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = xmalloc(2);
+  rettv->vval.v_string = xmallocz(1);
   rettv->vval.v_string[0] = get_cmdline_type();
-  rettv->vval.v_string[1] = NUL;
 }
 
 /*
@@ -12124,8 +12123,6 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
     if (start < p) {
       /* There's part of a line in buf, store it in "prev". */
       if (p - start + prevlen >= prevsize) {
-        /* need bigger "prev" buffer */
-        char_u *newprev;
 
         /* A common use case is ordinary text files and "prev" gets a
          * fragment of a line, so the first allocation is made
@@ -12138,8 +12135,7 @@ static void f_readfile(typval_T *argvars, typval_T *rettv)
           long growmin  = (long)((p - start) * 2 + prevlen);
           prevsize = grow50pc > growmin ? grow50pc : growmin;
         }
-        newprev = (prev == NULL) ? xmalloc(prevsize) : xrealloc(prev, prevsize);
-        prev = newprev;
+        prev = xrealloc(prev, prevsize);
       }
       /* Add the line part to end of "prev". */
       memmove(prev + prevlen, start, p - start);
@@ -12398,10 +12394,9 @@ static void f_repeat(typval_T *argvars, typval_T *rettv)
     if (len <= 0)
       return;
 
-    char_u *r = xmalloc(len + 1);
+    char_u *r = xmallocz(len);
     for (int i = 0; i < n; i++)
       memmove(r + i * slen, p, (size_t)slen);
-    r[len] = NUL;
 
     rettv->vval.v_string = r;
   }
@@ -15708,7 +15703,7 @@ static char_u *make_expanded_name(char_u *in_start, char_u *expr_start, char_u *
   temp_result = eval_to_string(expr_start + 1, &nextcmd, FALSE);
   if (temp_result != NULL && nextcmd == NULL) {
     retval = xmalloc(STRLEN(temp_result) + (expr_start - in_start)
-                              + (in_end - expr_end) + 1);
+                     + (in_end - expr_end) + 1);
     STRCPY(retval, in_start);
     STRCAT(retval, temp_result);
     STRCAT(retval, expr_end + 1);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19529,27 +19529,23 @@ repeat:
       p = vim_strchr(s, sep);
       if (p != NULL) {
         pat = vim_strnsave(s, (int)(p - s));
-        if (pat != NULL) {
-          s = p + 1;
-          /* find end of substitution */
-          p = vim_strchr(s, sep);
-          if (p != NULL) {
-            sub = vim_strnsave(s, (int)(p - s));
-            str = vim_strnsave(*fnamep, *fnamelen);
-            *usedlen = (int)(p + 1 - src);
-            s = do_string_sub(str, pat, sub, flags);
-            if (s != NULL) {
-              *fnamep = s;
-              *fnamelen = (int)STRLEN(s);
-              free(*bufp);
-              *bufp = s;
-              didit = TRUE;
-            }
-            free(sub);
-            free(str);
-          }
-          free(pat);
+        s = p + 1;
+        /* find end of substitution */
+        p = vim_strchr(s, sep);
+        if (p != NULL) {
+          sub = vim_strnsave(s, (int)(p - s));
+          str = vim_strnsave(*fnamep, *fnamelen);
+          *usedlen = (int)(p + 1 - src);
+          s = do_string_sub(str, pat, sub, flags);
+          *fnamep = s;
+          *fnamelen = (int)STRLEN(s);
+          free(*bufp);
+          *bufp = s;
+          didit = TRUE;
+          free(sub);
+          free(str);
         }
+        free(pat);
       }
       /* after using ":s", repeat all the modifiers */
       if (didit)
@@ -19581,7 +19577,6 @@ char_u *do_string_sub(char_u *str, char_u *pat, char_u *sub, char_u *flags)
   int do_all;
   char_u      *tail;
   garray_T ga;
-  char_u      *ret;
   char_u      *save_cpo;
   char_u      *zero_width = NULL;
 
@@ -19640,7 +19635,7 @@ char_u *do_string_sub(char_u *str, char_u *pat, char_u *sub, char_u *flags)
     vim_regfree(regmatch.regprog);
   }
 
-  ret = vim_strsave(ga.ga_data == NULL ? str : (char_u *)ga.ga_data);
+  char_u *ret = vim_strsave(ga.ga_data == NULL ? str : (char_u *)ga.ga_data);
   ga_clear(&ga);
   if (p_cpo == empty_option)
     p_cpo = save_cpo;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1451,8 +1451,6 @@ read_viminfo (
     return FAIL;
 
   fname = viminfo_filename(file);       /* get file name in allocated buffer */
-  if (fname == NULL)
-    return FAIL;
   fp = mch_fopen((char *)fname, READBIN);
 
   if (p_verbose > 0) {
@@ -1499,8 +1497,6 @@ void write_viminfo(char_u *file, int forceit)
     return;
 
   fname = viminfo_filename(file);       /* may set to default if NULL */
-  if (fname == NULL)
-    return;
 
   fp_in = mch_fopen((char *)fname, READBIN);
   if (fp_in == NULL) {
@@ -1667,7 +1663,7 @@ end:
  * cmdline functions).
  * Otherwise use "-i file_name", value from 'viminfo' or the default, and
  * expand environment variables.
- * Returns an allocated string.  NULL when out of memory.
+ * Returns an allocated string.
  */
 static char_u *viminfo_filename(char_u *file)
 {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -695,12 +695,10 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
     return FAIL;
   for (extra = 0, l = line1; l <= line2; l++) {
     str = vim_strsave(ml_get(l + extra));
-    if (str != NULL) {
-      ml_append(dest + l - line1, str, (colnr_T)0, FALSE);
-      free(str);
-      if (dest < line1)
-        extra++;
-    }
+    ml_append(dest + l - line1, str, (colnr_T)0, FALSE);
+    free(str);
+    if (dest < line1)
+      extra++;
   }
 
   /*
@@ -803,10 +801,9 @@ void ex_copy(linenr_T line1, linenr_T line2, linenr_T n)
     /* need to use vim_strsave() because the line will be unlocked within
      * ml_append() */
     p = vim_strsave(ml_get(line1));
-    if (p != NULL) {
-      ml_append(curwin->w_cursor.lnum, p, (colnr_T)0, FALSE);
-      free(p);
-    }
+    ml_append(curwin->w_cursor.lnum, p, (colnr_T)0, FALSE);
+    free(p);
+
     /* situation 2: skip already copied lines */
     if (line1 == n)
       line1 = curwin->w_cursor.lnum;
@@ -1886,8 +1883,6 @@ viminfo_readstring (
     s = retval + 1;         /* Skip the leading '<' */
   } else {
     retval = vim_strsave(virp->vir_line + off);
-    if (retval == NULL)
-      return NULL;
     s = retval;
   }
 
@@ -3937,17 +3932,14 @@ void do_sub(exarg_T *eap)
                  * what matches.  Temporarily replace the line
                  * and change it back afterwards. */
                 orig_line = vim_strsave(ml_get(lnum));
-                if (orig_line != NULL) {
-                  char_u *new_line = concat_str(new_start,
-                                                sub_firstline + copycol);
+                char_u *new_line = concat_str(new_start, sub_firstline + copycol);
 
-                  // Position the cursor relative to the end of the line, the
-                  // previous substitute may have inserted or deleted characters
-                  // before the cursor.
-                  len_change = (int)STRLEN(new_line) - (int)STRLEN(orig_line);
-                  curwin->w_cursor.col += len_change;
-                  ml_replace(lnum, new_line, FALSE);
-                }
+                // Position the cursor relative to the end of the line, the
+                // previous substitute may have inserted or deleted characters
+                // before the cursor.
+                len_change = (int)STRLEN(new_line) - (int)STRLEN(orig_line);
+                curwin->w_cursor.col += len_change;
+                ml_replace(lnum, new_line, FALSE);
               }
 
               search_match_lines = regmatch.endpos[0].lnum
@@ -5769,11 +5761,6 @@ void ex_sign(exarg_T *eap)
 			next_sign_typenr = 1; /* wrap around */
 
 		    sp->sn_name = vim_strsave(arg);
-		    if (sp->sn_name == NULL)  /* out of memory */
-		    {
-			free(sp);
-			return;
-		    }
 
 		    /* add the new sign to the list of signs */
 		    if (sp_prev == NULL)
@@ -5837,7 +5824,7 @@ void ex_sign(exarg_T *eap)
 			len = (int)(p - arg + ((cells == 1) ? 1 : 0));
 			sp->sn_text = vim_strnsave(arg, len);
 
-			if (sp->sn_text != NULL && cells == 1)
+			if (cells == 1)
 			    STRCPY(sp->sn_text + len - 1, " ");
 		    }
 		    else if (STRNCMP(arg, "linehl=", 7) == 0)

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1920,8 +1920,6 @@ void ex_argedit(exarg_T *eap)
   if (i == ARGCOUNT) {
     /* Can't find it, add it to the argument list. */
     s = vim_strsave(eap->arg);
-    if (s == NULL)
-      return;
     i = alist_add_list(1, &s,
         eap->addr_count > 0 ? (int)eap->line2 : curwin->w_arg_idx + 1);
     curwin->w_arg_idx = i;
@@ -2252,8 +2250,8 @@ void        *cookie;
   /* Make a copy of 'runtimepath'.  Invoking the callback may change the
    * value. */
   rtp_copy = vim_strsave(p_rtp);
-  buf = xmalloc(MAXPATHL);
-  if (rtp_copy != NULL) {
+  buf = xmallocz(MAXPATHL);
+  {
     if (p_verbose > 1 && name != NULL) {
       verbose_enter();
       smsg((char_u *)_("Searching for \"%s\" in \"%s\""),
@@ -2594,10 +2592,8 @@ do_source (
     p = string_convert(&cookie.conv, firstline + 3, NULL);
     if (p == NULL)
       p = vim_strsave(firstline + 3);
-    if (p != NULL) {
-      free(firstline);
-      firstline = p;
-    }
+    free(firstline);
+    firstline = p;
   }
 
 #ifdef STARTUPTIME
@@ -3483,8 +3479,6 @@ static char_u **find_locales(void)
   while (loc != NULL) {
     ga_grow(&locales_ga, 1);
     loc = vim_strsave(loc);
-    if (loc == NULL)
-      break;
 
     ((char_u **)locales_ga.ga_data)[locales_ga.ga_len++] = loc;
     loc = (char_u *)strtok(NULL, "\n");

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -721,11 +721,6 @@ int flags;
     /* 3. Make a copy of the command so we can mess with it. */
     else if (cmdline_copy == NULL) {
       next_cmdline = vim_strsave(next_cmdline);
-      if (next_cmdline == NULL) {
-        EMSG(_(e_outofmem));
-        retval = FAIL;
-        break;
-      }
     }
     cmdline_copy = next_cmdline;
 
@@ -4299,10 +4294,6 @@ static int uc_add_command(char_u *name, size_t name_len, char_u *rep, long argt,
   if (rep_buf == NULL) {
     /* Can't replace termcodes - try using the string as is */
     rep_buf = vim_strsave(rep);
-
-    /* Give up if out of memory */
-    if (rep_buf == NULL)
-      return FAIL;
   }
 
   /* get address of growarray: global or in curbuf */
@@ -4349,8 +4340,7 @@ static int uc_add_command(char_u *name, size_t name_len, char_u *rep, long argt,
   if (cmp != 0) {
     ga_grow(gap, 1);
 
-    if ((p = vim_strnsave(name, (int)name_len)) == NULL)
-      goto fail;
+    p = vim_strnsave(name, (int)name_len);
 
     cmd = USER_CMD_GA(gap, i);
     memmove(cmd + 1, cmd, (gap->ga_len - i) * sizeof(ucmd_T));
@@ -5256,12 +5246,11 @@ static void ex_colorscheme(exarg_T *eap)
     char_u *expr = vim_strsave((char_u *)"g:colors_name");
     char_u *p = NULL;
 
-    if (expr != NULL) {
-      ++emsg_off;
-      p = eval_to_string(expr, NULL, FALSE);
-      --emsg_off;
-      free(expr);
-    }
+    ++emsg_off;
+    p = eval_to_string(expr, NULL, FALSE);
+    --emsg_off;
+    free(expr);
+
     if (p != NULL) {
       MSG(p);
       free(p);
@@ -7994,8 +7983,6 @@ char_u *expand_sfile(char_u *arg)
   char_u      *p;
 
   result = vim_strsave(arg);
-  if (result == NULL)
-    return NULL;
 
   for (p = result; *p; ) {
     if (STRNCMP(p, "<sfile>", 7) != 0)

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7380,6 +7380,7 @@ static void ex_normal(exarg_T *eap)
    * ends with half a command.
    */
   save_typeahead(&tabuf);
+  // TODO(philix): after save_typeahead() this is always TRUE
   if (tabuf.typebuf_valid) {
     /*
      * Repeat the :normal command for each line in the range.  When no

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -250,11 +250,7 @@ int cause_errthrow(char_u *mesg, int severe, int *ignore)
         EMSG(_(e_outofmem));
       } else {
         elem->msg = vim_strsave(mesg);
-        if (elem->msg == NULL) {
-          free(elem);
-          suppress_errthrow = TRUE;
-          EMSG(_(e_outofmem));
-        } else {
+        {
           elem->next = NULL;
           elem->throw_msg = NULL;
           *plist = elem;
@@ -402,15 +398,11 @@ char_u *get_exception_string(void *value, int type, char_u *cmdname, int *should
       cmdlen = (int)STRLEN(cmdname);
       ret = vim_strnsave((char_u *)"Vim(",
           4 + cmdlen + 2 + (int)STRLEN(mesg));
-      if (ret == NULL)
-        return ret;
       STRCPY(&ret[4], cmdname);
       STRCPY(&ret[4 + cmdlen], "):");
       val = ret + 4 + cmdlen + 2;
     } else {
       ret = vim_strnsave((char_u *)"Vim:", 4 + (int)STRLEN(mesg));
-      if (ret == NULL)
-        return ret;
       val = ret + 4;
     }
 
@@ -493,11 +485,6 @@ static int throw_exception(void *value, int type, char_u *cmdname)
   excp->type = type;
   excp->throw_name = vim_strsave(sourcing_name == NULL
       ? (char_u *)"" : sourcing_name);
-  if (excp->throw_name == NULL) {
-    if (should_free)
-      free(excp->value);
-    goto nomem;
-  }
   excp->throw_lnum = sourcing_lnum;
 
   if (p_verbose >= 13 || debug_break_level > 0) {

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -244,11 +244,8 @@ int cause_errthrow(char_u *mesg, int severe, int *ignore)
       while (*plist != NULL)
         plist = &(*plist)->next;
 
-      elem = (struct msglist *)alloc((unsigned)sizeof(struct msglist));
-      if (elem == NULL) {
-        suppress_errthrow = TRUE;
-        EMSG(_(e_outofmem));
-      } else {
+      elem = xmalloc(sizeof(struct msglist));
+      {
         elem->msg = vim_strsave(mesg);
         {
           elem->next = NULL;
@@ -469,9 +466,7 @@ static int throw_exception(void *value, int type, char_u *cmdname)
     }
   }
 
-  excp = (except_T *)alloc((unsigned)sizeof(except_T));
-  if (excp == NULL)
-    goto nomem;
+  excp = xmalloc(sizeof(except_T));
 
   if (type == ET_ERROR)
     /* Store the original message and prefix the exception value with
@@ -1289,18 +1284,12 @@ void ex_try(exarg_T *eap)
        * to save the value.
        */
       if (emsg_silent) {
-        eslist_T        *elem;
-
-        elem = (eslist_T *)alloc((unsigned)sizeof(struct eslist_elem));
-        if (elem == NULL)
-          EMSG(_(e_outofmem));
-        else {
-          elem->saved_emsg_silent = emsg_silent;
-          elem->next = cstack->cs_emsg_silent_list;
-          cstack->cs_emsg_silent_list = elem;
-          cstack->cs_flags[cstack->cs_idx] |= CSF_SILENT;
-          emsg_silent = 0;
-        }
+        eslist_T *elem = xmalloc(sizeof(struct eslist_elem));
+        elem->saved_emsg_silent = emsg_silent;
+        elem->next = cstack->cs_emsg_silent_list;
+        cstack->cs_emsg_silent_list = elem;
+        cstack->cs_flags[cstack->cs_idx] |= CSF_SILENT;
+        emsg_silent = 0;
       }
     }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -232,8 +232,6 @@ getcmdline (
 
   /* alloc initial ccline.cmdbuff */
   alloc_cmdbuff(exmode_active ? 250 : indent + 1);
-  if (ccline.cmdbuff == NULL)
-    return NULL;                            /* out of memory */
   ccline.cmdlen = ccline.cmdpos = 0;
   ccline.cmdbuff[0] = NUL;
 
@@ -1285,15 +1283,11 @@ getcmdline (
             }
             if (i == 0) {
               alloc_cmdbuff(len);
-              if (ccline.cmdbuff == NULL)
-                goto returncmd;
             }
           }
           ccline.cmdbuff[len] = NUL;
         } else {
           alloc_cmdbuff((int)STRLEN(p));
-          if (ccline.cmdbuff == NULL)
-            goto returncmd;
           STRCPY(ccline.cmdbuff, p);
         }
 
@@ -1999,7 +1993,6 @@ static void alloc_cmdbuff(int len)
 
 /*
  * Re-allocate the command line to length len + something extra.
- * return FAIL for failure, OK otherwise
  */
 static int realloc_cmdbuff(int len)
 {
@@ -2010,10 +2003,6 @@ static int realloc_cmdbuff(int len)
 
   p = ccline.cmdbuff;
   alloc_cmdbuff(len);                   /* will get some more */
-  if (ccline.cmdbuff == NULL) {         /* out of memory */
-    ccline.cmdbuff = p;                 /* keep the old one */
-    return FAIL;
-  }
   /* There isn't always a NUL after the command, but it may need to be
    * there, thus copy up to the NUL and add a NUL. */
   memmove(ccline.cmdbuff, p, (size_t)ccline.cmdlen);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1986,7 +1986,7 @@ static void alloc_cmdbuff(int len)
   else
     len += 20;
 
-  ccline.cmdbuff = xmalloc(len);      /* caller should check for out-of-memory */
+  ccline.cmdbuff = xmalloc(len);
   ccline.cmdbufflen = len;
 }
 
@@ -2179,10 +2179,7 @@ void put_on_cmdline(char_u *str, int len, int redraw)
   if (len < 0)
     len = (int)STRLEN(str);
 
-  /* Check if ccline.cmdbuff needs to be longer */
-  if (ccline.cmdlen + len + 1 >= ccline.cmdbufflen) {
-    realloc_cmdbuff(ccline.cmdlen + len + 1);
-  }
+  realloc_cmdbuff(ccline.cmdlen + len + 1);
 
   if (!ccline.overstrike) {
     memmove(ccline.cmdbuff + ccline.cmdpos + len,

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3213,8 +3213,7 @@ static int showmatches(expand_T *xp, int wildmenu)
             exp_path = expand_env_save_opt(files_found[k], TRUE);
             halved_slash = backslash_halve_save(
                 exp_path != NULL ? exp_path : files_found[k]);
-            j = os_isdir(halved_slash != NULL ? halved_slash
-                : files_found[k]);
+            j = os_isdir(halved_slash);
             free(exp_path);
             free(halved_slash);
           } else

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1196,8 +1196,7 @@ getcmdline (
 
       /* save current command string so it can be restored later */
       if (lookfor == NULL) {
-        if ((lookfor = vim_strsave(ccline.cmdbuff)) == NULL)
-          goto cmdline_not_changed;
+        lookfor = vim_strsave(ccline.cmdbuff);
         lookfor[ccline.cmdpos] = NUL;
       }
 
@@ -4510,8 +4509,7 @@ add_to_history (
     /* Store the separator after the NUL of the string. */
     len = (int)STRLEN(new_entry);
     hisptr->hisstr = vim_strnsave(new_entry, len + 2);
-    if (hisptr->hisstr != NULL)
-      hisptr->hisstr[len + 1] = sep;
+    hisptr->hisstr[len + 1] = sep;
 
     hisptr->hisnum = ++hisnum[histype];
     hisptr->viminfo = FALSE;

--- a/src/nvim/ex_getln.h
+++ b/src/nvim/ex_getln.h
@@ -14,7 +14,7 @@ char_u *getexmodeline(int promptc, void *cookie, int indent);
 void free_cmdline_buf(void);
 void putcmdline(int c, int shift);
 void unputcmdline(void);
-int put_on_cmdline(char_u *str, int len, int redraw);
+void put_on_cmdline(char_u *str, int len, int redraw);
 char_u *save_cmdline_alloc(void);
 void restore_cmdline_alloc(char_u *p);
 void cmdline_paste_str(char_u *s, int literally);

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -278,8 +278,7 @@ vim_findfile_init (
   if (search_ctx_arg != NULL)
     search_ctx = search_ctx_arg;
   else {
-    search_ctx = (ff_search_ctx_T*)alloc((unsigned)sizeof(ff_search_ctx_T));
-    memset(search_ctx, 0, sizeof(ff_search_ctx_T));
+    search_ctx = xcalloc(1, sizeof(ff_search_ctx_T));
   }
   search_ctx->ffsc_find_what = find_what;
   search_ctx->ffsc_tagfile = tagfile;
@@ -305,7 +304,7 @@ vim_findfile_init (
   }
 
   if (ff_expand_buffer == NULL) {
-    ff_expand_buffer = (char_u*)alloc(MAXPATHL);
+    ff_expand_buffer = xmalloc(MAXPATHL);
   }
 
   /* Store information on starting dir now if path is relative.
@@ -370,8 +369,7 @@ vim_findfile_init (
       walker++;
 
     dircount = 1;
-    search_ctx->ffsc_stopdirs_v =
-      (char_u **)alloc((unsigned)sizeof(char_u *));
+    search_ctx->ffsc_stopdirs_v = xmalloc(sizeof(char_u *));
 
     do {
       char_u  *helper;
@@ -474,9 +472,8 @@ vim_findfile_init (
   STRCPY(ff_expand_buffer, search_ctx->ffsc_start_dir);
   add_pathsep(ff_expand_buffer);
   {
-    int eb_len = (int)STRLEN(ff_expand_buffer);
-    char_u *buf = alloc(eb_len
-        + (int)STRLEN(search_ctx->ffsc_fix_path) + 1);
+    size_t eb_len = STRLEN(ff_expand_buffer);
+    char_u *buf = xmalloc(eb_len + STRLEN(search_ctx->ffsc_fix_path) + 1);
 
     STRCPY(buf, ff_expand_buffer);
     STRCPY(buf + eb_len, search_ctx->ffsc_fix_path);
@@ -498,9 +495,9 @@ vim_findfile_init (
 
       if (search_ctx->ffsc_wc_path != NULL) {
         wc_path = vim_strsave(search_ctx->ffsc_wc_path);
-        temp = alloc((int)(STRLEN(search_ctx->ffsc_wc_path)
-                           + STRLEN(search_ctx->ffsc_fix_path + len)
-                           + 1));
+        temp = xmalloc(STRLEN(search_ctx->ffsc_wc_path)
+                       + STRLEN(search_ctx->ffsc_fix_path + len)
+                       + 1);
       }
 
       if (temp == NULL || wc_path == NULL) {
@@ -610,8 +607,7 @@ char_u *vim_findfile(void *search_ctx_arg)
    * filepath is used as buffer for various actions and as the storage to
    * return a found filename.
    */
-  if ((file_path = alloc((int)MAXPATHL)) == NULL)
-    return NULL;
+  file_path = xmalloc(MAXPATHL);
 
   /* store the end of the start dir -- needed for upward search */
   if (search_ctx->ffsc_start_dir != NULL)
@@ -763,12 +759,9 @@ char_u *vim_findfile(void *search_ctx_arg)
          * If the path is a URL don't try this.
          */
         if (path_with_url(dirptrs[0])) {
-          stackp->ffs_filearray = (char_u **)
-                                  alloc((unsigned)sizeof(char *));
-          if ((stackp->ffs_filearray[0] = vim_strsave(dirptrs[0])) != NULL)
-            stackp->ffs_filearray_size = 1;
-          else
-            stackp->ffs_filearray_size = 0;
+          stackp->ffs_filearray = (char_u **)xmalloc(sizeof(char *));
+          stackp->ffs_filearray[0] = vim_strsave(dirptrs[0]);
+          stackp->ffs_filearray_size = 1;
         } else
           /* Add EW_NOTWILD because the expanded path may contain
            * wildcard characters that are to be taken literally.
@@ -1053,7 +1046,7 @@ static ff_visited_list_hdr_T *ff_get_visited_list(char_u *filename, ff_visited_l
   /*
    * if we reach this we didn't find a list and we have to allocate new list
    */
-  retptr = (ff_visited_list_hdr_T*)alloc((unsigned)sizeof(*retptr));
+  retptr = xmalloc(sizeof(*retptr));
 
   retptr->ffvl_visited_list = NULL;
   retptr->ffvl_filename = vim_strsave(filename);
@@ -1139,8 +1132,7 @@ static int ff_check_visited(ff_visited_T **visited_list, char_u *fname, char_u *
   /*
    * New file/dir.  Add it to the list of visited files/dirs.
    */
-  vp = (ff_visited_T *)alloc((unsigned)(sizeof(ff_visited_T)
-                                        + STRLEN(ff_expand_buffer)));
+  vp = xmalloc(sizeof(ff_visited_T) + STRLEN(ff_expand_buffer));
 
   if (!url) {
     vp->ffv_dev_valid = TRUE;
@@ -1495,7 +1487,7 @@ find_file_in_path_option (
           break;
         }
 
-        buf = alloc((int)(MAXPATHL));
+        buf = xmalloc(MAXPATHL);
 
         /* copy next path */
         buf[0] = 0;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -520,9 +520,6 @@ vim_findfile_init (
       search_ctx->ffsc_wc_path,
       level, 0);
 
-  if (sptr == NULL)
-    goto error_return;
-
   ff_push(search_ctx, sptr);
   search_ctx->ffsc_file_to_search = vim_strsave(filename);
   return search_ctx;
@@ -949,8 +946,6 @@ char_u *vim_findfile(void *search_ctx_arg)
       /* create a new stack entry */
       sptr = ff_create_stack_element(file_path,
           search_ctx->ffsc_wc_path, search_ctx->ffsc_level, 0);
-      if (sptr == NULL)
-        break;
       ff_push(search_ctx, sptr);
     } else
       break;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -322,8 +322,6 @@ vim_findfile_init (
       search_ctx->ffsc_start_dir = FullName_save(ff_expand_buffer, FALSE);
     } else
       search_ctx->ffsc_start_dir = vim_strnsave(rel_fname, len);
-    if (search_ctx->ffsc_start_dir == NULL)
-      goto error_return;
     if (*++path != NUL)
       ++path;
   } else if (*path == NUL || !vim_isAbsName(path)) {
@@ -344,8 +342,6 @@ vim_findfile_init (
       goto error_return;
 
     search_ctx->ffsc_start_dir = vim_strsave(ff_expand_buffer);
-    if (search_ctx->ffsc_start_dir == NULL)
-      goto error_return;
 
 #ifdef BACKSLASH_IN_FILENAME
     /* A path that starts with "/dir" is relative to the drive, not to the
@@ -458,9 +454,6 @@ vim_findfile_init (
     }
     ff_expand_buffer[len] = NUL;
     search_ctx->ffsc_wc_path = vim_strsave(ff_expand_buffer);
-
-    if (search_ctx->ffsc_wc_path == NULL)
-      goto error_return;
   } else
     search_ctx->ffsc_fix_path = vim_strsave(path);
 
@@ -469,8 +462,6 @@ vim_findfile_init (
      * This is needed if the parameter path is fully qualified.
      */
     search_ctx->ffsc_start_dir = vim_strsave(search_ctx->ffsc_fix_path);
-    if (search_ctx->ffsc_start_dir == NULL)
-      goto error_return;
     search_ctx->ffsc_fix_path[0] = NUL;
   }
 
@@ -536,11 +527,7 @@ vim_findfile_init (
     goto error_return;
 
   ff_push(search_ctx, sptr);
-
   search_ctx->ffsc_file_to_search = vim_strsave(filename);
-  if (search_ctx->ffsc_file_to_search == NULL)
-    goto error_return;
-
   return search_ctx;
 
 error_return:
@@ -1070,10 +1057,6 @@ static ff_visited_list_hdr_T *ff_get_visited_list(char_u *filename, ff_visited_l
 
   retptr->ffvl_visited_list = NULL;
   retptr->ffvl_filename = vim_strsave(filename);
-  if (retptr->ffvl_filename == NULL) {
-    free(retptr);
-    return NULL;
-  }
   retptr->ffvl_next = *list_headp;
   *list_headp = retptr;
 
@@ -1185,9 +1168,7 @@ static int ff_check_visited(ff_visited_T **visited_list, char_u *fname, char_u *
  */
 static ff_stack_T *ff_create_stack_element(char_u *fix_part, char_u *wc_part, int level, int star_star_empty)
 {
-  ff_stack_T  *new;
-
-  new = (ff_stack_T *)alloc((unsigned)sizeof(ff_stack_T));
+  ff_stack_T *new = xmalloc(sizeof(ff_stack_T));
 
   new->ffs_prev          = NULL;
   new->ffs_filearray     = NULL;
@@ -1205,13 +1186,6 @@ static ff_stack_T *ff_create_stack_element(char_u *fix_part, char_u *wc_part, in
   if (wc_part == NULL)
     wc_part  = (char_u *)"";
   new->ffs_wc_path = vim_strsave(wc_part);
-
-  if (new->ffs_fix_path == NULL
-      || new->ffs_wc_path == NULL
-      ) {
-    ff_free_stack_element(new);
-    new = NULL;
-  }
 
   return new;
 }
@@ -1429,10 +1403,6 @@ find_file_in_path_option (
 
     free(ff_file_to_find);
     ff_file_to_find = vim_strsave(NameBuff);
-    if (ff_file_to_find == NULL) {      /* out of memory */
-      file_name = NULL;
-      goto theend;
-    }
   }
 
   rel_to_curdir = (ff_file_to_find[0] == '.'

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3704,7 +3704,7 @@ restore_backup:
               "E513: write error, conversion failed (make 'fenc' empty to override)");
         else {
           errmsg_allocated = TRUE;
-          errmsg = alloc(300);
+          errmsg = xmalloc(300);
           vim_snprintf((char *)errmsg, 300,
               _("E513: write error, conversion failed in line %" PRId64
                 " (make 'fenc' empty to override)"),
@@ -4649,7 +4649,7 @@ modname (
    * (we need the full path in case :cd is used).
    */
   if (fname == NULL || *fname == NUL) {
-    retval = alloc((unsigned)(MAXPATHL + extlen + 3));
+    retval = xmalloc(MAXPATHL + extlen + 3);
     if (os_dirname(retval, MAXPATHL) == FAIL ||
         (fnamelen = (int)STRLEN(retval)) == 0) {
       free(retval);
@@ -4662,7 +4662,7 @@ modname (
     prepend_dot = FALSE;            /* nothing to prepend a dot to */
   } else {
     fnamelen = (int)STRLEN(fname);
-    retval = alloc((unsigned)(fnamelen + extlen + 3));
+    retval = xmalloc(fnamelen + extlen + 3);
     STRCPY(retval, fname);
   }
 
@@ -5212,8 +5212,7 @@ buf_check_timestamp (
     if (path != NULL) {
       if (!helpmesg)
         mesg2 = "";
-      tbuf = alloc((unsigned)(STRLEN(path) + STRLEN(mesg)
-                              + STRLEN(mesg2) + 2));
+      tbuf = xmalloc(STRLEN(path) + STRLEN(mesg) + STRLEN(mesg2) + 2);
       sprintf((char *)tbuf, mesg, path);
       /* Set warningmsg here, before the unimportant and output-specific
        * mesg2 has been appended. */
@@ -6574,7 +6573,7 @@ static int do_autocmd_event(event_T event, char_u *pat, int nested, char_u *cmd,
           return FAIL;
         }
 
-        ap = (AutoPat *)alloc((unsigned)sizeof(AutoPat));
+        ap = xmalloc(sizeof(AutoPat));
         ap->pat = vim_strnsave(pat, patlen);
         ap->patlen = patlen;
 
@@ -6611,7 +6610,7 @@ static int do_autocmd_event(event_T event, char_u *pat, int nested, char_u *cmd,
       prev_ac = &(ap->cmds);
       while ((ac = *prev_ac) != NULL)
         prev_ac = &ac->next;
-      ac = (AutoCmd *)alloc((unsigned)sizeof(AutoCmd));
+      ac = xmalloc(sizeof(AutoCmd));
       ac->cmd = vim_strsave(cmd);
       ac->scriptID = current_SID;
       ac->next = NULL;
@@ -7420,8 +7419,7 @@ auto_next_pat (
           : ap->buflocal_nr == apc->arg_bufnr) {
         name = event_nr2name(apc->event);
         s = _("%s Auto commands for \"%s\"");
-        sourcing_name = alloc((unsigned)(STRLEN(s)
-                                         + STRLEN(name) + ap->patlen + 1));
+        sourcing_name = xmalloc(STRLEN(s) + STRLEN(name) + ap->patlen + 1);
         sprintf((char *)sourcing_name, s,
             (char *)name, (char *)ap->pat);
         if (p_verbose >= 8) {

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1610,7 +1610,7 @@ static void foldAddMarker(linenr_T lnum, char_u *marker, int markerlen)
   line_len = (int)STRLEN(line);
 
   if (u_save(lnum - 1, lnum + 1) == OK) {
-    newline = alloc((unsigned)(line_len + markerlen + STRLEN(cms) + 1));
+    newline = xmalloc(line_len + markerlen + STRLEN(cms) + 1);
     STRCPY(newline, line);
     if (p == NULL)
       vim_strncpy(newline + line_len, marker, markerlen);
@@ -1681,7 +1681,7 @@ static void foldDelMarker(linenr_T lnum, char_u *marker, int markerlen)
       }
       if (u_save(lnum - 1, lnum + 1) == OK) {
         /* Make new line: text-before-marker + text-after-marker */
-        newline = alloc((unsigned)(STRLEN(line) - len + 1));
+        newline = xmalloc(STRLEN(line) - len + 1);
         STRNCPY(newline, line, p - line);
         STRCPY(newline + (p - line), p + len);
         ml_replace(lnum, newline, FALSE);

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1177,12 +1177,11 @@ void free_typebuf(void)
  */
 static typebuf_T saved_typebuf[NSCRIPT];
 
-int save_typebuf(void)
+void save_typebuf(void)
 {
   init_typebuf();
   saved_typebuf[curscript] = typebuf;
   alloc_typebuf();
-  return OK;
 }
 
 static int old_char = -1;       /* character put back by vungetc() */
@@ -1262,8 +1261,7 @@ openscript (
       --curscript;
     return;
   }
-  if (save_typebuf() == FAIL)
-    return;
+  save_typebuf();
 
   /*
    * Execute the commands from the file right now when using ":source!"

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1142,7 +1142,7 @@ static void may_sync_undo(void)
 /*
  * Make "typebuf" empty and allocate new buffers.
  */
-int alloc_typebuf(void)
+void alloc_typebuf(void)
 {
   typebuf.tb_buf = xmalloc(TYPELEN_INIT);
   typebuf.tb_noremap = xmalloc(TYPELEN_INIT);
@@ -1154,7 +1154,6 @@ int alloc_typebuf(void)
   typebuf.tb_no_abbr_cnt = 0;
   if (++typebuf.tb_change_cnt == 0)
     typebuf.tb_change_cnt = 1;
-  return OK;
 }
 
 /*
@@ -1182,11 +1181,7 @@ int save_typebuf(void)
 {
   init_typebuf();
   saved_typebuf[curscript] = typebuf;
-  /* If out of memory: restore typebuf and close file. */
-  if (alloc_typebuf() == FAIL) {
-    closescript();
-    return FAIL;
-  }
+  alloc_typebuf();
   return OK;
 }
 
@@ -1202,10 +1197,8 @@ static int old_mouse_col;       /* mouse_col related to old_char */
 void save_typeahead(tasave_T *tp)
 {
   tp->save_typebuf = typebuf;
-  tp->typebuf_valid = (alloc_typebuf() == OK);
-  if (!tp->typebuf_valid)
-    typebuf = tp->save_typebuf;
-
+  alloc_typebuf();
+  tp->typebuf_valid = TRUE;
   tp->old_char = old_char;
   tp->old_mod_mask = old_mod_mask;
   old_char = -1;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2636,7 +2636,6 @@ do_map (
   char_u      *p;
   int n;
   int len = 0;                  /* init for GCC */
-  char_u      *newstr;
   int hasarg;
   int haskey;
   int did_it = FALSE;
@@ -2979,13 +2978,8 @@ do_map (
             } else {                          /* new rhs for existing entry */
               mp->m_mode &= ~mode;                      /* remove mode bits */
               if (mp->m_mode == 0 && !did_it) {             /* reuse entry */
-                newstr = vim_strsave(rhs);
-                if (newstr == NULL) {
-                  retval = 4;                           /* no mem */
-                  goto theend;
-                }
                 free(mp->m_str);
-                mp->m_str = newstr;
+                mp->m_str = vim_strsave(rhs);
                 free(mp->m_orig_str);
                 mp->m_orig_str = vim_strsave(orig_rhs);
                 mp->m_noremap = noremap;
@@ -3057,14 +3051,6 @@ do_map (
   mp->m_keys = vim_strsave(keys);
   mp->m_str = vim_strsave(rhs);
   mp->m_orig_str = vim_strsave(orig_rhs);
-  if (mp->m_keys == NULL || mp->m_str == NULL) {
-    free(mp->m_keys);
-    free(mp->m_str);
-    free(mp->m_orig_str);
-    free(mp);
-    retval = 4;         /* no mem */
-    goto theend;
-  }
   mp->m_keylen = (int)STRLEN(mp->m_keys);
   mp->m_noremap = noremap;
   mp->m_nowait = nowait;
@@ -3328,11 +3314,9 @@ showmap (
     /* Remove escaping of CSI, because "m_str" is in a format to be used
      * as typeahead. */
     char_u *s = vim_strsave(mp->m_str);
-    if (s != NULL) {
-      vim_unescape_csi(s);
-      msg_outtrans_special(s, FALSE);
-      free(s);
-    }
+    vim_unescape_csi(s);
+    msg_outtrans_special(s, FALSE);
+    free(s);
   }
   if (p_verbose > 0)
     last_set_msg(mp->m_script_ID);
@@ -3778,8 +3762,6 @@ eval_map_expr (
   /* Remove escaping of CSI, because "str" is in a format to be used as
    * typeahead. */
   expr = vim_strsave(str);
-  if (expr == NULL)
-    return NULL;
   vim_unescape_csi(expr);
 
   save_cmd = save_cmdline_alloc();
@@ -4325,10 +4307,8 @@ void add_map(char_u *map, int mode)
 
   p_cpo = (char_u *)"";         /* Allow <> notation */
   s = vim_strsave(map);
-  if (s != NULL) {
-    (void)do_map(0, s, mode, FALSE);
-    free(s);
-  }
+  (void)do_map(0, s, mode, FALSE);
+  free(s);
   p_cpo = cpo_save;
 }
 #endif

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -891,14 +891,8 @@ int ins_typebuf(char_u *str, int noremap, int offset, int nottyped, int silent)
       setcursor();
       return FAIL;
     }
-    s1 = alloc(newlen);
-    if (s1 == NULL)                 /* out of memory */
-      return FAIL;
-    s2 = alloc(newlen);
-    if (s2 == NULL) {               /* out of memory */
-      free(s1);
-      return FAIL;
-    }
+    s1 = xmalloc(newlen);
+    s2 = xmalloc(newlen);
     typebuf.tb_buflen = newlen;
 
     /* copy the old chars, before the insertion point */
@@ -1147,16 +1141,11 @@ static void may_sync_undo(void)
 
 /*
  * Make "typebuf" empty and allocate new buffers.
- * Returns FAIL when out of memory.
  */
 int alloc_typebuf(void)
 {
-  typebuf.tb_buf = alloc(TYPELEN_INIT);
-  typebuf.tb_noremap = alloc(TYPELEN_INIT);
-  if (typebuf.tb_buf == NULL || typebuf.tb_noremap == NULL) {
-    free_typebuf();
-    return FAIL;
-  }
+  typebuf.tb_buf = xmalloc(TYPELEN_INIT);
+  typebuf.tb_noremap = xmalloc(TYPELEN_INIT);
   typebuf.tb_buflen = TYPELEN_INIT;
   typebuf.tb_off = 0;
   typebuf.tb_len = 0;
@@ -3038,11 +3027,7 @@ do_map (
   /*
    * Get here when adding a new entry to the maphash[] list or abbrlist.
    */
-  mp = (mapblock_T *)alloc((unsigned)sizeof(mapblock_T));
-  if (mp == NULL) {
-    retval = 4;             /* no mem */
-    goto theend;
-  }
+  mp = xmalloc(sizeof(mapblock_T));
 
   /* If CTRL-C has been mapped, don't always use it for Interrupting */
   if (*keys == Ctrl_C)
@@ -3548,9 +3533,7 @@ int ExpandMappings(regmatch_T *regmatch, int *num_file, char_u ***file)
       break;       /* for (round) */
 
     if (round == 1) {
-      *file = (char_u **)alloc((unsigned)(count * sizeof(char_u *)));
-      if (*file == NULL)
-        return FAIL;
+      *file = (char_u **)xmalloc(count * sizeof(char_u *));
     }
   }   /* for (round) */
 
@@ -3813,7 +3796,7 @@ char_u *vim_strsave_escape_csi(char_u *p)
   char_u      *s, *d;
 
   /* Need a buffer to hold up to three times as much. */
-  res = alloc((unsigned)(STRLEN(p) * 3) + 1);
+  res = xmalloc(STRLEN(p) * 3 + 1);
   d = res;
   for (s = p; *s != NUL; ) {
     if (s[0] == K_SPECIAL && s[1] != NUL && s[2] != NUL) {

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -33,7 +33,7 @@ int typebuf_maplen(void);
 void del_typebuf(int len, int offset);
 void alloc_typebuf(void);
 void free_typebuf(void);
-int save_typebuf(void);
+void save_typebuf(void);
 void save_typeahead(tasave_T *tp);
 void restore_typeahead(tasave_T *tp);
 void openscript(char_u *name, int directly);

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -31,7 +31,7 @@ int typebuf_changed(int tb_change_cnt);
 int typebuf_typed(void);
 int typebuf_maplen(void);
 void del_typebuf(int len, int offset);
-int alloc_typebuf(void);
+void alloc_typebuf(void);
 void free_typebuf(void);
 int save_typebuf(void);
 void save_typeahead(tasave_T *tp);

--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -347,18 +347,7 @@ static int hash_may_resize(hashtab_T *ht, int minitems)
     }
   } else {
     // Allocate an array.
-    newarray = (hashitem_T *)alloc((unsigned)(sizeof(hashitem_T) * newsize));
-
-    if (newarray == NULL) {
-      // Out of memory.  When there are NULL items still return OK.
-      // Otherwise set ht_error, because lookup may result in a hang if
-      // we add another item.
-      if (ht->ht_filled < ht->ht_mask) {
-        return OK;
-      }
-      ht->ht_error = TRUE;
-      return FAIL;
-    }
+    newarray = xmalloc(sizeof(hashitem_T) * newsize);
     oldarray = ht->ht_array;
   }
   memset(newarray, 0, (size_t)(sizeof(hashitem_T) * newsize));

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -459,7 +459,7 @@ static int cs_add(exarg_T *eap)
 static void cs_stat_emsg(char *fname)
 {
   char *stat_emsg = _("E563: stat(%s) error: %d");
-  char *buf = (char *)alloc((unsigned)strlen(stat_emsg) + MAXPATHL + 10);
+  char *buf = xmalloc(strlen(stat_emsg) + MAXPATHL + 10);
 
   (void)sprintf(buf, stat_emsg, fname, errno);
   (void)EMSG(buf);
@@ -490,7 +490,7 @@ cs_add_common (
   char_u      *fbuf = NULL;
 
   /* get the filename (arg1), expand it, and try to stat it */
-  fname = (char *)alloc(MAXPATHL + 1);
+  fname = xmalloc(MAXPATHL + 1);
 
   expand_env((char_u *)arg1, (char_u *)fname, MAXPATHL);
   len = (int)STRLEN(fname);
@@ -512,7 +512,7 @@ staterr:
 
   // get the prepend path (arg2), expand it, and see if it exists
   if (arg2 != NULL) {
-    ppath = (char *)alloc(MAXPATHL + 1);
+    ppath = xmalloc(MAXPATHL + 1);
     expand_env((char_u *)arg2, (char_u *)ppath, MAXPATHL);
     if (!os_file_exists((char_u *)ppath))
       goto staterr;
@@ -520,7 +520,7 @@ staterr:
 
   /* if filename is a directory, append the cscope database name to it */
   if ((file_info.stat.st_mode & S_IFMT) == S_IFDIR) {
-    fname2 = (char *)alloc((unsigned)(strlen(CSCOPE_DBFILE) + strlen(fname) + 2));
+    fname2 = (char *)xmalloc(strlen(CSCOPE_DBFILE) + strlen(fname) + 2);
 
     while (fname[strlen(fname)-1] == '/'
            ) {
@@ -625,10 +625,9 @@ cs_reading_emsg (
 static int cs_cnt_matches(int idx)
 {
   char *stok;
-  char *buf;
   int nlines;
 
-  buf = (char *)alloc(CSREAD_BUFSIZE);
+  char *buf = xmalloc(CSREAD_BUFSIZE);
   for (;; ) {
     if (!fgets(buf, CSREAD_BUFSIZE, csinfo[idx].fr_fp)) {
       if (feof(csinfo[idx].fr_fp))
@@ -721,7 +720,7 @@ static char *cs_create_cmd(char *csoption, char *pattern)
     while (vim_iswhite(*pat))
       ++pat;
 
-  cmd = (char *)alloc((unsigned)(strlen(pat) + 2));
+  cmd = xmalloc(strlen(pat) + 2);
 
   (void)sprintf(cmd, "%d%s", search, pat);
 
@@ -801,14 +800,14 @@ err_closing:
   }
 #endif
     /* expand the cscope exec for env var's */
-    prog = (char *)alloc(MAXPATHL + 1);
+    prog = xmalloc(MAXPATHL + 1);
     expand_env((char_u *)p_csprg, (char_u *)prog, MAXPATHL);
 
     /* alloc space to hold the cscope command */
     len = (int)(strlen(prog) + strlen(csinfo[i].fname) + 32);
     if (csinfo[i].ppath) {
       /* expand the prepend path for env var's */
-      ppath = (char *)alloc(MAXPATHL + 1);
+      ppath = xmalloc(MAXPATHL + 1);
       expand_env((char_u *)csinfo[i].ppath, (char_u *)ppath, MAXPATHL);
 
       len += (int)strlen(ppath);
@@ -817,7 +816,7 @@ err_closing:
     if (csinfo[i].flags)
       len += (int)strlen(csinfo[i].flags);
 
-    cmd = (char *)alloc(len);
+    cmd = xmalloc(len);
 
     /* run the cscope command; is there execl for non-unix systems? */
 #if defined(UNIX)
@@ -1009,7 +1008,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int us
     if (strchr(CSQF_FLAGS, *qfpos) == NULL) {
       char *nf = _("E469: invalid cscopequickfix flag %c for %c");
       /* strlen will be enough because we use chars */
-      char *buf = (char *)alloc((unsigned)strlen(nf));
+      char *buf = xmalloc(strlen(nf));
 
       sprintf(buf, nf, *qfpos, *(qfpos-1));
       (void)EMSG(buf);
@@ -1030,7 +1029,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int us
   if (cmd == NULL)
     return FALSE;
 
-  nummatches = (int *)alloc(sizeof(int)*csinfo_size);
+  nummatches = xmalloc(sizeof(int) * csinfo_size);
 
   /* Send query to all open connections, then count the total number
    * of matches so we can alloc all in one swell foop. */
@@ -1064,7 +1063,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int us
       return FALSE;
     }
 
-    buf = (char *)alloc((unsigned)(strlen(opt) + strlen(pat) + strlen(nf)));
+    buf = xmalloc(strlen(opt) + strlen(pat) + strlen(nf));
     sprintf(buf, nf, opt, pat);
     (void)EMSG(buf);
     free(buf);
@@ -1249,18 +1248,18 @@ static int cs_insert_filelist(char *fname, char *ppath, char *flags,
       clear_csinfo(j);
   }
 
-  csinfo[i].fname = (char *)alloc((unsigned)strlen(fname)+1);
+  csinfo[i].fname = xmalloc(strlen(fname) + 1);
 
   (void)strcpy(csinfo[i].fname, (const char *)fname);
 
   if (ppath != NULL) {
-    csinfo[i].ppath = (char *)alloc((unsigned)strlen(ppath) + 1);
+    csinfo[i].ppath = xmalloc(strlen(ppath) + 1);
     (void)strcpy(csinfo[i].ppath, (const char *)ppath);
   } else
     csinfo[i].ppath = NULL;
 
   if (flags != NULL) {
-    csinfo[i].flags = (char *)alloc((unsigned)strlen(flags) + 1);
+    csinfo[i].flags = xmalloc(strlen(flags) + 1);
     (void)strcpy(csinfo[i].flags, (const char *)flags);
   } else
     csinfo[i].flags = NULL;
@@ -1553,13 +1552,12 @@ static char *cs_parse_results(int cnumber, char *buf, int bufsize, char **contex
 static void cs_file_results(FILE *f, int *nummatches_a)
 {
   int i, j;
-  char *buf;
   char *search, *slno;
   char *fullname;
   char *cntx;
   char *context;
 
-  buf = (char *)alloc(CSREAD_BUFSIZE);
+  char *buf = xmalloc(CSREAD_BUFSIZE);
 
   for (i = 0; i < csinfo_size; i++) {
     if (nummatches_a[i] < 1)
@@ -1570,7 +1568,7 @@ static void cs_file_results(FILE *f, int *nummatches_a)
                &slno, &search)) == NULL)
         continue;
 
-      context = (char *)alloc((unsigned)strlen(cntx)+5);
+      context = xmalloc(strlen(cntx) + 5);
 
       if (strcmp(cntx, "<global>")==0)
         strcpy(context, "<<global>>");
@@ -1686,9 +1684,6 @@ static char *cs_pathcomponents(char *path)
  */
 static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
 {
-  char        *buf = NULL;
-  int bufsize = 0;           /* Track available bufsize */
-  int newsize = 0;
   char        *ptag;
   char        *fname, *lno, *extra, *tbuf;
   int i, idx, num;
@@ -1700,14 +1695,14 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
 
   assert (num_matches > 0);
 
-  tbuf = (char *)alloc((unsigned)strlen(matches[0]) + 1);
+  tbuf = xmalloc(strlen(matches[0]) + 1);
 
   strcpy(tbuf, matches[0]);
   ptag = strtok(tbuf, "\t");
 
-  newsize = (int)(strlen(cstag_msg) + strlen(ptag));
-  buf = (char *)alloc(newsize);
-  bufsize = newsize;
+  size_t newsize = strlen(cstag_msg) + strlen(ptag);
+  char *buf = xmalloc(newsize);
+  size_t bufsize = newsize;  // Track available bufsize
   (void)sprintf(buf, cstag_msg, ptag);
   MSG_PUTS_ATTR(buf, hl_attr(HLF_T));
 
@@ -1725,7 +1720,7 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
      * by parsing matches[i] on the fly and placing stuff into buf
      * directly, but that's too much of a hassle
      */
-    tbuf = (char *)alloc((unsigned)strlen(matches[idx]) + 1);
+    tbuf = xmalloc(strlen(matches[idx]) + 1);
     (void)strcpy(tbuf, matches[idx]);
 
     if (strtok(tbuf, (const char *)"\t") == NULL)
@@ -1739,9 +1734,9 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
     lno[strlen(lno)-2] = '\0';      /* ignore ;" at the end */
 
     /* hopefully 'num' (num of matches) will be less than 10^16 */
-    newsize = (int)(strlen(csfmt_str) + 16 + strlen(lno));
+    newsize = strlen(csfmt_str) + 16 + strlen(lno);
     if (bufsize < newsize) {
-      buf = (char *)xrealloc(buf, newsize);
+      buf = xrealloc(buf, newsize);
       bufsize = newsize;
     }
     if (buf != NULL) {
@@ -1756,10 +1751,10 @@ static void cs_print_tags_priv(char **matches, char **cntxts, int num_matches)
       context = cntxts[idx];
     else
       context = globalcntx;
-    newsize = (int)(strlen(context) + strlen(cntxformat));
+    newsize = strlen(context) + strlen(cntxformat);
 
     if (bufsize < newsize) {
-      buf = (char *)xrealloc(buf, newsize);
+      buf = xrealloc(buf, newsize);
       bufsize = newsize;
     }
     if (buf != NULL) {
@@ -1819,9 +1814,11 @@ static int cs_read_prompt(int i)
     while ((ch = getc(csinfo[i].fr_fp)) != EOF && ch != CSCOPE_PROMPT[0])
       /* if there is room and char is printable */
       if (bufpos < maxlen - 1 && vim_isprintc(ch)) {
-        if (buf == NULL)         /* lazy buffer allocation */
-          buf = (char *)alloc(maxlen);
-        if (buf != NULL) {
+        // lazy buffer allocation
+        if (buf == NULL) {
+          buf = xmalloc(maxlen);
+        }
+        {
           /* append character to the message */
           buf[bufpos++] = ch;
           buf[bufpos] = NUL;
@@ -2072,7 +2069,6 @@ static int cs_reset(exarg_T *eap)
 static char *cs_resolve_file(int i, char *name)
 {
   char        *fullname;
-  int len;
   char_u      *csdir = NULL;
 
   /*
@@ -2080,17 +2076,17 @@ static char *cs_resolve_file(int i, char *name)
    * Fullname is freed after cs_make_vim_style_matches, after it's been
    * copied into the tag buffer used by Vim.
    */
-  len = (int)(strlen(name) + 2);
+  size_t len = strlen(name) + 2;
   if (csinfo[i].ppath != NULL)
-    len += (int)strlen(csinfo[i].ppath);
+    len += strlen(csinfo[i].ppath);
   else if (p_csre && csinfo[i].fname != NULL) {
     /* If 'cscoperelative' is set and ppath is not set, use cscope.out
      * path in path resolution. */
-    csdir = alloc(MAXPATHL);
+    csdir = xmalloc(MAXPATHL);
     vim_strncpy(csdir, (char_u *)csinfo[i].fname,
         path_tail((char_u *)csinfo[i].fname)
         - (char_u *)csinfo[i].fname);
-    len += (int)STRLEN(csdir);
+    len += STRLEN(csdir);
   }
 
   /* Note/example: this won't work if the cscope output already starts

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1633,10 +1633,7 @@ static void cs_fill_results(char *tagstr, int totmatches, int *nummatches_a, cha
       if (strcmp(cntx, "<global>") == 0)
         cntxts[totsofar] = NULL;
       else {
-        /* note: if vim_strsave returns NULL, then the context
-         * will be "<global>", which is misleading.
-         */
-        cntxts[totsofar] = (char *)vim_strsave((char_u *)cntx);
+        cntxts[totsofar] = xstrdup(cntx);
       }
 
       totsofar++;
@@ -2110,7 +2107,7 @@ static char *cs_resolve_file(int i, char *name)
      * cscope output. */
     fullname = (char *)concat_fnames(csdir, (char_u *)name, TRUE);
   } else {
-    fullname = (char *)vim_strsave((char_u *)name);
+    fullname = xstrdup(name);
   }
 
   free(csdir);

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -182,7 +182,7 @@ int set_indent(int size, int flags)
   // characters and allocate accordingly.  We will fill the rest with spaces
   // after the if (!curbuf->b_p_et) below.
   if (orig_char_len != -1) {
-    newline = alloc(orig_char_len + size - ind_done + line_len);
+    newline = xmalloc(orig_char_len + size - ind_done + line_len);
     todo = size - ind_done;
 
     // Set total length of indent in characters, which may have been
@@ -203,7 +203,7 @@ int set_indent(int size, int flags)
     }
   } else {
     todo = size;
-    newline = alloc(ind_len + line_len);
+    newline = xmalloc(ind_len + line_len);
     s = newline;
   }
 
@@ -368,7 +368,7 @@ int copy_indent(int size, char_u *src)
       // Allocate memory for the result: the copied indent, new indent
       // and the rest of the line.
       line_len = (int)STRLEN(ml_get_curline()) + 1;
-      line = alloc(ind_len + line_len);
+      line = xmalloc(ind_len + line_len);
       p = line;
     }
   }

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -122,7 +122,7 @@ int cin_is_cinword(char_u *line)
   int len;
 
   cinw_len = (int)STRLEN(curbuf->b_p_cinw) + 1;
-  cinw_buf = alloc((unsigned)cinw_len);
+  cinw_buf = xmalloc(cinw_len);
   line = skipwhite(line);
   for (cinw = curbuf->b_p_cinw; *cinw; ) {
     len = copy_option_part(&cinw, cinw_buf, cinw_len, ",");

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1365,8 +1365,7 @@ scripterror:
               mch_errmsg("\"\n");
               mch_exit(2);
             }
-            if (save_typebuf() == FAIL)
-              mch_exit(2);                /* out of memory */
+            save_typebuf();
             break;
 
           case 't':               /* "-t {tag}" */

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1428,8 +1428,8 @@ scripterror:
 
       /* Add the file to the global argument list. */
       ga_grow(&global_alist.al_ga, 1);
-      if ((p = vim_strsave((char_u *)argv[0])) == NULL)
-        mch_exit(2);
+      p = vim_strsave((char_u *)argv[0]);
+
       if (parmp->diff_mode && os_isdir(p) && GARGCOUNT > 0
           && !os_isdir(alist_name(&GARGLIST[0]))) {
         char_u      *r;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1321,7 +1321,7 @@ static void command_line_scan(mparm_T *parmp)
                 --argv;
               } else
                 a = argv[0];
-              p = alloc((unsigned)(STRLEN(a) + 4));
+              p = xmalloc(STRLEN(a) + 4);
               sprintf((char *)p, "so %s", a);
               parmp->cmds_tofree[parmp->n_commands] = TRUE;
               parmp->commands[parmp->n_commands++] = p;
@@ -1469,7 +1469,7 @@ scripterror:
   /* If there is a "+123" or "-c" command, set v:swapcommand to the first
    * one. */
   if (parmp->n_commands > 0) {
-    p = alloc((unsigned)STRLEN(parmp->commands[0]) + 3);
+    p = xmalloc(STRLEN(parmp->commands[0]) + 3);
     sprintf((char *)p, ":%s\r", parmp->commands[0]);
     set_vim_var_string(VV_SWAPCOMMAND, p, -1);
     free(p);
@@ -1515,7 +1515,7 @@ static void init_startuptime(mparm_T *paramp)
  */
 static void allocate_generic_buffers(void)
 {
-  NameBuff = alloc(MAXPATHL);
+  NameBuff = xmalloc(MAXPATHL);
   TIME_MSG("Allocated generic buffers");
 }
 

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1417,7 +1417,7 @@ void copy_viminfo_marks(vir_T *virp, FILE *fp_out, int count, int eof, int flags
   pos_T pos;
   list_T      *list = NULL;
 
-  name_buf = alloc(LSIZE);
+  name_buf = xmalloc(LSIZE);
   *name_buf = NUL;
 
   if (fp_out == NULL && (flags & (VIF_GET_OLDFILES | VIF_FORCEIT))) {

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -843,8 +843,6 @@ void ex_changes(exarg_T *eap)
           curbuf->b_changelist[i].col);
       msg_outtrans(IObuff);
       name = mark_line(&curbuf->b_changelist[i], 17);
-      if (name == NULL)
-        break;
       msg_outtrans_attr(name, hl_attr(HLF_D));
       free(name);
       ui_breakcheck();

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -606,8 +606,7 @@ static char_u *mark_line(pos_T *mp, int lead_len)
   if (mp->lnum == 0 || mp->lnum > curbuf->b_ml.ml_line_count)
     return vim_strsave((char_u *)"-invalid-");
   s = vim_strnsave(skipwhite(ml_get(mp->lnum)), (int)Columns);
-  if (s == NULL)
-    return NULL;
+
   /* Truncate the line to fit it in the window */
   len = 0;
   for (p = s; *p != NUL; mb_ptr_adv(p)) {

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -3333,7 +3333,7 @@ char_u * enc_canonize(char_u *enc)
   }
 
   /* copy "enc" to allocated memory, with room for two '-' */
-  r = alloc((unsigned)(STRLEN(enc) + 3));
+  r = xmalloc(STRLEN(enc) + 3);
   /* Make it all lower case and replace '_' with '-'. */
   p = r;
   for (s = enc; *s != NUL; ++s) {
@@ -3534,7 +3534,7 @@ static char_u * iconv_string(vimconv_T *vcp, char_u *str, int slen, int *unconvl
       /* Allocate enough room for most conversions.  When re-allocating
        * increase the buffer size. */
       len = len + fromlen * 2 + 40;
-      p = alloc((unsigned)len);
+      p = xmalloc(len);
       if (done > 0)
         memmove(p, result, done);
       free(result);
@@ -3852,7 +3852,7 @@ int convert_input_safe(ptr, len, maxlen, restp, restlenp)
     if (dlen <= maxlen) {
       if (unconvertlen > 0) {
         /* Move the unconverted characters to allocated memory. */
-        *restp = alloc(unconvertlen);
+        *restp = xmalloc(unconvertlen);
         memmove(*restp, ptr + len - unconvertlen, unconvertlen);
         *restlenp = unconvertlen;
       }
@@ -3908,7 +3908,7 @@ char_u * string_convert_ext(vcp, ptr, lenp, unconvlenp)
 
   switch (vcp->vc_type) {
     case CONV_TO_UTF8:            /* latin1 to utf-8 conversion */
-      retval = alloc(len * 2 + 1);
+      retval = xmalloc(len * 2 + 1);
       d = retval;
       for (i = 0; i < len; ++i) {
         c = ptr[i];
@@ -3925,7 +3925,7 @@ char_u * string_convert_ext(vcp, ptr, lenp, unconvlenp)
       break;
 
     case CONV_9_TO_UTF8:          /* latin9 to utf-8 conversion */
-      retval = alloc(len * 3 + 1);
+      retval = xmalloc(len * 3 + 1);
       d = retval;
       for (i = 0; i < len; ++i) {
         c = ptr[i];
@@ -3948,7 +3948,7 @@ char_u * string_convert_ext(vcp, ptr, lenp, unconvlenp)
 
     case CONV_TO_LATIN1:          /* utf-8 to latin1 conversion */
     case CONV_TO_LATIN9:          /* utf-8 to latin9 conversion */
-      retval = alloc(len + 1);
+      retval = xmalloc(len + 1);
       d = retval;
       for (i = 0; i < len; ++i) {
         l = utf_ptr2len_len(ptr + i, len - i);

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -315,8 +315,9 @@ bhdr_T *mf_new(memfile_T *mfp, int negative, int page_count)
      * just use the number and free the bhdr_T from the free list
      */
     if (freep->bh_page_count > page_count) {
-      if (hp == NULL && (hp = mf_alloc_bhdr(mfp, page_count)) == NULL)
-        return NULL;
+      if (hp == NULL) {
+        hp = mf_alloc_bhdr(mfp, page_count);
+      }
       hp->bh_bnum = freep->bh_bnum;
       freep->bh_bnum += page_count;
       freep->bh_page_count -= page_count;
@@ -330,8 +331,9 @@ bhdr_T *mf_new(memfile_T *mfp, int negative, int page_count)
       free(freep);
     }
   } else {    /* get a new number */
-    if (hp == NULL && (hp = mf_alloc_bhdr(mfp, page_count)) == NULL)
-      return NULL;
+    if (hp == NULL) {
+      hp = mf_alloc_bhdr(mfp, page_count);
+    }
     if (negative) {
       hp->bh_bnum = mfp->mf_blocknr_min--;
       mfp->mf_neg_count++;
@@ -384,8 +386,9 @@ bhdr_T *mf_get(memfile_T *mfp, blocknr_T nr, int page_count)
      * If not, allocate a new block.
      */
     hp = mf_release(mfp, page_count);
-    if (hp == NULL && (hp = mf_alloc_bhdr(mfp, page_count)) == NULL)
-      return NULL;
+    if (hp == NULL) {
+      hp = mf_alloc_bhdr(mfp, page_count);
+    }
 
     hp->bh_bnum = nr;
     hp->bh_flags = 0;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1015,7 +1015,7 @@ void ml_recover(void)
    * Allocate a buffer structure for the swap file that is used for recovery.
    * Only the memline and crypt information in it are really used.
    */
-  buf = (buf_T *)alloc((unsigned)sizeof(buf_T));
+  buf = xmalloc(sizeof(buf_T));
 
   /*
    * init fields in memline struct
@@ -1125,7 +1125,7 @@ void ml_recover(void)
     mfp->mf_infile_count = mfp->mf_blocknr_max;
 
     /* need to reallocate the memory used to store the data */
-    p = alloc(mfp->mf_page_size);
+    p = xmalloc(mfp->mf_page_size);
     memmove(p, hp->bh_data, previous_page_size);
     free(hp->bh_data);
     hp->bh_data = p;
@@ -1538,7 +1538,7 @@ recover_names (
    * Do the loop for every directory in 'directory'.
    * First allocate some memory to put the directory name in.
    */
-  dir_name = alloc((unsigned)STRLEN(p_dir) + 1);
+  dir_name = xmalloc(STRLEN(p_dir) + 1);
   dirp = p_dir;
   while (dir_name != NULL && *dirp) {
     /*
@@ -1612,7 +1612,7 @@ recover_names (
       char_u *swapname = modname(fname_res, (char_u *)".swp", TRUE);
       if (swapname != NULL) {
         if (os_file_exists(swapname)) {
-          files = (char_u **)alloc((unsigned)sizeof(char_u *));
+          files = (char_u **)xmalloc(sizeof(char_u *));
           files[0] = swapname;
           swapname = NULL;
           num_files = 1;
@@ -2607,8 +2607,9 @@ int ml_replace(linenr_T lnum, char_u *line, int copy)
   if (curbuf->b_ml.ml_mfp == NULL && open_buffer(FALSE, NULL, 0) == FAIL)
     return FAIL;
 
-  if (copy)
+  if (copy) {
     line = vim_strsave(line);
+  }
   if (curbuf->b_ml.ml_line_lnum != lnum)            /* other line buffered */
     ml_flush_line(curbuf);                          /* flush it */
   else if (curbuf->b_ml.ml_flags & ML_LINE_DIRTY)   /* same line allocated */
@@ -3539,7 +3540,7 @@ findswapname (
    * Isolate a directory name from *dirp and put it in dir_name.
    * First allocate some memory to put the directory name in.
    */
-  dir_name = alloc((unsigned)STRLEN(*dirp) + 1);
+  dir_name = xmalloc(STRLEN(*dirp) + 1);
   (void)copy_option_part(dirp, dir_name, 31000, ",");
 
   /*
@@ -3666,9 +3667,9 @@ findswapname (
           if (swap_exists_action != SEA_NONE && choice == 0) {
             char_u  *name;
 
-            name = alloc((unsigned)(STRLEN(fname)
-                                    + STRLEN(_("Swap file \""))
-                                    + STRLEN(_("\" already exists!")) + 5));
+            name = xmalloc(STRLEN(fname)
+                           + STRLEN(_("Swap file \""))
+                           + STRLEN(_("\" already exists!")) + 5);
             STRCPY(name, _("Swap file \""));
             home_replace(NULL, fname, name + STRLEN(name),
                 1000, TRUE);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -386,8 +386,7 @@ int ml_open(buf_T *buf)
   /*
    * Allocate first data block and create an empty line 1.
    */
-  if ((hp = ml_new_data(mfp, FALSE, 1)) == NULL)
-    goto error;
+  hp = ml_new_data(mfp, FALSE, 1);
   if (hp->bh_bnum != 2) {
     EMSG(_("E298: Didn't get block nr 2?"));
     goto error;
@@ -2321,12 +2320,7 @@ ml_append_int (
     }
 
     page_count = ((space_needed + HEADER_SIZE) + page_size - 1) / page_size;
-    if ((hp_new = ml_new_data(mfp, newfile, page_count)) == NULL) {
-      /* correct line counts in pointer blocks */
-      --(buf->b_ml.ml_locked_lineadd);
-      --(buf->b_ml.ml_locked_high);
-      return FAIL;
-    }
+    hp_new = ml_new_data(mfp, newfile, page_count);
     if (db_idx < 0) {           /* left block is new */
       hp_left = hp_new;
       hp_right = hp;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -2607,8 +2607,8 @@ int ml_replace(linenr_T lnum, char_u *line, int copy)
   if (curbuf->b_ml.ml_mfp == NULL && open_buffer(FALSE, NULL, 0) == FAIL)
     return FAIL;
 
-  if (copy && (line = vim_strsave(line)) == NULL)   /* allocate memory */
-    return FAIL;
+  if (copy)
+    line = vim_strsave(line);
   if (curbuf->b_ml.ml_line_lnum != lnum)            /* other line buffered */
     ml_flush_line(curbuf);                          /* flush it */
   else if (curbuf->b_ml.ml_flags & ML_LINE_DIRTY)   /* same line allocated */

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -325,8 +325,7 @@ int ml_open(buf_T *buf)
   /*
    * fill block0 struct and write page 0
    */
-  if ((hp = mf_new(mfp, FALSE, 1)) == NULL)
-    goto error;
+  hp = mf_new(mfp, FALSE, 1);
   if (hp->bh_bnum != 0) {
     EMSG(_("E298: Didn't get block nr 0?"));
     goto error;
@@ -2982,13 +2981,8 @@ static void ml_flush_line(buf_T *buf)
  */
 static bhdr_T *ml_new_data(memfile_T *mfp, int negative, int page_count)
 {
-  bhdr_T      *hp;
-  DATA_BL     *dp;
-
-  if ((hp = mf_new(mfp, negative, page_count)) == NULL)
-    return NULL;
-
-  dp = (DATA_BL *)(hp->bh_data);
+  bhdr_T *hp = mf_new(mfp, negative, page_count);
+  DATA_BL *dp = (DATA_BL *)(hp->bh_data);
   dp->db_id = DATA_ID;
   dp->db_txt_start = dp->db_txt_end = page_count * mfp->mf_page_size;
   dp->db_free = dp->db_txt_start - HEADER_SIZE;
@@ -3002,13 +2996,8 @@ static bhdr_T *ml_new_data(memfile_T *mfp, int negative, int page_count)
  */
 static bhdr_T *ml_new_ptr(memfile_T *mfp)
 {
-  bhdr_T      *hp;
-  PTR_BL      *pp;
-
-  if ((hp = mf_new(mfp, FALSE, 1)) == NULL)
-    return NULL;
-
-  pp = (PTR_BL *)(hp->bh_data);
+  bhdr_T *hp = mf_new(mfp, FALSE, 1);
+  PTR_BL *pp = (PTR_BL *)(hp->bh_data);
   pp->pb_id = PTR_ID;
   pp->pb_count = 0;
   pp->pb_count_max = (mfp->mf_page_size - sizeof(PTR_BL)) / sizeof(PTR_EN) + 1;

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -44,14 +44,6 @@
 
 static void try_to_free_memory();
 
-/*
- * Note: if unsigned is 16 bits we can only allocate up to 64K with alloc().
- */
-char_u *alloc(unsigned size)
-{
-  return xmalloc(size);
-}
-
 /// Try to free memory. Used when trying to recover from out of memory errors.
 /// @see {xmalloc}
 static void try_to_free_memory()

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -192,7 +192,7 @@ char *xstpncpy(char *restrict dst, const char *restrict src, size_t maxlen)
     }
 }
 
-char * xstrdup(const char *str)
+char *xstrdup(const char *str)
 {
   char *ret = strdup(str);
 

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -5,8 +5,6 @@
 #include "nvim/types.h"
 #include "nvim/vim.h"
 
-char_u *alloc(unsigned size) FUNC_ATTR_MALLOC FUNC_ATTR_ALLOC_SIZE(1);
-
 /// malloc() wrapper
 ///
 /// try_malloc() is a malloc() wrapper that tries to free some memory before

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -462,7 +462,7 @@ add_menu_path (
         }
 
         if (c != 0) {
-          menu->strings[i] = alloc((unsigned)(STRLEN(call_data) + 5 ));
+          menu->strings[i] = xmalloc(STRLEN(call_data) + 5 );
           menu->strings[i][0] = c;
           if (d == 0)
             STRCPY(menu->strings[i] + 1, call_data);

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -308,8 +308,6 @@ add_menu_path (
 
   /* Make a copy so we can stuff around with it, since it could be const */
   path_name = vim_strsave(menu_path);
-  if (path_name == NULL)
-    return FAIL;
   menup = &root_menu;
   parent = NULL;
   name = path_name;
@@ -728,8 +726,6 @@ static int show_menus(char_u *path_name, int modes)
 
   menu = root_menu;
   name = path_name = vim_strsave(path_name);
-  if (path_name == NULL)
-    return FAIL;
 
   /* First, find the (sub)menu with the given name */
   while (*name) {
@@ -1168,7 +1164,7 @@ get_menu_cmd_modes (
 
 /*
  * Modify a menu name starting with "PopUp" to include the mode character.
- * Returns the name in allocated memory (NULL for failure).
+ * Returns the name in allocated memory.
  */
 static char_u *popup_mode_name(char_u *name, int idx)
 {
@@ -1176,10 +1172,9 @@ static char_u *popup_mode_name(char_u *name, int idx)
   int len = (int)STRLEN(name);
 
   p = vim_strnsave(name, len + 1);
-  if (p != NULL) {
-    memmove(p + 6, p + 5, (size_t)(len - 4));
-    p[5] = menu_mode_chars[idx];
-  }
+  memmove(p + 6, p + 5, (size_t)(len - 4));
+  p[5] = menu_mode_chars[idx];
+
   return p;
 }
 
@@ -1305,8 +1300,6 @@ void ex_emenu(exarg_T *eap)
   char_u      *mode;
 
   saved_name = vim_strsave(eap->arg);
-  if (saved_name == NULL)
-    return;
 
   menu = root_menu;
   name = saved_name;
@@ -1419,8 +1412,6 @@ vimmenu_T *gui_find_menu(char_u *path_name)
   menu = root_menu;
 
   saved_name = vim_strsave(path_name);
-  if (saved_name == NULL)
-    return NULL;
 
   name = saved_name;
   while (*name) {
@@ -1513,23 +1504,21 @@ void ex_menutranslate(exarg_T *eap)
       ga_grow(&menutrans_ga, 1);
       tp = (menutrans_T *)menutrans_ga.ga_data;
       from = vim_strsave(from);
-      if (from != NULL) {
-        from_noamp = menu_text(from, NULL, NULL);
-        to = vim_strnsave(to, (int)(arg - to));
-        if (from_noamp != NULL && to != NULL) {
-          menu_translate_tab_and_shift(from);
-          menu_translate_tab_and_shift(to);
-          menu_unescape_name(from);
-          menu_unescape_name(to);
-          tp[menutrans_ga.ga_len].from = from;
-          tp[menutrans_ga.ga_len].from_noamp = from_noamp;
-          tp[menutrans_ga.ga_len].to = to;
-          ++menutrans_ga.ga_len;
-        } else {
-          free(from);
-          free(from_noamp);
-          free(to);
-        }
+      from_noamp = menu_text(from, NULL, NULL);
+      to = vim_strnsave(to, (int)(arg - to));
+      if (from_noamp != NULL) {
+        menu_translate_tab_and_shift(from);
+        menu_translate_tab_and_shift(to);
+        menu_unescape_name(from);
+        menu_unescape_name(to);
+        tp[menutrans_ga.ga_len].from = from;
+        tp[menutrans_ga.ga_len].from_noamp = from_noamp;
+        tp[menutrans_ga.ga_len].to = to;
+        ++menutrans_ga.ga_len;
+      } else {
+        free(from);
+        free(from_noamp);
+        free(to);
       }
     }
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -267,7 +267,7 @@ msg_strtrunc (
         len = (room + 2) * 2;
       else
         len = room + 2;
-      buf = alloc(len);
+      buf = xmalloc(len);
       trunc_string(s, buf, room, len);
     }
   }
@@ -421,7 +421,7 @@ static char_u *get_emsg_source(void)
 
   if (sourcing_name != NULL && other_sourcing_name()) {
     p = (char_u *)_("Error detected while processing %s:");
-    Buf = alloc((unsigned)(STRLEN(sourcing_name) + STRLEN(p)));
+    Buf = xmalloc(STRLEN(sourcing_name) + STRLEN(p));
     sprintf((char *)Buf, (char *)p, sourcing_name);
     return Buf;
   }
@@ -443,7 +443,7 @@ static char_u *get_emsg_lnum(void)
       && (other_sourcing_name() || sourcing_lnum != last_sourcing_lnum)
       && sourcing_lnum != 0) {
     p = (char_u *)_("line %4ld:");
-    Buf = alloc((unsigned)(STRLEN(p) + 20));
+    Buf = xmalloc(STRLEN(p) + 20);
     sprintf((char *)Buf, (char *)p, (long)sourcing_lnum);
     return Buf;
   }
@@ -680,8 +680,6 @@ add_msg_hist (
     int attr
 )
 {
-  struct msg_hist *p;
-
   if (msg_hist_off || msg_silent != 0)
     return;
 
@@ -690,7 +688,7 @@ add_msg_hist (
     (void)delete_first_msg();
 
   /* allocate an entry and add the message at the end of the history */
-  p = (struct msg_hist *)alloc((int)sizeof(struct msg_hist));
+  struct msg_hist *p = xmalloc(sizeof(struct msg_hist));
   if (len < 0)
     len = (int)STRLEN(s);
   /* remove leading and trailing newlines */
@@ -1841,7 +1839,7 @@ static void inc_msg_scrolled(void)
       p = (char_u *)_("Unknown");
     else {
       len = (int)STRLEN(p) + 40;
-      tofree = alloc(len);
+      tofree = xmalloc(len);
       vim_snprintf((char *)tofree, len, _("%s line %" PRId64),
           p, (int64_t)sourcing_lnum);
       p = tofree;
@@ -1893,7 +1891,7 @@ store_sb_text (
   }
 
   if (s > *sb_str) {
-    mp = (msgchunk_T *)alloc((int)(sizeof(msgchunk_T) + (s - *sb_str)));
+    mp = xmalloc((sizeof(msgchunk_T) + (s - *sb_str)));
     mp->sb_eol = finish;
     mp->sb_msg_col = *sb_col;
     mp->sb_attr = attr;

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -120,8 +120,6 @@ open_line (
    * make a copy of the current line so we can mess with it
    */
   saved_line = vim_strsave(ml_get_curline());
-  if (saved_line == NULL)           /* out of memory! */
-    return FALSE;
 
   if (State & VREPLACE_FLAG) {
     /*
@@ -137,8 +135,6 @@ open_line (
       next_line = vim_strsave(ml_get(curwin->w_cursor.lnum + 1));
     else
       next_line = vim_strsave((char_u *)"");
-    if (next_line == NULL)          /* out of memory! */
-      goto theend;
 
     /*
      * In VREPLACE mode, a NL replaces the rest of the line, and starts
@@ -918,8 +914,6 @@ open_line (
   if (State & VREPLACE_FLAG) {
     /* Put new line in p_extra */
     p_extra = vim_strsave(ml_get_curline());
-    if (p_extra == NULL)
-      goto theend;
 
     /* Put back original line */
     ml_replace(curwin->w_cursor.lnum, next_line, FALSE);
@@ -1742,9 +1736,6 @@ truncate_line (
     newp = vim_strsave((char_u *)"");
   else
     newp = vim_strnsave(ml_get(lnum), col);
-
-  if (newp == NULL)
-    return FAIL;
 
   ml_replace(lnum, newp, FALSE);
 
@@ -2874,13 +2865,11 @@ expand_env_esc (
       if (p_ssl && var != NULL && vim_strchr(var, '\\') != NULL) {
         char_u  *p = vim_strsave(var);
 
-        if (p != NULL) {
-          if (mustfree)
-            free(var);
-          var = p;
-          mustfree = TRUE;
-          forward_slash(var);
-        }
+        if (mustfree)
+          free(var);
+        var = p;
+        mustfree = TRUE;
+        forward_slash(var);
       }
 #endif
 
@@ -3033,7 +3022,7 @@ char_u *vim_getenv(char_u *name, int *mustfree)
       /* check that the result is a directory name */
       p = vim_strnsave(p, (int)(pend - p));
 
-      if (p != NULL && !os_isdir(p)) {
+      if (!os_isdir(p)) {
         free(p);
         p = NULL;
       } else {

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -501,7 +501,7 @@ open_line (
     }
     if (lead_len) {
       /* allocate buffer (may concatenate p_extra later) */
-      leader = alloc(lead_len + lead_repl_len + extra_space + extra_len
+      leader = xmalloc(lead_len + lead_repl_len + extra_space + extra_len
           + (second_line_indent > 0 ? second_line_indent : 0) + 1);
       allocated = leader;                   /* remember to free it later */
 
@@ -1702,9 +1702,7 @@ del_bytes (
   if (was_alloced)
     newp = oldp;                            /* use same allocated memory */
   else {                                    /* need to allocate a new line */
-    newp = alloc((unsigned)(oldlen + 1 - count));
-    if (newp == NULL)
-      return FAIL;
+    newp = xmalloc(oldlen + 1 - count);
     memmove(newp, oldp, (size_t)col);
   }
   memmove(newp + col, oldp + col + count, (size_t)movelen);
@@ -2395,7 +2393,7 @@ int get_keystroke(void)
      * bytes. */
     maxlen = (buflen - 6 - len) / 3;
     if (buf == NULL)
-      buf = alloc(buflen);
+      buf = xmalloc(buflen);
     else if (maxlen < 10) {
       /* Need some more space. This might happen when receiving a long
        * escape sequence. */
@@ -2715,9 +2713,7 @@ char_u *expand_env_save(char_u *src)
  */
 char_u *expand_env_save_opt(char_u *src, int one)
 {
-  char_u      *p;
-
-  p = alloc(MAXPATHL);
+  char_u *p = xmalloc(MAXPATHL);
   expand_env_esc(src, p, MAXPATHL, FALSE, one, NULL);
   return p;
 }
@@ -2865,8 +2861,9 @@ expand_env_esc (
       if (p_ssl && var != NULL && vim_strchr(var, '\\') != NULL) {
         char_u  *p = vim_strsave(var);
 
-        if (mustfree)
+        if (mustfree) {
           free(var);
+        }
         var = p;
         mustfree = TRUE;
         forward_slash(var);
@@ -3321,13 +3318,12 @@ home_replace_save (
 )
 {
   char_u      *dst;
-  unsigned len;
 
-  len = 3;                      /* space for "~/" and trailing NUL */
+  size_t len = 3;                      /* space for "~/" and trailing NUL */
   if (src != NULL)              /* just in case */
-    len += (unsigned)STRLEN(src);
-  dst = alloc(len);
-  home_replace(buf, src, dst, len, TRUE);
+    len += STRLEN(src);
+  dst = xmalloc(len);
+  home_replace(buf, src, dst, (int)len, TRUE);
   return dst;
 }
 
@@ -3488,7 +3484,7 @@ get_cmd_output (
   len = ftell(fd);                  /* get size of temp file */
   fseek(fd, 0L, SEEK_SET);
 
-  buffer = alloc(len + 1);
+  buffer = xmalloc(len + 1);
   i = (int)fread((char *)buffer, (size_t)1, (size_t)len, fd);
   fclose(fd);
   os_remove((char *)tempname);

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1718,10 +1718,8 @@ del_bytes (
 /*
  * Delete from cursor to end of line.
  * Caller must have prepared for undo.
- *
- * return FAIL for failure, OK otherwise
  */
-int 
+void
 truncate_line (
     int fixpos                 /* if TRUE fix the cursor position when done */
 )
@@ -1745,8 +1743,6 @@ truncate_line (
    */
   if (fixpos && curwin->w_cursor.col > 0)
     --curwin->w_cursor.col;
-
-  return OK;
 }
 
 /*

--- a/src/nvim/misc1.h
+++ b/src/nvim/misc1.h
@@ -22,7 +22,7 @@ void ins_str(char_u *s);
 int del_char(int fixpos);
 int del_chars(long count, int fixpos);
 int del_bytes(long count, int fixpos_arg, int use_delcombine);
-int truncate_line(int fixpos);
+void truncate_line(int fixpos);
 void del_lines(long nlines, int undo);
 int gchar_pos(pos_T *pos);
 int gchar_cursor(void);

--- a/src/nvim/misc2.c
+++ b/src/nvim/misc2.c
@@ -230,7 +230,7 @@ coladvance2 (
       if (line[idx] == NUL) {
         /* Append spaces */
         int correct = wcol - col;
-        char_u  *newline = alloc(idx + correct + 1);
+        char_u  *newline = xmalloc(idx + correct + 1);
         int t;
 
         for (t = 0; t < idx; ++t)
@@ -256,7 +256,7 @@ coladvance2 (
         if (-correct > csize)
           return FAIL;
 
-        newline = alloc(linelen + csize);
+        newline = xmalloc(linelen + csize);
 
         for (t = 0; t < linelen; t++) {
           if (t != idx)

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3382,7 +3382,7 @@ find_decl (
   int retval = OK;
   int incll;
 
-  pat = alloc(len + 7);
+  pat = xmalloc(len + 7);
 
   /* Put "\V" before the pattern to avoid that the special meaning of "."
    * and "~" causes trouble. */
@@ -4356,7 +4356,7 @@ static void nv_ident(cmdarg_T *cap)
   kp = (*curbuf->b_p_kp == NUL ? p_kp : curbuf->b_p_kp);
   kp_help = (*kp == NUL || STRCMP(kp, ":he") == 0
              || STRCMP(kp, ":help") == 0);
-  buf = alloc((unsigned)(n * 2 + 30 + STRLEN(kp)));
+  buf = xmalloc(n * 2 + 30 + STRLEN(kp));
   buf[0] = NUL;
 
   switch (cmdchar) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -905,7 +905,7 @@ static int stuff_yank(int regname, char_u *p)
     *pp = lp;
   } else {
     free_yank_all();
-    y_current->y_array = (char_u **)alloc((unsigned)sizeof(char_u *));
+    y_current->y_array = (char_u **)xmalloc(sizeof(char_u *));
     y_current->y_array[0] = p;
     y_current->y_size = 1;
     y_current->y_type = MCHAR;      /* used to be MLINE, why? */
@@ -2664,8 +2664,7 @@ do_put (
         }
         if (y_array != NULL)
           break;
-        y_array = (char_u **)alloc((unsigned)
-            (y_size * sizeof(char_u *)));
+        y_array = (char_u **)xmalloc(y_size * sizeof(char_u *));
       }
     } else {
       y_size = 1;               /* use fake one-line yank register */
@@ -4384,7 +4383,7 @@ int do_addsub(int command, linenr_T Prenum1)
      * When there are many leading zeros it could be very long.  Allocate
      * a bit too much.
      */
-    buf1 = alloc((unsigned)length + NUMBUFLEN);
+    buf1 = xmalloc(length + NUMBUFLEN);
     ptr = buf1;
     if (negative) {
       *ptr++ = '-';
@@ -4474,7 +4473,7 @@ int read_viminfo_register(vir_T *virp, int force)
       y_previous = y_current;
     free(y_current->y_array);
     array = y_current->y_array =
-              (char_u **)alloc((unsigned)(limit * sizeof(char_u *)));
+              (char_u **)xmalloc(limit * sizeof(char_u *));
     str = skipwhite(skiptowhite(str));
     if (STRNCMP(str, "CHAR", 4) == 0)
       y_current->y_type = MCHAR;
@@ -4491,8 +4490,7 @@ int read_viminfo_register(vir_T *virp, int force)
          && (virp->vir_line[0] == TAB || virp->vir_line[0] == '<')) {
     if (do_it) {
       if (size >= limit) {
-        y_current->y_array = (char_u **)
-                             alloc((unsigned)(limit * 2 * sizeof(char_u *)));
+        y_current->y_array = (char_u **)xmalloc(limit * 2 * sizeof(char_u *));
         for (i = 0; i < limit; i++)
           y_current->y_array[i] = array[i];
         free(array);
@@ -4512,7 +4510,7 @@ int read_viminfo_register(vir_T *virp, int force)
       y_current->y_array = NULL;
     } else if (size < limit) {
       y_current->y_array =
-        (char_u **)alloc((unsigned)(size * sizeof(char_u *)));
+        (char_u **)xmalloc(size * sizeof(char_u *));
       for (i = 0; i < size; i++)
         y_current->y_array[i] = array[i];
       free(array);
@@ -4867,7 +4865,7 @@ str_to_reg (
       extra = (int)STRLEN(y_ptr->y_array[lnum]);
     } else
       extra = 0;
-    s = alloc((unsigned)(i + extra + 1));
+    s = xmalloc(i + extra + 1);
     if (extra)
       memmove(s, y_ptr->y_array[lnum], (size_t)extra);
     if (append)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2102,7 +2102,8 @@ void set_init_1(void)
       p = (char_u *)_(*(char **)options[opt_idx].var);
     else
       p = option_expand(opt_idx, NULL);
-    if (p != NULL && (p = vim_strsave(p)) != NULL) {
+    if (p != NULL) {
+      p = vim_strsave(p);
       *(char_u **)options[opt_idx].var = p;
       /* VIMEXP
        * Defaults for all expanded options are currently the same for Vi
@@ -2291,14 +2292,12 @@ void set_string_default(char *name, char_u *val)
   int opt_idx;
 
   p = vim_strsave(val);
-  if (p != NULL) {              /* we don't want a NULL */
-    opt_idx = findoption((char_u *)name);
-    if (opt_idx >= 0) {
-      if (options[opt_idx].flags & P_DEF_ALLOCED)
-        free(options[opt_idx].def_val[VI_DEFAULT]);
-      options[opt_idx].def_val[VI_DEFAULT] = p;
-      options[opt_idx].flags |= P_DEF_ALLOCED;
-    }
+  opt_idx = findoption((char_u *)name);
+  if (opt_idx >= 0) {
+    if (options[opt_idx].flags & P_DEF_ALLOCED)
+      free(options[opt_idx].def_val[VI_DEFAULT]);
+    options[opt_idx].def_val[VI_DEFAULT] = p;
+    options[opt_idx].flags |= P_DEF_ALLOCED;
   }
 }
 
@@ -2463,7 +2462,7 @@ void set_init_3(void)
         p1 = p2 + 1;
     p = vim_strnsave(p1, (int)(p - p1));
   }
-  if (p != NULL) {
+  {
     /*
      * Default for p_sp is "| tee", for p_srr is ">".
      * For known shells it is changed here to include stderr.
@@ -2519,16 +2518,12 @@ void set_helplang_default(char_u *lang)
     if (options[idx].flags & P_ALLOCED)
       free_string_option(p_hlg);
     p_hlg = vim_strsave(lang);
-    if (p_hlg == NULL)
-      p_hlg = empty_option;
-    else {
-      /* zh_CN becomes "cn", zh_TW becomes "tw". */
-      if (STRNICMP(p_hlg, "zh_", 3) == 0 && STRLEN(p_hlg) >= 5) {
-        p_hlg[0] = TOLOWER_ASC(p_hlg[3]);
-        p_hlg[1] = TOLOWER_ASC(p_hlg[4]);
-      }
-      p_hlg[2] = NUL;
+    /* zh_CN becomes "cn", zh_TW becomes "tw". */
+    if (STRNICMP(p_hlg, "zh_", 3) == 0 && STRLEN(p_hlg) >= 5) {
+      p_hlg[0] = TOLOWER_ASC(p_hlg[3]);
+      p_hlg[1] = TOLOWER_ASC(p_hlg[4]);
     }
+    p_hlg[2] = NUL;
     options[idx].flags |= P_ALLOCED;
   }
 }
@@ -3754,7 +3749,7 @@ set_string_option_direct (
     return;
 
   s = vim_strsave(val);
-  if (s != NULL) {
+  {
     varp = (char_u **)get_varp_scope(&(options[idx]),
         both ? OPT_LOCAL : opt_flags);
     if ((opt_flags & OPT_FREE) && (options[idx].flags & P_ALLOCED))
@@ -3795,9 +3790,8 @@ set_string_option_global (
     p = (char_u **)GLOBAL_WO(varp);
   else
     p = (char_u **)options[opt_idx].var;
-  if (options[opt_idx].indir != PV_NONE
-      && p != varp
-      && (s = vim_strsave(*varp)) != NULL) {
+  if (options[opt_idx].indir != PV_NONE && p != varp) {
+    s = vim_strsave(*varp);
     free_string_option(*p);
     *p = s;
   }
@@ -3824,18 +3818,17 @@ set_string_option (
     return NULL;
 
   s = vim_strsave(value);
-  if (s != NULL) {
-    varp = (char_u **)get_varp_scope(&(options[opt_idx]),
-        (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0
-        ? (((int)options[opt_idx].indir & PV_BOTH)
-           ? OPT_GLOBAL : OPT_LOCAL)
-        : opt_flags);
-    oldval = *varp;
-    *varp = s;
-    if ((r = did_set_string_option(opt_idx, varp, TRUE, oldval, NULL,
-             opt_flags)) == NULL)
-      did_set_option(opt_idx, opt_flags, TRUE);
-  }
+  varp = (char_u **)get_varp_scope(&(options[opt_idx]),
+      (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0
+      ? (((int)options[opt_idx].indir & PV_BOTH)
+        ? OPT_GLOBAL : OPT_LOCAL)
+      : opt_flags);
+  oldval = *varp;
+  *varp = s;
+  if ((r = did_set_string_option(opt_idx, varp, TRUE, oldval, NULL,
+          opt_flags)) == NULL)
+    did_set_option(opt_idx, opt_flags, TRUE);
+
   return r;
 }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3083,7 +3083,7 @@ do_set (
               newlen = (unsigned)STRLEN(arg) + 1;
               if (adding || prepending || removing)
                 newlen += (unsigned)STRLEN(origval) + 1;
-              newval = alloc(newlen);
+              newval = xmalloc(newlen);
               s = newval;
 
               /*
@@ -3129,7 +3129,7 @@ do_set (
                   newlen = (unsigned)STRLEN(s) + 1;
                   if (adding || prepending || removing)
                     newlen += (unsigned)STRLEN(origval) + 1;
-                  newval = alloc(newlen);
+                  newval = xmalloc(newlen);
                   STRCPY(newval, s);
                 }
               }
@@ -4828,7 +4828,7 @@ skip:
   if (count == 0)
     wp->w_p_cc_cols = NULL;
   else {
-    wp->w_p_cc_cols = (int *)alloc((unsigned)sizeof(int) * (count + 1));
+    wp->w_p_cc_cols = xmalloc(sizeof(int) * (count + 1));
     /* sort the columns for faster usage on screen redraw inside
      * win_line() */
     qsort(color_cols, count, sizeof(int), int_cmp);
@@ -6204,7 +6204,6 @@ showoptions (
   int col;
   int isterm;
   char_u              *varp;
-  struct vimoption    **items;
   int item_count;
   int run;
   int row, rows;
@@ -6215,8 +6214,7 @@ showoptions (
 #define INC 20
 #define GAP 3
 
-  items = (struct vimoption **)alloc((unsigned)(sizeof(struct vimoption *) *
-                                                PARAM_COUNT));
+  struct vimoption **items = xmalloc(sizeof(struct vimoption *) * PARAM_COUNT);
 
   /* Highlight title */
   if (all == 2)
@@ -6505,7 +6503,7 @@ static int put_setstring(FILE *fd, char *cmd, char *name, char_u **valuep, int e
         if (put_escstr(fd, str2special(&s, FALSE), 2) == FAIL)
           return FAIL;
     } else if (expand) {
-      buf = alloc(MAXPATHL);
+      buf = xmalloc(MAXPATHL);
       home_replace(NULL, *valuep, buf, MAXPATHL, FALSE);
       if (put_escstr(fd, buf, 2) == FAIL) {
         free(buf);
@@ -7525,11 +7523,7 @@ int ExpandSettings(expand_T *xp, regmatch_T *regmatch, int *num_file, char_u ***
         *num_file = num_term;
       else
         return OK;
-      *file = (char_u **)alloc((unsigned)(*num_file * sizeof(char_u *)));
-      if (*file == NULL) {
-        *file = (char_u **)"";
-        return FAIL;
-      }
+      *file = (char_u **)xmalloc(*num_file * sizeof(char_u *));
     }
   }
   return OK;
@@ -7541,7 +7535,7 @@ int ExpandOldSetting(int *num_file, char_u ***file)
   char_u  *buf;
 
   *num_file = 0;
-  *file = (char_u **)alloc((unsigned)sizeof(char_u *));
+  *file = (char_u **)xmalloc(sizeof(char_u *));
 
   /*
    * For a terminal key code expand_option_idx is < 0.

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -89,8 +89,8 @@ static bool is_executable_in_path(const char_u *name)
     return false;
   }
 
-  int buf_len = STRLEN(name) + STRLEN(path) + 2;
-  char_u *buf = alloc((unsigned)(buf_len));
+  size_t buf_len = STRLEN(name) + STRLEN(path) + 2;
+  char_u *buf = xmalloc(buf_len);
 
   // Walk through all entries in $PATH to check if "name" exists there and
   // is an executable file.
@@ -103,7 +103,7 @@ static bool is_executable_in_path(const char_u *name)
     // Glue together the given directory from $PATH with name and save into
     // buf.
     vim_strncpy(buf, (char_u *) path, e - path);
-    append_path((char *) buf, (const char *) name, buf_len);
+    append_path((char *) buf, (const char *) name, (int)buf_len);
 
     if (is_executable(buf)) {
       // Found our executable. Free buf and return.

--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -28,10 +28,7 @@ int os_get_usernames(garray_T *users)
     // pw->pw_name shouldn't be NULL but just in case...
     if (pw->pw_name != NULL) {
       ga_grow(users, 1);
-      user = (char *)vim_strsave((char_u*)pw->pw_name);
-      if (user == NULL) {
-        return FAIL;
-      }
+      user = xstrdup(pw->pw_name);
       ((char **)(users->ga_data))[users->ga_len++] = user;
     }
   }
@@ -79,8 +76,7 @@ char *os_get_user_directory(const char *name)
   pw = getpwnam(name);
   if (pw != NULL) {
     // save the string from the static passwd entry into malloced memory
-    char *user_directory = (char *)vim_strsave((char_u *)pw->pw_dir);
-    return user_directory;
+    return vim_strsave(pw->pw_dir);
   }
 #endif
   return NULL;

--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -4,6 +4,7 @@
 
 #include "nvim/os/os.h"
 #include "nvim/garray.h"
+#include "nvim/memory.h"
 #include "nvim/misc2.h"
 #include "nvim/strings.h"
 #ifdef HAVE_PWD_H
@@ -76,7 +77,7 @@ char *os_get_user_directory(const char *name)
   pw = getpwnam(name);
   if (pw != NULL) {
     // save the string from the static passwd entry into malloced memory
-    return vim_strsave(pw->pw_dir);
+    return xstrdup(pw->pw_dir);
   }
 #endif
   return NULL;

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -1120,7 +1120,7 @@ int flags;                      /* EW_* flags */
       ++len;
     }
   }
-  command = alloc(len);
+  command = xmalloc(len);
 
   /*
    * Build the shell command:
@@ -1269,7 +1269,7 @@ int flags;                      /* EW_* flags */
   fseek(fd, 0L, SEEK_END);
   len = ftell(fd);                      /* get size of temp file */
   fseek(fd, 0L, SEEK_SET);
-  buffer = alloc(len + 1);
+  buffer = xmalloc(len + 1);
   i = fread((char *)buffer, 1, len, fd);
   fclose(fd);
   os_remove((char *)tempname);
@@ -1353,7 +1353,7 @@ int flags;                      /* EW_* flags */
     goto notfound;
   }
   *num_file = i;
-  *file = (char_u **)alloc(sizeof(char_u *) * i);
+  *file = (char_u **)xmalloc(sizeof(char_u *) * i);
 
   /*
    * Isolate the individual file names.
@@ -1397,7 +1397,7 @@ int flags;                      /* EW_* flags */
     if (!dir && (flags & EW_EXEC) && !os_can_exe((*file)[i]))
       continue;
 
-    p = alloc((unsigned)(STRLEN((*file)[i]) + 1 + dir));
+    p = xmalloc(STRLEN((*file)[i]) + 1 + dir);
     STRCPY(p, (*file)[i]);
     if (dir)
       add_pathsep(p);             /* add '/' to a directory name */

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -1437,10 +1437,9 @@ char_u      ***file;
 
   for (i = 0; i < num_pat; i++) {
     s = vim_strsave(pat[i]);
-    if (s != NULL)
-      /* Be compatible with expand_filename(): halve the number of
-       * backslashes. */
-      backslash_halve(s);
+    /* Be compatible with expand_filename(): halve the number of
+     * backslashes. */
+    backslash_halve(s);
     (*file)[i] = s;
   }
   *num_file = num_pat;

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -296,7 +296,7 @@ void add_pathsep(char_u *p)
 
 /*
  * FullName_save - Make an allocated copy of a full file name.
- * Returns NULL when out of memory.
+ * Returns NULL when fname is NULL.
  */
 char_u *
 FullName_save (
@@ -305,20 +305,19 @@ FullName_save (
                                  * like a full path name */
 )
 {
-  char_u      *buf;
   char_u      *new_fname = NULL;
 
   if (fname == NULL)
     return NULL;
 
-  buf = alloc((unsigned)MAXPATHL);
-  if (buf != NULL) {
-    if (vim_FullName(fname, buf, MAXPATHL, force) != FAIL)
-      new_fname = vim_strsave(buf);
-    else
-      new_fname = vim_strsave(fname);
-    free(buf);
-  }
+  char_u *buf = xmalloc(MAXPATHL);
+
+  if (vim_FullName(fname, buf, MAXPATHL, force) != FAIL)
+    new_fname = vim_strsave(buf);
+  else
+    new_fname = vim_strsave(fname);
+  free(buf);
+
   return new_fname;
 }
 
@@ -650,8 +649,6 @@ static void expand_path_option(char_u *curdir, garray_T *gap)
     ga_grow(gap, 1);
 
     p = vim_strsave(buf);
-    if (p == NULL)
-      break;
     ((char_u **)gap->ga_data)[gap->ga_len++] = p;
   }
 
@@ -1137,8 +1134,6 @@ expand_backtick (
 
   /* Create the command: lop off the backticks. */
   cmd = vim_strnsave(pat + 1, (int)STRLEN(pat) - 2);
-  if (cmd == NULL)
-    return 0;
 
   if (*cmd == '=')          /* `={expr}`: Expand expression */
     buffer = eval_to_string(cmd + 1, &p, TRUE);
@@ -1563,9 +1558,7 @@ char_u *fix_fname(char_u *fname)
   fname = vim_strsave(fname);
 
 # ifdef USE_FNAME_CASE
-  if (fname != NULL) {
-    fname_case(fname, 0);             /* set correct case for file name */
-  }
+  fname_case(fname, 0);  // set correct case for file name
 # endif
 
   return fname;

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -312,10 +312,11 @@ FullName_save (
 
   char_u *buf = xmalloc(MAXPATHL);
 
-  if (vim_FullName(fname, buf, MAXPATHL, force) != FAIL)
+  if (vim_FullName(fname, buf, MAXPATHL, force) != FAIL) {
     new_fname = vim_strsave(buf);
-  else
+  } else {
     new_fname = vim_strsave(fname);
+  }
   free(buf);
 
   return new_fname;
@@ -379,7 +380,7 @@ unix_expandpath (
   }
 
   /* make room for file name */
-  buf = alloc((int)STRLEN(path) + BASENAMELEN + 5);
+  buf = xmalloc(STRLEN(path) + BASENAMELEN + 5);
 
   /*
    * Find the first part in the path name that contains a wildcard.
@@ -608,7 +609,7 @@ static void expand_path_option(char_u *curdir, garray_T *gap)
   char_u      *p;
   int len;
 
-  buf = alloc((int)MAXPATHL);
+  buf = xmalloc(MAXPATHL);
 
   while (*path_option != NUL) {
     copy_option_part(&path_option, buf, MAXPATHL, " ,");
@@ -720,7 +721,7 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
    * possible patterns?
    */
   len = (int)STRLEN(pattern);
-  file_pattern = alloc(len + 2);
+  file_pattern = xmalloc(len + 2);
   file_pattern[0] = '*';
   file_pattern[1] = NUL;
   STRCAT(file_pattern, pattern);
@@ -735,7 +736,7 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
   if (regmatch.regprog == NULL)
     return;
 
-  curdir = alloc((int)(MAXPATHL));
+  curdir = xmalloc(MAXPATHL);
   os_dirname(curdir, MAXPATHL);
   expand_path_option(curdir, &path_ga);
 
@@ -811,7 +812,7 @@ static void uniquefy_paths(garray_T *gap, char_u *pattern)
       continue;
     }
 
-    rel_path = alloc((int)(STRLEN(short_name) + STRLEN(PATHSEPSTR) + 2));
+    rel_path = xmalloc(STRLEN(short_name) + STRLEN(PATHSEPSTR) + 2);
     STRCPY(rel_path, ".");
     add_pathsep(rel_path);
     STRCAT(rel_path, short_name);
@@ -884,7 +885,7 @@ expand_in_path (
   char_u      *e;       /* end */
   char_u      *paths = NULL;
 
-  curdir = alloc((unsigned)MAXPATHL);
+  curdir = xmalloc(MAXPATHL);
   os_dirname(curdir, MAXPATHL);
 
   ga_init(&path_ga, (int)sizeof(char_u *), 1);
@@ -1206,7 +1207,7 @@ addfile (
   /* Make room for another item in the file list. */
   ga_grow(gap, 1);
 
-  p = alloc((unsigned)(STRLEN(f) + 1 + isdir));
+  p = xmalloc(STRLEN(f) + 1 + isdir);
 
   STRCPY(p, f);
 #ifdef BACKSLASH_IN_FILENAME

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -345,32 +345,27 @@ void pum_redraw(void)
             *p = saved;
 
             if (curwin->w_p_rl) {
-              char_u  *rt = reverse_text(st);
+              char_u *rt = reverse_text(st);
+              char_u *rt_start = rt;
+              int size = vim_strsize(rt);
 
-              if (rt != NULL) {
-                char_u *rt_start = rt;
-                int size;
+              if (size > pum_width) {
+                do {
+                  size -= has_mbyte ? (*mb_ptr2cells)(rt) : 1;
+                  mb_ptr_adv(rt);
+                } while (size > pum_width);
 
-                size = vim_strsize(rt);
-
-                if (size > pum_width) {
-                  do {
-                    size -= has_mbyte ? (*mb_ptr2cells)(rt) : 1;
-                    mb_ptr_adv(rt);
-                  } while (size > pum_width);
-
-                  if (size < pum_width) {
-                    // Most left character requires 2-cells but only 1 cell
-                    // is available on screen.  Put a '<' on the left of the 
-                    // pum item
-                    *(--rt) = '<';
-                    size++;
-                  }
+                if (size < pum_width) {
+                  // Most left character requires 2-cells but only 1 cell
+                  // is available on screen.  Put a '<' on the left of the 
+                  // pum item
+                  *(--rt) = '<';
+                  size++;
                 }
-                screen_puts_len(rt, (int)STRLEN(rt), row, col - size + 1,
-                                attr);
-                free(rt_start);
               }
+              screen_puts_len(rt, (int)STRLEN(rt), row, col - size + 1,
+                              attr);
+              free(rt_start);
               free(st);
 
               col -= width;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -283,9 +283,9 @@ qf_init_ext (
     {'s', ".\\+"}
   };
 
-  namebuf = alloc(CMDBUFFSIZE + 1);
-  errmsg = alloc(CMDBUFFSIZE + 1);
-  pattern = alloc(CMDBUFFSIZE + 1);
+  namebuf = xmalloc(CMDBUFFSIZE + 1);
+  errmsg = xmalloc(CMDBUFFSIZE + 1);
+  pattern = xmalloc(CMDBUFFSIZE + 1);
 
   if (efile != NULL && (fd = mch_fopen((char *)efile, "r")) == NULL) {
     EMSG2(_(e_openerrf), efile);
@@ -321,7 +321,7 @@ qf_init_ext (
 #else
   i += 2;   /* "%f" can become two chars longer */
 #endif
-  fmtstr = alloc(i);
+  fmtstr = xmalloc(i);
 
   while (efm[0] != NUL) {
     /*
@@ -720,7 +720,7 @@ restofline:
           goto error2;
         if (*errmsg && !multiignore) {
           len = (int)STRLEN(qfprev->qf_text);
-          ptr = alloc((unsigned)(len + STRLEN(errmsg) + 2));
+          ptr = xmalloc(len + STRLEN(errmsg) + 2);
           STRCPY(ptr, qfprev->qf_text);
           free(qfprev->qf_text);
           qfprev->qf_text = ptr;
@@ -856,7 +856,7 @@ static void qf_new_list(qf_info_T *qi, char_u *qf_title)
     qi->qf_curlist = qi->qf_listcount++;
   memset(&qi->qf_lists[qi->qf_curlist], 0, (size_t)(sizeof(qf_list_T)));
   if (qf_title != NULL) {
-    char_u *p = alloc((int)STRLEN(qf_title) + 2);
+    char_u *p = xmalloc(STRLEN(qf_title) + 2);
 
     qi->qf_lists[qi->qf_curlist].qf_title = p;
     sprintf((char *)p, ":%s", (char *)qf_title);
@@ -921,9 +921,7 @@ qf_add_entry (
     int valid                      /* valid entry */
 )
 {
-  qfline_T    *qfp;
-
-  qfp = (qfline_T *)alloc((unsigned)sizeof(qfline_T));
+  qfline_T *qfp = xmalloc(sizeof(qfline_T));
 
   if (bufnum != 0)
     qfp->qf_fnum = bufnum;
@@ -1140,11 +1138,10 @@ static int qf_get_fnum(char_u *directory, char_u *fname)
  */
 static char_u *qf_push_dir(char_u *dirbuf, struct dir_stack_T **stackptr)
 {
-  struct dir_stack_T  *ds_new;
   struct dir_stack_T  *ds_ptr;
 
   /* allocate new stack element and hook it in */
-  ds_new = (struct dir_stack_T *)alloc((unsigned)sizeof(struct dir_stack_T));
+  struct dir_stack_T *ds_new = xmalloc(sizeof(struct dir_stack_T));
 
   ds_new->next = *stackptr;
   *stackptr = ds_new;
@@ -2516,7 +2513,7 @@ void ex_make(exarg_T *eap)
   len = (unsigned)STRLEN(p_shq) * 2 + (unsigned)STRLEN(eap->arg) + 1;
   if (*p_sp != NUL)
     len += (unsigned)STRLEN(p_sp) + (unsigned)STRLEN(fname) + 3;
-  cmd = alloc(len);
+  cmd = xmalloc(len);
   sprintf((char *)cmd, "%s%s%s", (char *)p_shq, (char *)eap->arg,
       (char *)p_shq);
   if (*p_sp != NUL)
@@ -2591,7 +2588,7 @@ static char_u *get_mef_name(void)
     else
       off += 19;
 
-    name = alloc((unsigned)STRLEN(p_mef) + 30);
+    name = xmalloc(STRLEN(p_mef) + 30);
     STRCPY(name, p_mef);
     sprintf((char *)name + (p - p_mef), "%d%d", start, off);
     STRCAT(name, p + 2);
@@ -2838,8 +2835,8 @@ void ex_vimgrep(exarg_T *eap)
     goto theend;
   }
 
-  dirname_start = alloc(MAXPATHL);
-  dirname_now = alloc(MAXPATHL);
+  dirname_start = xmalloc(MAXPATHL);
+  dirname_now = xmalloc(MAXPATHL);
 
   /* Remember the current directory, because a BufRead autocommand that does
    * ":lcd %:p:h" changes the meaning of short path names. */
@@ -3107,7 +3104,7 @@ char_u *skip_vimgrep_pat(char_u *p, char_u **s, int *flags)
  */
 static void restore_start_dir(char_u *dirname_start)
 {
-  char_u *dirname_now = alloc(MAXPATHL);
+  char_u *dirname_now = xmalloc(MAXPATHL);
 
   os_dirname(dirname_now, MAXPATHL);
   if (STRCMP(dirname_start, dirname_now) != 0) {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -929,19 +929,14 @@ qf_add_entry (
     qfp->qf_fnum = bufnum;
   else
     qfp->qf_fnum = qf_get_fnum(dir, fname);
-  if ((qfp->qf_text = vim_strsave(mesg)) == NULL) {
-    free(qfp);
-    return FAIL;
-  }
+  qfp->qf_text = vim_strsave(mesg);
   qfp->qf_lnum = lnum;
   qfp->qf_col = col;
   qfp->qf_viscol = vis_col;
-  if (pattern == NULL || *pattern == NUL)
+  if (pattern == NULL || *pattern == NUL) {
     qfp->qf_pattern = NULL;
-  else if ((qfp->qf_pattern = vim_strsave(pattern)) == NULL) {
-    free(qfp->qf_text);
-    free(qfp);
-    return FAIL;
+  } else {
+    qfp->qf_pattern = vim_strsave(pattern);
   }
   qfp->qf_nr = nr;
   if (type != 1 && !vim_isprintc(type))   /* only printable chars allowed */

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -719,13 +719,10 @@ restofline:
         if (qfprev == NULL)
           goto error2;
         if (*errmsg && !multiignore) {
-          len = (int)STRLEN(qfprev->qf_text);
-          ptr = xmalloc(len + STRLEN(errmsg) + 2);
-          STRCPY(ptr, qfprev->qf_text);
-          free(qfprev->qf_text);
-          qfprev->qf_text = ptr;
-          *(ptr += len) = '\n';
-          STRCPY(++ptr, errmsg);
+          size_t len = STRLEN(qfprev->qf_text);
+          qfprev->qf_text = xrealloc(qfprev->qf_text, len + STRLEN(errmsg) + 2);
+          qfprev->qf_text[len] = '\n';
+          STRCPY(qfprev->qf_text + len + 1, errmsg);
         }
         if (qfprev->qf_nr == -1)
           qfprev->qf_nr = enr;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -5653,7 +5653,7 @@ static int match_with_backref(linenr_T start_lnum, colnr_T start_col, linenr_T e
       if (reg_tofree == NULL || len >= (int)reg_tofreelen) {
         len += 50;              /* get some extra */
         free(reg_tofree);
-        reg_tofree = alloc(len);
+        reg_tofree = xmalloc(len);
         reg_tofreelen = len;
       }
       STRCPY(reg_tofree, regline);
@@ -6404,7 +6404,7 @@ char_u *regtilde(char_u *source, int magic)
       if (reg_prev_sub != NULL) {
         /* length = len(newsub) - 1 + len(prev_sub) + 1 */
         prevlen = (int)STRLEN(reg_prev_sub);
-        tmpsub = alloc((unsigned)(STRLEN(newsub) + prevlen));
+        tmpsub = xmalloc(STRLEN(newsub) + prevlen);
         /* copy prefix */
         len = (int)(p - newsub);              /* not including ~ */
         memmove(tmpsub, newsub, (size_t)len);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1141,8 +1141,7 @@ char_u *skip_regexp(char_u *startp, int dirc, int magic, char_u **newp)
         /* change "\?" to "?", make a copy first. */
         if (*newp == NULL) {
           *newp = vim_strsave(startp);
-          if (*newp != NULL)
-            p = *newp + (p - startp);
+          p = *newp + (p - startp);
         }
         if (*newp != NULL)
           STRMOVE(p, p + 1);

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -516,7 +516,7 @@ static char_u *nfa_get_match_text(nfa_state_T *start)
   if (p->c != NFA_MCLOSE || p->out->c != NFA_MATCH)
     return NULL;
 
-  ret = alloc(len);
+  ret = xmalloc(len);
   p = start->out->out;     /* skip first char, it goes into regstart */
   s = ret;
   while (p->c > 0) {
@@ -4193,10 +4193,9 @@ addstate_here (
     if (l->n + count - 1 >= l->len) {
       /* not enough space to move the new states, reallocate the list
        * and move the states to the right position */
-      nfa_thread_T *newl;
 
       l->len = l->len * 3 / 2 + 50;
-      newl = (nfa_thread_T *)alloc(l->len * sizeof(nfa_thread_T));
+      nfa_thread_T *newl = xmalloc(l->len * sizeof(nfa_thread_T));
       memmove(&(newl[0]),
           &(l->t[0]),
           sizeof(nfa_thread_T) * listidx);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4691,10 +4691,7 @@ win_redr_status_matches (
   if (matches == NULL)          /* interrupted completion? */
     return;
 
-  if (has_mbyte)
-    buf = xmalloc(Columns * MB_MAXBYTES + 1);
-  else
-    buf = xmalloc(Columns + 1);
+  buf = xmalloc(has_mbyte ? Columns * MB_MAXBYTES + 1 : Columns + 1);
 
   if (match == -1) {    /* don't show match but original text */
     match = 0;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4692,9 +4692,9 @@ win_redr_status_matches (
     return;
 
   if (has_mbyte)
-    buf = alloc((unsigned)Columns * MB_MAXBYTES + 1);
+    buf = xmalloc(Columns * MB_MAXBYTES + 1);
   else
-    buf = alloc((unsigned)Columns + 1);
+    buf = xmalloc(Columns + 1);
 
   if (match == -1) {    /* don't show match but original text */
     match = 0;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -230,7 +230,9 @@ char_u *get_search_pat(void)
 
 /*
  * Reverse text into allocated memory.
- * Returns the allocated string, NULL when out of memory.
+ * Returns the allocated string.
+ *
+ * TODO(philix): move reverse_text() to strings.c
  */
 char_u *reverse_text(char_u *s)
 {
@@ -1080,13 +1082,9 @@ proftime_T      *tm;            /* timeout limit or NULL */
          * it would be blanked out again very soon.  Show it on the
          * left, but do reverse the text. */
         if (curwin->w_p_rl && *curwin->w_p_rlc == 's') {
-          char_u *r;
-
-          r = reverse_text(trunc != NULL ? trunc : msgbuf);
-          if (r != NULL) {
-            free(trunc);
-            trunc = r;
-          }
+          char_u *r = reverse_text(trunc != NULL ? trunc : msgbuf);
+          free(trunc);
+          trunc = r;
         }
         if (trunc != NULL) {
           msg_outtrans(trunc);

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -234,31 +234,23 @@ char_u *get_search_pat(void)
  */
 char_u *reverse_text(char_u *s)
 {
-  unsigned len;
-  unsigned s_i, rev_i;
-  char_u      *rev;
-
   /*
    * Reverse the pattern.
    */
-  len = (unsigned)STRLEN(s);
-  rev = alloc(len + 1);
-  if (rev != NULL) {
-    rev_i = len;
-    for (s_i = 0; s_i < len; ++s_i) {
-      if (has_mbyte) {
-        int mb_len;
-
-        mb_len = (*mb_ptr2len)(s + s_i);
-        rev_i -= mb_len;
-        memmove(rev + rev_i, s + s_i, mb_len);
-        s_i += mb_len - 1;
-      } else
-        rev[--rev_i] = s[s_i];
-
-    }
-    rev[len] = NUL;
+  size_t len = STRLEN(s);
+  char_u *rev = xmalloc(len + 1);
+  size_t rev_i = len;
+  for (size_t s_i = 0; s_i < len; ++s_i) {
+    if (has_mbyte) {
+      int mb_len = (*mb_ptr2len)(s + s_i);
+      rev_i -= mb_len;
+      memmove(rev + rev_i, s + s_i, mb_len);
+      s_i += mb_len - 1;
+    } else
+      rev[--rev_i] = s[s_i];
   }
+  rev[len] = NUL;
+
   return rev;
 }
 
@@ -1056,8 +1048,8 @@ proftime_T      *tm;            /* timeout limit or NULL */
         p = spats[last_idx].pat;
       else
         p = searchstr;
-      msgbuf = alloc((unsigned)(STRLEN(p) + 40));
-      if (msgbuf != NULL) {
+      msgbuf = xmalloc(STRLEN(p) + 40);
+      {
         msgbuf[0] = dirc;
         if (enc_utf8 && utf_iscomposing(utf_ptr2char(p))) {
           /* Use a space to draw the composing char on. */
@@ -3257,14 +3249,8 @@ again:
     curwin->w_cursor = old_pos;
     goto theend;
   }
-  spat = alloc(len + 31);
-  epat = alloc(len + 9);
-  if (spat == NULL || epat == NULL) {
-    free(spat);
-    free(epat);
-    curwin->w_cursor = old_pos;
-    goto theend;
-  }
+  spat = xmalloc(len + 31);
+  epat = xmalloc(len + 9);
   sprintf((char *)spat, "<%.*s\\>\\%%(\\s\\_[^>]\\{-}[^/]>\\|>\\)\\c", len, p);
   sprintf((char *)epat, "</%.*s>\\c", len, p);
 
@@ -4024,18 +4010,14 @@ find_pattern_in_path (
   incl_regmatch.regprog = NULL;
   def_regmatch.regprog = NULL;
 
-  file_line = alloc(LSIZE);
-  if (file_line == NULL)
-    return;
+  file_line = xmalloc(LSIZE);
 
   if (type != CHECK_PATH && type != FIND_DEFINE
       /* when CONT_SOL is set compare "ptr" with the beginning of the line
        * is faster than quote_meta/regcomp/regexec "ptr" -- Acevedo */
       && !(compl_cont_status & CONT_SOL)
       ) {
-    pat = alloc(len + 5);
-    if (pat == NULL)
-      goto fpip_end;
+    pat = xmalloc(len + 5);
     sprintf((char *)pat, whole ? "\\<%.*s\\>" : "%.*s", len, ptr);
     /* ignore case according to p_ic, p_scs and pat */
     regmatch.rm_ic = ignorecase(pat);

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2479,8 +2479,6 @@ spell_load_file (
 
     // Remember the file name, used to reload the file when it's updated.
     lp->sl_fname = vim_strsave(fname);
-    if (lp->sl_fname == NULL)
-      goto endFAIL;
 
     // Check for .add.spl.
     lp->sl_add = strstr((char *)path_tail(fname), SPL_FNAME_ADD) != NULL;
@@ -3669,8 +3667,6 @@ char_u *did_set_spelllang(win_T *wp)
   // Make a copy of 'spelllang', the SpellFileMissing autocommands may change
   // it under our fingers.
   spl_copy = vim_strsave(wp->w_s->b_p_spl);
-  if (spl_copy == NULL)
-    goto theend;
 
   wp->w_s->b_cjk = 0;
 
@@ -3936,11 +3932,9 @@ static void use_midword(slang_T *lp, win_T *wp)
         // Append multi-byte chars to "b_spell_ismw_mb".
         n = (int)STRLEN(wp->w_s->b_spell_ismw_mb);
         bp = vim_strnsave(wp->w_s->b_spell_ismw_mb, n + l);
-        if (bp != NULL) {
-          free(wp->w_s->b_spell_ismw_mb);
-          wp->w_s->b_spell_ismw_mb = bp;
-          vim_strncpy(bp + n, p, l);
-        }
+        free(wp->w_s->b_spell_ismw_mb);
+        wp->w_s->b_spell_ismw_mb = bp;
+        vim_strncpy(bp + n, p, l);
       }
       p += l;
     } else
@@ -5175,8 +5169,6 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
           if (HASHITEM_EMPTY(hash_find(&spin->si_commonwords,
                       items[i]))) {
             p = vim_strsave(items[i]);
-            if (p == NULL)
-              break;
             hash_add(&spin->si_commonwords, p);
           }
         }
@@ -8679,8 +8671,6 @@ void spell_suggest(int count)
 
   // Make a copy of current line since autocommands may free the line.
   line = vim_strsave(ml_get_curline());
-  if (line == NULL)
-    goto skip;
 
   // Get the list of suggestions.  Limit to 'lines' - 2 or the number in
   // 'spellsuggest', whatever is smaller.
@@ -8819,8 +8809,6 @@ void spell_suggest(int count)
     curwin->w_cursor = prev_cursor;
 
   spell_find_cleanup(&sug);
-skip:
-  free(line);
 }
 
 // Check if the word at line "lnum" column "col" is required to start with a
@@ -9064,8 +9052,6 @@ spell_find_suggest (
 
   // Make a copy of 'spellsuggest', because the expression may change it.
   sps_copy = vim_strsave(p_sps);
-  if (sps_copy == NULL)
-    return;
 
   // Loop over the items in 'spellsuggest'.
   for (p = sps_copy; *p != NUL; ) {
@@ -11025,13 +11011,11 @@ static void score_comp_sal(suginfo_T *su)
           // Add the suggestion.
           sstp = &SUG(su->su_sga, su->su_sga.ga_len);
           sstp->st_word = vim_strsave(stp->st_word);
-          if (sstp->st_word != NULL) {
-            sstp->st_wordlen = stp->st_wordlen;
-            sstp->st_score = score;
-            sstp->st_altscore = 0;
-            sstp->st_orglen = stp->st_orglen;
-            ++su->su_sga.ga_len;
-          }
+          sstp->st_wordlen = stp->st_wordlen;
+          sstp->st_score = score;
+          sstp->st_altscore = 0;
+          sstp->st_orglen = stp->st_orglen;
+          ++su->su_sga.ga_len;
         }
       }
       break;
@@ -11731,25 +11715,23 @@ add_suggestion (
     // Add a suggestion.
     stp = &SUG(*gap, gap->ga_len);
     stp->st_word = vim_strnsave(goodword, goodlen);
-    if (stp->st_word != NULL) {
-      stp->st_wordlen = goodlen;
-      stp->st_score = score;
-      stp->st_altscore = altscore;
-      stp->st_had_bonus = had_bonus;
-      stp->st_orglen = badlen;
-      stp->st_slang = slang;
-      ++gap->ga_len;
+    stp->st_wordlen = goodlen;
+    stp->st_score = score;
+    stp->st_altscore = altscore;
+    stp->st_had_bonus = had_bonus;
+    stp->st_orglen = badlen;
+    stp->st_slang = slang;
+    ++gap->ga_len;
 
-      // If we have too many suggestions now, sort the list and keep
-      // the best suggestions.
-      if (gap->ga_len > SUG_MAX_COUNT(su)) {
-        if (maxsf)
-          su->su_sfmaxscore = cleanup_suggestions(gap,
-              su->su_sfmaxscore, SUG_CLEAN_COUNT(su));
-        else
-          su->su_maxscore = cleanup_suggestions(gap,
-              su->su_maxscore, SUG_CLEAN_COUNT(su));
-      }
+    // If we have too many suggestions now, sort the list and keep
+    // the best suggestions.
+    if (gap->ga_len > SUG_MAX_COUNT(su)) {
+      if (maxsf)
+        su->su_sfmaxscore = cleanup_suggestions(gap,
+            su->su_sfmaxscore, SUG_CLEAN_COUNT(su));
+      else
+        su->su_maxscore = cleanup_suggestions(gap,
+            su->su_maxscore, SUG_CLEAN_COUNT(su));
     }
   }
 }
@@ -11800,8 +11782,7 @@ static void add_banned(suginfo_T *su, char_u *word)
   hi = hash_lookup(&su->su_banned, word, hash);
   if (HASHITEM_EMPTY(hi)) {
     s = vim_strsave(word);
-    if (s != NULL)
-      hash_add_item(&su->su_banned, hi, s, hash);
+    hash_add_item(&su->su_banned, hi, s, hash);
   }
 }
 

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2010,7 +2010,7 @@ spell_move_to (
     if (buflen < len + MAXWLEN + 2) {
       free(buf);
       buflen = len + MAXWLEN + 2;
-      buf = alloc(buflen);
+      buf = xmalloc(buflen);
     }
 
     // In first line check first word for Capital.
@@ -2854,7 +2854,7 @@ static int read_sal_section(FILE *fd, slang_T *slang)
     ccnt = getc(fd);                            // <salfromlen>
     if (ccnt < 0)
       return SP_TRUNCERROR;
-    p = alloc(ccnt + 2);
+    p = xmalloc(ccnt + 2);
     smp->sm_lead = p;
 
     // Read up to the first special char into sm_lead.
@@ -2917,7 +2917,7 @@ static int read_sal_section(FILE *fd, slang_T *slang)
     // Add one extra entry to mark the end with an empty sm_lead.  Avoids
     // that we need to check the index every time.
     smp = &((salitem_T *)gap->ga_data)[gap->ga_len];
-    p = alloc(1);
+    p = xmalloc(1);
     p[0] = NUL;
     smp->sm_lead = p;
     smp->sm_leadlen = 0;
@@ -2994,7 +2994,7 @@ count_common_word (
   hash = hash_hash(p);
   hi = hash_lookup(&lp->sl_wordcount, p, hash);
   if (HASHITEM_EMPTY(hi)) {
-    wc = (wordcount_T *)alloc((unsigned)(sizeof(wordcount_T) + STRLEN(p)));
+    wc = xmalloc(sizeof(wordcount_T) + STRLEN(p));
     STRCPY(wc->wc_word, p);
     wc->wc_count = count;
     hash_add_item(&lp->sl_wordcount, hi, wc->wc_word, hash);
@@ -3144,22 +3144,22 @@ static int read_compound(FILE *fd, slang_T *slang, int len)
   c = todo * 2 + 7;
   if (enc_utf8)
     c += todo * 2;
-  pat = alloc((unsigned)c);
+  pat = xmalloc(c);
 
   // We also need a list of all flags that can appear at the start and one
   // for all flags.
-  cp = alloc(todo + 1);
+  cp = xmalloc(todo + 1);
   slang->sl_compstartflags = cp;
   *cp = NUL;
 
-  ap = alloc(todo + 1);
+  ap = xmalloc(todo + 1);
   slang->sl_compallflags = ap;
   *ap = NUL;
 
   // And a list of all patterns in their original form, for checking whether
   // compounding may work in match_compoundrule().  This is freed when we
   // encounter a wildcard, the check doesn't work then.
-  crp = alloc(todo + 1);
+  crp = xmalloc(todo + 1);
   slang->sl_comprules = crp;
 
   pp = pat;
@@ -3376,7 +3376,7 @@ static int set_sofo(slang_T *lp, char_u *from, char_u *to)
     // Allocate the lists.
     for (i = 0; i < 256; ++i)
       if (lp->sl_sal_first[i] > 0) {
-        p = alloc(sizeof(int) * (lp->sl_sal_first[i] * 2 + 1));
+        p = xmalloc(sizeof(int) * (lp->sl_sal_first[i] * 2 + 1));
         ((int **)gap->ga_data)[i] = (int *)p;
         *(int *)p = 0;
       }
@@ -7374,7 +7374,7 @@ static void spell_make_sugfile(spellinfo_T *spin, char_u *wfname)
 
   // Write the .sug file.
   // Make the file name by changing ".spl" to ".sug".
-  fname = alloc(MAXPATHL);
+  fname = xmalloc(MAXPATHL);
   vim_strncpy(fname, wfname, MAXPATHL - 1);
   len = (int)STRLEN(fname);
   fname[len - 2] = 'u';
@@ -7782,7 +7782,7 @@ mkspell (
   innames = &fnames[1];
   incount = fcount - 1;
 
-  wfname = alloc(MAXPATHL);
+  wfname = xmalloc(MAXPATHL);
 
   if (fcount >= 1) {
     len = (int)STRLEN(fnames[0]);
@@ -7833,7 +7833,7 @@ mkspell (
       goto theend;
     }
 
-    fname = alloc(MAXPATHL);
+    fname = xmalloc(MAXPATHL);
 
     // Init the aff and dic pointers.
     // Get the region names if there are more than 2 arguments.
@@ -8025,7 +8025,7 @@ spell_add_word (
       EMSG2(_(e_notset), "spellfile");
       return;
     }
-    fnamebuf = alloc(MAXPATHL);
+    fnamebuf = xmalloc(MAXPATHL);
 
     for (spf = curwin->w_s->b_p_spf, i = 1; *spf != NUL; ++i) {
       copy_option_part(&spf, fnamebuf, MAXPATHL, ",");
@@ -8144,7 +8144,7 @@ static void init_spellfile(void)
   char_u      *lstart = curbuf->b_s.b_p_spl;
 
   if (*curwin->w_s->b_p_spl != NUL && !GA_EMPTY(&curwin->w_s->b_langp)) {
-    buf = alloc(MAXPATHL);
+    buf = xmalloc(MAXPATHL);
 
     // Find the end of the language name.  Exclude the region.  If there
     // is a path separator remember the start of the tail.
@@ -8787,8 +8787,7 @@ void spell_suggest(int count)
     }
 
     // Replace the word.
-    p = alloc((unsigned)STRLEN(line) - stp->st_orglen
-        + stp->st_wordlen + 1);
+    p = xmalloc(STRLEN(line) - stp->st_orglen + stp->st_wordlen + 1);
     c = (int)(sug.su_badptr - line);
     memmove(p, line, c);
     STRCPY(p + c, stp->st_word);
@@ -8886,7 +8885,7 @@ void ex_spellrepall(exarg_T *eap)
   }
   addlen = (int)(STRLEN(repl_to) - STRLEN(repl_from));
 
-  frompat = alloc((unsigned)STRLEN(repl_from) + 7);
+  frompat = xmalloc(STRLEN(repl_from) + 7);
   sprintf((char *)frompat, "\\V\\<%s\\>", repl_from);
   p_ws = FALSE;
 
@@ -8903,7 +8902,7 @@ void ex_spellrepall(exarg_T *eap)
     line = ml_get_curline();
     if (addlen <= 0 || STRNCMP(line + curwin->w_cursor.col,
             repl_to, STRLEN(repl_to)) != 0) {
-      p = alloc((unsigned)STRLEN(line) + addlen + 1);
+      p = xmalloc(STRLEN(line) + addlen + 1);
       memmove(p, line, curwin->w_cursor.col);
       STRCPY(p + curwin->w_cursor.col, repl_to);
       STRCAT(p, line + curwin->w_cursor.col + STRLEN(repl_from));
@@ -8955,8 +8954,8 @@ spell_suggest_list (
 
     // The suggested word may replace only part of "word", add the not
     // replaced part.
-    wcopy = alloc(stp->st_wordlen
-        + (unsigned)STRLEN(sug.su_badptr + stp->st_orglen) + 1);
+    wcopy = xmalloc(stp->st_wordlen
+                    + STRLEN(sug.su_badptr + stp->st_orglen) + 1);
     STRCPY(wcopy, stp->st_word);
     STRCPY(wcopy + stp->st_wordlen, sug.su_badptr + stp->st_orglen);
     ((char_u **)gap->ga_data)[gap->ga_len++] = wcopy;
@@ -11298,8 +11297,7 @@ add_sound_suggest (
   hash = hash_hash(goodword);
   hi = hash_lookup(&slang->sl_sounddone, goodword, hash);
   if (HASHITEM_EMPTY(hi)) {
-    sft = (sftword_T *)alloc((unsigned)(sizeof(sftword_T)
-                                        + STRLEN(goodword)));
+    sft = xmalloc(sizeof(sftword_T) + STRLEN(goodword));
     sft->sft_score = score;
     STRCPY(sft->sft_word, goodword);
     hash_add_item(&slang->sl_sounddone, hi, sft->sft_word, hash);
@@ -11563,7 +11561,7 @@ static void set_map_str(slang_T *lp, char_u *map)
         hash_T hash;
         hashitem_T  *hi;
 
-        b = alloc((unsigned)(cl + headcl + 2));
+        b = xmalloc(cl + headcl + 2);
         mb_char2bytes(c, b);
         b[cl] = NUL;
         mb_char2bytes(headc, b + cl + 1);

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -97,7 +97,7 @@ char_u *vim_strsave_escaped_ext(char_u *string, char_u *esc_chars, int cc, int b
       ++length;                         /* count a backslash */
     ++length;                           /* count an ordinary char */
   }
-  escaped_string = alloc(length);
+  escaped_string = xmalloc(length);
   p2 = escaped_string;
   for (p = string; *p; p++) {
     if (has_mbyte && (l = (*mb_ptr2len)(p)) > 1) {
@@ -158,7 +158,7 @@ char_u *vim_strsave_shellescape(char_u *string, bool do_special, bool do_newline
   }
 
   /* Allocate memory for the result and fill it. */
-  escaped_string = alloc(length);
+  escaped_string = xmalloc(length);
   d = escaped_string;
 
   /* add opening quote */
@@ -264,7 +264,7 @@ char_u *strup_save(char_u *orig)
       l = utf_ptr2len(p);
       newl = utf_char2len(uc);
       if (newl != l) {
-        s = alloc((unsigned)STRLEN(res) + 1 + newl - l);
+        s = xmalloc(STRLEN(res) + 1 + newl - l);
         memmove(s, res, p - res);
         STRCPY(s + (p - res) + newl, p + l);
         p = s + (p - res);

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -46,14 +46,7 @@
  */
 char_u *vim_strsave(char_u *string)
 {
-  char_u      *p;
-  unsigned len;
-
-  len = (unsigned)STRLEN(string) + 1;
-  p = alloc(len);
-  if (p != NULL)
-    memmove(p, string, (size_t)len);
-  return p;
+  return (char_u *)xstrdup((char *)string);
 }
 
 /*
@@ -64,12 +57,7 @@ char_u *vim_strsave(char_u *string)
  */
 char_u *vim_strnsave(char_u *string, int len)
 {
-  char_u      *p;
-
-  p = alloc((unsigned)(len + 1));
-  STRNCPY(p, string, len);
-  p[len] = NUL;
-  return p;
+  return (char_u *)strncpy(xmallocz(len), (char *)string, len);
 }
 
 /*

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -242,49 +242,45 @@ void vim_strup(char_u *p)
 /*
  * Make string "s" all upper-case and return it in allocated memory.
  * Handles multi-byte characters as well as possible.
- * Returns NULL when out of memory.
  */
 char_u *strup_save(char_u *orig)
 {
-  char_u      *p;
-  char_u      *res;
+  char_u *res = vim_strsave(orig);
 
-  res = p = vim_strsave(orig);
+  char_u *p = res;
+  while (*p != NUL) {
+    int l;
 
-  if (res != NULL)
-    while (*p != NUL) {
-      int l;
+    if (enc_utf8) {
+      int c, uc;
+      int newl;
+      char_u  *s;
 
-      if (enc_utf8) {
-        int c, uc;
-        int newl;
-        char_u  *s;
+      c = utf_ptr2char(p);
+      uc = utf_toupper(c);
 
-        c = utf_ptr2char(p);
-        uc = utf_toupper(c);
-
-        /* Reallocate string when byte count changes.  This is rare,
-         * thus it's OK to do another malloc()/free(). */
-        l = utf_ptr2len(p);
-        newl = utf_char2len(uc);
-        if (newl != l) {
-          s = alloc((unsigned)STRLEN(res) + 1 + newl - l);
-          memmove(s, res, p - res);
-          STRCPY(s + (p - res) + newl, p + l);
-          p = s + (p - res);
-          free(res);
-          res = s;
-        }
-
-        utf_char2bytes(uc, p);
-        p += newl;
-      } else if (has_mbyte && (l = (*mb_ptr2len)(p)) > 1)
-        p += l;                 /* skip multi-byte character */
-      else {
-        *p = TOUPPER_LOC(*p);         /* note that toupper() can be a macro */
-        p++;
+      /* Reallocate string when byte count changes.  This is rare,
+       * thus it's OK to do another malloc()/free(). */
+      l = utf_ptr2len(p);
+      newl = utf_char2len(uc);
+      if (newl != l) {
+        s = alloc((unsigned)STRLEN(res) + 1 + newl - l);
+        memmove(s, res, p - res);
+        STRCPY(s + (p - res) + newl, p + l);
+        p = s + (p - res);
+        free(res);
+        res = s;
       }
+
+      utf_char2bytes(uc, p);
+      p += newl;
+    } else if (has_mbyte && (l = (*mb_ptr2len)(p)) > 1)
+      p += l;                 /* skip multi-byte character */
+    else {
+      *p = TOUPPER_LOC(*p);         /* note that toupper() can be a macro */
+      p++;
     }
+  }
 
   return res;
 }

--- a/src/nvim/strings.h
+++ b/src/nvim/strings.h
@@ -1,7 +1,10 @@
 #ifndef NVIM_STRINGS_H
 #define NVIM_STRINGS_H
-char_u *vim_strsave(char_u *string);
-char_u *vim_strnsave(char_u *string, int len);
+
+#include "func_attr.h"
+
+char_u *vim_strsave(char_u *string) FUNC_ATTR_NONNULL_RET;
+char_u *vim_strnsave(char_u *string, int len) FUNC_ATTR_NONNULL_RET;
 char_u *vim_strsave_escaped(char_u *string, char_u *esc_chars);
 char_u *vim_strsave_escaped_ext(char_u *string, char_u *esc_chars,
                                 int cc,

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4113,8 +4113,6 @@ get_syn_options (
         if (gname_start == arg)
           return NULL;
         gname = vim_strnsave(gname_start, (int)(arg - gname_start));
-        if (gname == NULL)
-          return NULL;
         if (STRCMP(gname, "NONE") == 0)
           *opt->sync_idx = NONE_IDX;
         else {
@@ -4823,14 +4821,10 @@ static int syn_scl_name2id(char_u *name)
  */
 static int syn_scl_namen2id(char_u *linep, int len)
 {
-  char_u  *name;
-  int id = 0;
+  char_u *name = vim_strnsave(linep, len);
+  int id = syn_scl_name2id(name);
+  free(name);
 
-  name = vim_strnsave(linep, len);
-  if (name != NULL) {
-    id = syn_scl_name2id(name);
-    free(name);
-  }
   return id;
 }
 
@@ -4846,8 +4840,6 @@ static int syn_check_cluster(char_u *pp, int len)
   char_u      *name;
 
   name = vim_strnsave(pp, len);
-  if (name == NULL)
-    return 0;
 
   id = syn_scl_name2id(name);
   if (id == 0)                          /* doesn't exist yet */
@@ -4996,8 +4988,7 @@ static char_u *get_syn_pattern(char_u *arg, synpat_T *ci)
     return NULL;
   }
   /* store the pattern and compiled regexp program */
-  if ((ci->sp_pattern = vim_strnsave(arg + 1, (int)(end - arg - 1))) == NULL)
-    return NULL;
+  ci->sp_pattern = vim_strnsave(arg + 1, (int)(end - arg - 1));
 
   /* Make 'cpoptions' empty, to avoid the 'l' flag */
   cpo_save = p_cpo;
@@ -5139,11 +5130,8 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
 
       if (!eap->skip) {
         /* store the pattern and compiled regexp program */
-        if ((curwin->w_s->b_syn_linecont_pat = vim_strnsave(next_arg + 1,
-                 (int)(arg_end - next_arg - 1))) == NULL) {
-          finished = TRUE;
-          break;
-        }
+        curwin->w_s->b_syn_linecont_pat =
+          vim_strnsave(next_arg + 1, (int)(arg_end - next_arg - 1));
         curwin->w_s->b_syn_linecont_ic = curwin->w_s->b_syn_ic;
 
         /* Make 'cpoptions' empty, to avoid the 'l' flag */
@@ -5518,24 +5506,22 @@ void ex_syntax(exarg_T *eap)
   for (subcmd_end = arg; ASCII_ISALPHA(*subcmd_end); ++subcmd_end)
     ;
   subcmd_name = vim_strnsave(arg, (int)(subcmd_end - arg));
-  if (subcmd_name != NULL) {
-    if (eap->skip)              /* skip error messages for all subcommands */
-      ++emsg_skip;
-    for (i = 0;; ++i) {
-      if (subcommands[i].name == NULL) {
-        EMSG2(_("E410: Invalid :syntax subcommand: %s"), subcmd_name);
-        break;
-      }
-      if (STRCMP(subcmd_name, (char_u *)subcommands[i].name) == 0) {
-        eap->arg = skipwhite(subcmd_end);
-        (subcommands[i].func)(eap, FALSE);
-        break;
-      }
+  if (eap->skip)              /* skip error messages for all subcommands */
+    ++emsg_skip;
+  for (i = 0;; ++i) {
+    if (subcommands[i].name == NULL) {
+      EMSG2(_("E410: Invalid :syntax subcommand: %s"), subcmd_name);
+      break;
     }
-    free(subcmd_name);
-    if (eap->skip)
-      --emsg_skip;
+    if (STRCMP(subcmd_name, (char_u *)subcommands[i].name) == 0) {
+      eap->arg = skipwhite(subcmd_end);
+      (subcommands[i].func)(eap, FALSE);
+      break;
+    }
   }
+  free(subcmd_name);
+  if (eap->skip)
+    --emsg_skip;
 }
 
 void ex_ownsyntax(exarg_T *eap)
@@ -6392,10 +6378,6 @@ do_highlight (
         ++linep;
       free(key);
       key = vim_strnsave_up(key_start, (int)(linep - key_start));
-      if (key == NULL) {
-        error = TRUE;
-        break;
-      }
       linep = skipwhite(linep);
 
       if (STRCMP(key, "NONE") == 0) {
@@ -6440,10 +6422,7 @@ do_highlight (
       }
       free(arg);
       arg = vim_strnsave(arg_start, (int)(linep - arg_start));
-      if (arg == NULL) {
-        error = TRUE;
-        break;
-      }
+
       if (*linep == '\'')
         ++linep;
 
@@ -6725,10 +6704,6 @@ do_highlight (
                  arg[off + len] != ','; ++len)
               ;
             tname = vim_strnsave(arg + off, len);
-            if (tname == NULL) {                /* out of memory */
-              error = TRUE;
-              break;
-            }
             /* lookup the escape sequence for the item */
             p = get_term_code(tname);
             free(tname);
@@ -7410,14 +7385,10 @@ char_u *syn_id2name(int id)
  */
 int syn_namen2id(char_u *linep, int len)
 {
-  char_u  *name;
-  int id = 0;
+  char_u *name = vim_strnsave(linep, len);
+  int id = syn_name2id(name);
+  free(name);
 
-  name = vim_strnsave(linep, len);
-  if (name != NULL) {
-    id = syn_name2id(name);
-    free(name);
-  }
   return id;
 }
 
@@ -7433,8 +7404,6 @@ int syn_check_group(char_u *pp, int len)
   char_u  *name;
 
   name = vim_strnsave(pp, len);
-  if (name == NULL)
-    return 0;
 
   id = syn_name2id(name);
   if (id == 0)                          /* doesn't exist yet */

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3924,7 +3924,6 @@ add_keyword (
     int conceal_char
 )
 {
-  keyentry_T  *kp;
   hashtab_T   *ht;
   hashitem_T  *hi;
   char_u      *name_ic;
@@ -3936,7 +3935,7 @@ add_keyword (
         name_folded, MAXKEYWLEN + 1);
   else
     name_ic = name;
-  kp = (keyentry_T *)alloc((int)(sizeof(keyentry_T) + STRLEN(name_ic)));
+  keyentry_T *kp = xmalloc(sizeof(keyentry_T) + STRLEN(name_ic));
   STRCPY(kp->keyword, name_ic);
   kp->k_syn.id = id;
   kp->k_syn.inc_tag = current_syn_inc_tag;
@@ -4154,7 +4153,7 @@ static void syn_incl_toplevel(int id, int *flagsp)
   *flagsp |= HL_CONTAINED;
   if (curwin->w_s->b_syn_topgrp >= SYNID_CLUSTER) {
     /* We have to alloc this, because syn_combine_list() will free it. */
-    short       *grp_list = (short *)alloc((unsigned)(2 * sizeof(short)));
+    short *grp_list = xmalloc(2 * sizeof(short));
     int tlg_id = curwin->w_s->b_syn_topgrp - SYNID_CLUSTER;
 
     grp_list[0] = id;
@@ -4255,7 +4254,7 @@ static void syn_cmd_keyword(exarg_T *eap, int syncing)
     syn_id = syn_check_group(arg, (int)(group_name_end - arg));
     if (syn_id != 0)
       /* allocate a buffer, for removing backslashes in the keyword */
-      keyword_copy = alloc((unsigned)STRLEN(rest) + 1);
+      keyword_copy = xmalloc(STRLEN(rest) + 1);
     syn_opt_arg.flags = 0;
     syn_opt_arg.keyword = TRUE;
     syn_opt_arg.sync_idx = NULL;
@@ -4556,7 +4555,7 @@ syn_cmd_region (
        * syn_patterns for this item, at the start (because the list is
        * used from end to start).
        */
-      ppp = (struct pat_ptr *)alloc((unsigned)sizeof(struct pat_ptr));
+      ppp = xmalloc(sizeof(struct pat_ptr));
       ppp->pp_next = pat_ptrs[item];
       pat_ptrs[item] = ppp;
       ppp->pp_synp = xcalloc(1, sizeof(synpat_T));
@@ -4782,7 +4781,7 @@ static void syn_combine_list(short **clstr1, short **clstr2, int list_op)
         clstr = NULL;
         break;
       }
-      clstr = (short *)alloc((unsigned)((count + 1) * sizeof(short)));
+      clstr = xmalloc((count + 1) * sizeof(short));
       clstr[count] = 0;
     }
   }
@@ -5231,7 +5230,7 @@ get_id_list (
     while (!ends_excmd(*p)) {
       for (end = p; *end && !vim_iswhite(*end) && *end != ','; ++end)
         ;
-      name = alloc((int)(end - p + 3));             /* leave room for "^$" */
+      name = xmalloc((int)(end - p + 3));             /* leave room for "^$" */
       vim_strncpy(name + 1, p, end - p);
       if (       STRCMP(name + 1, "ALLBUT") == 0
                  || STRCMP(name + 1, "ALL") == 0
@@ -5325,7 +5324,7 @@ get_id_list (
     if (failed)
       break;
     if (round == 1) {
-      retval = (short *)alloc((unsigned)((count + 1) * sizeof(short)));
+      retval = xmalloc((count + 1) * sizeof(short));
       retval[count] = 0;            /* zero means end of the list */
       total_count = count;
     }
@@ -5360,7 +5359,7 @@ static short *copy_id_list(short *list)
   for (count = 0; list[count]; ++count)
     ;
   len = (count + 1) * sizeof(short);
-  retval = (short *)alloc((unsigned)len);
+  retval = xmalloc(len);
   memmove(retval, list, (size_t)len);
 
   return retval;
@@ -5530,7 +5529,7 @@ void ex_ownsyntax(exarg_T *eap)
   char_u      *new_value;
 
   if (curwin->w_s == &curwin->w_buffer->b_s) {
-    curwin->w_s = (synblock_T *)alloc(sizeof(synblock_T));
+    curwin->w_s = xmalloc(sizeof(synblock_T));
     memset(curwin->w_s, 0, sizeof(synblock_T));
     curwin->w_p_spell = FALSE;          /* No spell checking */
     clear_string_option(&curwin->w_s->b_p_spc);
@@ -6170,7 +6169,7 @@ int load_colors(char_u *name)
     return OK;
 
   recursive = TRUE;
-  buf = alloc((unsigned)(STRLEN(name) + 12));
+  buf = xmalloc(STRLEN(name) + 12);
   sprintf((char *)buf, "colors/%s.vim", name);
   retval = source_runtime(buf, FALSE);
   free(buf);

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -557,10 +557,9 @@ do_tag (
           /* Find out the actual file name. If it is long, truncate
            * it and put "..." in the middle */
           p = tag_full_fname(&tagp);
-          if (p != NULL) {
-            msg_puts_long_attr(p, hl_attr(HLF_D));
-            free(p);
-          }
+          msg_puts_long_attr(p, hl_attr(HLF_D));
+          free(p);
+
           if (msg_col > 0)
             msg_putchar('\n');
           if (got_int)
@@ -699,8 +698,6 @@ do_tag (
 
           /* Save the tag file name */
           p = tag_full_fname(&tagp);
-          if (p == NULL)
-            continue;
           vim_strncpy(fname, p, MAXPATHL);
           free(p);
 
@@ -2321,19 +2318,13 @@ parse_match (
 /*
  * Find out the actual file name of a tag.  Concatenate the tags file name
  * with the matching tag file name.
- * Returns an allocated string or NULL (out of memory).
+ * Returns an allocated string.
  */
 static char_u *tag_full_fname(tagptrs_T *tagp)
 {
-  char_u      *fullname;
-  int c;
-
-  {
-    c = *tagp->fname_end;
-    *tagp->fname_end = NUL;
-  }
-  fullname = expand_tag_fname(tagp->fname, tagp->tag_fname, FALSE);
-
+  int c = *tagp->fname_end;
+  *tagp->fname_end = NUL;
+  char_u *fullname = expand_tag_fname(tagp->fname, tagp->tag_fname, FALSE);
   *tagp->fname_end = c;
 
   return fullname;
@@ -2406,8 +2397,6 @@ jumpto_tag (
    * If 'tagrelative' option set, may change file name.
    */
   fname = expand_tag_fname(fname, tagp.tag_fname, TRUE);
-  if (fname == NULL)
-    goto erret;
   tofree_fname = fname;         /* free() it later */
 
   /*
@@ -2642,7 +2631,6 @@ erret:
 static char_u *expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
 {
   char_u      *p;
-  char_u      *retval;
   char_u      *expanded_fname = NULL;
   expand_T xpc;
 
@@ -2658,6 +2646,7 @@ static char_u *expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
       fname = expanded_fname;
   }
 
+  char_u *retval;
   if ((p_tr || curbuf->b_help)
       && !vim_isAbsName(fname)
       && (p = path_tail(tag_fname)) != tag_fname) {
@@ -2695,10 +2684,8 @@ static int test_for_current(char_u *fname, char_u *fname_end, char_u *tag_fname,
       *fname_end = NUL;
     }
     fullname = expand_tag_fname(fname, tag_fname, TRUE);
-    if (fullname != NULL) {
-      retval = (path_full_compare(fullname, buf_ffname, TRUE) & kEqualFiles);
-      free(fullname);
-    }
+    retval = (path_full_compare(fullname, buf_ffname, TRUE) & kEqualFiles);
+    free(fullname);
     *fname_end = c;
   }
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -236,8 +236,7 @@ do_tag (
           cur_fnum = ptag_entry.cur_fnum;
         } else {
           free(ptag_entry.tagname);
-          if ((ptag_entry.tagname = vim_strsave(tag)) == NULL)
-            goto end_do_tag;
+          ptag_entry.tagname = vim_strsave(tag);
         }
       } else {
         /*
@@ -256,13 +255,9 @@ do_tag (
           --tagstackidx;
         }
 
-        /*
-         * put the tag name in the tag stack
-         */
-        if ((tagstack[tagstackidx].tagname = vim_strsave(tag)) == NULL) {
-          curwin->w_tagstacklen = tagstacklen - 1;
-          goto end_do_tag;
-        }
+        // put the tag name in the tag stack
+        tagstack[tagstackidx].tagname = vim_strsave(tag);
+
         curwin->w_tagstacklen = tagstacklen;
 
         save_pos = TRUE;                /* save the cursor position below */
@@ -1211,11 +1206,9 @@ find_tags (
         && ASCII_ISALPHA(pat[orgpat.len - 2])
         && ASCII_ISALPHA(pat[orgpat.len - 1])) {
       saved_pat = vim_strnsave(pat, orgpat.len - 3);
-      if (saved_pat != NULL) {
-        help_lang_find = &pat[orgpat.len - 2];
-        orgpat.pat = saved_pat;
-        orgpat.len -= 3;
-      }
+      help_lang_find = &pat[orgpat.len - 2];
+      orgpat.pat = saved_pat;
+      orgpat.len -= 3;
     }
   }
   if (p_tl != 0 && orgpat.len > p_tl)           /* adjust for 'taglength' */
@@ -2099,8 +2092,6 @@ get_tagfname (
      * the value without notifying us. */
     tnp->tn_tags = vim_strsave((*curbuf->b_p_tags != NUL)
         ? curbuf->b_p_tags : p_tags);
-    if (tnp->tn_tags == NULL)
-      return FAIL;
     tnp->tn_np = tnp->tn_tags;
   }
 
@@ -2435,8 +2426,6 @@ jumpto_tag (
     retval = NOTAGFILE;
     free(nofile_fname);
     nofile_fname = vim_strsave(fname);
-    if (nofile_fname == NULL)
-      nofile_fname = empty_option;
     goto erret;
   }
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -679,8 +679,8 @@ do_tag (
          * window.
          */
 
-        fname = alloc(MAXPATHL + 1);
-        cmd = alloc(CMDBUFFSIZE + 1);
+        fname = xmalloc(MAXPATHL + 1);
+        cmd = xmalloc(CMDBUFFSIZE + 1);
         list = list_alloc();
 
         for (i = 0; i < num_matches; ++i) {
@@ -1185,8 +1185,8 @@ find_tags (
   /*
    * Allocate memory for the buffers that are used
    */
-  lbuf = alloc(lbuf_size);
-  tag_fname = alloc(MAXPATHL + 1);
+  lbuf = xmalloc(lbuf_size);
+  tag_fname = xmalloc(MAXPATHL + 1);
   for (mtt = 0; mtt < MT_COUNT; ++mtt)
     ga_init(&ga_match[mtt], (int)sizeof(struct match_found *), 100);
 
@@ -1814,9 +1814,7 @@ parse_line:
                */
               *tagp.tagname_end = NUL;
               len = (int)(tagp.tagname_end - tagp.tagname);
-              mfp = (struct match_found *)
-                    alloc((int)sizeof(struct match_found) + len
-                  + 10 + ML_EXTRA);
+              mfp = xmalloc(sizeof(struct match_found) + len + 10 + ML_EXTRA);
               /* "len" includes the language and the NUL, but
                * not the priority. */
               mfp->len = len + ML_EXTRA + 1;
@@ -1844,8 +1842,7 @@ parse_line:
 
                 if (tagp.command + 2 < temp_end) {
                   len = (int)(temp_end - tagp.command - 2);
-                  mfp = (struct match_found *)alloc(
-                      (int)sizeof(struct match_found) + len);
+                  mfp = xmalloc(sizeof(struct match_found) + len);
                   mfp->len = len + 1;                 /* include the NUL */
                   p = mfp->match;
                   vim_strncpy(p, tagp.command + 2, len);
@@ -1854,8 +1851,7 @@ parse_line:
                 get_it_again = FALSE;
               } else {
                 len = (int)(tagp.tagname_end - tagp.tagname);
-                mfp = (struct match_found *)alloc(
-                    (int)sizeof(struct match_found) + len);
+                mfp = xmalloc(sizeof(struct match_found) + len);
                 mfp->len = len + 1;               /* include the NUL */
                 p = mfp->match;
                 vim_strncpy(p, tagp.tagname, len);
@@ -1872,8 +1868,7 @@ parse_line:
                */
               len = (int)STRLEN(tag_fname)
                     + (int)STRLEN(lbuf) + 3;
-              mfp = (struct match_found *)alloc(
-                  (int)sizeof(struct match_found) + len);
+              mfp = xmalloc(sizeof(struct match_found) + len);
               mfp->len = len;
               p = mfp->match;
               p[0] = mtt;
@@ -2375,7 +2370,7 @@ jumpto_tag (
   char_u      *full_fname = NULL;
   int old_KeyTyped = KeyTyped;              /* getting the file may reset it */
 
-  pbuf = alloc(LSIZE);
+  pbuf = xmalloc(LSIZE);
 
   /* parse the match line into the tagp structure */
   if (parse_match(lbuf, &tagp) == FAIL) {
@@ -2642,7 +2637,7 @@ erret:
  * If "expand" is TRUE, expand wildcards in fname.
  * If 'tagrelative' option set, change fname (name of file containing tag)
  * according to tag_fname (name of tag file containing fname).
- * Returns a pointer to allocated memory (or NULL when out of memory).
+ * Returns a pointer to allocated memory.
  */
 static char_u *expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
 {
@@ -2666,7 +2661,7 @@ static char_u *expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
   if ((p_tr || curbuf->b_help)
       && !vim_isAbsName(fname)
       && (p = path_tail(tag_fname)) != tag_fname) {
-    retval = alloc(MAXPATHL);
+    retval = xmalloc(MAXPATHL);
     STRCPY(retval, tag_fname);
     vim_strncpy(retval + (p - tag_fname), fname,
         MAXPATHL - (p - tag_fname) - 1);
@@ -2805,7 +2800,6 @@ add_tag_field (
     char_u *end                   /* after the value; can be NULL */
 )
 {
-  char_u      *buf;
   int len = 0;
   int retval;
 
@@ -2818,7 +2812,7 @@ add_tag_field (
     }
     return FAIL;
   }
-  buf = alloc(MAXPATHL);
+  char_u *buf = xmalloc(MAXPATHL);
   if (start != NULL) {
     if (end == NULL) {
       end = start + STRLEN(start);

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -2983,8 +2983,7 @@ void add_termcode(char_u *name, char_u *string, int flags)
    */
   if (tc_len == tc_max_len) {
     tc_max_len += 20;
-    new_tc = (struct termcode *)alloc(
-        (unsigned)(tc_max_len * sizeof(struct termcode)));
+    new_tc = xmalloc(tc_max_len * sizeof(struct termcode));
     for (i = 0; i < tc_len; ++i)
       new_tc[i] = termcodes[i];
     free(termcodes);
@@ -4170,7 +4169,7 @@ replace_termcodes (
    * Allocate space for the translation.  Worst case a single character is
    * replaced by 6 bytes (shifted special key), plus a NUL at the end.
    */
-  result = alloc((unsigned)STRLEN(from) * 6 + 1);
+  result = xmalloc(STRLEN(from) * 6 + 1);
 
   src = from;
 
@@ -4376,7 +4375,7 @@ void show_termcodes(void)
 
   if (tc_len == 0)          /* no terminal codes (must be GUI) */
     return;
-  items = (int *)alloc((unsigned)(sizeof(int) * tc_len));
+  items = xmalloc(sizeof(int) * tc_len);
 
   /* Highlight title */
   MSG_PUTS_TITLE(_("\n--- Terminal keys ---"));

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -4304,14 +4304,9 @@ replace_termcodes (
   }
   result[dlen] = NUL;
 
-  /*
-   * Copy the new string to allocated memory.
-   * If this fails, just return from.
-   */
-  *bufp = vim_strsave(result);
-  from = *bufp;
-  free(result);
-  return from;
+  *bufp = xrealloc(result, dlen + 1);
+
+  return *bufp;
 }
 
 /*

--- a/src/nvim/term.c
+++ b/src/nvim/term.c
@@ -1198,15 +1198,13 @@ static void parse_builtin_tcap(char_u *term)
           char_u  *s, *t;
 
           s = vim_strsave((char_u *)p->bt_string);
-          if (s != NULL) {
-            for (t = s; *t; ++t)
-              if (term_7to8bit(t)) {
-                *t = term_7to8bit(t);
-                STRCPY(t + 1, t + 2);
-              }
-            term_strings[p->bt_entry] = s;
-            set_term_option_alloced(&term_strings[p->bt_entry]);
-          }
+          for (t = s; *t; ++t)
+            if (term_7to8bit(t)) {
+              *t = term_7to8bit(t);
+              STRCPY(t + 1, t + 2);
+            }
+          term_strings[p->bt_entry] = s;
+          set_term_option_alloced(&term_strings[p->bt_entry]);
         } else
           term_strings[p->bt_entry] = (char_u *)p->bt_string;
       }
@@ -2970,8 +2968,6 @@ void add_termcode(char_u *name, char_u *string, int flags)
   }
 
   s = vim_strsave(string);
-  if (s == NULL)
-    return;
 
   /* Change leading <Esc>[ to CSI, change <Esc>O to <M-O>. */
   if (flags != 0 && flags != ATC_FROM_TERM && term_7to8bit(string) != 0) {
@@ -4313,8 +4309,8 @@ replace_termcodes (
    * Copy the new string to allocated memory.
    * If this fails, just return from.
    */
-  if ((*bufp = vim_strsave(result)) != NULL)
-    from = *bufp;
+  *bufp = vim_strsave(result);
+  from = *bufp;
   free(result);
   return from;
 }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -272,12 +272,10 @@ int vim_is_input_buf_empty(void)
  */
 char_u *get_input_buf(void)
 {
-  garray_T    *gap;
-
   /* We use a growarray to store the data pointer and the length. */
-  gap = (garray_T *)alloc((unsigned)sizeof(garray_T));
+  garray_T *gap = xmalloc(sizeof(garray_T));
   /* Add one to avoid a zero size. */
-  gap->ga_data = alloc((unsigned)inbufcount + 1);
+  gap->ga_data = xmalloc(inbufcount + 1);
   if (gap->ga_data != NULL)
     memmove(gap->ga_data, inbuf, (size_t)inbufcount);
   gap->ga_len = inbufcount;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -700,8 +700,6 @@ char_u *u_get_undo_file_name(char_u *buf_ffname, int reading)
       /* Use same directory as the ffname,
        * "dir/name" -> "dir/.name.un~" */
       undo_file_name = vim_strnsave(ffname, (int)(STRLEN(ffname) + 5));
-      if (undo_file_name == NULL)
-        break;
       p = path_tail(undo_file_name);
       memmove(p + 1, p, STRLEN(p) + 1);
       *p = '.';
@@ -711,8 +709,6 @@ char_u *u_get_undo_file_name(char_u *buf_ffname, int reading)
       if (os_isdir(dir_name)) {
         if (munged_name == NULL) {
           munged_name = vim_strsave(ffname);
-          if (munged_name == NULL)
-            return NULL;
           for (p = munged_name; *p != NUL; mb_ptr_adv(p))
             if (vim_ispathsep(*p))
               *p = '%';

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5263,7 +5263,7 @@ int match_add(win_T *wp, char_u *grp, char_u *pat, int prio, int id)
   }
 
   /* Build new match. */
-  m = (matchitem_T *)alloc(sizeof(matchitem_T));
+  m = xmalloc(sizeof(matchitem_T));
   m->id = id;
   m->priority = prio;
   m->pattern = vim_strsave(pat);


### PR DESCRIPTION
- [x] Implement `vim_str(n)save` using `xstr(n)dup`
- [x] Remove NULL/non-NULL tests after calls to `vim_strsave`
- [x] Remove NULL/non-NULL tests after calls to `vim_strnsave`
- [x] Replace `alloc` with `xmalloc` and refactor immediate OOM tests
- [x] Remove OOM tests after calls to functions that don't have an OOM error condition
